### PR TITLE
Tsserver tests can be baselined

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -658,6 +658,11 @@ namespace ts.server {
         reloadLevel?: ConfigFileProgramReloadLevel.Partial | ConfigFileProgramReloadLevel.Full;
     }
 
+    function createProjectNameFactoryWithCounter(nameFactory: (counter: number) => string) {
+        let nextId = 1;
+        return () => nameFactory(nextId++);
+    }
+
     export class ProjectService {
 
         /*@internal*/
@@ -703,6 +708,10 @@ namespace ts.server {
          * projects specified by a tsconfig.json file
          */
         readonly configuredProjects: Map<ConfiguredProject> = new Map<string, ConfiguredProject>();
+        /*@internal*/
+        readonly newInferredProjectName = createProjectNameFactoryWithCounter(makeInferredProjectName);
+        /*@internal*/
+        readonly newAutoImportProviderProjectName = createProjectNameFactoryWithCounter(makeAutoImportProviderProjectName);
         /**
          * Open files: with value being project root path, and key being Path of the file that is open
          */

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1753,18 +1753,11 @@ namespace ts.server {
         });
     }
 
-    function createProjectNameFactoryWithCounter(nameFactory: (counter: number) => string) {
-        let nextId = 1;
-        return () => nameFactory(nextId++);
-    }
-
     /**
      * If a file is opened and no tsconfig (or jsconfig) is found,
      * the file and its imports/references are put into an InferredProject.
      */
     export class InferredProject extends Project {
-        private static readonly newName = createProjectNameFactoryWithCounter(makeInferredProjectName);
-
         private _isJsInferredProject = false;
 
         toggleJsInferredProject(isJsInferredProject: boolean) {
@@ -1807,7 +1800,7 @@ namespace ts.server {
             currentDirectory: string | undefined,
             pluginConfigOverrides: ESMap<string, any> | undefined,
             typeAcquisition: TypeAcquisition | undefined) {
-            super(InferredProject.newName(),
+            super(projectService.newInferredProjectName(),
                 ProjectKind.Inferred,
                 projectService,
                 documentRegistry,
@@ -1874,8 +1867,6 @@ namespace ts.server {
     }
 
     export class AutoImportProviderProject extends Project {
-        private static readonly newName = createProjectNameFactoryWithCounter(makeAutoImportProviderProjectName);
-
         /*@internal*/
         private static readonly maxDependencies = 10;
 
@@ -1966,7 +1957,7 @@ namespace ts.server {
             documentRegistry: DocumentRegistry,
             compilerOptions: CompilerOptions,
         ) {
-            super(AutoImportProviderProject.newName(),
+            super(hostProject.projectService.newAutoImportProviderProjectName(),
                 ProjectKind.AutoImportProvider,
                 hostProject.projectService,
                 documentRegistry,

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1225,12 +1225,12 @@ namespace ts.server {
             );
             const elapsed = timestamp() - start;
             this.sendPerformanceEvent("UpdateGraph", elapsed);
-            this.writeLog(`Finishing updateGraphWorker: Project: ${this.getProjectName()} Version: ${this.getProjectVersion()} structureChanged: ${hasNewProgram} Elapsed: ${elapsed}ms`);
+            this.writeLog(`Finishing updateGraphWorker: Project: ${this.getProjectName()} Version: ${this.getProjectVersion()} structureChanged: ${hasNewProgram}${this.program ? ` structureIsReused:: ${(ts as any).StructureIsReused[this.program.structureIsReused]}` : ""} Elapsed: ${elapsed}ms`);
             if (this.hasAddedorRemovedFiles) {
                 this.print(/*writeProjectFileNames*/ true);
             }
             else if (this.program !== oldProgram) {
-                this.writeLog(`Different program with same set of files:: structureIsReused:: ${this.program?.structureIsReused}`);
+                this.writeLog(`Different program with same set of files`);
             }
             return hasNewProgram;
         }

--- a/src/testRunner/unittests/tsserver/compileOnSave.ts
+++ b/src/testRunner/unittests/tsserver/compileOnSave.ts
@@ -1,7 +1,5 @@
 namespace ts.projectSystem {
     import CommandNames = server.CommandNames;
-    const nullCancellationToken = server.nullCancellationToken;
-
     function createTestTypingsInstaller(host: server.ServerHost) {
         return new TestTypingsInstaller("/a/data/", /*throttleLimit*/5, host);
     }
@@ -25,21 +23,6 @@ namespace ts.projectSystem {
                     arrayIsEqualTo(actualResultSingleProjectFileNameList, expectedResultSingleProjectFileNameList),
                     `For project ${actualResultSingleProject.projectFileName}, the actual result is ${actualResultSingleProjectFileNameList}, while expected ${expectedResultSingleProjectFileNameList}`);
             }
-        }
-
-        function createSession(host: server.ServerHost, typingsInstaller?: server.ITypingsInstaller): server.Session {
-            const opts: server.SessionOptions = {
-                host,
-                cancellationToken: nullCancellationToken,
-                useSingleInferredProject: false,
-                useInferredProjectPerProjectRoot: false,
-                typingsInstaller: typingsInstaller || server.nullTypingsInstaller,
-                byteLength: Utils.byteLength,
-                hrtime: process.hrtime,
-                logger: createHasErrorMessageLogger().logger,
-                canUseEvents: false
-            };
-            return new server.Session(opts);
         }
 
         describe("for configured projects", () => {
@@ -113,7 +96,7 @@ namespace ts.projectSystem {
             it("should contains only itself if a module file's shape didn't change, and all files referencing it if its shape changed", () => {
                 const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer2, globalFile3, moduleFile2, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
 
                 openFilesForSession([moduleFile1, file1Consumer1], session);
 
@@ -138,7 +121,7 @@ namespace ts.projectSystem {
             it("should be up-to-date with the reference map changes", () => {
                 const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer2, globalFile3, moduleFile2, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
 
                 openFilesForSession([moduleFile1, file1Consumer1], session);
 
@@ -185,7 +168,7 @@ namespace ts.projectSystem {
             it("should be up-to-date with changes made in non-open files", () => {
                 const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer2, globalFile3, moduleFile2, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
 
                 openFilesForSession([moduleFile1], session);
 
@@ -201,7 +184,7 @@ namespace ts.projectSystem {
             it("should be up-to-date with deleted files", () => {
                 const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer2, globalFile3, moduleFile2, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
 
                 openFilesForSession([moduleFile1], session);
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer1, file1Consumer2] }]);
@@ -215,7 +198,7 @@ namespace ts.projectSystem {
             it("should be up-to-date with newly created files", () => {
                 const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer2, globalFile3, moduleFile2, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
 
                 openFilesForSession([moduleFile1], session);
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer1, file1Consumer2] }]);
@@ -251,7 +234,7 @@ namespace ts.projectSystem {
 
                 const host = createServerHost([moduleFile1, file1Consumer1, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
 
                 openFilesForSession([moduleFile1, file1Consumer1], session);
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer1] }]);
@@ -268,7 +251,7 @@ namespace ts.projectSystem {
             it("should return all files if a global file changed shape", () => {
                 const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer2, globalFile3, moduleFile2, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
 
                 openFilesForSession([globalFile3], session);
                 const changeGlobalFile3ShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
@@ -294,7 +277,7 @@ namespace ts.projectSystem {
 
                 const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer2, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
                 openFilesForSession([moduleFile1], session);
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, []);
             });
@@ -312,7 +295,7 @@ namespace ts.projectSystem {
 
                 const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer2, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
                 openFilesForSession([moduleFile1], session);
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, []);
             });
@@ -334,7 +317,7 @@ namespace ts.projectSystem {
 
                 const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer2, configFile2, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
 
                 openFilesForSession([moduleFile1, file1Consumer1], session);
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer1, file1Consumer2] }]);
@@ -353,7 +336,7 @@ namespace ts.projectSystem {
 
                 const host = createServerHost([moduleFile1, file1Consumer1, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
                 openFilesForSession([moduleFile1], session);
 
                 const file1ChangeShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
@@ -382,7 +365,7 @@ namespace ts.projectSystem {
 
                 const host = createServerHost([moduleFile1, file1Consumer1, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
                 openFilesForSession([moduleFile1], session);
 
                 const file1ChangeShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
@@ -404,7 +387,7 @@ namespace ts.projectSystem {
                 };
                 const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer1Consumer1, globalFile3, configFile, libFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
 
                 openFilesForSession([moduleFile1, file1Consumer1], session);
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer1, file1Consumer1Consumer1] }]);
@@ -437,7 +420,7 @@ namespace ts.projectSystem {
                 };
                 const host = createServerHost([file1, file2, configFile]);
                 const typingsInstaller = createTestTypingsInstaller(host);
-                const session = createSession(host, typingsInstaller);
+                const session = createSession(host, { typingsInstaller });
 
                 openFilesForSession([file1, file2], session);
                 const file1AffectedListRequest = makeSessionRequest<server.protocol.FileRequestArgs>(CommandNames.CompileOnSaveAffectedFileList, { file: file1.path });
@@ -520,7 +503,7 @@ namespace ts.projectSystem {
                     })
                 };
                 const host = createServerHost([dtsFile, f2, config]);
-                const session = projectSystem.createSession(host);
+                const session = createSession(host);
                 session.executeCommand({
                     seq: 1,
                     type: "request",
@@ -626,7 +609,7 @@ namespace ts.projectSystem {
                     })
                 };
                 const host = createServerHost([f1, f2, config]);
-                const session = projectSystem.createSession(host);
+                const session = createSession(host);
                 session.executeCommand({
                     seq: 1,
                     type: "request",

--- a/src/testRunner/unittests/tsserver/events/projectLanguageServiceState.ts
+++ b/src/testRunner/unittests/tsserver/events/projectLanguageServiceState.ts
@@ -68,18 +68,12 @@ namespace ts.projectSystem {
                 content: "{}"
             };
             const host = createServerHost([f1, f2, f3, libFile, config]);
-            const logs: string[] = [];
-            const logger: server.Logger = {
-                ...nullLogger,
-                info: s => logs.push(s)
-            };
-            const service = createProjectService(host, { logger });
+            const service = createProjectService(host, { logger: createLoggerWithInMemoryLogs() });
             service.openClientFile(f1.path);
-            checkNumberOfProjects(service, { configuredProjects: 1 });
             const project = service.configuredProjects.get(config.path)!;
-            assert.isFalse(project.languageServiceEnabled, "Language service enabled");
-            assert.equal(project.lastFileExceededProgramSize, f2.path);
-            assert.isTrue(contains(logs, `Non TS file size exceeded limit (${f1.content.length + f2.fileSize!}). Largest files: ${f2.path}:${f2.fileSize}, ${f1.path}:${f1.content.length}`));
+            service.logger.logs.push(`languageServiceEnabled: ${project.languageServiceEnabled}`);
+            service.logger.logs.push(`lastFileExceededProgramSize: ${project.lastFileExceededProgramSize}`);
+            baselineTsserverLogs("projectLanguageServiceStateEvent", "large file size is determined correctly", service);
         });
     });
 }

--- a/src/testRunner/unittests/tsserver/forceConsistentCasingInFileNames.ts
+++ b/src/testRunner/unittests/tsserver/forceConsistentCasingInFileNames.ts
@@ -59,13 +59,9 @@ namespace ts.projectSystem {
             };
 
             const host = createServerHost([loggerFile, anotherFile, tsconfig, libFile, tsconfig]);
-            const session = createSession(host, { canUseEvents: true });
+            const session = createSession(host, { canUseEvents: true, logger: createLoggerWithInMemoryLogs() });
             openFilesForSession([{ file: loggerFile, projectRootPath: tscWatch.projectRoot }], session);
-            const service = session.getProjectService();
-            checkNumberOfProjects(service, { configuredProjects: 1 });
-            const project = service.configuredProjects.get(tsconfig.path)!;
-            checkProjectActualFiles(project, [loggerFile.path, anotherFile.path, libFile.path, tsconfig.path]);
-            verifyGetErrRequestNoErrors({ session, host, files: [loggerFile] });
+            verifyGetErrRequest({ session, host, files: [loggerFile] });
 
             const newLoggerPath = loggerFile.path.toLowerCase();
             host.renameFile(loggerFile.path, newLoggerPath);
@@ -91,7 +87,8 @@ namespace ts.projectSystem {
             });
 
             // Check errors in both files
-            verifyGetErrRequestNoErrors({ session, host, files: [newLoggerPath, anotherFile] });
+            verifyGetErrRequest({ session, host, files: [newLoggerPath, anotherFile] });
+            baselineTsserverLogs("forceConsistentCasingInFileNames", "works when renaming file with different casing", session);
         });
 
         it("when changing module name with different casing", () => {
@@ -111,13 +108,9 @@ namespace ts.projectSystem {
             };
 
             const host = createServerHost([loggerFile, anotherFile, tsconfig, libFile, tsconfig]);
-            const session = createSession(host, { canUseEvents: true });
+            const session = createSession(host, { canUseEvents: true, logger: createLoggerWithInMemoryLogs() });
             openFilesForSession([{ file: anotherFile, projectRootPath: tscWatch.projectRoot }], session);
-            const service = session.getProjectService();
-            checkNumberOfProjects(service, { configuredProjects: 1 });
-            const project = service.configuredProjects.get(tsconfig.path)!;
-            checkProjectActualFiles(project, [loggerFile.path, anotherFile.path, libFile.path, tsconfig.path]);
-            verifyGetErrRequestNoErrors({ session, host, files: [anotherFile] });
+            verifyGetErrRequest({ session, host, files: [anotherFile] });
 
             session.executeCommandSeq<protocol.UpdateOpenRequest>({
                 command: protocol.CommandTypes.UpdateOpen,
@@ -135,32 +128,9 @@ namespace ts.projectSystem {
                 }
             });
 
-            const location = protocolTextSpanFromSubstring(anotherFile.content, `"./Logger"`);
             // Check errors in both files
-            verifyGetErrRequest({
-                host,
-                session,
-                expected: [{
-                    file: anotherFile.path,
-                    syntax: [],
-                    semantic: [createDiagnostic(
-                        location.start,
-                        location.end,
-                        {
-                            message: Diagnostics.File_name_0_differs_from_already_included_file_name_1_only_in_casing,
-                            args: [loggerFile.path.toLowerCase(), loggerFile.path],
-                            next: [{
-                                message: Diagnostics.The_file_is_in_the_program_because_Colon,
-                                next: [
-                                    { message: Diagnostics.Matched_by_include_pattern_0_in_1, args: ["**/*", tsconfig.path] },
-                                    { message: Diagnostics.Imported_via_0_from_file_1, args: [`"./logger"`, anotherFile.path] }
-                                ]
-                            }]
-                        }
-                    )],
-                    suggestion: []
-                }]
-            });
+            verifyGetErrRequest({ host, session, files: [anotherFile] });
+            baselineTsserverLogs("forceConsistentCasingInFileNames", "when changing module name with different casing", session);
         });
     });
 }

--- a/src/testRunner/unittests/tsserver/helpers.ts
+++ b/src/testRunner/unittests/tsserver/helpers.ts
@@ -710,24 +710,6 @@ namespace ts.projectSystem {
         }
     }
 
-    export interface ErrorInformation {
-        diagnosticMessage: DiagnosticMessage;
-        errorTextArguments?: string[];
-    }
-
-    function getProtocolDiagnosticMessage({ diagnosticMessage, errorTextArguments = [] }: ErrorInformation) {
-        return formatStringFromArgs(diagnosticMessage.message, errorTextArguments);
-    }
-
-    export function verifyDiagnostics(actual: readonly server.protocol.Diagnostic[], expected: readonly ErrorInformation[]) {
-        const expectedErrors = expected.map(getProtocolDiagnosticMessage);
-        assert.deepEqual(actual.map(diag => flattenDiagnosticMessageText(diag.text, "\n")), expectedErrors);
-    }
-
-    export function verifyNoDiagnostics(actual: server.protocol.Diagnostic[]) {
-        verifyDiagnostics(actual, []);
-    }
-
     export interface MakeReferenceItem extends DocumentSpanFromSubstring {
         isDefinition: boolean;
         isWriteAccess?: boolean;

--- a/src/testRunner/unittests/tsserver/helpers.ts
+++ b/src/testRunner/unittests/tsserver/helpers.ts
@@ -55,44 +55,78 @@ namespace ts.projectSystem {
         readonly callback: TI.RequestCompletedAction;
     }
 
-    export const nullLogger: server.Logger = {
-        close: noop,
-        hasLevel: returnFalse,
-        loggingEnabled: returnFalse,
-        perftrc: noop,
-        info: noop,
-        msg: noop,
-        startGroup: noop,
-        endGroup: noop,
-        getLogFileName: returnUndefined,
-    };
-
-    export function createHasErrorMessageLogger() {
-        let hasErrorMsg = false;
-        const { close, hasLevel, loggingEnabled, startGroup, endGroup, info, getLogFileName, perftrc } = nullLogger;
-        const logger: server.Logger = {
-            close, hasLevel, loggingEnabled, startGroup, endGroup, info, getLogFileName, perftrc,
-            msg: (s, type) => {
-                Debug.fail(`Error: ${s}, type: ${type}`);
-                hasErrorMsg = true;
-            }
-        };
-        return { logger, hasErrorMsg: () => hasErrorMsg };
+    export interface Logger extends server.Logger {
+        logs: string[];
     }
 
-    export function createLoggerWritingToConsole(): server.Logger {
-        const { close, startGroup, endGroup, getLogFileName } = nullLogger;
+    export function nullLogger(): Logger {
         return {
-            close,
+            close: noop,
+            hasLevel: returnFalse,
+            loggingEnabled: returnFalse,
+            perftrc: noop,
+            info: noop,
+            msg: noop,
+            startGroup: noop,
+            endGroup: noop,
+            getLogFileName: returnUndefined,
+            logs: [],
+        };
+    }
+
+    export function createHasErrorMessageLogger(): Logger {
+        return {
+            ...nullLogger(),
+            msg: (s, type) => Debug.fail(`Error: ${s}, type: ${type}`),
+        };
+    }
+
+    export function createLoggerWritingToConsole(): Logger {
+        return {
+            ...nullLogger(),
             hasLevel: returnTrue,
             loggingEnabled: returnTrue,
             perftrc: s => console.log(s),
             info: s => console.log(s),
             msg: (s, type) => console.log(`${type}:: ${s}`),
-            startGroup,
-            endGroup,
-            getLogFileName
         };
+    }
+
+    export function createLoggerWithInMemoryLogs(): Logger {
+        const logger = createHasErrorMessageLogger();
+        return {
+            ...logger,
+            hasLevel: returnTrue,
+            loggingEnabled: returnTrue,
+            info: s => logger.logs.push(
+                s.replace(/Elapsed::?\s*\d+(?:\.\d+)?ms/g, "Elapsed:: *ms")
+                    .replace(/\"updateGraphDurationMs\"\:\d+(?:\.\d+)?/g, `"updateGraphDurationMs":*`)
+                    .replace(/\"createAutoImportProviderProgramDurationMs\"\:\d+(?:\.\d+)?/g, `"createAutoImportProviderProgramDurationMs":*`)
+            )
+        };
+    }
+
+    export function baselineTsserverLogs(scenario: string, subScenario: string, sessionOrService: TestSession | TestProjectService) {
+        Debug.assert(sessionOrService.logger.logs.length); // Ensure caller used in memory logger
+        Harness.Baseline.runBaseline(`tsserver/${scenario}/${subScenario.split(" ").join("-")}.js`, sessionOrService.logger.logs.join("\r\n"));
+    }
+
+    export function appendAllScriptInfos(service: server.ProjectService, logs: string[]) {
+        logs.push("");
+        logs.push(`ScriptInfos:`);
+        service.filenameToScriptInfo.forEach(info => logs.push(`path: ${info.path} fileName: ${info.fileName}`));
+        logs.push("");
+    }
+
+    export function appendProjectFileText(project: server.Project, logs: string[]) {
+        logs.push("");
+        logs.push(`Project: ${project.getProjectName()}`);
+        project.getCurrentProgram()?.getSourceFiles().forEach(f => {
+            logs.push(JSON.stringify({ fileName: f.fileName, version: f.version }));
+            logs.push(f.text);
+            logs.push("");
+        });
+        logs.push("");
     }
 
     export class TestTypingsInstaller extends TI.TypingsInstaller implements server.ITypingsInstaller {
@@ -196,19 +230,6 @@ namespace ts.projectSystem {
         return { ts: 0, tsSize: 0, tsx: 0, tsxSize: 0, dts: 0, dtsSize: 0, js: 0, jsSize: 0, jsx: 0, jsxSize: 0, deferred: 0, deferredSize: 0, ...nonZeroStats };
     }
 
-    export interface ConfigFileDiagnostic {
-        fileName: string | undefined;
-        start: number | undefined;
-        length: number | undefined;
-        messageText: string;
-        category: DiagnosticCategory;
-        code: number;
-        reportsUnnecessary?: {};
-        reportsDeprecated?: {};
-        source?: string;
-        relatedInformation?: DiagnosticRelatedInformation[];
-    }
-
     export class TestServerEventManager {
         private events: server.ProjectServiceEvent[] = [];
         readonly session: TestSession;
@@ -249,16 +270,6 @@ namespace ts.projectSystem {
             this.events.forEach(event => assert.notEqual(event.eventName, eventName));
         }
 
-        checkSingleConfigFileDiagEvent(configFileName: string, triggerFile: string, errors: readonly ConfigFileDiagnostic[]) {
-            const eventData = this.getEvent<server.ConfigFileDiagEvent>(server.ConfigFileDiagEvent);
-            assert.equal(eventData.configFileName, configFileName);
-            assert.equal(eventData.triggerFile, triggerFile);
-            const actual = eventData.diagnostics.map(({ file, messageText, ...rest }) => ({ fileName: file && file.fileName, messageText: isString(messageText) ? messageText : "", ...rest }));
-            if (errors) {
-                assert.deepEqual(actual, errors);
-            }
-        }
-
         assertProjectInfoTelemetryEvent(partial: Partial<server.ProjectInfoTelemetryEventData>, configFile = "/tsconfig.json"): void {
             assert.deepEqual<server.ProjectInfoTelemetryEventData>(this.getEvent<server.ProjectInfoTelemetryEvent>(server.ProjectInfoTelemetryEvent), {
                 projectId: sys.createSHA256Hash!(configFile),
@@ -290,10 +301,20 @@ namespace ts.projectSystem {
         }
     }
 
+    export interface TestSessionOptions extends server.SessionOptions {
+        logger: Logger;
+    }
+
     export class TestSession extends server.Session {
         private seq = 0;
         public events: protocol.Event[] = [];
         public testhost: TestServerHost = this.host as TestServerHost;
+        public logger: Logger;
+
+        constructor(opts: TestSessionOptions) {
+            super(opts);
+            this.logger = opts.logger;
+        }
 
         getProjectService() {
             return this.projectService;
@@ -305,6 +326,14 @@ namespace ts.projectSystem {
 
         public getNextSeq() {
             return this.seq + 1;
+        }
+
+        public executeCommand(request: protocol.Request) {
+            const verboseLogging = this.logger.hasLevel(server.LogLevel.verbose);
+            if (verboseLogging) this.logger.info(`request:${JSON.stringify(request)}`);
+            const result = super.executeCommand(request);
+            if (verboseLogging) this.logger.info(`response:${JSON.stringify(result)}`);
+            return result;
         }
 
         public executeCommandSeq<T extends server.protocol.Request>(request: Partial<T>) {
@@ -325,7 +354,7 @@ namespace ts.projectSystem {
         }
     }
 
-    export function createSession(host: server.ServerHost, opts: Partial<server.SessionOptions> = {}) {
+    export function createSession(host: server.ServerHost, opts: Partial<TestSessionOptions> = {}) {
         if (opts.typingsInstaller === undefined) {
             opts.typingsInstaller = new TestTypingsInstaller("/a/data/", /*throttleLimit*/ 5, host);
         }
@@ -334,7 +363,7 @@ namespace ts.projectSystem {
             opts.canUseEvents = true;
         }
 
-        const sessionOptions: server.SessionOptions = {
+        const sessionOptions: TestSessionOptions = {
             host,
             cancellationToken: server.nullCancellationToken,
             useSingleInferredProject: false,
@@ -342,7 +371,7 @@ namespace ts.projectSystem {
             typingsInstaller: undefined!, // TODO: GH#18217
             byteLength: Utils.byteLength,
             hrtime: process.hrtime,
-            logger: opts.logger || createHasErrorMessageLogger().logger,
+            logger: opts.logger || createHasErrorMessageLogger(),
             canUseEvents: false
         };
 
@@ -362,7 +391,7 @@ namespace ts.projectSystem {
         return { session, events };
     }
 
-    export function createSessionWithDefaultEventHandler<T extends protocol.AnyEvent>(host: TestServerHost, eventNames: T["event"] | T["event"][], opts: Partial<server.SessionOptions> = {}) {
+    export function createSessionWithDefaultEventHandler<T extends protocol.AnyEvent>(host: TestServerHost, eventNames: T["event"] | T["event"][], opts: Partial<TestSessionOptions> = {}) {
         const session = createSession(host, { canUseEvents: true, ...opts });
 
         return {
@@ -383,9 +412,13 @@ namespace ts.projectSystem {
         }
     }
 
+    export interface TestProjectServiceOptions extends server.ProjectServiceOptions {
+        logger: Logger;
+    }
+
     export class TestProjectService extends server.ProjectService {
-        constructor(host: server.ServerHost, logger: server.Logger, cancellationToken: HostCancellationToken, useSingleInferredProject: boolean,
-            typingsInstaller: server.ITypingsInstaller, opts: Partial<server.ProjectServiceOptions> = {}) {
+        constructor(host: server.ServerHost, public logger: Logger, cancellationToken: HostCancellationToken, useSingleInferredProject: boolean,
+            typingsInstaller: server.ITypingsInstaller, opts: Partial<TestProjectServiceOptions> = {}) {
             super({
                 host,
                 logger,
@@ -403,9 +436,9 @@ namespace ts.projectSystem {
         }
     }
 
-    export function createProjectService(host: server.ServerHost, options?: Partial<server.ProjectServiceOptions>) {
+    export function createProjectService(host: server.ServerHost, options?: Partial<TestProjectServiceOptions>) {
         const cancellationToken = options?.cancellationToken || server.nullCancellationToken;
-        const logger = options?.logger || createHasErrorMessageLogger().logger;
+        const logger = options?.logger || createHasErrorMessageLogger();
         const useSingleInferredProject = options?.useSingleInferredProject !== undefined ? options.useSingleInferredProject : false;
         return new TestProjectService(host, logger, cancellationToken, useSingleInferredProject, options?.typingsInstaller || server.nullTypingsInstaller, options);
     }
@@ -695,135 +728,6 @@ namespace ts.projectSystem {
         verifyDiagnostics(actual, []);
     }
 
-    export function checkErrorMessage(session: TestSession, eventName: protocol.DiagnosticEventKind, diagnostics: protocol.DiagnosticEventBody, isMostRecent = false): void {
-        checkNthEvent(session, server.toEvent(eventName, diagnostics), 0, isMostRecent);
-    }
-
-    interface DiagnosticChainText {
-        message: DiagnosticMessage;
-        args?: readonly string[];
-        next?: DiagnosticChainText[];
-    }
-
-    function isDiagnosticMessage(diagnostic: DiagnosticMessage | DiagnosticChainText): diagnostic is DiagnosticMessage {
-        return !!diagnostic && isString((diagnostic as DiagnosticMessage).message);
-    }
-    function getTextForDiagnostic(diag: DiagnosticMessage | DiagnosticChainText | undefined, args?: readonly string[], indent = 0) {
-        if (diag === undefined) return "";
-        if (isDiagnosticMessage(diag)) return formatStringFromArgs(diag.message, args || emptyArray);
-        let result = "";
-        if (indent) {
-            result += "\n";
-
-            for (let i = 0; i < indent; i++) {
-                result += "  ";
-            }
-        }
-        result += formatStringFromArgs(diag.message.message, diag.args || emptyArray);
-        indent++;
-        if (diag.next) {
-            for (const kid of diag.next) {
-                result += getTextForDiagnostic(kid, /*args*/ undefined, indent);
-            }
-        }
-        return result;
-    }
-
-    export function createDiagnostic(start: protocol.Location, end: protocol.Location, message: DiagnosticMessage | DiagnosticChainText, args?: readonly string[], category?: string, reportsUnnecessary?: {}, relatedInformation?: protocol.DiagnosticRelatedInformation[], reportsDeprecated?: {}): protocol.Diagnostic {
-        const diag = isDiagnosticMessage(message) ? message : message.message;
-        return { start, end, text: getTextForDiagnostic(message, args), code: diag.code, category: category || diagnosticCategoryName(diag), reportsUnnecessary, reportsDeprecated, relatedInformation, source: undefined };
-    }
-
-    export function checkCompleteEvent(session: TestSession, numberOfCurrentEvents: number, expectedSequenceId: number, isMostRecent = true): void {
-        checkNthEvent(session, server.toEvent("requestCompleted", { request_seq: expectedSequenceId }), numberOfCurrentEvents - 1, isMostRecent);
-    }
-
-    export function checkProjectUpdatedInBackgroundEvent(session: TestSession, openFiles: string[]) {
-        checkNthEvent(session, server.toEvent("projectsUpdatedInBackground", { openFiles }), 0, /*isMostRecent*/ true);
-    }
-
-    export function checkNoDiagnosticEvents(session: TestSession) {
-        for (const event of session.events) {
-            assert.isFalse(event.event.endsWith("Diag"), JSON.stringify(event));
-        }
-    }
-    export function projectLoadingStartEvent(projectName: string, reason: string, seq?: number): protocol.ProjectLoadingStartEvent {
-        return {
-            seq: seq || 0,
-            type: "event",
-            event: server.ProjectLoadingStartEvent,
-            body: { projectName, reason }
-        };
-    }
-
-    export function projectLoadingFinishEvent(projectName: string, seq?: number): protocol.ProjectLoadingFinishEvent {
-        return {
-            seq: seq || 0,
-            type: "event",
-            event: server.ProjectLoadingFinishEvent,
-            body: { projectName }
-        };
-    }
-
-    export function projectInfoTelemetryEvent(seq?: number): protocol.TelemetryEvent {
-        return telemetryEvent(server.ProjectInfoTelemetryEvent, "", seq);
-    }
-
-    function telemetryEvent(telemetryEventName: string, payload: any, seq?: number): protocol.TelemetryEvent {
-        return {
-            seq: seq || 0,
-            type: "event",
-            event: "telemetry",
-            body: {
-                telemetryEventName,
-                payload
-            }
-        };
-    }
-
-    export function configFileDiagEvent(triggerFile: string, configFile: string, diagnostics: protocol.DiagnosticWithFileName[], seq?: number): protocol.ConfigFileDiagnosticEvent {
-        return {
-            seq: seq || 0,
-            type: "event",
-            event: server.ConfigFileDiagEvent,
-            body: {
-                triggerFile,
-                configFile,
-                diagnostics
-            }
-        };
-    }
-
-    export function checkEvents(session: TestSession, expectedEvents: protocol.Event[]) {
-        const events = session.events;
-        assert.equal(events.length, expectedEvents.length, `Actual:: ${JSON.stringify(session.events, /*replacer*/ undefined, " ")}`);
-        expectedEvents.forEach((expectedEvent, index) => {
-            if (expectedEvent.event === "telemetry") {
-                // Ignore payload
-                const { body, ...actual } = events[index] as protocol.TelemetryEvent;
-                const { body: expectedBody, ...expected } = expectedEvent as protocol.TelemetryEvent;
-                assert.deepEqual(actual, expected, `Expected ${JSON.stringify(expectedEvent)} at ${index} in ${JSON.stringify(events)}`);
-                assert.equal(body.telemetryEventName, expectedBody.telemetryEventName, `Expected ${JSON.stringify(expectedEvent)} at ${index} in ${JSON.stringify(events)}`);
-            }
-            else {
-                checkNthEvent(session, expectedEvent, index, index === expectedEvents.length);
-            }
-        });
-    }
-
-    export function checkNthEvent(session: TestSession, expectedEvent: protocol.Event, index: number, isMostRecent: boolean) {
-        const events = session.events;
-        assert.deepEqual(events[index], expectedEvent, `Expected ${JSON.stringify(expectedEvent)} at ${index} in ${JSON.stringify(events)}`);
-
-        const outputs = session.testhost.getOutput();
-        assert.equal(outputs[index], server.formatMessage(expectedEvent, nullLogger, Utils.byteLength, session.testhost.newLine));
-
-        if (isMostRecent) {
-            assert.strictEqual(events.length, index + 1, JSON.stringify(events));
-            assert.strictEqual(outputs.length, index + 1, JSON.stringify(outputs));
-        }
-    }
-
     export interface MakeReferenceItem extends DocumentSpanFromSubstring {
         isDefinition: boolean;
         isWriteAccess?: boolean;
@@ -839,218 +743,121 @@ namespace ts.projectSystem {
         };
     }
 
-    export interface GetErrDiagnostics {
-        file: string | File;
-        syntax?: protocol.Diagnostic[];
-        semantic?: protocol.Diagnostic[];
-        suggestion?: protocol.Diagnostic[];
-    }
     export interface VerifyGetErrRequestBase {
         session: TestSession;
         host: TestServerHost;
-        onErrEvent?: () => void;
         existingTimeouts?: number;
     }
     export interface VerifyGetErrRequest extends VerifyGetErrRequestBase {
-        expected: readonly GetErrDiagnostics[];
+        files: readonly (string | File)[];
+        skip?: CheckAllErrors["skip"];
     }
     export function verifyGetErrRequest(request: VerifyGetErrRequest) {
-        const { session, expected } = request;
-        session.clearMessages();
-        const expectedSequenceId = session.getNextSeq();
+        const { session, files } = request;
         session.executeCommandSeq<protocol.GeterrRequest>({
             command: protocol.CommandTypes.Geterr,
-            arguments: {
-                delay: 0,
-                files: expected.map(f => filePath(f.file))
+            arguments: { delay: 0, files: files.map(filePath) }
+        });
+        checkAllErrors(request);
+    }
+
+    interface SkipErrors { semantic?: true; suggestion?: true };
+    export interface CheckAllErrors extends VerifyGetErrRequestBase {
+        files: readonly any[];
+        skip?: readonly (SkipErrors | undefined)[];
+    }
+    function checkAllErrors({ session, host, existingTimeouts, files, skip }: CheckAllErrors) {
+        Debug.assert(session.logger.logs.length);
+        for (let i = 0; i < files.length; i++) {
+            if (existingTimeouts !== undefined) {
+                host.checkTimeoutQueueLength(existingTimeouts + 1);
+                host.runQueuedTimeoutCallbacks(host.getNextTimeoutId() - 1);
             }
-        });
-        checkAllErrors({ ...request, expectedSequenceId });
-    }
-
-    export interface VerifyGetErrRequestNoErrors extends VerifyGetErrRequestBase {
-        files: readonly (string | File)[];
-    }
-    export function verifyGetErrRequestNoErrors(request: VerifyGetErrRequestNoErrors) {
-        verifyGetErrRequest({
-            ...request,
-            expected: request.files.map(file => ({ file, syntax: [], semantic: [], suggestion: [] }))
-        });
-    }
-
-    export interface CheckAllErrors extends VerifyGetErrRequest {
-        expectedSequenceId: number;
-    }
-    function checkAllErrors({ expected, expectedSequenceId, ...rest }: CheckAllErrors) {
-        for (let i = 0; i < expected.length; i++) {
-            checkErrorsInFile({
-                ...rest,
-                expected: expected[i],
-                expectedSequenceId: i === expected.length - 1 ? expectedSequenceId : undefined,
-            });
+            else {
+                host.checkTimeoutQueueLengthAndRun(1);
+            }
+            if (!skip?.[i]?.semantic) host.runQueuedImmediateCallbacks(1);
+            if (!skip?.[i]?.suggestion) host.runQueuedImmediateCallbacks(1);
         }
     }
 
     function filePath(file: string | File) {
         return isString(file) ? file : file.path;
     }
-    interface CheckErrorsInFile extends VerifyGetErrRequestBase {
-        expected: GetErrDiagnostics;
-        expectedSequenceId?: number;
-    }
-    function checkErrorsInFile({
-        session, host, onErrEvent, existingTimeouts, expectedSequenceId,
-        expected: { file, syntax, semantic, suggestion },
-    }: CheckErrorsInFile) {
-        onErrEvent = onErrEvent || noop;
-        if (existingTimeouts !== undefined) {
-            host.checkTimeoutQueueLength(existingTimeouts + 1);
-            host.runQueuedTimeoutCallbacks(host.getNextTimeoutId() - 1);
-        }
-        else {
-            host.checkTimeoutQueueLengthAndRun(1);
-        }
-        if (syntax) {
-            onErrEvent();
-            checkErrorMessage(session, "syntaxDiag", { file: filePath(file), diagnostics: syntax });
-        }
-        if (semantic) {
-            session.clearMessages();
 
-            host.runQueuedImmediateCallbacks(1);
-            onErrEvent();
-            checkErrorMessage(session, "semanticDiag", { file: filePath(file), diagnostics: semantic });
-        }
-        if (suggestion) {
-            session.clearMessages();
-
-            host.runQueuedImmediateCallbacks(1);
-            onErrEvent();
-            checkErrorMessage(session, "suggestionDiag", { file: filePath(file), diagnostics: suggestion });
-        }
-        if (expectedSequenceId !== undefined) {
-            checkCompleteEvent(session, syntax || semantic || suggestion ? 2 : 1, expectedSequenceId);
-        }
-        session.clearMessages();
-    }
-
-    function verifyErrorsUsingGeterr({ allFiles, openFiles, expectedGetErr }: VerifyGetErrScenario) {
+    function verifyErrorsUsingGeterr({scenario, subScenario, allFiles, openFiles, getErrRequest }: VerifyGetErrScenario) {
         it("verifies the errors in open file", () => {
             const host = createServerHost([...allFiles(), libFile]);
-            const session = createSession(host, { canUseEvents: true, });
+            const session = createSession(host, { canUseEvents: true, logger: createLoggerWithInMemoryLogs() });
             openFilesForSession(openFiles(), session);
 
-            verifyGetErrRequest({ session, host, expected: expectedGetErr() });
+            verifyGetErrRequest({ session, host, files: getErrRequest() });
+            baselineTsserverLogs(scenario, `${subScenario} getErr`, session);
         });
     }
 
-    function verifyErrorsUsingGeterrForProject({ allFiles, openFiles, expectedGetErrForProject }: VerifyGetErrScenario) {
+    function verifyErrorsUsingGeterrForProject({ scenario, subScenario, allFiles, openFiles, getErrForProjectRequest }: VerifyGetErrScenario) {
         it("verifies the errors in projects", () => {
             const host = createServerHost([...allFiles(), libFile]);
-            const session = createSession(host, { canUseEvents: true, });
+            const session = createSession(host, { canUseEvents: true, logger: createLoggerWithInMemoryLogs() });
             openFilesForSession(openFiles(), session);
 
-            session.clearMessages();
-            for (const expected of expectedGetErrForProject()) {
-                const expectedSequenceId = session.getNextSeq();
+            for (const expected of getErrForProjectRequest()) {
                 session.executeCommandSeq<protocol.GeterrForProjectRequest>({
                     command: protocol.CommandTypes.GeterrForProject,
-                    arguments: {
-                        delay: 0,
-                        file: expected.project
-                    }
+                    arguments: { delay: 0, file: filePath(expected.project) }
                 });
-
-                checkAllErrors({ session, host, expected: expected.errors, expectedSequenceId });
+                checkAllErrors({ session, host, files: expected.files });
             }
+            baselineTsserverLogs(scenario, `${subScenario} geterrForProject`, session);
         });
     }
 
-    function verifyErrorsUsingSyncMethods({ allFiles, openFiles, expectedSyncDiagnostics }: VerifyGetErrScenario) {
+    function verifyErrorsUsingSyncMethods({ scenario, subScenario, allFiles, openFiles, syncDiagnostics }: VerifyGetErrScenario) {
         it("verifies the errors using sync commands", () => {
             const host = createServerHost([...allFiles(), libFile]);
-            const session = createSession(host);
+            const session = createSession(host, { logger: createLoggerWithInMemoryLogs() });
             openFilesForSession(openFiles(), session);
-            for (const { file, project, syntax, semantic, suggestion } of expectedSyncDiagnostics()) {
-                const actualSyntax = session.executeCommandSeq<protocol.SyntacticDiagnosticsSyncRequest>({
+            for (const { file, project } of syncDiagnostics()) {
+                const reqArgs = { file: filePath(file), projectFileName: project && filePath(project) };
+                session.executeCommandSeq<protocol.SyntacticDiagnosticsSyncRequest>({
                     command: protocol.CommandTypes.SyntacticDiagnosticsSync,
-                    arguments: {
-                        file: filePath(file),
-                        projectFileName: project
-                    }
-                }).response as protocol.Diagnostic[];
-                assert.deepEqual(actualSyntax, syntax, `Syntax diagnostics for file: ${filePath(file)}, project: ${project}`);
-                const actualSemantic = session.executeCommandSeq<protocol.SemanticDiagnosticsSyncRequest>({
+                    arguments: reqArgs
+                });
+                session.executeCommandSeq<protocol.SemanticDiagnosticsSyncRequest>({
                     command: protocol.CommandTypes.SemanticDiagnosticsSync,
-                    arguments: {
-                        file: filePath(file),
-                        projectFileName: project
-                    }
-                }).response as protocol.Diagnostic[];
-                assert.deepEqual(actualSemantic, semantic, `Semantic diagnostics for file: ${filePath(file)}, project: ${project}`);
-                const actualSuggestion = session.executeCommandSeq<protocol.SuggestionDiagnosticsSyncRequest>({
+                    arguments: reqArgs
+                });
+                session.executeCommandSeq<protocol.SuggestionDiagnosticsSyncRequest>({
                     command: protocol.CommandTypes.SuggestionDiagnosticsSync,
-                    arguments: {
-                        file: filePath(file),
-                        projectFileName: project
-                    }
-                }).response as protocol.Diagnostic[];
-                assert.deepEqual(actualSuggestion, suggestion, `Suggestion diagnostics for file: ${filePath(file)}, project: ${project}`);
-            }
-        });
-    }
-
-    function verifyConfigFileErrors({ allFiles, openFiles, expectedConfigFileDiagEvents }: VerifyGetErrScenario) {
-        it("verify config file errors", () => {
-            const host = createServerHost([...allFiles(), libFile]);
-            const { session, events } = createSessionWithEventTracking<server.ConfigFileDiagEvent>(host, server.ConfigFileDiagEvent);
-
-            for (const file of openFiles()) {
-                session.executeCommandSeq<protocol.OpenRequest>({
-                    command: protocol.CommandTypes.Open,
-                    arguments: { file: file.path }
+                    arguments: reqArgs
                 });
             }
-
-            assert.deepEqual(events, expectedConfigFileDiagEvents().map(data => ({
-                eventName: server.ConfigFileDiagEvent,
-                data
-            })));
+            baselineTsserverLogs(scenario, `${subScenario} gerErr with sync commands`, session);
         });
     }
 
     export interface GetErrForProjectDiagnostics {
-        project: string;
-        errors: readonly GetErrDiagnostics[];
+        project: string | File;
+        files: readonly (string | File)[];
+        skip?: CheckAllErrors["skip"];
     }
-    export interface SyncDiagnostics extends GetErrDiagnostics {
-        project?: string;
+    export interface SyncDiagnostics {
+        file: string | File;
+        project?: string | File;
     }
     export interface VerifyGetErrScenario {
+        scenario: string;
+        subScenario: string;
         allFiles: () => readonly File[];
         openFiles: () => readonly File[];
-        expectedGetErr: () => readonly GetErrDiagnostics[];
-        expectedGetErrForProject: () => readonly GetErrForProjectDiagnostics[];
-        expectedSyncDiagnostics: () => readonly SyncDiagnostics[];
-        expectedConfigFileDiagEvents: () => readonly server.ConfigFileDiagEvent["data"][];
+        getErrRequest: () => VerifyGetErrRequest["files"];
+        getErrForProjectRequest: () => readonly GetErrForProjectDiagnostics[];
+        syncDiagnostics: () => readonly SyncDiagnostics[];
     }
     export function verifyGetErrScenario(scenario: VerifyGetErrScenario) {
         verifyErrorsUsingGeterr(scenario);
         verifyErrorsUsingGeterrForProject(scenario);
         verifyErrorsUsingSyncMethods(scenario);
-        verifyConfigFileErrors(scenario);
-    }
-
-    export function emptyDiagnostics(file: File): GetErrDiagnostics {
-        return {
-            file,
-            syntax: emptyArray,
-            semantic: emptyArray,
-            suggestion: emptyArray
-        };
-    }
-
-    export function syncDiagnostics(diagnostics: GetErrDiagnostics, project: string): SyncDiagnostics {
-        return { project, ...diagnostics };
     }
 }

--- a/src/testRunner/unittests/tsserver/navTo.ts
+++ b/src/testRunner/unittests/tsserver/navTo.ts
@@ -61,20 +61,13 @@ namespace ts.projectSystem {
 export const ghijkl = a.abcdef;`
             };
             const host = createServerHost([configFile1, file1, configFile2, file2]);
-            const logger = createHasErrorMessageLogger().logger;
-            const logs: string[] = [];
-            logger.info = s => logs.push(s);
-            const session = createSession(host, { logger });
+            const session = createSession(host, { logger: createLoggerWithInMemoryLogs() });
             openFilesForSession([file1, file2], session);
-            logs.length = 0;
 
             const request = makeSessionRequest<protocol.NavtoRequestArgs>(CommandNames.Navto, { searchValue: "abcdef", file: file1.path });
-            const items = session.executeCommand(request).response as protocol.NavtoItem[];
-            assert.strictEqual(items.length, 1);
-            const item = items[0];
-            assert.strictEqual(item.name, "abcdef");
-            assert.strictEqual(item.file, file1.path);
-            assert.deepEqual(logs, []);
+            session.executeCommand(request).response as protocol.NavtoItem[];
+
+            baselineTsserverLogs("navTo", "should de-duplicate symbols", session);
         });
 
         it("should de-duplicate symbols when searching all projects", () => {
@@ -114,22 +107,12 @@ export const ghijkl = a.abcdef;`
 export const ghijkl = a.abcdef;`
             };
             const host = createServerHost([configFile1, file1, configFile2, file2, solutionConfig]);
-            const logger = createHasErrorMessageLogger().logger;
-            const logs: string[] = [];
-            logger.info = s => logs.push(s);
-            const session = createSession(host, { logger });
+            const session = createSession(host, { logger: createLoggerWithInMemoryLogs() });
             openFilesForSession([file1], session);
-            logs.length = 0;
 
             const request = makeSessionRequest<protocol.NavtoRequestArgs>(CommandNames.Navto, { searchValue: "abcdef" });
-            const items = session.executeCommand(request).response as protocol.NavtoItem[];
-            assert.strictEqual(items.length, 1);
-            const item = items[0];
-            assert.strictEqual(item.name, "abcdef");
-            assert.strictEqual(item.file, file1.path);
-            // Cannt check logs as empty since it loads projects and writes information for those in the log
-            assert.isFalse(contains(logs, "Search path: /a"));
-            assert.isFalse(contains(logs, "For info: /a/index.ts :: Config file name: /a/tsconfig.json"));
+            session.executeCommand(request).response as protocol.NavtoItem[];
+            baselineTsserverLogs("navTo", "should de-duplicate symbols when searching all projects", session);
         });
 
         it("should work with Deprecated", () => {

--- a/src/testRunner/unittests/tsserver/openFile.ts
+++ b/src/testRunner/unittests/tsserver/openFile.ts
@@ -147,9 +147,9 @@ foo();
 bar();`
             };
             const host = createServerHost([file, libFile]);
-            const session = createSession(host, { canUseEvents: true, });
+            const session = createSession(host, { canUseEvents: true, logger: createLoggerWithInMemoryLogs() });
             openFilesForSession([file], session);
-            verifyGetErrRequestNoErrors({ session, host, files: [file] });
+            verifyGetErrRequest({ session, host, files: [file] });
 
             // Remove first ts-ignore and check only first error is reported
             const tsIgnoreComment = `// @ts-ignore`;
@@ -166,22 +166,7 @@ bar();`
                     }]
                 }
             });
-            const locationOfY = protocolTextSpanFromSubstring(file.content, "y");
-            verifyGetErrRequest({
-                session,
-                host,
-                expected: [
-                    {
-                        file,
-                        syntax: [],
-                        semantic: [
-                            createDiagnostic(locationOfY.start, locationOfY.end, Diagnostics.Type_0_is_not_assignable_to_type_1, ["number", "string"]),
-                        ],
-                        suggestion: []
-                    },
-                ]
-            });
-
+            verifyGetErrRequest({ session, host, files: [file] });
             // Revert the change and no errors should be reported
             session.executeCommandSeq<protocol.UpdateOpenRequest>({
                 command: protocol.CommandTypes.UpdateOpen,
@@ -195,7 +180,8 @@ bar();`
                     }]
                 }
             });
-            verifyGetErrRequestNoErrors({ session, host, files: [file] });
+            verifyGetErrRequest({ session, host, files: [file] });
+            baselineTsserverLogs("openfile", "when file makes edits to add/remove comment directives, they are handled correcrly", session);
         });
     });
 }

--- a/src/testRunner/unittests/tsserver/session.ts
+++ b/src/testRunner/unittests/tsserver/session.ts
@@ -48,7 +48,7 @@ namespace ts.server {
                 typingsInstaller: undefined!, // TODO: GH#18217
                 byteLength: Utils.byteLength,
                 hrtime: process.hrtime,
-                logger: projectSystem.nullLogger,
+                logger: projectSystem.nullLogger(),
                 canUseEvents: true
             };
             return new TestSession(opts);
@@ -469,7 +469,7 @@ namespace ts.server {
                     typingsInstaller: undefined!, // TODO: GH#18217
                     byteLength: Utils.byteLength,
                     hrtime: process.hrtime,
-                    logger: projectSystem.nullLogger,
+                    logger: projectSystem.nullLogger(),
                     canUseEvents: true
                 });
                 this.addProtocolHandler(command, this.exceptionRaisingHandler);
@@ -516,7 +516,7 @@ namespace ts.server {
                     typingsInstaller: undefined!, // TODO: GH#18217
                     byteLength: Utils.byteLength,
                     hrtime: process.hrtime,
-                    logger: projectSystem.createHasErrorMessageLogger().logger,
+                    logger: projectSystem.createHasErrorMessageLogger(),
                     canUseEvents: true
                 });
                 this.addProtocolHandler(this.customHandler, () => {
@@ -584,7 +584,7 @@ namespace ts.server {
                     typingsInstaller: undefined!, // TODO: GH#18217
                     byteLength: Utils.byteLength,
                     hrtime: process.hrtime,
-                    logger: projectSystem.createHasErrorMessageLogger().logger,
+                    logger: projectSystem.createHasErrorMessageLogger(),
                     canUseEvents: true
                 });
                 this.addProtocolHandler("echo", (req: protocol.Request) => ({

--- a/src/testRunner/unittests/tsserver/webServer.ts
+++ b/src/testRunner/unittests/tsserver/webServer.ts
@@ -36,7 +36,7 @@ namespace ts.projectSystem {
                 writeMessage: s => messages.push(s),
             };
             const webSys = server.createWebSystem(webHost, emptyArray, () => host.getExecutingFilePath());
-            const logger = logLevel !== undefined ? new server.MainProcessLogger(logLevel, webHost) : nullLogger;
+            const logger = logLevel !== undefined ? new server.MainProcessLogger(logLevel, webHost) : nullLogger();
             const session = new TestWorkerSession(webSys, webHost, { serverMode: LanguageServiceMode.PartialSemantic }, logger);
             return { getMessages: () => messages, clearMessages: () => messages.length = 0, session };
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9717,7 +9717,6 @@ declare namespace ts.server {
      * the file and its imports/references are put into an InferredProject.
      */
     class InferredProject extends Project {
-        private static readonly newName;
         private _isJsInferredProject;
         toggleJsInferredProject(isJsInferredProject: boolean): void;
         setCompilerOptions(options?: CompilerOptions): void;
@@ -9731,7 +9730,6 @@ declare namespace ts.server {
     }
     class AutoImportProviderProject extends Project {
         private hostProject;
-        private static readonly newName;
         private rootFileNames;
         isOrphan(): boolean;
         updateGraph(): boolean;

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
@@ -1,0 +1,119 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/foo.ts","fileContent":"export function foo() { }","projectRootPath":"/user/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/foo.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/foo.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/bar.ts",
+  "/user/username/projects/myproject/src/foo.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":50,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":true,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/foo.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected excluded file: /user/username/projects/myproject/src/sub/fooBar.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","fileContent":"export function fooBar() { }","projectRootPath":"/user/username/projects/myproject"},"seq":2,"type":"request"}
+Search path: /user/username/projects/myproject/src/sub
+For info: /user/username/projects/myproject/src/sub/fooBar.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/sub/fooBar.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/sub/fooBar.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	fooBar.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+	FileName: /user/username/projects/myproject/src/sub/fooBar.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/foo.ts","/user/username/projects/myproject/src/sub/fooBar.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
@@ -23,7 +23,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -74,7 +74,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
@@ -23,7 +23,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -61,7 +61,7 @@ request:{"command":"open","arguments":{"file":"/user/username/projects/myproject
 Search path: /user/username/projects/myproject/src/sub
 For info: /user/username/projects/myproject/src/sub/fooBar.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
@@ -1,0 +1,108 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/foo.ts","fileContent":"export function foo() { }","projectRootPath":"/user/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/foo.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/foo.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/bar.ts",
+  "/user/username/projects/myproject/src/foo.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":50,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/foo.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","fileContent":"export function fooBar() { }","projectRootPath":"/user/username/projects/myproject"},"seq":2,"type":"request"}
+Search path: /user/username/projects/myproject/src/sub
+For info: /user/username/projects/myproject/src/sub/fooBar.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+	/user/username/projects/myproject/src/sub/fooBar.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/sub/fooBar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+	FileName: /user/username/projects/myproject/src/sub/fooBar.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/foo.ts","/user/username/projects/myproject/src/sub/fooBar.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
@@ -23,7 +23,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -74,7 +74,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
@@ -1,0 +1,119 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/foo.ts","fileContent":"export function foo() { }","projectRootPath":"/user/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/foo.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/foo.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/bar.ts",
+  "/user/username/projects/myproject/src/foo.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":50,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":true,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/foo.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected excluded file: /user/username/projects/myproject/src/sub/fooBar.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","fileContent":"export function fooBar() { }","projectRootPath":"/user/username/projects/myproject"},"seq":2,"type":"request"}
+Search path: /user/username/projects/myproject/src/sub
+For info: /user/username/projects/myproject/src/sub/fooBar.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/sub/fooBar.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/sub/fooBar.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	fooBar.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+	FileName: /user/username/projects/myproject/src/sub/fooBar.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/sub/fooBar.ts","/user/username/projects/myproject/src/foo.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
@@ -23,7 +23,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -61,7 +61,7 @@ request:{"command":"open","arguments":{"file":"/user/username/projects/myproject
 Search path: /user/username/projects/myproject/src/sub
 For info: /user/username/projects/myproject/src/sub/fooBar.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-after-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
@@ -1,0 +1,108 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/foo.ts","fileContent":"export function foo() { }","projectRootPath":"/user/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/foo.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/foo.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/bar.ts",
+  "/user/username/projects/myproject/src/foo.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":50,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/foo.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","fileContent":"export function fooBar() { }","projectRootPath":"/user/username/projects/myproject"},"seq":2,"type":"request"}
+Search path: /user/username/projects/myproject/src/sub
+For info: /user/username/projects/myproject/src/sub/fooBar.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+	/user/username/projects/myproject/src/sub/fooBar.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/sub/fooBar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+	FileName: /user/username/projects/myproject/src/sub/fooBar.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/sub/fooBar.ts","/user/username/projects/myproject/src/foo.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
@@ -1,0 +1,119 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/foo.ts","fileContent":"export function foo() { }","projectRootPath":"/user/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/foo.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/foo.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/bar.ts",
+  "/user/username/projects/myproject/src/foo.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":50,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":true,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/foo.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","fileContent":"export function fooBar() { }","projectRootPath":"/user/username/projects/myproject"},"seq":2,"type":"request"}
+Search path: /user/username/projects/myproject/src/sub
+For info: /user/username/projects/myproject/src/sub/fooBar.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/sub/fooBar.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/sub/fooBar.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	fooBar.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+	FileName: /user/username/projects/myproject/src/sub/fooBar.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected excluded file: /user/username/projects/myproject/src/sub/fooBar.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/foo.ts","/user/username/projects/myproject/src/sub/fooBar.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one-without-file-being-in-config.js
@@ -23,7 +23,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -71,7 +71,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
@@ -1,0 +1,145 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/foo.ts","fileContent":"export function foo() { }","projectRootPath":"/user/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/foo.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/foo.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/bar.ts",
+  "/user/username/projects/myproject/src/foo.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":50,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/foo.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","fileContent":"export function fooBar() { }","projectRootPath":"/user/username/projects/myproject"},"seq":2,"type":"request"}
+Search path: /user/username/projects/myproject/src/sub
+For info: /user/username/projects/myproject/src/sub/fooBar.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/sub/fooBar.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/sub/fooBar.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	fooBar.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+	FileName: /user/username/projects/myproject/src/sub/fooBar.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/foo.ts","/user/username/projects/myproject/src/sub/fooBar.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+	/user/username/projects/myproject/src/sub/fooBar.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/sub/fooBar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-after-old-one.js
@@ -23,7 +23,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -71,7 +71,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -110,7 +110,7 @@ FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/tsconfig.
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
@@ -23,7 +23,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -71,7 +71,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one-without-file-being-in-config.js
@@ -1,0 +1,119 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/foo.ts","fileContent":"export function foo() { }","projectRootPath":"/user/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/foo.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/foo.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/bar.ts",
+  "/user/username/projects/myproject/src/foo.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":50,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":true,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/foo.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","fileContent":"export function fooBar() { }","projectRootPath":"/user/username/projects/myproject"},"seq":2,"type":"request"}
+Search path: /user/username/projects/myproject/src/sub
+For info: /user/username/projects/myproject/src/sub/fooBar.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/sub/fooBar.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/sub/fooBar.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	fooBar.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+	FileName: /user/username/projects/myproject/src/sub/fooBar.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected excluded file: /user/username/projects/myproject/src/sub/fooBar.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/sub/fooBar.ts","/user/username/projects/myproject/src/foo.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
@@ -1,0 +1,145 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/foo.ts","fileContent":"export function foo() { }","projectRootPath":"/user/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/foo.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/foo.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/bar.ts",
+  "/user/username/projects/myproject/src/foo.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":50,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/foo.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"open","arguments":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","fileContent":"export function fooBar() { }","projectRootPath":"/user/username/projects/myproject"},"seq":2,"type":"request"}
+Search path: /user/username/projects/myproject/src/sub
+For info: /user/username/projects/myproject/src/sub/fooBar.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/sub/fooBar.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/sub/fooBar.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	fooBar.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/foo.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+	FileName: /user/username/projects/myproject/src/sub/fooBar.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/sub/fooBar.ts :: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/sub/fooBar.ts","/user/username/projects/myproject/src/foo.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/sub/fooBar.ts","diagnostics":[]}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/bar.ts
+	/user/username/projects/myproject/src/foo.ts
+	/user/username/projects/myproject/src/sub/fooBar.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/bar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/foo.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+	src/sub/fooBar.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/foo.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/creating-new-file-and-then-open-it-before-watcher-is-invoked,-ask-errors-on-it-before-old-one.js
@@ -23,7 +23,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -71,7 +71,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -116,7 +116,7 @@ FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/tsconfig.
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/configuredProjects/when-multiple-projects-are-open-detects-correct-default-project.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/when-multiple-projects-are-open-detects-correct-default-project.js
@@ -27,7 +27,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/foo/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/foo/node_modules/@types 1 undefined Project: /user/username/projects/myproject/foo/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/foo/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/foo/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/foo/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/foo/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/foo/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.es2017.d.ts
@@ -84,7 +84,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/bar/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/bar/node_modules/@types 1 undefined Project: /user/username/projects/myproject/bar/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/bar/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/bar/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/bar/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/bar/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/bar/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.es2017.d.ts

--- a/tests/baselines/reference/tsserver/configuredProjects/when-multiple-projects-are-open-detects-correct-default-project.js
+++ b/tests/baselines/reference/tsserver/configuredProjects/when-multiple-projects-are-open-detects-correct-default-project.js
@@ -1,0 +1,138 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/foo/index.ts"}}
+Search path: /user/username/projects/myproject/foo
+For info: /user/username/projects/myproject/foo/index.ts :: Config file name: /user/username/projects/myproject/foo/tsconfig.json
+Creating configuration project /user/username/projects/myproject/foo/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/foo/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/foo/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/foo/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/foo/index.ts to open"}}
+Config: /user/username/projects/myproject/foo/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/foo/index.ts"
+ ],
+ "options": {
+  "lib": [
+   "lib.es2017.d.ts"
+  ],
+  "configFilePath": "/user/username/projects/myproject/foo/tsconfig.json"
+ }
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/foo/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/bar/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.es2017.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/foo/node_modules 1 undefined Project: /user/username/projects/myproject/foo/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/foo/node_modules 1 undefined Project: /user/username/projects/myproject/foo/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/foo/node_modules/@types 1 undefined Project: /user/username/projects/myproject/foo/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/foo/node_modules/@types 1 undefined Project: /user/username/projects/myproject/foo/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/foo/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/foo/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/foo/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/foo/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.es2017.d.ts
+	/user/username/projects/myproject/bar/index.ts
+	/user/username/projects/myproject/foo/index.ts
+
+
+	../../../../../a/lib/lib.es2017.d.ts
+	  Library 'lib.es2017.d.ts' specified in compilerOptions
+	../bar/index.ts
+	  Imported via "bar" from file 'index.ts'
+	index.ts
+	  Matched by include pattern 'index.ts' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/foo/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"36730603d9c37d63f14b455060fadde05a7a93dcbc44aecd507b60e066616be6","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":90,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"lib":["es2017"]},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/foo/index.ts","configFile":"/user/username/projects/myproject/foo/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/foo/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/foo/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/foo/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/bar/index.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/bar/index.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/bar
+For info: /user/username/projects/myproject/bar/index.ts :: Config file name: /user/username/projects/myproject/bar/tsconfig.json
+Creating configuration project /user/username/projects/myproject/bar/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/bar/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/bar/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/bar/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/bar/index.ts to open"}}
+Config: /user/username/projects/myproject/bar/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/bar/index.ts"
+ ],
+ "options": {
+  "lib": [
+   "lib.dom.d.ts",
+   "lib.es2017.d.ts"
+  ],
+  "configFilePath": "/user/username/projects/myproject/bar/tsconfig.json"
+ }
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/bar/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.dom.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/bar/node_modules/@types 1 undefined Project: /user/username/projects/myproject/bar/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/bar/node_modules/@types 1 undefined Project: /user/username/projects/myproject/bar/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/bar/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/bar/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/bar/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/bar/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.es2017.d.ts
+	/a/lib/lib.dom.d.ts
+	/user/username/projects/myproject/bar/index.ts
+
+
+	../../../../../a/lib/lib.es2017.d.ts
+	  Library 'lib.es2017.d.ts' specified in compilerOptions
+	../../../../../a/lib/lib.dom.d.ts
+	  Library 'lib.dom.d.ts' specified in compilerOptions
+	index.ts
+	  Matched by include pattern 'index.ts' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/bar/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"5370ca7ca3faf398ecd694700ec7a0793b5e111125c5b8f56f69d3de23ff19ae","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":56,"tsx":0,"tsxSize":0,"dts":2,"dtsSize":391,"deferred":0,"deferredSize":0},"compilerOptions":{"lib":["dom","es2017"]},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/bar/index.ts","configFile":"/user/username/projects/myproject/bar/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/foo/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/bar/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/foo/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/foo/tsconfig.json
+	FileName: /user/username/projects/myproject/bar/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/foo/tsconfig.json,/user/username/projects/myproject/bar/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/bar/index.ts","/user/username/projects/myproject/foo/index.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/bar/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/bar/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/bar/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/foo/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/foo/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/foo/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-changing-module-name-with-different-casing.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-changing-module-name-with-different-casing.js
@@ -1,0 +1,82 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/another.ts","projectRootPath":"/user/username/projects/myproject"}}
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/another.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/another.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/Logger.ts",
+  "/user/username/projects/myproject/another.ts"
+ ],
+ "options": {
+  "forceConsistentCasingInFileNames": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/Logger.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/Logger.ts
+	/user/username/projects/myproject/another.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	Logger.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	  Imported via "./Logger" from file 'another.ts'
+	another.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":71,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"forceConsistentCasingInFileNames":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/another.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/another.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/another.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/another.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/another.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/another.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/another.ts","textChanges":[{"newText":"./logger","start":{"line":1,"offset":25},"end":{"line":1,"offset":33}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/another.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 1
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/another.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/another.ts","diagnostics":[{"start":{"line":1,"offset":24},"end":{"line":1,"offset":34},"text":"File name '/user/username/projects/myproject/logger.ts' differs from already included file name '/user/username/projects/myproject/Logger.ts' only in casing.\n  The file is in the program because:\n    Matched by include pattern '**/*' in '/user/username/projects/myproject/tsconfig.json'\n    Imported via \"./logger\" from file '/user/username/projects/myproject/another.ts'","code":1149,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/another.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-changing-module-name-with-different-casing.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/when-changing-module-name-with-different-casing.js
@@ -24,7 +24,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -70,8 +70,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/another.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 1
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/another.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/works-when-renaming-file-with-different-casing.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/works-when-renaming-file-with-different-casing.js
@@ -24,7 +24,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -82,8 +82,8 @@ FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/Logger.ts 500
 Search path: /user/username/projects/myproject
 For info: /user/username/projects/myproject/Logger.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 
@@ -111,8 +111,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/logger.ts","/user/username/projects/myproject/another.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 1
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 3 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/logger.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/works-when-renaming-file-with-different-casing.js
+++ b/tests/baselines/reference/tsserver/forceConsistentCasingInFileNames/works-when-renaming-file-with-different-casing.js
@@ -1,0 +1,129 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/Logger.ts","projectRootPath":"/user/username/projects/myproject"}}
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/Logger.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/Logger.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/Logger.ts",
+  "/user/username/projects/myproject/another.ts"
+ ],
+ "options": {
+  "forceConsistentCasingInFileNames": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/another.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/Logger.ts
+	/user/username/projects/myproject/another.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	Logger.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	  Imported via "./Logger" from file 'another.ts'
+	another.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":71,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"forceConsistentCasingInFileNames":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/Logger.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/Logger.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/Logger.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/Logger.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/Logger.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/Logger.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/Logger.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/Logger.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/logger.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/logger.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"seq":0,"type":"request","command":"close","arguments":{"file":"/user/username/projects/myproject/Logger.ts"}}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/Logger.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/logger.ts","projectRootPath":"/user/username/projects/myproject"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/Logger.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/Logger.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/Logger.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/another.ts","projectRootPath":"/user/username/projects/myproject"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/another.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/another.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/Logger.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+	FileName: /user/username/projects/myproject/another.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/another.ts","textChanges":[{"newText":"./logger","start":{"line":1,"offset":25},"end":{"line":1,"offset":33}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/logger.ts","/user/username/projects/myproject/another.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 1
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/logger.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/logger.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/logger.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/another.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/another.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/another.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/navTo/should-de-duplicate-symbols-when-searching-all-projects.js
+++ b/tests/baselines/reference/tsserver/navTo/should-de-duplicate-symbols-when-searching-all-projects.js
@@ -1,0 +1,111 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/index.ts"}}
+Search path: /a
+For info: /a/index.ts :: Config file name: /a/tsconfig.json
+Creating configuration project /a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/tsconfig.json 2000 undefined Project: /a/tsconfig.json WatchType: Config file
+Config: /a/tsconfig.json : {
+ "rootNames": [
+  "/a/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/a/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /a 1 undefined Config: /a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a 1 undefined Config: /a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /a/node_modules/@types 1 undefined Project: /a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/node_modules/@types 1 undefined Project: /a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/tsconfig.json' (Configured)
+	Files (1)
+	/a/index.ts
+
+
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /a
+For info: /a/tsconfig.json :: Config file name: /tsconfig.json
+Creating configuration project /tsconfig.json
+FileWatcher:: Added:: WatchInfo: /tsconfig.json 2000 undefined Project: /tsconfig.json WatchType: Config file
+Search path: /
+For info: /tsconfig.json :: No config files found.
+Project '/a/tsconfig.json' (Configured)
+	Files (1)
+
+-----------------------------------------------
+Project '/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/index.ts ProjectRootPath: undefined
+		Projects: /a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"navto","arguments":{"searchValue":"abcdef"}}
+Loading configured project /tsconfig.json
+Config: /tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/a",
+   "originalPath": "./a"
+  },
+  {
+   "path": "/b",
+   "originalPath": "./b"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /tsconfig.json
+Config: /b/tsconfig.json : {
+ "rootNames": [
+  "/b/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/b/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/a",
+   "originalPath": "../a"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /b/tsconfig.json 2000 undefined Project: /tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /b 1 undefined Config: /b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /b 1 undefined Config: /b/tsconfig.json WatchType: Wild card directory
+Finishing updateGraphWorker: Project: /tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Creating configuration project /b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /b/index.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /b/node_modules/@types 1 undefined Project: /b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /b/node_modules/@types 1 undefined Project: /b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/index.ts
+	/b/index.ts
+
+
+	../a/index.ts
+	  Imported via "../a" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+response:{"response":[{"name":"abcdef","kind":"const","kindModifiers":"export","isCaseSensitive":true,"matchKind":"exact","file":"/a/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":24}}],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/navTo/should-de-duplicate-symbols-when-searching-all-projects.js
+++ b/tests/baselines/reference/tsserver/navTo/should-de-duplicate-symbols-when-searching-all-projects.js
@@ -20,7 +20,7 @@ Starting updateGraphWorker: Project: /a/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /a/tsconfig.json WatchType: Missing file
 DirectoryWatcher:: Added:: WatchInfo: /a/node_modules/@types 1 undefined Project: /a/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/node_modules/@types 1 undefined Project: /a/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/tsconfig.json' (Configured)
 	Files (1)
 	/a/index.ts
@@ -86,8 +86,8 @@ Config: /b/tsconfig.json : {
 FileWatcher:: Added:: WatchInfo: /b/tsconfig.json 2000 undefined Project: /tsconfig.json WatchType: Config file
 DirectoryWatcher:: Added:: WatchInfo: /b 1 undefined Config: /b/tsconfig.json WatchType: Wild card directory
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /b 1 undefined Config: /b/tsconfig.json WatchType: Wild card directory
-Finishing updateGraphWorker: Project: /tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Creating configuration project /b/tsconfig.json
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 FileWatcher:: Added:: WatchInfo: /b/index.ts 500 undefined WatchType: Closed Script info
@@ -95,7 +95,7 @@ Starting updateGraphWorker: Project: /b/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /b/tsconfig.json WatchType: Missing file
 DirectoryWatcher:: Added:: WatchInfo: /b/node_modules/@types 1 undefined Project: /b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /b/node_modules/@types 1 undefined Project: /b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/b/tsconfig.json' (Configured)
 	Files (2)
 	/a/index.ts

--- a/tests/baselines/reference/tsserver/navTo/should-de-duplicate-symbols.js
+++ b/tests/baselines/reference/tsserver/navTo/should-de-duplicate-symbols.js
@@ -1,0 +1,100 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/index.ts"}}
+Search path: /a
+For info: /a/index.ts :: Config file name: /a/tsconfig.json
+Creating configuration project /a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/tsconfig.json 2000 undefined Project: /a/tsconfig.json WatchType: Config file
+Config: /a/tsconfig.json : {
+ "rootNames": [
+  "/a/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/a/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /a 1 undefined Config: /a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a 1 undefined Config: /a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /a/node_modules/@types 1 undefined Project: /a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/node_modules/@types 1 undefined Project: /a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/tsconfig.json' (Configured)
+	Files (1)
+	/a/index.ts
+
+
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /a
+For info: /a/tsconfig.json :: No config files found.
+Project '/a/tsconfig.json' (Configured)
+	Files (1)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/index.ts ProjectRootPath: undefined
+		Projects: /a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/b/index.ts"}}
+Search path: /b
+For info: /b/index.ts :: Config file name: /b/tsconfig.json
+Creating configuration project /b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /b/tsconfig.json 2000 undefined Project: /b/tsconfig.json WatchType: Config file
+Config: /b/tsconfig.json : {
+ "rootNames": [
+  "/b/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/b/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/a",
+   "originalPath": "../a"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /b 1 undefined Config: /b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /b 1 undefined Config: /b/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /b/node_modules/@types 1 undefined Project: /b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /b/node_modules/@types 1 undefined Project: /b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/index.ts
+	/b/index.ts
+
+
+	../a/index.ts
+	  Imported via "../a" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /b
+For info: /b/tsconfig.json :: No config files found.
+Project '/a/tsconfig.json' (Configured)
+	Files (1)
+
+-----------------------------------------------
+Project '/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/index.ts ProjectRootPath: undefined
+		Projects: /a/tsconfig.json,/b/tsconfig.json
+	FileName: /b/index.ts ProjectRootPath: undefined
+		Projects: /b/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"navto","arguments":{"searchValue":"abcdef","file":"/a/index.ts"}}
+response:{"response":[{"name":"abcdef","kind":"const","kindModifiers":"export","isCaseSensitive":true,"matchKind":"exact","file":"/a/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":24}}],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/navTo/should-de-duplicate-symbols.js
+++ b/tests/baselines/reference/tsserver/navTo/should-de-duplicate-symbols.js
@@ -20,7 +20,7 @@ Starting updateGraphWorker: Project: /a/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /a/tsconfig.json WatchType: Missing file
 DirectoryWatcher:: Added:: WatchInfo: /a/node_modules/@types 1 undefined Project: /a/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/node_modules/@types 1 undefined Project: /a/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/tsconfig.json' (Configured)
 	Files (1)
 	/a/index.ts
@@ -67,7 +67,7 @@ Starting updateGraphWorker: Project: /b/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /b/tsconfig.json WatchType: Missing file
 DirectoryWatcher:: Added:: WatchInfo: /b/node_modules/@types 1 undefined Project: /b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /b/node_modules/@types 1 undefined Project: /b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/b/tsconfig.json' (Configured)
 	Files (2)
 	/a/index.ts

--- a/tests/baselines/reference/tsserver/openfile/when-file-makes-edits-to-add/remove-comment-directives,-they-are-handled-correcrly.js
+++ b/tests/baselines/reference/tsserver/openfile/when-file-makes-edits-to-add/remove-comment-directives,-they-are-handled-correcrly.js
@@ -1,0 +1,72 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/file.ts"}}
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/file.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/file.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	file.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/file.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/file.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/file.ts","textChanges":[{"newText":"             ","start":{"line":3,"offset":5},"end":{"line":3,"offset":18}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/file.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[{"start":{"line":4,"offset":9},"end":{"line":4,"offset":10},"text":"Type 'number' is not assignable to type 'string'.","code":2322,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/file.ts","textChanges":[{"newText":"// @ts-ignore","start":{"line":3,"offset":5},"end":{"line":3,"offset":18}}]}]},"seq":4,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/file.ts"]},"seq":5,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":5}}

--- a/tests/baselines/reference/tsserver/openfile/when-file-makes-edits-to-add/remove-comment-directives,-they-are-handled-correcrly.js
+++ b/tests/baselines/reference/tsserver/openfile/when-file-makes-edits-to-add/remove-comment-directives,-they-are-handled-correcrly.js
@@ -9,7 +9,7 @@ Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -45,8 +45,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/file.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[]}}
 event:
@@ -60,8 +60,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/file.ts"]},"seq":5,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/file.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-changes.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-changes.js
@@ -21,7 +21,7 @@ Starting updateGraphWorker: Project: /a/b/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/b/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -66,8 +66,8 @@ Config: /a/b/tsconfig.json : {
 }
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 Starting updateGraphWorker: Project: /a/b/tsconfig.json
-Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
 event:
@@ -109,8 +109,8 @@ Config: /a/b/tsconfig.json : {
 }
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 Starting updateGraphWorker: Project: /a/b/tsconfig.json
-Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 3 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 3 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
 event:

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-changes.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-changes.js
@@ -1,0 +1,140 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/app.ts"}}
+Search path: /a/b
+For info: /a/b/app.ts :: Config file name: /a/b/tsconfig.json
+Creating configuration project /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/a/b/tsconfig.json","reason":"Creating possible configured project for /a/b/app.ts to open"}}
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/app.ts
+
+
+	../lib/lib.d.ts
+	  Default library
+	app.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"e10a1dc99ee63f16cb9b69bcee75540cdf41a1137371d3afbd4e7de507be5207","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":10,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/app.ts","configFile":"/a/b/tsconfig.json","diagnostics":[]}}
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+response:{"responseRequired":false}
+FileWatcher:: Triggered with /a/b/tsconfig.json 1:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+Scheduled: /a/b/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /a/b/tsconfig.json 1:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+Running: /a/b/tsconfig.json
+Reloading configured project /a/b/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/a/b/tsconfig.json","reason":"Change in config file detected"}}
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ }
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/tsconfig.json","configFile":"/a/b/tsconfig.json","diagnostics":[{"start":{"line":3,"offset":21},"end":{"line":3,"offset":27},"text":"Unknown compiler option 'haha'.","code":5023,"category":"error","fileName":"/a/b/tsconfig.json"}]}}
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+got projects updated in background, updating diagnostics for /a/b/app.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/a/b/app.ts"]}}
+FileWatcher:: Triggered with /a/b/tsconfig.json 1:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+Scheduled: /a/b/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /a/b/tsconfig.json 1:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+Reloading configured project /a/b/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/a/b/tsconfig.json","reason":"Change in config file detected"}}
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ }
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 3 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/tsconfig.json","configFile":"/a/b/tsconfig.json","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/a/b/app.ts","diagnostics":[]}}
+Running: /a/b/tsconfig.json
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+got projects updated in background, updating diagnostics for /a/b/app.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/a/b/app.ts"]}}

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-doesnt-have-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-doesnt-have-errors.js
@@ -1,0 +1,50 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/app.ts"}}
+Search path: /a/b
+For info: /a/b/app.ts :: Config file name: /a/b/tsconfig.json
+Creating configuration project /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/a/b/tsconfig.json","reason":"Creating possible configured project for /a/b/app.ts to open"}}
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/app.ts
+
+
+	../lib/lib.d.ts
+	  Default library
+	app.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"e10a1dc99ee63f16cb9b69bcee75540cdf41a1137371d3afbd4e7de507be5207","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":10,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/app.ts","configFile":"/a/b/tsconfig.json","diagnostics":[]}}
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+response:{"responseRequired":false}

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-doesnt-have-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-doesnt-have-errors.js
@@ -21,7 +21,7 @@ Starting updateGraphWorker: Project: /a/b/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/b/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-has-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-has-errors.js
@@ -21,7 +21,7 @@ Starting updateGraphWorker: Project: /a/b/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/b/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-has-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-generated-when-the-config-file-has-errors.js
@@ -1,0 +1,50 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/app.ts"}}
+Search path: /a/b
+For info: /a/b/app.ts :: Config file name: /a/b/tsconfig.json
+Creating configuration project /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/a/b/tsconfig.json","reason":"Creating possible configured project for /a/b/app.ts to open"}}
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/app.ts
+
+
+	../lib/lib.d.ts
+	  Default library
+	app.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"e10a1dc99ee63f16cb9b69bcee75540cdf41a1137371d3afbd4e7de507be5207","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":10,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/app.ts","configFile":"/a/b/tsconfig.json","diagnostics":[{"start":{"line":3,"offset":25},"end":{"line":3,"offset":30},"text":"Unknown compiler option 'foo'.","code":5023,"category":"error","fileName":"/a/b/tsconfig.json"},{"start":{"line":4,"offset":25},"end":{"line":4,"offset":34},"text":"Unknown compiler option 'allowJS'. Did you mean 'allowJs'?","code":5025,"category":"error","fileName":"/a/b/tsconfig.json"}]}}
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+response:{"responseRequired":false}

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-does-not-include-file-opened-and-config-file-has-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-does-not-include-file-opened-and-config-file-has-errors.js
@@ -1,0 +1,130 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/test.ts"}}
+Search path: /a/b
+For info: /a/b/test.ts :: Config file name: /a/b/tsconfig.json
+Creating configuration project /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/a/b/tsconfig.json","reason":"Creating possible configured project for /a/b/test.ts to open"}}
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ }
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /a/b/app.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/app.ts
+
+
+	../lib/lib.d.ts
+	  Default library
+	app.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"e10a1dc99ee63f16cb9b69bcee75540cdf41a1137371d3afbd4e7de507be5207","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":10,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/test.ts","configFile":"/a/b/tsconfig.json","diagnostics":[{"start":{"line":3,"offset":25},"end":{"line":3,"offset":30},"text":"Unknown compiler option 'foo'.","code":5023,"category":"error","fileName":"/a/b/tsconfig.json"},{"start":{"line":4,"offset":25},"end":{"line":4,"offset":34},"text":"Unknown compiler option 'allowJS'. Did you mean 'allowJs'?","code":5025,"category":"error","fileName":"/a/b/tsconfig.json"}]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/test.ts
+
+
+	../lib/lib.d.ts
+	  Default library for target 'es5'
+	test.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/test.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/app.ts"}}
+FileWatcher:: Close:: WatchInfo: /a/b/app.ts 500 undefined WatchType: Closed Script info
+Search path: /a/b
+For info: /a/b/app.ts :: Config file name: /a/b/tsconfig.json
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/test.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/test2.ts"}}
+Search path: /a/b
+For info: /a/b/test2.ts :: Config file name: /a/b/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/test2.ts","configFile":"/a/b/tsconfig.json","diagnostics":[{"start":{"line":3,"offset":25},"end":{"line":3,"offset":30},"text":"Unknown compiler option 'foo'.","code":5023,"category":"error","fileName":"/a/b/tsconfig.json"},{"start":{"line":4,"offset":25},"end":{"line":4,"offset":34},"text":"Unknown compiler option 'allowJS'. Did you mean 'allowJs'?","code":5025,"category":"error","fileName":"/a/b/tsconfig.json"}]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject2*
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/test2.ts
+
+
+	../lib/lib.d.ts
+	  Default library for target 'es5'
+	test2.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/test.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+	FileName: /a/b/test2.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject2*
+response:{"responseRequired":false}

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-does-not-include-file-opened-and-config-file-has-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-does-not-include-file-opened-and-config-file-has-errors.js
@@ -20,7 +20,7 @@ Starting updateGraphWorker: Project: /a/b/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/b/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -43,7 +43,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -95,7 +95,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject2*
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject2*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-does-not-include-file-opened-and-doesnt-contain-any-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-does-not-include-file-opened-and-doesnt-contain-any-errors.js
@@ -1,0 +1,130 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/test.ts"}}
+Search path: /a/b
+For info: /a/b/test.ts :: Config file name: /a/b/tsconfig.json
+Creating configuration project /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/a/b/tsconfig.json","reason":"Creating possible configured project for /a/b/test.ts to open"}}
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ }
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /a/b/app.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/app.ts
+
+
+	../lib/lib.d.ts
+	  Default library
+	app.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"e10a1dc99ee63f16cb9b69bcee75540cdf41a1137371d3afbd4e7de507be5207","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":10,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/test.ts","configFile":"/a/b/tsconfig.json","diagnostics":[]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/test.ts
+
+
+	../lib/lib.d.ts
+	  Default library for target 'es5'
+	test.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/test.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/app.ts"}}
+FileWatcher:: Close:: WatchInfo: /a/b/app.ts 500 undefined WatchType: Closed Script info
+Search path: /a/b
+For info: /a/b/app.ts :: Config file name: /a/b/tsconfig.json
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/test.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/test2.ts"}}
+Search path: /a/b
+For info: /a/b/test2.ts :: Config file name: /a/b/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/test2.ts","configFile":"/a/b/tsconfig.json","diagnostics":[]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject2*
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/test2.ts
+
+
+	../lib/lib.d.ts
+	  Default library for target 'es5'
+	test2.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/test.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+	FileName: /a/b/test2.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject2*
+response:{"responseRequired":false}

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-does-not-include-file-opened-and-doesnt-contain-any-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-does-not-include-file-opened-and-doesnt-contain-any-errors.js
@@ -20,7 +20,7 @@ Starting updateGraphWorker: Project: /a/b/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/b/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -43,7 +43,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -95,7 +95,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject2*
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject2*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-has-errors-but-suppressDiagnosticEvents-is-true.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-has-errors-but-suppressDiagnosticEvents-is-true.js
@@ -21,7 +21,7 @@ Starting updateGraphWorker: Project: /a/b/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/b/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-has-errors-but-suppressDiagnosticEvents-is-true.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-are-not-generated-when-the-config-file-has-errors-but-suppressDiagnosticEvents-is-true.js
@@ -1,0 +1,48 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/app.ts"}}
+Search path: /a/b
+For info: /a/b/app.ts :: Config file name: /a/b/tsconfig.json
+Creating configuration project /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/a/b/tsconfig.json","reason":"Creating possible configured project for /a/b/app.ts to open"}}
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/app.ts
+
+
+	../lib/lib.d.ts
+	  Default library
+	app.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"e10a1dc99ee63f16cb9b69bcee75540cdf41a1137371d3afbd4e7de507be5207","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":10,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+response:{"responseRequired":false}

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-contains-the-project-reference-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-contains-the-project-reference-errors.js
@@ -34,7 +34,7 @@ FileWatcher:: Added:: WatchInfo: /a/b/no-such-tsconfig.json 2000 undefined Proje
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/b/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-contains-the-project-reference-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/configFileDiagnostic-events-contains-the-project-reference-errors.js
@@ -1,0 +1,63 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/app.ts"}}
+Search path: /a/b
+For info: /a/b/app.ts :: Config file name: /a/b/tsconfig.json
+Creating configuration project /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/a/b/tsconfig.json","reason":"Creating possible configured project for /a/b/app.ts to open"}}
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/a/b/no-such-tsconfig.json",
+   "originalPath": "./no-such-tsconfig.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+Config: /a/b/no-such-tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/no-such-tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /a/b/no-such-tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/app.ts
+
+
+	../lib/lib.d.ts
+	  Default library
+	app.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"e10a1dc99ee63f16cb9b69bcee75540cdf41a1137371d3afbd4e7de507be5207","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":10,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/app.ts","configFile":"/a/b/tsconfig.json","diagnostics":[{"start":{"line":3,"offset":36},"end":{"line":3,"offset":70},"text":"File '/a/b/no-such-tsconfig.json' not found.","code":6053,"category":"error","fileName":"/a/b/tsconfig.json"}]}}
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+response:{"responseRequired":false}

--- a/tests/baselines/reference/tsserver/projectErrors/correct-errors-when-resolution-resolves-to-file-that-has-same-ambient-module-and-is-also-module.js
+++ b/tests/baselines/reference/tsserver/projectErrors/correct-errors-when-resolution-resolves-to-file-that-has-same-ambient-module-and-is-also-module.js
@@ -25,7 +25,7 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myp
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -73,8 +73,8 @@ response:{"responseRequired":false}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/src/a.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /users/username/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/src/a.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectErrors/correct-errors-when-resolution-resolves-to-file-that-has-same-ambient-module-and-is-also-module.js
+++ b/tests/baselines/reference/tsserver/projectErrors/correct-errors-when-resolution-resolves-to-file-that-has-same-ambient-module-and-is-also-module.js
@@ -1,0 +1,85 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/users/username/projects/myproject/src/a.ts"}}
+Search path: /users/username/projects/myproject/src
+For info: /users/username/projects/myproject/src/a.ts :: Config file name: /users/username/projects/myproject/tsconfig.json
+Creating configuration project /users/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/tsconfig.json 2000 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/users/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /users/username/projects/myproject/src/a.ts to open"}}
+Config: /users/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/users/username/projects/myproject/src/a.ts"
+ ],
+ "options": {
+  "configFilePath": "/users/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/src 1 undefined Config: /users/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/src 1 undefined Config: /users/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /users/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined WatchType: node_modules for closed script infos in them
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined WatchType: node_modules for closed script infos in them
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/node_modules/@custom/plugin/proposed.d.ts
+	/users/username/projects/myproject/node_modules/@custom/plugin/index.d.ts
+	/users/username/projects/myproject/src/a.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	node_modules/@custom/plugin/proposed.d.ts
+	  Imported via './proposed' from file 'node_modules/@custom/plugin/index.d.ts'
+	node_modules/@custom/plugin/index.d.ts
+	  Imported via "@custom/plugin" from file 'src/a.ts'
+	src/a.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/users/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"49814c247d0e4666719ac54e31c3f19091be4020c5ac046c86474826dc7e4ede","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":73,"tsx":0,"tsxSize":0,"dts":3,"dtsSize":486,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/users/username/projects/myproject/src/a.ts","configFile":"/users/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/users/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/src/a.ts ProjectRootPath: undefined
+		Projects: /users/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/src/a.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/src/a.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/src/a.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/src/a.ts","diagnostics":[{"start":{"line":1,"offset":1},"end":{"line":1,"offset":44},"text":"'myModule' is declared but its value is never read.","code":6133,"category":"suggestion","reportsUnnecessary":true},{"start":{"line":2,"offset":10},"end":{"line":2,"offset":13},"text":"'foo' is declared but its value is never read.","code":6133,"category":"suggestion","reportsUnnecessary":true}]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"change","arguments":{"file":"/users/username/projects/myproject/src/a.ts","line":3,"offset":8,"endLine":3,"endOffset":8,"insertString":"o"},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/src/a.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /users/username/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/src/a.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/src/a.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/src/a.ts","diagnostics":[{"start":{"line":1,"offset":1},"end":{"line":1,"offset":44},"text":"'myModule' is declared but its value is never read.","code":6133,"category":"suggestion","reportsUnnecessary":true},{"start":{"line":2,"offset":10},"end":{"line":2,"offset":13},"text":"'foo' is declared but its value is never read.","code":6133,"category":"suggestion","reportsUnnecessary":true}]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectErrors/folder-rename-updates-project-structure-and-reports-no-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/folder-rename-updates-project-structure-and-reports-no-errors.js
@@ -1,0 +1,132 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/a/b/projects/myproject/bar/app.ts"},"seq":1,"type":"request"}
+Search path: /a/b/projects/myproject/bar
+For info: /a/b/projects/myproject/bar/app.ts :: Config file name: /a/b/projects/myproject/tsconfig.json
+Creating configuration project /a/b/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/projects/myproject/tsconfig.json 2000 undefined Project: /a/b/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/a/b/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /a/b/projects/myproject/bar/app.ts to open"}}
+Config: /a/b/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/a/b/projects/myproject/bar/app.ts",
+  "/a/b/projects/myproject/foo/foo.ts"
+ ],
+ "options": {
+  "module": 0,
+  "configFilePath": "/a/b/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /a/b/projects/myproject/foo/foo.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /a/b/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /a/b/projects/myproject/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/myproject/node_modules/@types 1 undefined Project: /a/b/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/myproject/node_modules/@types 1 undefined Project: /a/b/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/b/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+	/a/b/projects/myproject/bar/app.ts
+	/a/b/projects/myproject/foo/foo.ts
+
+
+	bar/app.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	foo/foo.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/a/b/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"c56abb8c7c51bef5953613f05226da8e72cd9eafe09ab58ca2ccd81b65ba193a","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":154,"tsx":0,"tsxSize":0,"dts":0,"dtsSize":0,"deferred":0,"deferredSize":0},"compilerOptions":{"module":"none"},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":true,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/a/b/projects/myproject/bar/app.ts","configFile":"/a/b/projects/myproject/tsconfig.json","diagnostics":[{"text":"File '/a/lib/lib.d.ts' not found.\n  The file is in the program because:\n    Default library","code":6053,"category":"error"},{"text":"Cannot find global type 'Array'.","code":2318,"category":"error"},{"text":"Cannot find global type 'Boolean'.","code":2318,"category":"error"},{"text":"Cannot find global type 'Function'.","code":2318,"category":"error"},{"text":"Cannot find global type 'IArguments'.","code":2318,"category":"error"},{"text":"Cannot find global type 'Number'.","code":2318,"category":"error"},{"text":"Cannot find global type 'Object'.","code":2318,"category":"error"},{"text":"Cannot find global type 'RegExp'.","code":2318,"category":"error"},{"text":"Cannot find global type 'String'.","code":2318,"category":"error"},{"start":{"line":1,"offset":37},"end":{"line":1,"offset":45},"text":"Unknown compiler option 'targer'. Did you mean 'target'?","code":5025,"category":"error","fileName":"/a/b/projects/myproject/tsconfig.json"}]}}
+Project '/a/b/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/myproject/bar/app.ts ProjectRootPath: undefined
+		Projects: /a/b/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/a/b/projects/myproject/bar/app.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/a/b/projects/myproject/bar/app.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/a/b/projects/myproject/bar/app.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/a/b/projects/myproject/bar/app.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /a/b/projects/myproject/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo2 :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /a/b/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo2 :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Triggered with /a/b/projects/myproject/foo/foo.ts 2:: WatchInfo: /a/b/projects/myproject/foo/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /a/b/projects/myproject/foo/foo.ts 500 undefined WatchType: Closed Script info
+Scheduled: /a/b/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms FileWatcher:: Triggered with /a/b/projects/myproject/foo/foo.ts 2:: WatchInfo: /a/b/projects/myproject/foo/foo.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo/foo.ts :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /a/b/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo/foo.ts :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo2/foo.ts :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /a/b/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo2/foo.ts :: WatchInfo: /a/b/projects/myproject 1 undefined Config: /a/b/projects/myproject/tsconfig.json WatchType: Wild card directory
+Running: /a/b/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/projects/myproject/foo2/foo.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /a/b/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /a/b/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/a/b/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+	/a/b/projects/myproject/bar/app.ts
+	/a/b/projects/myproject/foo2/foo.ts
+
+
+	bar/app.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	foo2/foo.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/a/b/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/myproject/bar/app.ts ProjectRootPath: undefined
+		Projects: /a/b/projects/myproject/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/a/b/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/myproject/bar/app.ts ProjectRootPath: undefined
+		Projects: /a/b/projects/myproject/tsconfig.json
+got projects updated in background, updating diagnostics for /a/b/projects/myproject/bar/app.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/a/b/projects/myproject/bar/app.ts"]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/a/b/projects/myproject/bar/app.ts","diagnostics":[]}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/a/b/projects/myproject/bar/app.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/a/b/projects/myproject/bar/app.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/a/b/projects/myproject/bar/app.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/a/b/projects/myproject/bar/app.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectErrors/folder-rename-updates-project-structure-and-reports-no-errors.js
+++ b/tests/baselines/reference/tsserver/projectErrors/folder-rename-updates-project-structure-and-reports-no-errors.js
@@ -24,7 +24,7 @@ Starting updateGraphWorker: Project: /a/b/projects/myproject/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /a/b/projects/myproject/tsconfig.json WatchType: Missing file
 DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/myproject/node_modules/@types 1 undefined Project: /a/b/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/myproject/node_modules/@types 1 undefined Project: /a/b/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/b/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/b/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/b/projects/myproject/tsconfig.json' (Configured)
 	Files (2)
 	/a/b/projects/myproject/bar/app.ts
@@ -85,7 +85,7 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/myproject/foo2/foo
 Running: /a/b/projects/myproject/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/b/projects/myproject/foo2/foo.ts 500 undefined WatchType: Closed Script info
 Starting updateGraphWorker: Project: /a/b/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /a/b/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/b/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/b/projects/myproject/tsconfig.json' (Configured)
 	Files (2)
 	/a/b/projects/myproject/bar/app.ts

--- a/tests/baselines/reference/tsserver/projectErrors/getting-errors-before-opening-file.js
+++ b/tests/baselines/reference/tsserver/projectErrors/getting-errors-before-opening-file.js
@@ -1,0 +1,5 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"geterr","arguments":{"delay":0,"files":["/a/b/project/file.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-after-installation.js
+++ b/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-after-installation.js
@@ -25,7 +25,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_mod
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -95,8 +95,8 @@ request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/proj
 response:{"responseRequired":false}
 Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 1
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
 event:
@@ -224,7 +224,7 @@ Running: /user/username/projects/myproject/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined WatchType: node_modules for closed script infos in them
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined WatchType: node_modules for closed script infos in them
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 3 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-after-installation.js
+++ b/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-after-installation.js
@@ -1,0 +1,272 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/src/main.ts","projectRootPath":"/user/username/projects/myproject"}}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/main.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":36,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[{"start":{"line":1,"offset":21},"end":{"line":1,"offset":36},"text":"Cannot find module '@angular/core' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /user/username/projects/myproject/tsconfig.jsonFailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /user/username/projects/myproject/tsconfig.jsonFailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@babel
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/core-js-db53158d
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 1
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[{"start":{"line":1,"offset":21},"end":{"line":1,"offset":36},"text":"Cannot find module '@angular/core' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[{"start":{"line":1,"offset":21},"end":{"line":1,"offset":36},"text":"Cannot find module '@angular/core' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":4,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[{"start":{"line":1,"offset":21},"end":{"line":1,"offset":36},"text":"Cannot find module '@angular/core' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":4}}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@babel
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/core-js-db53158d
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /user/username/projects/myproject/tsconfig.jsonFailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/tsconfig.jsonFailedLookupInvalidation
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Running: /user/username/projects/myproject/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined WatchType: node_modules for closed script infos in them
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined WatchType: node_modules for closed script infos in them
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/node_modules/@angular/core/index.d.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	node_modules/@angular/core/index.d.ts
+	  Imported via '@angular/core' from file 'src/main.ts'
+	src/main.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+got projects updated in background, updating diagnostics for /user/username/projects/myproject/src/main.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/user/username/projects/myproject/src/main.ts"]}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":5,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":5}}

--- a/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-inbetween-installation.js
+++ b/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-inbetween-installation.js
@@ -25,7 +25,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_mod
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -96,8 +96,8 @@ Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier on
 Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Running: /user/username/projects/myproject/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 1
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Different program with same set of files
 Running: *ensureProjectForOpenFiles*
 Before ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
@@ -247,7 +247,7 @@ Running: /user/username/projects/myproject/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined WatchType: node_modules for closed script infos in them
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined WatchType: node_modules for closed script infos in them
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 3 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-inbetween-installation.js
+++ b/tests/baselines/reference/tsserver/projectErrors/npm-install-when-timeout-occurs-inbetween-installation.js
@@ -1,0 +1,295 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/src/main.ts","projectRootPath":"/user/username/projects/myproject"}}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/main.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":36,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[{"start":{"line":1,"offset":21},"end":{"line":1,"offset":36},"text":"Cannot find module '@angular/core' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /user/username/projects/myproject/tsconfig.jsonFailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /user/username/projects/myproject/tsconfig.jsonFailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@babel
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/core-js-db53158d
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/tsconfig.jsonFailedLookupInvalidation
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Running: /user/username/projects/myproject/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 1
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+got projects updated in background, updating diagnostics for /user/username/projects/myproject/src/main.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/user/username/projects/myproject/src/main.ts"]}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[{"start":{"line":1,"offset":21},"end":{"line":1,"offset":36},"text":"Cannot find module '@angular/core' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[{"start":{"line":1,"offset":21},"end":{"line":1,"offset":36},"text":"Cannot find module '@angular/core' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":4,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[{"start":{"line":1,"offset":21},"end":{"line":1,"offset":36},"text":"Cannot find module '@angular/core' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":4}}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models/analytics.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05/models :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/cli-c1e44b05 :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/core-0963aebf :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular/platform-browser-dynamic-5efaaa1a :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@angular
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@angular :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel/helper-plugin-utils-a06c629f :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/@babel
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/@babel :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected ignored path: /user/username/projects/myproject/node_modules/.staging/core-js-db53158d
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging/core-js-db53158d :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /user/username/projects/myproject/tsconfig.jsonFailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/.staging :: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/tsconfig.jsonFailedLookupInvalidation
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Running: /user/username/projects/myproject/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined WatchType: node_modules for closed script infos in them
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined WatchType: node_modules for closed script infos in them
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/node_modules/@angular/core/index.d.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	node_modules/@angular/core/index.d.ts
+	  Imported via '@angular/core' from file 'src/main.ts'
+	src/main.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: /user/username/projects/myproject
+		Projects: /user/username/projects/myproject/tsconfig.json
+got projects updated in background, updating diagnostics for /user/username/projects/myproject/src/main.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/user/username/projects/myproject/src/main.ts"]}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":5,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":5}}

--- a/tests/baselines/reference/tsserver/projectErrors/reports-errors-correctly-when-file-referenced-by-inferred-project-root,-is-opened-right-after-closing-the-root-file.js
+++ b/tests/baselines/reference/tsserver/projectErrors/reports-errors-correctly-when-file-referenced-by-inferred-project-root,-is-opened-right-after-closing-the-root-file.js
@@ -1,0 +1,172 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/src/client/app.js","projectRootPath":"/user/username/projects/myproject"}}
+Search path: /user/username/projects/myproject/src/client
+For info: /user/username/projects/myproject/src/client/app.js :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/client/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/client/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/client/app.js
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	src/client/app.js
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/client/app.js ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/test/backend/index.js","projectRootPath":"/user/username/projects/myproject"}}
+Search path: /user/username/projects/myproject/test/backend
+For info: /user/username/projects/myproject/test/backend/index.js :: No config files found.
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/test/backend/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/test/backend/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/test/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/test/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/server/utilities.js 500 undefined WatchType: Closed Script info
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/client/app.js
+	/user/username/projects/myproject/src/server/utilities.js
+	/user/username/projects/myproject/test/backend/index.js
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	src/client/app.js
+	  Root file specified for compilation
+	src/server/utilities.js
+	  Imported via '../../src/server/utilities' from file 'test/backend/index.js'
+	test/backend/index.js
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/client/app.js ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/test/backend/index.js ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/test/backend/index.js","/user/username/projects/myproject/src/client/app.js"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/test/backend/index.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/test/backend/index.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/test/backend/index.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/client/app.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/client/app.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/client/app.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"seq":0,"type":"request","command":"close","arguments":{"file":"/user/username/projects/myproject/test/backend/index.js"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/test/backend/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/test/backend/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/test/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/test/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/test/backend/index.js 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/client/app.js ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/src/server/utilities.js","projectRootPath":"/user/username/projects/myproject"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/server/utilities.js 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/src/server
+For info: /user/username/projects/myproject/src/server/utilities.js :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/client/app.js
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	src/client/app.js
+	  Root file specified for compilation
+
+-----------------------------------------------
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/server/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/server/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/client/app.js
+	/user/username/projects/myproject/src/server/utilities.js
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	src/client/app.js
+	  Root file specified for compilation
+	src/server/utilities.js
+	  Root file specified for compilation
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/test/backend/index.js 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/client/app.js ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/server/utilities.js ProjectRootPath: /user/username/projects/myproject
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/server/utilities.js","/user/username/projects/myproject/src/client/app.js"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/server/utilities.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/server/utilities.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/server/utilities.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/client/app.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/client/app.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/client/app.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}

--- a/tests/baselines/reference/tsserver/projectErrors/reports-errors-correctly-when-file-referenced-by-inferred-project-root,-is-opened-right-after-closing-the-root-file.js
+++ b/tests/baselines/reference/tsserver/projectErrors/reports-errors-correctly-when-file-referenced-by-inferred-project-root,-is-opened-right-after-closing-the-root-file.js
@@ -13,7 +13,7 @@ Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -45,7 +45,7 @@ Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/server/utilities.js 500 undefined WatchType: Closed Script info
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -111,7 +111,7 @@ For info: /user/username/projects/myproject/src/server/utilities.js :: No config
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -127,7 +127,7 @@ Project '/dev/null/inferredProject1*' (Inferred)
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/server/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/server/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/should-not-report-incorrect-error-when-json-is-root-file-found-by-tsconfig.js
+++ b/tests/baselines/reference/tsserver/projectErrors/should-not-report-incorrect-error-when-json-is-root-file-found-by-tsconfig.js
@@ -27,7 +27,7 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/mypr
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/should-not-report-incorrect-error-when-json-is-root-file-found-by-tsconfig.js
+++ b/tests/baselines/reference/tsserver/projectErrors/should-not-report-incorrect-error-when-json-is-root-file-found-by-tsconfig.js
@@ -1,0 +1,72 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/src/test.ts"}}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/test.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/test.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/test.ts",
+  "/user/username/projects/myproject/src/blabla.json"
+ ],
+ "options": {
+  "resolveJsonModule": true,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 0 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 0 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/blabla.json 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/blabla.json
+	/user/username/projects/myproject/src/test.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/blabla.json
+	  Imported via "./blabla.json" from file 'src/test.ts'
+	  Matched by include pattern './src/*.json' in 'tsconfig.json'
+	src/test.ts
+	  Matched by include pattern './src/*.ts' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":87,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"resolveJsonModule":true,"composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/test.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/test.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/test.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projectErrors/should-report-error-when-json-is-not-root-file-found-by-tsconfig.js
+++ b/tests/baselines/reference/tsserver/projectErrors/should-report-error-when-json-is-not-root-file-found-by-tsconfig.js
@@ -1,0 +1,70 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/src/test.ts"}}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/test.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/test.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/test.ts"
+ ],
+ "options": {
+  "resolveJsonModule": true,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 0 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 0 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/blabla.json 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/blabla.json
+	/user/username/projects/myproject/src/test.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/blabla.json
+	  Imported via "./blabla.json" from file 'src/test.ts'
+	src/test.ts
+	  Matched by include pattern './src/*.ts' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":87,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"resolveJsonModule":true,"composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/test.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/test.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/test.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/test.ts","diagnostics":[{"start":{"line":1,"offset":25},"end":{"line":1,"offset":40},"text":"File '/user/username/projects/myproject/src/blabla.json' is not listed within the file list of project '/user/username/projects/myproject/tsconfig.json'. Projects must list all files or use an 'include' pattern.","code":6307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projectErrors/should-report-error-when-json-is-not-root-file-found-by-tsconfig.js
+++ b/tests/baselines/reference/tsserver/projectErrors/should-report-error-when-json-is-not-root-file-found-by-tsconfig.js
@@ -26,7 +26,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/blabla.js
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-with-projectRoot.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-with-projectRoot.js
@@ -9,7 +9,7 @@ FileWatcher:: Added:: WatchInfo: /typings/@epic/core.d.ts 500 undefined Project:
 FileWatcher:: Added:: WatchInfo: /user/someuser/projects/somefolder/src/somefile.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
 DirectoryWatcher:: Added:: WatchInfo: /user/someuser/projects/someFolder/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/someuser/projects/someFolder/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-with-projectRoot.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-with-projectRoot.js
@@ -1,0 +1,47 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"untitled:Untitled-1","fileContent":"/// <reference path=\"../../../../../../typings/@epic/Core.d.ts\" />\n/// <reference path=\"./src/somefile.d.ts\" />","scriptKindName":"TS","projectRootPath":"/user/someuser/projects/someFolder"},"seq":1,"type":"request"}
+Search path: 
+For info: untitled:Untitled-1 :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /typings/@epic/core.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+FileWatcher:: Added:: WatchInfo: /user/someuser/projects/somefolder/src/somefile.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/someuser/projects/someFolder/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/someuser/projects/someFolder/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	untitled:Untitled-1
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	untitled:Untitled-1
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: untitled:Untitled-1 ProjectRootPath: /user/someuser/projects/someFolder
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+
+ScriptInfos:
+path: /user/someuser/projects/somefolder/untitled:untitled-1 fileName: untitled:Untitled-1
+path: /a/lib/lib.d.ts fileName: /a/lib/lib.d.ts
+
+request:{"command":"geterr","arguments":{"delay":0,"files":["untitled:Untitled-1"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"untitled:Untitled-1","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"untitled:Untitled-1","diagnostics":[{"start":{"line":1,"offset":22},"end":{"line":1,"offset":63},"text":"File '../../../../../../typings/@epic/Core.d.ts' not found.","code":6053,"category":"error"},{"start":{"line":2,"offset":22},"end":{"line":2,"offset":41},"text":"File 'src/somefile.d.ts' not found.","code":6053,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"untitled:Untitled-1","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}

--- a/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-without-projectRoot.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-without-projectRoot.js
@@ -7,7 +7,7 @@ Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 FileWatcher:: Added:: WatchInfo: /typings/@epic/core.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
 FileWatcher:: Added:: WatchInfo: /src/somefile.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-without-projectRoot.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-opening-new-file-that-doesnt-exist-on-disk-yet-without-projectRoot.js
@@ -1,0 +1,45 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"untitled:Untitled-1","fileContent":"/// <reference path=\"../../../../../../typings/@epic/Core.d.ts\" />\n/// <reference path=\"./src/somefile.d.ts\" />","scriptKindName":"TS"},"seq":1,"type":"request"}
+Search path: 
+For info: untitled:Untitled-1 :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /typings/@epic/core.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+FileWatcher:: Added:: WatchInfo: /src/somefile.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	untitled:Untitled-1
+
+
+	a/lib/lib.d.ts
+	  Default library for target 'es5'
+	untitled:Untitled-1
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: untitled:Untitled-1 ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+
+ScriptInfos:
+path: /untitled:untitled-1 fileName: untitled:Untitled-1
+path: /a/lib/lib.d.ts fileName: /a/lib/lib.d.ts
+
+request:{"command":"geterr","arguments":{"delay":0,"files":["untitled:Untitled-1"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"untitled:Untitled-1","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"untitled:Untitled-1","diagnostics":[{"start":{"line":1,"offset":22},"end":{"line":1,"offset":63},"text":"File '../../../../../../typings/@epic/Core.d.ts' not found.","code":6053,"category":"error"},{"start":{"line":2,"offset":22},"end":{"line":2,"offset":41},"text":"File 'src/somefile.d.ts' not found.","code":6053,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"untitled:Untitled-1","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}

--- a/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-gerErr-with-sync-commands.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-gerErr-with-sync-commands.js
@@ -1,0 +1,48 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/ui.ts"}}
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/ui.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/ui.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/ui.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	ui.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/ui.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/ui.ts","projectFileName":"/user/username/projects/myproject/tsconfig.json"},"seq":1,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/ui.ts","projectFileName":"/user/username/projects/myproject/tsconfig.json"},"seq":2,"type":"request"}
+response:{"response":[{"start":{"line":1,"offset":11},"end":{"line":1,"offset":39},"text":"An async function or method must return a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your '--lib' option.","code":2697,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/ui.ts","projectFileName":"/user/username/projects/myproject/tsconfig.json"},"seq":3,"type":"request"}
+response:{"response":[],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-gerErr-with-sync-commands.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-gerErr-with-sync-commands.js
@@ -19,7 +19,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-getErr.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-getErr.js
@@ -1,0 +1,60 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/ui.ts"}}
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/ui.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/ui.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/ui.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/ui.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	ui.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":41,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/ui.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/ui.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/ui.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/ui.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/ui.ts","diagnostics":[{"start":{"line":1,"offset":11},"end":{"line":1,"offset":39},"text":"An async function or method must return a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your '--lib' option.","code":2697,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/ui.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-getErr.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-getErr.js
@@ -21,7 +21,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-geterrForProject.js
@@ -1,0 +1,60 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/ui.ts"}}
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/ui.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/ui.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/ui.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/ui.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	ui.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":41,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/ui.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/ui.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterrForProject","arguments":{"delay":0,"file":"/user/username/projects/myproject/ui.ts"},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/ui.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/ui.ts","diagnostics":[{"start":{"line":1,"offset":11},"end":{"line":1,"offset":39},"text":"An async function or method must return a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your '--lib' option.","code":2697,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/ui.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectErrors/when-semantic-error-returns-includes-global-error-geterrForProject.js
@@ -21,7 +21,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectLanguageServiceStateEvent/large-file-size-is-determined-correctly.js
+++ b/tests/baselines/reference/tsserver/projectLanguageServiceStateEvent/large-file-size-is-determined-correctly.js
@@ -25,7 +25,7 @@ FileWatcher:: Added:: WatchInfo: /a/extremlylarge.d.ts 500 undefined WatchType: 
 FileWatcher:: Added:: WatchInfo: /a/largefile.js 500 undefined WatchType: Closed Script info
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 Starting updateGraphWorker: Project: /a/jsconfig.json
-Finishing updateGraphWorker: Project: /a/jsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/jsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/jsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectLanguageServiceStateEvent/large-file-size-is-determined-correctly.js
+++ b/tests/baselines/reference/tsserver/projectLanguageServiceStateEvent/large-file-size-is-determined-correctly.js
@@ -1,0 +1,49 @@
+Provided types map file "/typesMap.json" doesn't exist
+Search path: /a
+For info: /a/app.js :: Config file name: /a/jsconfig.json
+Creating configuration project /a/jsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/jsconfig.json 2000 undefined Project: /a/jsconfig.json WatchType: Config file
+Config: /a/jsconfig.json : {
+ "rootNames": [
+  "/a/app.js",
+  "/a/extremlylarge.d.ts",
+  "/a/largefile.js",
+  "/a/lib/lib.d.ts"
+ ],
+ "options": {
+  "allowJs": true,
+  "maxNodeModuleJsDepth": 2,
+  "allowSyntheticDefaultImports": true,
+  "skipLibCheck": true,
+  "noEmit": true,
+  "configFilePath": "/a/jsconfig.json"
+ }
+}
+Non TS file size exceeded limit (20971531). Largest files: /a/largefile.js:20971521, /a/app.js:10
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /a/extremlylarge.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/largefile.js 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /a/jsconfig.json
+Finishing updateGraphWorker: Project: /a/jsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/jsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/app.js
+
+
+	lib/lib.d.ts
+	  Default library
+	app.js
+	  Matched by include pattern '**/*' in 'jsconfig.json'
+
+-----------------------------------------------
+Project '/a/jsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/app.js ProjectRootPath: undefined
+		Projects: /a/jsconfig.json
+languageServiceEnabled: false
+lastFileExceededProgramSize: /a/largefile.js

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-gerErr-with-sync-commands.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-gerErr-with-sync-commands.js
@@ -1,0 +1,96 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "declarationDir": "/user/username/projects/myproject/decls",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Imported via '../decls/fns' from file 'usage.ts'
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":1,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":2,"type":"request"}
+response:{"response":[{"start":{"line":4,"offset":5},"end":{"line":4,"offset":10},"text":"Module '\"../decls/fns\"' has no exported member 'fnErr'.","code":2305,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":3,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":4,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":5,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":6,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":7,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":8,"type":"request"}
+response:{"response":[{"start":{"line":4,"offset":5},"end":{"line":4,"offset":10},"text":"Module '\"../decls/fns\"' has no exported member 'fnErr'.","code":2305,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":9,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":10,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":11,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":12,"type":"request"}
+response:{"response":[],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-gerErr-with-sync-commands.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-gerErr-with-sync-commands.js
@@ -44,7 +44,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-getErr.js
@@ -1,0 +1,90 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/usage/usage.ts to open"}}
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "declarationDir": "/user/username/projects/myproject/decls",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Imported via '../decls/fns' from file 'usage.ts'
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"2b96539513e8810fb8ec0c078e4cb28919c0c28cdb8f7646118c5a6f4ff4cb10","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":266,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/usage/usage.ts","configFile":"/user/username/projects/myproject/usage/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/usage/usage.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[{"start":{"line":4,"offset":5},"end":{"line":4,"offset":10},"text":"Module '\"../decls/fns\"' has no exported member 'fnErr'.","code":2305,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-getErr.js
@@ -46,7 +46,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-geterrForProject.js
@@ -1,0 +1,112 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/usage/usage.ts to open"}}
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "declarationDir": "/user/username/projects/myproject/decls",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Imported via '../decls/fns' from file 'usage.ts'
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"2b96539513e8810fb8ec0c078e4cb28919c0c28cdb8f7646118c5a6f4ff4cb10","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":266,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/usage/usage.ts","configFile":"/user/username/projects/myproject/usage/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterrForProject","arguments":{"delay":0,"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[{"start":{"line":4,"offset":5},"end":{"line":4,"offset":10},"text":"Module '\"../decls/fns\"' has no exported member 'fnErr'.","code":2305,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"geterrForProject","arguments":{"delay":0,"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[{"start":{"line":4,"offset":5},"end":{"line":4,"offset":10},"text":"Module '\"../decls/fns\"' has no exported member 'fnErr'.","code":2305,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-dependency-project-is-not-open-geterrForProject.js
@@ -46,7 +46,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-gerErr-with-sync-commands.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-gerErr-with-sync-commands.js
@@ -44,7 +44,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -81,7 +81,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependen
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-gerErr-with-sync-commands.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-gerErr-with-sync-commands.js
@@ -1,0 +1,142 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "declarationDir": "/user/username/projects/myproject/decls",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Imported via '../decls/fns' from file 'usage.ts'
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/fns.ts :: Config file name: /user/username/projects/myproject/dependency/tsconfig.json
+Creating configuration project /user/username/projects/myproject/dependency/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	fns.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+	FileName: /user/username/projects/myproject/dependency/fns.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json,/user/username/projects/myproject/dependency/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":1,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":2,"type":"request"}
+response:{"response":[{"start":{"line":4,"offset":5},"end":{"line":4,"offset":10},"text":"Module '\"../decls/fns\"' has no exported member 'fnErr'.","code":2305,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":3,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":4,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":5,"type":"request"}
+response:{"response":[{"start":{"line":6,"offset":12},"end":{"line":6,"offset":13},"text":"Type 'number' is not assignable to type 'string'.","code":2322,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":6,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":7,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":8,"type":"request"}
+response:{"response":[{"start":{"line":4,"offset":5},"end":{"line":4,"offset":10},"text":"Module '\"../decls/fns\"' has no exported member 'fnErr'.","code":2305,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":9,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":10,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":11,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":12,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/dependency/tsconfig.json"},"seq":13,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/dependency/tsconfig.json"},"seq":14,"type":"request"}
+response:{"response":[{"start":{"line":6,"offset":12},"end":{"line":6,"offset":13},"text":"Type 'number' is not assignable to type 'string'.","code":2322,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/dependency/tsconfig.json"},"seq":15,"type":"request"}
+response:{"response":[],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-getErr.js
@@ -1,0 +1,144 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/usage/usage.ts to open"}}
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "declarationDir": "/user/username/projects/myproject/decls",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Imported via '../decls/fns' from file 'usage.ts'
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"2b96539513e8810fb8ec0c078e4cb28919c0c28cdb8f7646118c5a6f4ff4cb10","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":266,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/usage/usage.ts","configFile":"/user/username/projects/myproject/usage/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/fns.ts :: Config file name: /user/username/projects/myproject/dependency/tsconfig.json
+Creating configuration project /user/username/projects/myproject/dependency/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/dependency/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/dependency/fns.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	fns.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/dependency/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"80216eb4c9c6d41fcd26650a22a2df8f2cac81cda661de72dc723e6251203d22","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":184,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"declarationDir":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/dependency/fns.ts","configFile":"/user/username/projects/myproject/dependency/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+	FileName: /user/username/projects/myproject/dependency/fns.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json,/user/username/projects/myproject/dependency/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/usage/usage.ts","/user/username/projects/myproject/dependency/fns.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[{"start":{"line":4,"offset":5},"end":{"line":4,"offset":10},"text":"Module '\"../decls/fns\"' has no exported member 'fnErr'.","code":2305,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[{"start":{"line":6,"offset":12},"end":{"line":6,"offset":13},"text":"Type 'number' is not assignable to type 'string'.","code":2322,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-getErr.js
@@ -46,7 +46,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -91,7 +91,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependen
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-geterrForProject.js
@@ -1,0 +1,154 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/usage/usage.ts to open"}}
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "declarationDir": "/user/username/projects/myproject/decls",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/decls 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Imported via '../decls/fns' from file 'usage.ts'
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"2b96539513e8810fb8ec0c078e4cb28919c0c28cdb8f7646118c5a6f4ff4cb10","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":266,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/usage/usage.ts","configFile":"/user/username/projects/myproject/usage/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/fns.ts :: Config file name: /user/username/projects/myproject/dependency/tsconfig.json
+Creating configuration project /user/username/projects/myproject/dependency/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/dependency/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/dependency/fns.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	fns.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/dependency/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"80216eb4c9c6d41fcd26650a22a2df8f2cac81cda661de72dc723e6251203d22","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":184,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"declarationDir":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/dependency/fns.ts","configFile":"/user/username/projects/myproject/dependency/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+	FileName: /user/username/projects/myproject/dependency/fns.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json,/user/username/projects/myproject/dependency/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterrForProject","arguments":{"delay":0,"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[{"start":{"line":4,"offset":5},"end":{"line":4,"offset":10},"text":"Module '\"../decls/fns\"' has no exported member 'fnErr'.","code":2305,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"geterrForProject","arguments":{"delay":0,"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[{"start":{"line":6,"offset":12},"end":{"line":6,"offset":13},"text":"Type 'number' is not assignable to type 'string'.","code":2322,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-module-scenario-when-the-depedency-file-is-open-geterrForProject.js
@@ -46,7 +46,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -91,7 +91,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependen
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-gerErr-with-sync-commands.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-gerErr-with-sync-commands.js
@@ -43,7 +43,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-gerErr-with-sync-commands.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-gerErr-with-sync-commands.js
@@ -1,0 +1,95 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/usage.js",
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/dependency.js",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Source from referenced project '../dependency/tsconfig.json' included because '--outFile' specified
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":1,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":2,"type":"request"}
+response:{"response":[{"start":{"line":3,"offset":1},"end":{"line":3,"offset":6},"text":"Cannot find name 'fnErr'.","code":2304,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":3,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":4,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":5,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":6,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":7,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":8,"type":"request"}
+response:{"response":[{"start":{"line":3,"offset":1},"end":{"line":3,"offset":6},"text":"Cannot find name 'fnErr'.","code":2304,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":9,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":10,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":11,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":12,"type":"request"}
+response:{"response":[],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-getErr.js
@@ -45,7 +45,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-getErr.js
@@ -1,0 +1,89 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/usage/usage.ts to open"}}
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/usage.js",
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/dependency.js",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Source from referenced project '../dependency/tsconfig.json' included because '--outFile' specified
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"2b96539513e8810fb8ec0c078e4cb28919c0c28cdb8f7646118c5a6f4ff4cb10","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":179,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outFile":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/usage/usage.ts","configFile":"/user/username/projects/myproject/usage/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/usage/usage.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[{"start":{"line":3,"offset":1},"end":{"line":3,"offset":6},"text":"Cannot find name 'fnErr'.","code":2304,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-geterrForProject.js
@@ -45,7 +45,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-dependency-project-is-not-open-geterrForProject.js
@@ -1,0 +1,111 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/usage/usage.ts to open"}}
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/usage.js",
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/dependency.js",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Source from referenced project '../dependency/tsconfig.json' included because '--outFile' specified
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"2b96539513e8810fb8ec0c078e4cb28919c0c28cdb8f7646118c5a6f4ff4cb10","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":179,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outFile":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/usage/usage.ts","configFile":"/user/username/projects/myproject/usage/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterrForProject","arguments":{"delay":0,"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[{"start":{"line":3,"offset":1},"end":{"line":3,"offset":6},"text":"Cannot find name 'fnErr'.","code":2304,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"geterrForProject","arguments":{"delay":0,"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[{"start":{"line":3,"offset":1},"end":{"line":3,"offset":6},"text":"Cannot find name 'fnErr'.","code":2304,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-gerErr-with-sync-commands.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-gerErr-with-sync-commands.js
@@ -1,0 +1,141 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/usage.js",
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/dependency.js",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Source from referenced project '../dependency/tsconfig.json' included because '--outFile' specified
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/fns.ts :: Config file name: /user/username/projects/myproject/dependency/tsconfig.json
+Creating configuration project /user/username/projects/myproject/dependency/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	fns.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+	FileName: /user/username/projects/myproject/dependency/fns.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json,/user/username/projects/myproject/dependency/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":1,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":2,"type":"request"}
+response:{"response":[{"start":{"line":3,"offset":1},"end":{"line":3,"offset":6},"text":"Cannot find name 'fnErr'.","code":2304,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":3,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":4,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":5,"type":"request"}
+response:{"response":[{"start":{"line":6,"offset":5},"end":{"line":6,"offset":6},"text":"Type 'number' is not assignable to type 'string'.","code":2322,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":6,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":7,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":8,"type":"request"}
+response:{"response":[{"start":{"line":3,"offset":1},"end":{"line":3,"offset":6},"text":"Cannot find name 'fnErr'.","code":2304,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":9,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":10,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":11,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/usage/tsconfig.json"},"seq":12,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/dependency/tsconfig.json"},"seq":13,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/dependency/tsconfig.json"},"seq":14,"type":"request"}
+response:{"response":[{"start":{"line":6,"offset":5},"end":{"line":6,"offset":6},"text":"Type 'number' is not assignable to type 'string'.","code":2322,"category":"error"}],"responseRequired":true}
+request:{"command":"suggestionDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts","projectFileName":"/user/username/projects/myproject/dependency/tsconfig.json"},"seq":15,"type":"request"}
+response:{"response":[],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-gerErr-with-sync-commands.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-gerErr-with-sync-commands.js
@@ -43,7 +43,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -80,7 +80,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependen
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-getErr.js
@@ -1,0 +1,143 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/usage/usage.ts to open"}}
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/usage.js",
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/dependency.js",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Source from referenced project '../dependency/tsconfig.json' included because '--outFile' specified
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"2b96539513e8810fb8ec0c078e4cb28919c0c28cdb8f7646118c5a6f4ff4cb10","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":179,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outFile":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/usage/usage.ts","configFile":"/user/username/projects/myproject/usage/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/fns.ts :: Config file name: /user/username/projects/myproject/dependency/tsconfig.json
+Creating configuration project /user/username/projects/myproject/dependency/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/dependency/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/dependency/fns.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	fns.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/dependency/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"80216eb4c9c6d41fcd26650a22a2df8f2cac81cda661de72dc723e6251203d22","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":156,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outFile":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/dependency/fns.ts","configFile":"/user/username/projects/myproject/dependency/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+	FileName: /user/username/projects/myproject/dependency/fns.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json,/user/username/projects/myproject/dependency/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/usage/usage.ts","/user/username/projects/myproject/dependency/fns.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[{"start":{"line":3,"offset":1},"end":{"line":3,"offset":6},"text":"Cannot find name 'fnErr'.","code":2304,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[{"start":{"line":6,"offset":5},"end":{"line":6,"offset":6},"text":"Type 'number' is not assignable to type 'string'.","code":2322,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-getErr.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-getErr.js
@@ -45,7 +45,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -90,7 +90,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependen
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-geterrForProject.js
@@ -1,0 +1,153 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/usage/usage.ts"}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/usage.ts :: Config file name: /user/username/projects/myproject/usage/tsconfig.json
+Creating configuration project /user/username/projects/myproject/usage/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/usage/usage.ts to open"}}
+Config: /user/username/projects/myproject/usage/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/usage/usage.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/usage.js",
+  "configFilePath": "/user/username/projects/myproject/usage/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/dependency",
+   "originalPath": "../dependency"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage 1 undefined Config: /user/username/projects/myproject/usage/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json
+Config: /user/username/projects/myproject/dependency/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/dependency/fns.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outFile": "/user/username/projects/myproject/dependency.js",
+  "configFilePath": "/user/username/projects/myproject/dependency/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency 1 undefined Config: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+	/user/username/projects/myproject/usage/usage.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../dependency/fns.ts
+	  Source from referenced project '../dependency/tsconfig.json' included because '--outFile' specified
+	usage.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/usage/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"2b96539513e8810fb8ec0c078e4cb28919c0c28cdb8f7646118c5a6f4ff4cb10","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":179,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outFile":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/usage/usage.ts","configFile":"/user/username/projects/myproject/usage/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/usage
+For info: /user/username/projects/myproject/usage/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/dependency/fns.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/dependency/fns.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/fns.ts :: Config file name: /user/username/projects/myproject/dependency/tsconfig.json
+Creating configuration project /user/username/projects/myproject/dependency/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/dependency/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/dependency/fns.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/dependency/fns.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	fns.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/dependency/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"80216eb4c9c6d41fcd26650a22a2df8f2cac81cda661de72dc723e6251203d22","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":156,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outFile":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/dependency/fns.ts","configFile":"/user/username/projects/myproject/dependency/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/dependency
+For info: /user/username/projects/myproject/dependency/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/usage/usage.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json
+	FileName: /user/username/projects/myproject/dependency/fns.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/usage/tsconfig.json,/user/username/projects/myproject/dependency/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterrForProject","arguments":{"delay":0,"file":"/user/username/projects/myproject/usage/usage.ts"},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[{"start":{"line":3,"offset":1},"end":{"line":3,"offset":6},"text":"Cannot find name 'fnErr'.","code":2304,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/usage/usage.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"geterrForProject","arguments":{"delay":0,"file":"/user/username/projects/myproject/dependency/fns.ts"},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[{"start":{"line":6,"offset":5},"end":{"line":6,"offset":6},"text":"Type 'number' is not assignable to type 'string'.","code":2322,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/dependency/fns.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}

--- a/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-geterrForProject.js
+++ b/tests/baselines/reference/tsserver/projectReferenceErrors/with-non-module-when-the-depedency-file-is-open-geterrForProject.js
@@ -45,7 +45,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/usage/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/usage/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/usage/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/usage/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -90,7 +90,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependen
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/dependency/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/dependency/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/dependency/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/dependency/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/ancestor-and-project-ref-management.js
+++ b/tests/baselines/reference/tsserver/projectReferences/ancestor-and-project-ref-management.js
@@ -1,0 +1,427 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/container/compositeExec/index.ts"}}
+Search path: /user/username/projects/container/compositeExec
+For info: /user/username/projects/container/compositeExec/index.ts :: Config file name: /user/username/projects/container/compositeExec/tsconfig.json
+Creating configuration project /user/username/projects/container/compositeExec/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/tsconfig.json 2000 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Config file
+Config: /user/username/projects/container/compositeExec/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/container/compositeExec/index.ts"
+ ],
+ "options": {
+  "outFile": "/user/username/projects/container/built/local/compositeExec.js",
+  "composite": true,
+  "declarationMap": true,
+  "configFilePath": "/user/username/projects/container/compositeExec/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/container/lib",
+   "originalPath": "../lib",
+   "prepend": true
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json
+Config: /user/username/projects/container/lib/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/container/lib/index.ts"
+ ],
+ "options": {
+  "outFile": "/user/username/projects/container/built/local/lib.js",
+  "composite": true,
+  "declarationMap": true,
+  "configFilePath": "/user/username/projects/container/lib/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/tsconfig.json 2000 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Config file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+	/user/username/projects/container/compositeExec/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../lib/index.ts
+	  Source from referenced project '../lib/tsconfig.json' included because '--outFile' specified
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+Search path: /user/username/projects/container/compositeExec
+For info: /user/username/projects/container/compositeExec/tsconfig.json :: Config file name: /user/username/projects/container/tsconfig.json
+Creating configuration project /user/username/projects/container/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/tsconfig.json 2000 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/container
+For info: /user/username/projects/container/tsconfig.json :: No config files found.
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/container/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/container/compositeExec/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/container/compositeExec/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/temp/temp.ts"}}
+Search path: /user/username/projects/temp
+For info: /user/username/projects/temp/temp.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/temp/temp.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	temp.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/container/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/container/compositeExec/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/container/compositeExec/tsconfig.json
+	FileName: /user/username/projects/temp/temp.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"rename","arguments":{"file":"/user/username/projects/container/compositeExec/index.ts","line":3,"offset":16},"seq":1,"type":"request"}
+Search path: /user/username/projects/container/lib
+For info: /user/username/projects/container/lib/index.ts :: Config file name: /user/username/projects/container/lib/tsconfig.json
+Creating configuration project /user/username/projects/container/lib/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+Loading configured project /user/username/projects/container/tsconfig.json
+Config: /user/username/projects/container/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/container/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/container/exec",
+   "originalPath": "./exec"
+  },
+  {
+   "path": "/user/username/projects/container/compositeExec",
+   "originalPath": "./compositeExec"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/container/tsconfig.json
+Config: /user/username/projects/container/exec/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/container/exec/index.ts"
+ ],
+ "options": {
+  "outFile": "/user/username/projects/container/built/local/exec.js",
+  "configFilePath": "/user/username/projects/container/exec/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/container/lib",
+   "originalPath": "../lib",
+   "prepend": true
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/tsconfig.json 2000 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Creating configuration project /user/username/projects/container/exec/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/index.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+	/user/username/projects/container/exec/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../lib/index.ts
+	  Source from referenced project '../lib/tsconfig.json' included because '--outFile' specified
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+response:{"response":{"info":{"canRename":true,"displayName":"myConst","fullDisplayName":"container.myConst","kind":"const","kindModifiers":"export","triggerSpan":{"start":{"line":3,"offset":16},"end":{"line":3,"offset":23}}},"locs":[{"file":"/user/username/projects/container/lib/index.ts","locs":[{"start":{"line":2,"offset":18},"end":{"line":2,"offset":25},"contextStart":{"line":2,"offset":5},"contextEnd":{"line":2,"offset":31}}]},{"file":"/user/username/projects/container/compositeExec/index.ts","locs":[{"start":{"line":3,"offset":16},"end":{"line":3,"offset":23}}]},{"file":"/user/username/projects/container/exec/index.ts","locs":[{"start":{"line":3,"offset":16},"end":{"line":3,"offset":23}}]}]},"responseRequired":true}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/temp/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/temp/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/temp.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/container/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/container/compositeExec/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/container/compositeExec/tsconfig.json
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/temp/temp.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/temp/temp.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/temp
+For info: /user/username/projects/temp/temp.ts :: No config files found.
+FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/temp/temp.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	temp.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/container/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/container/compositeExec/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/container/compositeExec/tsconfig.json
+	FileName: /user/username/projects/temp/temp.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/index.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/container/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/temp/temp.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Close:: WatchInfo: /user/username/projects/temp/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/temp/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/temp.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/container/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/temp/temp.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/temp/temp.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/temp
+For info: /user/username/projects/temp/temp.ts :: No config files found.
+FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/temp/temp.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	temp.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+	/user/username/projects/container/compositeExec/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../lib/index.ts
+	  Source from referenced project '../lib/tsconfig.json' included because '--outFile' specified
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/container/tsconfig.json' (Configured)
+	Files (0)
+
+
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/container/compositeExec/tsconfig.json 2000 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/container/tsconfig.json 2000 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+	/user/username/projects/container/exec/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../lib/index.ts
+	  Source from referenced project '../lib/tsconfig.json' included because '--outFile' specified
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/container/lib/tsconfig.json 2000 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/container/exec/tsconfig.json 2000 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/container/compositeExec/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/container/lib/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/container/exec/index.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/temp/temp.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}

--- a/tests/baselines/reference/tsserver/projectReferences/ancestor-and-project-ref-management.js
+++ b/tests/baselines/reference/tsserver/projectReferences/ancestor-and-project-ref-management.js
@@ -42,7 +42,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/composit
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -85,7 +85,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/jsconfig.json 2000
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -126,7 +126,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -177,8 +177,8 @@ Config: /user/username/projects/container/exec/tsconfig.json : {
 FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/tsconfig.json 2000 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Config file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/container/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Creating configuration project /user/username/projects/container/exec/tsconfig.json
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/index.ts 500 undefined WatchType: Closed Script info
@@ -187,7 +187,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/nod
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -237,7 +237,7 @@ For info: /user/username/projects/temp/temp.ts :: No config files found.
 FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -331,7 +331,7 @@ For info: /user/username/projects/temp/temp.ts :: No config files found.
 FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 FileWatcher:: Added:: WatchInfo: /user/username/projects/temp/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project-when-built-with-disableSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project-when-built-with-disableSourceOfProjectReferenceRedirect.js
@@ -58,7 +58,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/app/src/program/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project-when-built-with-disableSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project-when-built-with-disableSourceOfProjectReferenceRedirect.js
@@ -1,0 +1,99 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/app/src/program/index.ts"}}
+Search path: /user/username/projects/myproject/app/src/program
+For info: /user/username/projects/myproject/app/src/program/index.ts :: Config file name: /user/username/projects/myproject/app/src/program/tsconfig.json
+Creating configuration project /user/username/projects/myproject/app/src/program/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/app/src/program/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/app/src/program/bar.ts",
+  "/user/username/projects/myproject/app/src/program/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/app/bld/program",
+  "disableSourceOfProjectReferenceRedirect": true,
+  "configFilePath": "/user/username/projects/myproject/app/src/program/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/shared/src/library",
+   "originalPath": "../../../shared/src/library"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program 1 undefined Config: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program 1 undefined Config: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json
+Config: /user/username/projects/myproject/shared/src/library/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/shared/src/library/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/shared/bld/library",
+  "configFilePath": "/user/username/projects/myproject/shared/src/library/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library 1 undefined Config: /user/username/projects/myproject/shared/src/library/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library 1 undefined Config: /user/username/projects/myproject/shared/src/library/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/bld/library/index.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/app/src/program/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/shared/bld/library/index.d.ts
+	/user/username/projects/myproject/app/src/program/bar.ts
+	/user/username/projects/myproject/app/src/program/index.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	../../../shared/bld/library/index.d.ts
+	  Imported via "shared" from file 'bar.ts' with packageId 'shared/bld/library/index.d.ts@1.0.0'
+	bar.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/app/src/program
+For info: /user/username/projects/myproject/app/src/program/tsconfig.json :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/app/src/program/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/app/src/program/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/app/src/program/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"getCodeFixes","arguments":{"file":"/user/username/projects/myproject/app/src/program/index.ts","startLine":1,"startOffset":1,"endLine":1,"endOffset":4,"errorCodes":[2304]},"seq":1,"type":"request"}
+response:{"response":[{"fixName":"import","description":"Import 'foo' from module \"shared\"","changes":[{"fileName":"/user/username/projects/myproject/app/src/program/index.ts","textChanges":[{"start":{"line":1,"offset":1},"end":{"line":1,"offset":1},"newText":"import { foo } from \"shared\";\n\n"}]}]}],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project-when-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project-when-built.js
@@ -1,0 +1,98 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/app/src/program/index.ts"}}
+Search path: /user/username/projects/myproject/app/src/program
+For info: /user/username/projects/myproject/app/src/program/index.ts :: Config file name: /user/username/projects/myproject/app/src/program/tsconfig.json
+Creating configuration project /user/username/projects/myproject/app/src/program/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/app/src/program/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/app/src/program/bar.ts",
+  "/user/username/projects/myproject/app/src/program/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/app/bld/program",
+  "configFilePath": "/user/username/projects/myproject/app/src/program/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/shared/src/library",
+   "originalPath": "../../../shared/src/library"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program 1 undefined Config: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program 1 undefined Config: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json
+Config: /user/username/projects/myproject/shared/src/library/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/shared/src/library/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/shared/bld/library",
+  "configFilePath": "/user/username/projects/myproject/shared/src/library/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library 1 undefined Config: /user/username/projects/myproject/shared/src/library/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library 1 undefined Config: /user/username/projects/myproject/shared/src/library/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/app/src/program/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/shared/src/library/index.ts
+	/user/username/projects/myproject/app/src/program/bar.ts
+	/user/username/projects/myproject/app/src/program/index.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	../../../shared/src/library/index.ts
+	  Imported via "shared" from file 'bar.ts' with packageId 'shared/bld/library/index.d.ts@1.0.0'
+	bar.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/app/src/program
+For info: /user/username/projects/myproject/app/src/program/tsconfig.json :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/app/src/program/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/app/src/program/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/app/src/program/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"getCodeFixes","arguments":{"file":"/user/username/projects/myproject/app/src/program/index.ts","startLine":1,"startOffset":1,"endLine":1,"endOffset":4,"errorCodes":[2304]},"seq":1,"type":"request"}
+response:{"response":[{"fixName":"import","description":"Import 'foo' from module \"shared\"","changes":[{"fileName":"/user/username/projects/myproject/app/src/program/index.ts","textChanges":[{"start":{"line":1,"offset":1},"end":{"line":1,"offset":1},"newText":"import { foo } from \"shared\";\n\n"}]}]}],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project-when-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project-when-built.js
@@ -57,7 +57,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/app/src/program/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project.js
@@ -1,0 +1,98 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/app/src/program/index.ts"}}
+Search path: /user/username/projects/myproject/app/src/program
+For info: /user/username/projects/myproject/app/src/program/index.ts :: Config file name: /user/username/projects/myproject/app/src/program/tsconfig.json
+Creating configuration project /user/username/projects/myproject/app/src/program/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/app/src/program/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/app/src/program/bar.ts",
+  "/user/username/projects/myproject/app/src/program/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/app/bld/program",
+  "configFilePath": "/user/username/projects/myproject/app/src/program/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/shared/src/library",
+   "originalPath": "../../../shared/src/library"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program 1 undefined Config: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program 1 undefined Config: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/bar.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json
+Config: /user/username/projects/myproject/shared/src/library/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/shared/src/library/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/shared/bld/library",
+  "configFilePath": "/user/username/projects/myproject/shared/src/library/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library 1 undefined Config: /user/username/projects/myproject/shared/src/library/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library 1 undefined Config: /user/username/projects/myproject/shared/src/library/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/shared/src/library/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/program/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/src/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/app/src/program/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/shared/src/library/index.ts
+	/user/username/projects/myproject/app/src/program/bar.ts
+	/user/username/projects/myproject/app/src/program/index.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	../../../shared/src/library/index.ts
+	  Imported via "shared" from file 'bar.ts' with packageId 'shared/bld/library/index.d.ts@1.0.0'
+	bar.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/app/src/program
+For info: /user/username/projects/myproject/app/src/program/tsconfig.json :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/myproject
+For info: /user/username/projects/myproject/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/app/src/program/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/app/src/program/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/app/src/program/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"getCodeFixes","arguments":{"file":"/user/username/projects/myproject/app/src/program/index.ts","startLine":1,"startOffset":1,"endLine":1,"endOffset":4,"errorCodes":[2304]},"seq":1,"type":"request"}
+response:{"response":[{"fixName":"import","description":"Import 'foo' from module \"shared\"","changes":[{"fileName":"/user/username/projects/myproject/app/src/program/index.ts","textChanges":[{"start":{"line":1,"offset":1},"end":{"line":1,"offset":1},"newText":"import { foo } from \"shared\";\n\n"}]}]}],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/auto-import-with-referenced-project.js
@@ -57,7 +57,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/app/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/app/src/program/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/app/src/program/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/app/src/program/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/can-successfully-find-references-with-out-option.js
+++ b/tests/baselines/reference/tsserver/projectReferences/can-successfully-find-references-with-out-option.js
@@ -42,7 +42,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/composit
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -86,7 +86,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -137,8 +137,8 @@ Config: /user/username/projects/container/exec/tsconfig.json : {
 FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/tsconfig.json 2000 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Config file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/container/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Creating configuration project /user/username/projects/container/exec/tsconfig.json
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/index.ts 500 undefined WatchType: Closed Script info
@@ -147,7 +147,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/nod
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/can-successfully-find-references-with-out-option.js
+++ b/tests/baselines/reference/tsserver/projectReferences/can-successfully-find-references-with-out-option.js
@@ -1,0 +1,166 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/container/compositeExec/index.ts"}}
+Search path: /user/username/projects/container/compositeExec
+For info: /user/username/projects/container/compositeExec/index.ts :: Config file name: /user/username/projects/container/compositeExec/tsconfig.json
+Creating configuration project /user/username/projects/container/compositeExec/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/tsconfig.json 2000 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Config file
+Config: /user/username/projects/container/compositeExec/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/container/compositeExec/index.ts"
+ ],
+ "options": {
+  "outFile": "/user/username/projects/container/built/local/compositeExec.js",
+  "composite": true,
+  "declarationMap": true,
+  "configFilePath": "/user/username/projects/container/compositeExec/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/container/lib",
+   "originalPath": "../lib",
+   "prepend": true
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json
+Config: /user/username/projects/container/lib/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/container/lib/index.ts"
+ ],
+ "options": {
+  "outFile": "/user/username/projects/container/built/local/lib.js",
+  "composite": true,
+  "declarationMap": true,
+  "configFilePath": "/user/username/projects/container/lib/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/tsconfig.json 2000 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Config file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+	/user/username/projects/container/compositeExec/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../lib/index.ts
+	  Source from referenced project '../lib/tsconfig.json' included because '--outFile' specified
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+Search path: /user/username/projects/container/compositeExec
+For info: /user/username/projects/container/compositeExec/tsconfig.json :: Config file name: /user/username/projects/container/tsconfig.json
+Creating configuration project /user/username/projects/container/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/tsconfig.json 2000 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/container
+For info: /user/username/projects/container/tsconfig.json :: No config files found.
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/container/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/container/compositeExec/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/container/compositeExec/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"rename","arguments":{"file":"/user/username/projects/container/compositeExec/index.ts","line":3,"offset":16},"seq":1,"type":"request"}
+Search path: /user/username/projects/container/lib
+For info: /user/username/projects/container/lib/index.ts :: Config file name: /user/username/projects/container/lib/tsconfig.json
+Creating configuration project /user/username/projects/container/lib/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+Loading configured project /user/username/projects/container/tsconfig.json
+Config: /user/username/projects/container/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/container/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/container/exec",
+   "originalPath": "./exec"
+  },
+  {
+   "path": "/user/username/projects/container/compositeExec",
+   "originalPath": "./compositeExec"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/container/tsconfig.json
+Config: /user/username/projects/container/exec/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/container/exec/index.ts"
+ ],
+ "options": {
+  "outFile": "/user/username/projects/container/built/local/exec.js",
+  "configFilePath": "/user/username/projects/container/exec/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/container/lib",
+   "originalPath": "../lib",
+   "prepend": true
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/tsconfig.json 2000 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Creating configuration project /user/username/projects/container/exec/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/index.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+	/user/username/projects/container/exec/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../lib/index.ts
+	  Source from referenced project '../lib/tsconfig.json' included because '--outFile' specified
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+response:{"response":{"info":{"canRename":true,"displayName":"myConst","fullDisplayName":"container.myConst","kind":"const","kindModifiers":"export","triggerSpan":{"start":{"line":3,"offset":16},"end":{"line":3,"offset":23}}},"locs":[{"file":"/user/username/projects/container/lib/index.ts","locs":[{"start":{"line":2,"offset":18},"end":{"line":2,"offset":25},"contextStart":{"line":2,"offset":5},"contextEnd":{"line":2,"offset":31}}]},{"file":"/user/username/projects/container/compositeExec/index.ts","locs":[{"start":{"line":3,"offset":16},"end":{"line":3,"offset":23}}]},{"file":"/user/username/projects/container/exec/index.ts","locs":[{"start":{"line":3,"offset":16},"end":{"line":3,"offset":23}}]}]},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
@@ -1,0 +1,532 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":0,"tsSize":0,"tsx":0,"tsxSize":0,"dts":0,"dtsSize":0,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"75d5ba36c0a162a329bf40235b10e96d2d129b95469e1f02c08da775fb38a2b4","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":77,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+
+getDefaultProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+findDefaultConfiguredProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+reload projects.
+Scheduled: /dev/null/inferredProject1*
+Scheduled: /user/username/projects/myproject/tsconfig-src.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/tsconfig-src.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"User requested reload projects"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig.json","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"User requested reload projects"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig-src.json","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
@@ -77,8 +77,8 @@ Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -92,7 +92,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -136,7 +136,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -200,7 +200,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -334,8 +334,8 @@ Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 Creating configuration project /user/username/projects/myproject/tsconfig-src.json
@@ -346,7 +346,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/f
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -466,8 +466,8 @@ Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
 }
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -481,8 +481,8 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
 event:
@@ -510,8 +510,8 @@ Open files:
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 After ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (0)

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
@@ -55,8 +55,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 un
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -71,7 +71,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/f
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -117,7 +117,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -181,7 +181,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -295,8 +295,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 un
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
@@ -308,7 +308,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -411,8 +411,8 @@ Config: /user/username/projects/myproject/tsconfig-src.json : {
 }
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -426,8 +426,8 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
 event:
@@ -455,8 +455,8 @@ Open files:
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 After ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (0)

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
@@ -1,0 +1,477 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":0,"tsSize":0,"tsx":0,"tsxSize":0,"dts":0,"dtsSize":0,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"9ccc3aed1af08832ccb25ea453f7b771199f56af238b53cc428549dbd2d59246","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":"","disableReferencedProjectLoad":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-indirect1.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-indirect1.json
+
+getDefaultProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-indirect1.json
+findDefaultConfiguredProject for /user/username/projects/myproject/src/main.ts: undefined
+
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-indirect1.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-indirect1.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-indirect1.json
+reload projects.
+Scheduled: /dev/null/inferredProject1*
+Scheduled: /user/username/projects/myproject/tsconfig-indirect1.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/tsconfig-indirect1.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig-indirect1.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"User requested reload projects"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig.json","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig-indirect1.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json","reason":"User requested reload projects"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig-indirect1.json","configFile":"/user/username/projects/myproject/tsconfig-indirect1.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-indirect1.json
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-indirect1.json

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
@@ -37,8 +37,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 un
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -59,7 +59,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -93,7 +93,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject2*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject2*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -161,7 +161,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject2*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject2*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -241,8 +241,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 un
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -260,7 +260,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject3* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject3* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject3*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -332,8 +332,8 @@ Config: /user/username/projects/myproject/tsconfig-src.json : {
 }
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -369,8 +369,8 @@ Open files:
 Starting updateGraphWorker: Project: /dev/null/inferredProject2*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 3 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Starting updateGraphWorker: Project: /dev/null/inferredProject3*
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
@@ -380,8 +380,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject3* Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject3* Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 After ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (0)

--- a/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
+++ b/tests/baselines/reference/tsserver/projectReferences/disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
@@ -1,0 +1,402 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":0,"tsSize":0,"tsx":0,"tsxSize":0,"dts":0,"dtsSize":0,"deferred":0,"deferredSize":0},"compilerOptions":{"disableReferencedProjectLoad":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	main.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+
+getDefaultProject for /user/username/projects/myproject/src/main.ts: /dev/null/inferredProject1*
+findDefaultConfiguredProject for /user/username/projects/myproject/src/main.ts: undefined
+
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject2*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject2*
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject2*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject2*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	main.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject2*
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject3*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject3* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject3*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	main.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject3*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject2*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject3*
+reload projects.
+Scheduled: /dev/null/inferredProject2*
+Scheduled: /dev/null/inferredProject3*
+Scheduled: *ensureProjectForOpenFiles*
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"User requested reload projects"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig.json","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject3*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject2*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject3*
+Starting updateGraphWorker: Project: /dev/null/inferredProject2*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 3 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Starting updateGraphWorker: Project: /dev/null/inferredProject3*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /dev/null/inferredProject3* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject3* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject3* Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject3*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject2*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject3*

--- a/tests/baselines/reference/tsserver/projectReferences/does-not-error-on-container-only-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/does-not-error-on-container-only-project.js
@@ -40,7 +40,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/composit
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -81,7 +81,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/nod
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -104,7 +104,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -139,8 +139,8 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/container/tsconfig.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/container/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/container/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/a/lib/lib.d.ts"},"seq":1,"type":"request"}
 response:{"response":[],"responseRequired":true}
 request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/a/lib/lib.d.ts"},"seq":2,"type":"request"}

--- a/tests/baselines/reference/tsserver/projectReferences/does-not-error-on-container-only-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/does-not-error-on-container-only-project.js
@@ -1,0 +1,177 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Creating configuration project /user/username/projects/container/compositeExec/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/tsconfig.json 2000 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Config file
+Config: /user/username/projects/container/compositeExec/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/container/compositeExec/index.ts"
+ ],
+ "options": {
+  "outFile": "/user/username/projects/container/built/local/compositeExec.js",
+  "composite": true,
+  "declarationMap": true,
+  "configFilePath": "/user/username/projects/container/compositeExec/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/container/lib",
+   "originalPath": "../lib",
+   "prepend": true
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/index.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json
+Config: /user/username/projects/container/lib/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/container/lib/index.ts"
+ ],
+ "options": {
+  "outFile": "/user/username/projects/container/built/local/lib.js",
+  "composite": true,
+  "declarationMap": true,
+  "configFilePath": "/user/username/projects/container/lib/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/tsconfig.json 2000 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Config file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/compositeExec/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/compositeExec/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/compositeExec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/container/compositeExec/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+	/user/username/projects/container/compositeExec/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../lib/index.ts
+	  Source from referenced project '../lib/tsconfig.json' included because '--outFile' specified
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+Creating configuration project /user/username/projects/container/exec/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/tsconfig.json 2000 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Config file
+Config: /user/username/projects/container/exec/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/container/exec/index.ts"
+ ],
+ "options": {
+  "outFile": "/user/username/projects/container/built/local/exec.js",
+  "configFilePath": "/user/username/projects/container/exec/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/container/lib",
+   "originalPath": "../lib",
+   "prepend": true
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/index.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/exec/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/exec/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/exec/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/container/exec/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+	/user/username/projects/container/exec/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../lib/index.ts
+	  Source from referenced project '../lib/tsconfig.json' included because '--outFile' specified
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+Creating configuration project /user/username/projects/container/lib/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/lib/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/lib/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/lib/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/container/lib/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/container/lib/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	index.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+Creating configuration project /user/username/projects/container/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/container/tsconfig.json 2000 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Config file
+Config: /user/username/projects/container/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/container/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/container/exec",
+   "originalPath": "./exec"
+  },
+  {
+   "path": "/user/username/projects/container/compositeExec",
+   "originalPath": "./compositeExec"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/container/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/container/node_modules/@types 1 undefined Project: /user/username/projects/container/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/container/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/a/lib/lib.d.ts"},"seq":1,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/a/lib/lib.d.ts"},"seq":2,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/lib/tsconfig.json","projectFileName":"/user/username/projects/container/lib/tsconfig.json"},"seq":3,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/lib/tsconfig.json","projectFileName":"/user/username/projects/container/lib/tsconfig.json"},"seq":4,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/lib/index.ts"},"seq":5,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/lib/index.ts"},"seq":6,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/exec/tsconfig.json","projectFileName":"/user/username/projects/container/exec/tsconfig.json"},"seq":7,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/exec/tsconfig.json","projectFileName":"/user/username/projects/container/exec/tsconfig.json"},"seq":8,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/exec/index.ts"},"seq":9,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/exec/index.ts"},"seq":10,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/compositeExec/tsconfig.json","projectFileName":"/user/username/projects/container/compositeExec/tsconfig.json"},"seq":11,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/compositeExec/tsconfig.json","projectFileName":"/user/username/projects/container/compositeExec/tsconfig.json"},"seq":12,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/compositeExec/index.ts"},"seq":13,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/compositeExec/index.ts"},"seq":14,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/tsconfig.json","projectFileName":"/user/username/projects/container/tsconfig.json"},"seq":15,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"semanticDiagnosticsSync","arguments":{"file":"/user/username/projects/container/tsconfig.json","projectFileName":"/user/username/projects/container/tsconfig.json"},"seq":16,"type":"request"}
+response:{"response":[],"responseRequired":true}
+request:{"command":"compilerOptionsDiagnostics-full","arguments":{"projectFileName":"/user/username/projects/container/tsconfig.json"},"seq":17,"type":"request"}
+response:{"response":[],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/finding-local-reference-doesnt-load-ancestor/sibling-projects.js
+++ b/tests/baselines/reference/tsserver/projectReferences/finding-local-reference-doesnt-load-ancestor/sibling-projects.js
@@ -23,7 +23,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/compiler/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/compiler/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/compiler/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -97,8 +97,8 @@ Config: /user/username/projects/solution/services/tsconfig.json : {
 FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/services/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Creating configuration project /user/username/projects/solution/services/tsconfig.json
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/services/services.ts 500 undefined WatchType: Closed Script info
@@ -107,7 +107,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/services/
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/services/node_modules/@types 1 undefined Project: /user/username/projects/solution/services/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/services/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/services/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/services/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/services/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/services/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/finding-local-reference-doesnt-load-ancestor/sibling-projects.js
+++ b/tests/baselines/reference/tsserver/projectReferences/finding-local-reference-doesnt-load-ancestor/sibling-projects.js
@@ -1,0 +1,132 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/solution/compiler/program.ts"}}
+Search path: /user/username/projects/solution/compiler
+For info: /user/username/projects/solution/compiler/program.ts :: Config file name: /user/username/projects/solution/compiler/tsconfig.json
+Creating configuration project /user/username/projects/solution/compiler/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/tsconfig.json 2000 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Config file
+Config: /user/username/projects/solution/compiler/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/compiler/types.ts",
+  "/user/username/projects/solution/compiler/program.ts"
+ ],
+ "options": {
+  "composite": true,
+  "module": 0,
+  "configFilePath": "/user/username/projects/solution/compiler/tsconfig.json"
+ }
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/types.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/solution/compiler/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/compiler/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/compiler/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/compiler/types.ts
+	/user/username/projects/solution/compiler/program.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	types.ts
+	  Part of 'files' list in tsconfig.json
+	program.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/compiler
+For info: /user/username/projects/solution/compiler/tsconfig.json :: Config file name: /user/username/projects/solution/tsconfig.json
+Creating configuration project /user/username/projects/solution/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/solution
+For info: /user/username/projects/solution/tsconfig.json :: No config files found.
+Project '/user/username/projects/solution/compiler/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/solution/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/solution/compiler/program.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/solution/compiler/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/solution/compiler/program.ts","line":4,"offset":48},"seq":1,"type":"request"}
+response:{"response":{"refs":[{"file":"/user/username/projects/solution/compiler/program.ts","start":{"line":4,"offset":48},"end":{"line":4,"offset":61},"lineText":"                        getSourceFiles: () => [getSourceFile()]","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/solution/compiler/program.ts","start":{"line":6,"offset":30},"end":{"line":6,"offset":43},"contextStart":{"line":6,"offset":21},"contextEnd":{"line":6,"offset":69},"lineText":"                    function getSourceFile() { return \"something\"; }","isWriteAccess":true,"isDefinition":true}],"symbolName":"getSourceFile","symbolStartOffset":48,"symbolDisplayString":"function getSourceFile(): string"},"responseRequired":true}
+request:{"command":"references","arguments":{"file":"/user/username/projects/solution/compiler/program.ts","line":4,"offset":25},"seq":2,"type":"request"}
+Loading configured project /user/username/projects/solution/tsconfig.json
+Config: /user/username/projects/solution/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/solution/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/compiler",
+   "originalPath": "./compiler"
+  },
+  {
+   "path": "/user/username/projects/solution/services",
+   "originalPath": "./services"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json
+Config: /user/username/projects/solution/services/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/services/services.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/solution/services/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/compiler",
+   "originalPath": "../compiler"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/services/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Creating configuration project /user/username/projects/solution/services/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/services/services.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/solution/services/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/services/node_modules/@types 1 undefined Project: /user/username/projects/solution/services/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/services/node_modules/@types 1 undefined Project: /user/username/projects/solution/services/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/services/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/services/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/services/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/services/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/compiler/types.ts
+	/user/username/projects/solution/compiler/program.ts
+	/user/username/projects/solution/services/services.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../compiler/types.ts
+	  Source from referenced project '../compiler/tsconfig.json' included because '--module' is specified as 'none'
+	../compiler/program.ts
+	  Source from referenced project '../compiler/tsconfig.json' included because '--module' is specified as 'none'
+	services.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/types.d.ts 2000 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Missing generated file
+Search path: /user/username/projects/solution/compiler
+For info: /user/username/projects/solution/compiler/types.ts :: Config file name: /user/username/projects/solution/compiler/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/solution/compiler/types.ts","start":{"line":4,"offset":25},"end":{"line":4,"offset":39},"contextStart":{"line":4,"offset":25},"contextEnd":{"line":4,"offset":52},"lineText":"                        getSourceFiles(): string[];","isWriteAccess":false,"isDefinition":true},{"file":"/user/username/projects/solution/compiler/program.ts","start":{"line":4,"offset":25},"end":{"line":4,"offset":39},"contextStart":{"line":4,"offset":25},"contextEnd":{"line":4,"offset":64},"lineText":"                        getSourceFiles: () => [getSourceFile()]","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/solution/services/services.ts","start":{"line":3,"offset":44},"end":{"line":3,"offset":58},"lineText":"                    const result = program.getSourceFiles();","isWriteAccess":false,"isDefinition":false}],"symbolName":"getSourceFiles","symbolStartOffset":25,"symbolDisplayString":"(method) ts.Program.getSourceFiles(): string[]"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built-with-preserveSymlinks.js
@@ -61,7 +61,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -111,8 +111,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built-with-preserveSymlinks.js
@@ -1,0 +1,123 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/index.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/index.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/index.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/bar.ts",
+  "/user/username/projects/myproject/packages/B/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/index.ts
+	/user/username/projects/myproject/packages/B/src/bar.ts
+	/user/username/projects/myproject/packages/A/src/index.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/index.ts
+	  Imported via 'b' from file 'src/index.ts'
+	../B/src/bar.ts
+	  Imported via 'b/lib/bar' from file 'src/index.ts'
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":122,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true,"preserveSymlinks":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/index.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/index.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built.js
@@ -1,0 +1,121 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/index.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/index.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/index.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/bar.ts",
+  "/user/username/projects/myproject/packages/B/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/index.ts
+	/user/username/projects/myproject/packages/B/src/bar.ts
+	/user/username/projects/myproject/packages/A/src/index.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/index.ts
+	  Imported via 'b' from file 'src/index.ts'
+	../B/src/bar.ts
+	  Imported via 'b/lib/bar' from file 'src/index.ts'
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":122,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/index.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/index.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-built.js
@@ -59,7 +59,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -109,8 +109,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built-with-preserveSymlinks.js
@@ -61,7 +61,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -111,8 +111,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built-with-preserveSymlinks.js
@@ -1,0 +1,123 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/index.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/index.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/index.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/bar.ts",
+  "/user/username/projects/myproject/packages/B/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/index.ts
+	/user/username/projects/myproject/packages/B/src/bar.ts
+	/user/username/projects/myproject/packages/A/src/index.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/index.ts
+	  Imported via 'b' from file 'src/index.ts'
+	../B/src/bar.ts
+	  Imported via 'b/lib/bar' from file 'src/index.ts'
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":122,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true,"preserveSymlinks":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/index.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/index.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built.js
@@ -1,0 +1,121 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/index.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/index.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/index.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/bar.ts",
+  "/user/username/projects/myproject/packages/B/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/index.ts
+	/user/username/projects/myproject/packages/B/src/bar.ts
+	/user/username/projects/myproject/packages/A/src/index.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/index.ts
+	  Imported via 'b' from file 'src/index.ts'
+	../B/src/bar.ts
+	  Imported via 'b/lib/bar' from file 'src/index.ts'
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":122,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/index.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/index.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-and-solution-is-not-built.js
@@ -59,7 +59,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -109,8 +109,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
@@ -61,7 +61,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -111,8 +111,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
@@ -1,0 +1,123 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/index.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/index.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/index.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/bar.ts",
+  "/user/username/projects/myproject/packages/B/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/index.ts
+	/user/username/projects/myproject/packages/B/src/bar.ts
+	/user/username/projects/myproject/packages/A/src/index.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/index.ts
+	  Imported via '@issue/b' from file 'src/index.ts'
+	../B/src/bar.ts
+	  Imported via '@issue/b/lib/bar' from file 'src/index.ts'
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":136,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true,"preserveSymlinks":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/index.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/index.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built.js
@@ -1,0 +1,121 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/index.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/index.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/index.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/bar.ts",
+  "/user/username/projects/myproject/packages/B/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/index.ts
+	/user/username/projects/myproject/packages/B/src/bar.ts
+	/user/username/projects/myproject/packages/A/src/index.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/index.ts
+	  Imported via '@issue/b' from file 'src/index.ts'
+	../B/src/bar.ts
+	  Imported via '@issue/b/lib/bar' from file 'src/index.ts'
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":136,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/index.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/index.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-built.js
@@ -59,7 +59,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -109,8 +109,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
@@ -61,7 +61,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -111,8 +111,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
@@ -1,0 +1,123 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/index.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/index.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/index.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/bar.ts",
+  "/user/username/projects/myproject/packages/B/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/index.ts
+	/user/username/projects/myproject/packages/B/src/bar.ts
+	/user/username/projects/myproject/packages/A/src/index.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/index.ts
+	  Imported via '@issue/b' from file 'src/index.ts'
+	../B/src/bar.ts
+	  Imported via '@issue/b/lib/bar' from file 'src/index.ts'
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":136,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true,"preserveSymlinks":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/index.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/index.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built.js
@@ -1,0 +1,121 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/index.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/index.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/index.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/bar.ts",
+  "/user/username/projects/myproject/packages/B/src/index.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/index.ts
+	/user/username/projects/myproject/packages/B/src/bar.ts
+	/user/username/projects/myproject/packages/A/src/index.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/index.ts
+	  Imported via '@issue/b' from file 'src/index.ts'
+	../B/src/bar.ts
+	  Imported via '@issue/b/lib/bar' from file 'src/index.ts'
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":136,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/index.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/index.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-packageJson-has-types-field-and-has-index.ts-with-scoped-package-and-solution-is-not-built.js
@@ -59,7 +59,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -109,8 +109,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/index.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/index.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built-with-preserveSymlinks.js
@@ -61,7 +61,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -111,8 +111,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built-with-preserveSymlinks.js
@@ -1,0 +1,123 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/test.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/test.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/test.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/test.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/foo.ts",
+  "/user/username/projects/myproject/packages/B/src/bar/foo.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/foo.ts
+	/user/username/projects/myproject/packages/B/src/bar/foo.ts
+	/user/username/projects/myproject/packages/A/src/test.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/foo.ts
+	  Imported via 'b/lib/foo' from file 'src/test.ts'
+	../B/src/bar/foo.ts
+	  Imported via 'b/lib/bar/foo' from file 'src/test.ts'
+	src/test.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true,"preserveSymlinks":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/test.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/test.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/test.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built.js
@@ -1,0 +1,121 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/test.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/test.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/test.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/test.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/foo.ts",
+  "/user/username/projects/myproject/packages/B/src/bar/foo.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/foo.ts
+	/user/username/projects/myproject/packages/B/src/bar/foo.ts
+	/user/username/projects/myproject/packages/A/src/test.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/foo.ts
+	  Imported via 'b/lib/foo' from file 'src/test.ts'
+	../B/src/bar/foo.ts
+	  Imported via 'b/lib/bar/foo' from file 'src/test.ts'
+	src/test.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/test.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/test.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/test.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-built.js
@@ -59,7 +59,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -109,8 +109,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built-with-preserveSymlinks.js
@@ -61,7 +61,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -111,8 +111,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built-with-preserveSymlinks.js
@@ -1,0 +1,123 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/test.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/test.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/test.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/test.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/foo.ts",
+  "/user/username/projects/myproject/packages/B/src/bar/foo.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/foo.ts
+	/user/username/projects/myproject/packages/B/src/bar/foo.ts
+	/user/username/projects/myproject/packages/A/src/test.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/foo.ts
+	  Imported via 'b/lib/foo' from file 'src/test.ts'
+	../B/src/bar/foo.ts
+	  Imported via 'b/lib/bar/foo' from file 'src/test.ts'
+	src/test.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true,"preserveSymlinks":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/test.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/test.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/test.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built.js
@@ -1,0 +1,121 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/test.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/test.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/test.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/test.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/foo.ts",
+  "/user/username/projects/myproject/packages/B/src/bar/foo.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/foo.ts
+	/user/username/projects/myproject/packages/B/src/bar/foo.ts
+	/user/username/projects/myproject/packages/A/src/test.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/foo.ts
+	  Imported via 'b/lib/foo' from file 'src/test.ts'
+	../B/src/bar/foo.ts
+	  Imported via 'b/lib/bar/foo' from file 'src/test.ts'
+	src/test.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/test.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/test.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/test.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-and-solution-is-not-built.js
@@ -59,7 +59,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -109,8 +109,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
@@ -61,7 +61,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -111,8 +111,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built-with-preserveSymlinks.js
@@ -1,0 +1,123 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/test.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/test.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/test.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/test.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/foo.ts",
+  "/user/username/projects/myproject/packages/B/src/bar/foo.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/foo.ts
+	/user/username/projects/myproject/packages/B/src/bar/foo.ts
+	/user/username/projects/myproject/packages/A/src/test.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/foo.ts
+	  Imported via '@issue/b/lib/foo' from file 'src/test.ts'
+	../B/src/bar/foo.ts
+	  Imported via '@issue/b/lib/bar/foo' from file 'src/test.ts'
+	src/test.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":148,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true,"preserveSymlinks":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/test.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/test.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/test.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built.js
@@ -59,7 +59,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -109,8 +109,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-built.js
@@ -1,0 +1,121 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/test.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/test.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/test.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/test.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/foo.ts",
+  "/user/username/projects/myproject/packages/B/src/bar/foo.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/foo.ts
+	/user/username/projects/myproject/packages/B/src/bar/foo.ts
+	/user/username/projects/myproject/packages/A/src/test.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/foo.ts
+	  Imported via '@issue/b/lib/foo' from file 'src/test.ts'
+	../B/src/bar/foo.ts
+	  Imported via '@issue/b/lib/bar/foo' from file 'src/test.ts'
+	src/test.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":148,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/test.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/test.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/test.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
@@ -61,7 +61,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -111,8 +111,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built-with-preserveSymlinks.js
@@ -1,0 +1,123 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/test.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/test.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/test.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/test.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/foo.ts",
+  "/user/username/projects/myproject/packages/B/src/bar/foo.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "preserveSymlinks": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/foo.ts
+	/user/username/projects/myproject/packages/B/src/bar/foo.ts
+	/user/username/projects/myproject/packages/A/src/test.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/foo.ts
+	  Imported via '@issue/b/lib/foo' from file 'src/test.ts'
+	../B/src/bar/foo.ts
+	  Imported via '@issue/b/lib/bar/foo' from file 'src/test.ts'
+	src/test.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":148,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true,"preserveSymlinks":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/test.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/test.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/test.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built.js
@@ -59,7 +59,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -109,8 +109,8 @@ response:{"response":true,"responseRequired":true}
 request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
 response:{"responseRequired":false}
 Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 2
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false structureIsReused:: Completely Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
 event:

--- a/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built.js
+++ b/tests/baselines/reference/tsserver/projectReferences/monorepo-like-with-symlinks-when-referencing-file-from-subFolder-with-scoped-package-and-solution-is-not-built.js
@@ -1,0 +1,121 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/A/src/test.ts"}}
+Search path: /user/username/projects/myproject/packages/A/src
+For info: /user/username/projects/myproject/packages/A/src/test.ts :: Config file name: /user/username/projects/myproject/packages/A/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/A/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/A/src/test.ts to open"}}
+Config: /user/username/projects/myproject/packages/A/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/A/src/test.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/A/lib",
+  "rootDir": "/user/username/projects/myproject/packages/A/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/A/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/B",
+   "originalPath": "../B"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/a/src 1 undefined Config: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Config: /user/username/projects/myproject/packages/B/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/B/src/foo.ts",
+  "/user/username/projects/myproject/packages/B/src/bar/foo.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/packages/B/lib",
+  "rootDir": "/user/username/projects/myproject/packages/B/src",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/packages/B/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/b/src 1 undefined Config: /user/username/projects/myproject/packages/B/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/B/src/bar/foo.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/src 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/A/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/A/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/B/src/foo.ts
+	/user/username/projects/myproject/packages/B/src/bar/foo.ts
+	/user/username/projects/myproject/packages/A/src/test.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../B/src/foo.ts
+	  Imported via '@issue/b/lib/foo' from file 'src/test.ts'
+	../B/src/bar/foo.ts
+	  Imported via '@issue/b/lib/bar/foo' from file 'src/test.ts'
+	src/test.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/A/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"8c5cfb88fb6a6125ddaca4c198af63d261c8feb2786e348cbf3223fcf8461e16","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":148,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","rootDir":"","composite":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/A/src/test.ts","configFile":"/user/username/projects/myproject/packages/A/tsconfig.json","diagnostics":[]}}
+Search path: /user/username/projects/myproject/packages/A
+For info: /user/username/projects/myproject/packages/A/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/packages/A/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/A/src/test.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/A/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+request:{"command":"updateOpen","arguments":{"changedFiles":[{"fileName":"/user/username/projects/myproject/packages/A/src/test.ts","textChanges":[{"newText":"\n","start":{"line":5,"offset":1},"end":{"line":5,"offset":1}}]}]},"seq":2,"type":"request"}
+response:{"response":true,"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/A/src/test.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/A/tsconfig.json Version: 2 structureChanged: false Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 2
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/A/src/test.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-not-open-with-disableSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-not-open-with-disableSourceOfProjectReferenceRedirect.js
@@ -1,0 +1,244 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/projects/project2/class2.ts"}}
+Search path: /user/username/projects/myproject/projects/project2
+For info: /user/username/projects/myproject/projects/project2/class2.ts :: Config file name: /user/username/projects/myproject/projects/project2/tsconfig.json
+Creating configuration project /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/projects/project2/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/projects/project2/class2.ts"
+ ],
+ "options": {
+  "module": 0,
+  "composite": true,
+  "disableSourceOfProjectReferenceRedirect": true,
+  "configFilePath": "/user/username/projects/myproject/projects/project2/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/projects/project1",
+   "originalPath": "../project1"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Config: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Config: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+Config: /user/username/projects/myproject/projects/project1/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/projects/project1/class1.ts"
+ ],
+ "options": {
+  "module": 0,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/projects/project1/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class1.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.d.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/projects/project2
+For info: /user/username/projects/myproject/projects/project2/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/projects/project2/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/projects/project2/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 0:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+Scheduled: /user/username/projects/myproject/projects/project2/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 0:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/projects/project2/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.d.ts
+	/user/username/projects/myproject/projects/project1/class3.d.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	../project1/class3.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected excluded file: /user/username/projects/myproject/projects/project1/temp
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp/file.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected excluded file: /user/username/projects/myproject/projects/project1/temp/file.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp/file.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 2:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
+Scheduled: /user/username/projects/myproject/projects/project2/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 2:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/projects/project2/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 4 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.d.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 0:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+Scheduled: /user/username/projects/myproject/projects/project2/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 0:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/projects/project2/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 5 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.d.ts
+	/user/username/projects/myproject/projects/project1/class3.d.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	../project1/class3.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-not-open-with-disableSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-not-open-with-disableSourceOfProjectReferenceRedirect.js
@@ -46,7 +46,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -79,8 +79,8 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Running: /user/username/projects/myproject/projects/project2/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Running: *ensureProjectForOpenFiles*
 Before ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
@@ -109,7 +109,7 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Running: /user/username/projects/myproject/projects/project2/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -162,7 +162,7 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Running: /user/username/projects/myproject/projects/project2/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 4 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 4 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -206,7 +206,7 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Running: /user/username/projects/myproject/projects/project2/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 5 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 5 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-not-open.js
+++ b/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-not-open.js
@@ -45,7 +45,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -78,7 +78,7 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Running: /user/username/projects/myproject/projects/project2/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.ts 500 undefined WatchType: Closed Script info
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-not-open.js
+++ b/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-not-open.js
@@ -1,0 +1,125 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/projects/project2/class2.ts"}}
+Search path: /user/username/projects/myproject/projects/project2
+For info: /user/username/projects/myproject/projects/project2/class2.ts :: Config file name: /user/username/projects/myproject/projects/project2/tsconfig.json
+Creating configuration project /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/projects/project2/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/projects/project2/class2.ts"
+ ],
+ "options": {
+  "module": 0,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/projects/project2/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/projects/project1",
+   "originalPath": "../project1"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Config: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Config: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+Config: /user/username/projects/myproject/projects/project1/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/projects/project1/class1.ts"
+ ],
+ "options": {
+  "module": 0,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/projects/project1/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class1.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.ts
+	  Source from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/projects/project2
+For info: /user/username/projects/myproject/projects/project2/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/projects/project2/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/projects/project2/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.ts 500 undefined WatchType: Closed Script info
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.ts
+	/user/username/projects/myproject/projects/project1/class3.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.ts
+	  Source from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	../project1/class3.ts
+	  Source from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected excluded file: /user/username/projects/myproject/projects/project1/temp
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp/file.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected excluded file: /user/username/projects/myproject/projects/project1/temp/file.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp/file.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-open-with-disableSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-open-with-disableSourceOfProjectReferenceRedirect.js
@@ -1,0 +1,354 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/projects/project2/class2.ts"}}
+Search path: /user/username/projects/myproject/projects/project2
+For info: /user/username/projects/myproject/projects/project2/class2.ts :: Config file name: /user/username/projects/myproject/projects/project2/tsconfig.json
+Creating configuration project /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/projects/project2/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/projects/project2/class2.ts"
+ ],
+ "options": {
+  "module": 0,
+  "composite": true,
+  "disableSourceOfProjectReferenceRedirect": true,
+  "configFilePath": "/user/username/projects/myproject/projects/project2/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/projects/project1",
+   "originalPath": "../project1"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Config: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Config: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+Config: /user/username/projects/myproject/projects/project1/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/projects/project1/class1.ts"
+ ],
+ "options": {
+  "module": 0,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/projects/project1/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class1.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.d.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/projects/project2
+For info: /user/username/projects/myproject/projects/project2/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/projects/project1/class1.ts"}}
+Search path: /user/username/projects/myproject/projects/project1
+For info: /user/username/projects/myproject/projects/project1/class1.ts :: Config file name: /user/username/projects/myproject/projects/project1/tsconfig.json
+Creating configuration project /user/username/projects/myproject/projects/project1/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	class1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/projects/project1
+For info: /user/username/projects/myproject/projects/project1/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project1/tsconfig.json
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/projects/project2/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/projects/project1/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/projects/project2/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Running: /user/username/projects/myproject/projects/project1/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.ts
+	/user/username/projects/myproject/projects/project1/class3.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	class1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	class3.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project1/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project1/tsconfig.json
+FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 0:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+Scheduled: /user/username/projects/myproject/projects/project2/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 0:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/projects/project2/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.d.ts
+	/user/username/projects/myproject/projects/project1/class3.d.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	../project1/class3.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project1/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project1/tsconfig.json
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected excluded file: /user/username/projects/myproject/projects/project1/temp
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp/file.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected excluded file: /user/username/projects/myproject/projects/project1/temp/file.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp/file.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 2:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
+Scheduled: /user/username/projects/myproject/projects/project2/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 2:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/projects/project2/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 4 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.d.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project1/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project1/tsconfig.json
+FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 0:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+Scheduled: /user/username/projects/myproject/projects/project2/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts 0:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/projects/project2/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 5 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.d.ts
+	/user/username/projects/myproject/projects/project1/class3.d.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	../project1/class3.d.ts
+	  Output from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project1/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project1/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-open-with-disableSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-open-with-disableSourceOfProjectReferenceRedirect.js
@@ -46,7 +46,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -84,7 +84,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -122,12 +122,12 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Running: /user/username/projects/myproject/projects/project2/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Running: /user/username/projects/myproject/projects/project1/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.ts 500 undefined WatchType: Closed Script info
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -183,7 +183,7 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Running: /user/username/projects/myproject/projects/project2/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -248,7 +248,7 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Running: /user/username/projects/myproject/projects/project2/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Missing file
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 4 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 4 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -304,7 +304,7 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Running: /user/username/projects/myproject/projects/project2/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined WatchType: Closed Script info
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 5 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 5 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-open.js
+++ b/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-open.js
@@ -45,7 +45,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -84,7 +84,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -122,7 +122,7 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Running: /user/username/projects/myproject/projects/project2/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.ts 500 undefined WatchType: Closed Script info
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -143,7 +143,7 @@ Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Con
 -----------------------------------------------
 Running: /user/username/projects/myproject/projects/project1/tsconfig.json
 Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-open.js
+++ b/tests/baselines/reference/tsserver/projectReferences/new-file-is-added-to-the-referenced-project-when-referenced-project-is-open.js
@@ -1,0 +1,199 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/projects/project2/class2.ts"}}
+Search path: /user/username/projects/myproject/projects/project2
+For info: /user/username/projects/myproject/projects/project2/class2.ts :: Config file name: /user/username/projects/myproject/projects/project2/tsconfig.json
+Creating configuration project /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/projects/project2/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/projects/project2/class2.ts"
+ ],
+ "options": {
+  "module": 0,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/projects/project2/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/projects/project1",
+   "originalPath": "../project1"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Config: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2 1 undefined Config: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+Config: /user/username/projects/myproject/projects/project1/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/projects/project1/class1.ts"
+ ],
+ "options": {
+  "module": 0,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/projects/project1/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class1.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project2/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.ts
+	  Source from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/projects/project2
+For info: /user/username/projects/myproject/projects/project2/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/projects/project1/class1.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class1.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/projects/project1
+For info: /user/username/projects/myproject/projects/project1/class1.ts :: Config file name: /user/username/projects/myproject/projects/project1/tsconfig.json
+Creating configuration project /user/username/projects/myproject/projects/project1/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	class1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/projects/project1
+For info: /user/username/projects/myproject/projects/project1/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json,/user/username/projects/myproject/projects/project1/tsconfig.json
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Scheduled: /user/username/projects/myproject/projects/project2/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/projects/project1/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Running: /user/username/projects/myproject/projects/project2/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.ts 500 undefined WatchType: Closed Script info
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project2/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.ts
+	/user/username/projects/myproject/projects/project1/class3.ts
+	/user/username/projects/myproject/projects/project2/class2.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../project1/class1.ts
+	  Source from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	../project1/class3.ts
+	  Source from referenced project '../project1/tsconfig.json' included because '--module' is specified as 'none'
+	class2.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: /user/username/projects/myproject/projects/project1/tsconfig.json
+Starting updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/projects/project1/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/projects/project1/class1.ts
+	/user/username/projects/myproject/projects/project1/class3.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	class1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	class3.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json,/user/username/projects/myproject/projects/project1/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/projects/project2/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/projects/project1/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/projects/project2/class2.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json
+	FileName: /user/username/projects/myproject/projects/project1/class1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/projects/project2/tsconfig.json,/user/username/projects/myproject/projects/project1/tsconfig.json
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected excluded file: /user/username/projects/myproject/projects/project1/temp
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp/file.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected excluded file: /user/username/projects/myproject/projects/project1/temp/file.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/temp/file.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory
+Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Config: /user/username/projects/myproject/projects/project1/tsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/projectReferences/project-is-directly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/project-is-directly-referenced-by-solution.js
@@ -1,0 +1,689 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":0,"tsSize":0,"tsx":0,"tsxSize":0,"dts":0,"dtsSize":0,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"75d5ba36c0a162a329bf40235b10e96d2d129b95469e1f02c08da775fb38a2b4","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":77,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+
+getDefaultProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+findDefaultConfiguredProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+reload projects.
+Scheduled: /dev/null/inferredProject1*
+Scheduled: /user/username/projects/myproject/tsconfig-src.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/tsconfig-src.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"User requested reload projects"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig.json","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"User requested reload projects"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig-src.json","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/src/main.ts","line":2,"offset":10},"seq":2,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/helpers/functions.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/helpers/functions.d.ts.map 500 undefined WatchType: Closed Script info
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":41},"lineText":"import { foo } from 'helpers/functions';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":2,"offset":10},"end":{"line":2,"offset":13},"contextStart":{"line":2,"offset":1},"contextEnd":{"line":2,"offset":16},"lineText":"export { foo };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/helpers/functions.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":17},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":22},"lineText":"export const foo = 1;","isWriteAccess":true,"isDefinition":true}],"symbolName":"foo","symbolStartOffset":10,"symbolDisplayString":"(alias) const foo: 1\nexport foo"},"responseRequired":true}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+Search path: /user/username/projects/myproject/indirect3
+For info: /user/username/projects/myproject/indirect3/main.ts :: Config file name: /user/username/projects/myproject/indirect3/tsconfig.json
+Creating configuration project /user/username/projects/myproject/indirect3/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/indirect3/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/indirect3/main.ts to open"}}
+Config: /user/username/projects/myproject/indirect3/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect3/main.ts"
+ ],
+ "options": {
+  "baseUrl": "/user/username/projects/myproject/target/src",
+  "configFilePath": "/user/username/projects/myproject/indirect3/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3 1 undefined Config: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3 1 undefined Config: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/main.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/target/src/helpers/functions.d.ts
+	/user/username/projects/myproject/target/src/main.d.ts
+	/user/username/projects/myproject/indirect3/main.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../target/src/helpers/functions.d.ts
+	  Imported via 'helpers/functions' from file '../target/src/main.d.ts'
+	../target/src/main.d.ts
+	  Imported via 'main' from file 'main.ts'
+	main.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/indirect3/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"5b0817f69b6871821661b976aa73f4f2533b37c5f4b920541094c2d727d0dc39","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":57,"tsx":0,"tsxSize":0,"dts":3,"dtsSize":494,"deferred":0,"deferredSize":0},"compilerOptions":{"baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/indirect3/main.ts","configFile":"/user/username/projects/myproject/indirect3/tsconfig.json","diagnostics":[]}}
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+`remove Project::
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/indirect3/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/indirect3/tsconfig.json
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/indirect3/main.ts","line":1,"offset":10},"seq":3,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/main.d.ts.map 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating project for original file: /user/username/projects/myproject/src/main.ts for location: /user/username/projects/myproject/target/src/main.d.ts"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for original file: /user/username/projects/myproject/src/main.ts for location: /user/username/projects/myproject/target/src/main.d.ts"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/indirect3/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect3/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":41},"lineText":"import { foo } from 'helpers/functions';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":2,"offset":10},"end":{"line":2,"offset":13},"contextStart":{"line":2,"offset":1},"contextEnd":{"line":2,"offset":16},"lineText":"export { foo };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/helpers/functions.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":17},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":22},"lineText":"export const foo = 1;","isWriteAccess":true,"isDefinition":true}],"symbolName":"foo","symbolStartOffset":10,"symbolDisplayString":"(alias) const foo: 1\nimport foo"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/project-is-directly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/project-is-directly-referenced-by-solution.js
@@ -36,8 +36,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 un
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -51,7 +51,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -105,7 +105,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -169,7 +169,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -260,8 +260,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 un
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 Creating configuration project /user/username/projects/myproject/tsconfig-src.json
@@ -272,7 +272,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/f
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -330,7 +330,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -401,8 +401,8 @@ Config: /user/username/projects/myproject/tsconfig-src.json : {
 }
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -416,8 +416,8 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
 event:
@@ -447,8 +447,8 @@ Open files:
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 After ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (0)
@@ -527,7 +527,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -648,8 +648,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 un
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 Creating configuration project /user/username/projects/myproject/tsconfig-src.json
@@ -659,7 +659,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/project-is-indirectly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/project-is-indirectly-referenced-by-solution.js
@@ -1,0 +1,1053 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":0,"tsSize":0,"tsx":0,"tsxSize":0,"dts":0,"dtsSize":0,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"75d5ba36c0a162a329bf40235b10e96d2d129b95469e1f02c08da775fb38a2b4","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":77,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+
+getDefaultProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+findDefaultConfiguredProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+reload projects.
+Scheduled: /dev/null/inferredProject1*
+Scheduled: /user/username/projects/myproject/tsconfig-src.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/tsconfig-src.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"User requested reload projects"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig.json","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"User requested reload projects"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig-src.json","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/src/main.ts","line":2,"offset":10},"seq":2,"type":"request"}
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json","reason":"Creating project referenced by : /user/username/projects/myproject/tsconfig.json as it references project /user/username/projects/myproject/tsconfig-src.json"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"9ccc3aed1af08832ccb25ea453f7b771199f56af238b53cc428549dbd2d59246","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect2.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect2.json","reason":"Creating project referenced by : /user/username/projects/myproject/tsconfig.json as it references project /user/username/projects/myproject/tsconfig-src.json"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect2/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect2/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect2/main.ts'
+	indirect2/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect2.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"d9a040bddd6b85b85abd507a988a4b809b1515b5e61257ea3f8263da59589565","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/helpers/functions.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/helpers/functions.d.ts.map 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":41},"lineText":"import { foo } from 'helpers/functions';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":2,"offset":10},"end":{"line":2,"offset":13},"contextStart":{"line":2,"offset":1},"contextEnd":{"line":2,"offset":16},"lineText":"export { foo };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/helpers/functions.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":17},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":22},"lineText":"export const foo = 1;","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect1/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect1/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/indirect2/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect2/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false}],"symbolName":"foo","symbolStartOffset":10,"symbolDisplayString":"(alias) const foo: 1\nexport foo"},"responseRequired":true}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+Search path: /user/username/projects/myproject/indirect3
+For info: /user/username/projects/myproject/indirect3/main.ts :: Config file name: /user/username/projects/myproject/indirect3/tsconfig.json
+Creating configuration project /user/username/projects/myproject/indirect3/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/indirect3/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/indirect3/main.ts to open"}}
+Config: /user/username/projects/myproject/indirect3/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect3/main.ts"
+ ],
+ "options": {
+  "baseUrl": "/user/username/projects/myproject/target/src",
+  "configFilePath": "/user/username/projects/myproject/indirect3/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3 1 undefined Config: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3 1 undefined Config: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/main.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/target/src/helpers/functions.d.ts
+	/user/username/projects/myproject/target/src/main.d.ts
+	/user/username/projects/myproject/indirect3/main.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../target/src/helpers/functions.d.ts
+	  Imported via 'helpers/functions' from file '../target/src/main.d.ts'
+	../target/src/main.d.ts
+	  Imported via 'main' from file 'main.ts'
+	main.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/indirect3/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"5b0817f69b6871821661b976aa73f4f2533b37c5f4b920541094c2d727d0dc39","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":57,"tsx":0,"tsxSize":0,"dts":3,"dtsSize":494,"deferred":0,"deferredSize":0},"compilerOptions":{"baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/indirect3/main.ts","configFile":"/user/username/projects/myproject/indirect3/tsconfig.json","diagnostics":[]}}
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (0)
+
+
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect2/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect2/main.ts'
+	indirect2/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+`remove Project::
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/indirect2/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/indirect3/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/indirect3/tsconfig.json
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/indirect3/main.ts","line":1,"offset":10},"seq":3,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/main.d.ts.map 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating project for original file: /user/username/projects/myproject/src/main.ts for location: /user/username/projects/myproject/target/src/main.d.ts"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for original file: /user/username/projects/myproject/src/main.ts for location: /user/username/projects/myproject/target/src/main.d.ts"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json","reason":"Creating project referenced by : /user/username/projects/myproject/tsconfig.json as it references project /user/username/projects/myproject/tsconfig-src.json"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect2.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect2.json","reason":"Creating project referenced by : /user/username/projects/myproject/tsconfig.json as it references project /user/username/projects/myproject/tsconfig-src.json"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect2/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect2/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect2/main.ts'
+	indirect2/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect2.json"}}
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/indirect3/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect3/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":41},"lineText":"import { foo } from 'helpers/functions';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":2,"offset":10},"end":{"line":2,"offset":13},"contextStart":{"line":2,"offset":1},"contextEnd":{"line":2,"offset":16},"lineText":"export { foo };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/helpers/functions.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":17},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":22},"lineText":"export const foo = 1;","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect1/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect1/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/indirect2/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect2/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false}],"symbolName":"foo","symbolStartOffset":10,"symbolDisplayString":"(alias) const foo: 1\nimport foo"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/project-is-indirectly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/project-is-indirectly-referenced-by-solution.js
@@ -76,8 +76,8 @@ Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -91,7 +91,7 @@ Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -145,7 +145,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -209,7 +209,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -342,8 +342,8 @@ Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 Creating configuration project /user/username/projects/myproject/tsconfig-src.json
@@ -354,7 +354,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/f
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -412,7 +412,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -521,8 +521,8 @@ Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
 }
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -536,8 +536,8 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
 event:
@@ -567,8 +567,8 @@ Open files:
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 After ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (0)
@@ -596,7 +596,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/mai
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -627,7 +627,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect2/mai
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -733,7 +733,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -940,8 +940,8 @@ Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 Creating configuration project /user/username/projects/myproject/tsconfig-src.json
@@ -951,7 +951,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -986,7 +986,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/mai
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -1015,7 +1015,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect2/mai
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project-and-using-declaration-maps.js
+++ b/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project-and-using-declaration-maps.js
@@ -1,0 +1,153 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/project/src/common/input/keyboard.ts"}}
+Search path: /user/username/projects/project/src/common/input
+For info: /user/username/projects/project/src/common/input/keyboard.ts :: Config file name: /user/username/projects/project/src/common/tsconfig.json
+Creating configuration project /user/username/projects/project/src/common/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common/tsconfig.json 2000 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Config file
+Config: /user/username/projects/project/src/common/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/project/src/common/input/keyboard.test.ts",
+  "/user/username/projects/project/src/common/input/keyboard.ts"
+ ],
+ "options": {
+  "composite": true,
+  "declarationMap": true,
+  "outDir": "/user/username/projects/project/out",
+  "baseUrl": "/user/username/projects/project/src",
+  "disableSourceOfProjectReferenceRedirect": true,
+  "configFilePath": "/user/username/projects/project/src/common/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common 1 undefined Config: /user/username/projects/project/src/common/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common 1 undefined Config: /user/username/projects/project/src/common/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common/input/keyboard.test.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/project/src/common/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/project/src/common/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/project/src/common/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/project/src/common/input/keyboard.ts
+	/user/username/projects/project/src/common/input/keyboard.test.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	input/keyboard.ts
+	  Imported via 'common/input/keyboard' from file 'input/keyboard.test.ts'
+	  Matched by include pattern './**/*' in 'tsconfig.json'
+	input/keyboard.test.ts
+	  Matched by include pattern './**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/project/src/common
+For info: /user/username/projects/project/src/common/tsconfig.json :: Config file name: /user/username/projects/project/src/tsconfig.json
+Creating configuration project /user/username/projects/project/src/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/project/src/tsconfig.json 2000 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/project/src
+For info: /user/username/projects/project/src/tsconfig.json :: No config files found.
+Project '/user/username/projects/project/src/common/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/project/src/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/project/src/common/input/keyboard.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/project/src/common/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/project/src/terminal.ts"}}
+Search path: /user/username/projects/project/src
+For info: /user/username/projects/project/src/terminal.ts :: Config file name: /user/username/projects/project/src/tsconfig.json
+Loading configured project /user/username/projects/project/src/tsconfig.json
+Config: /user/username/projects/project/src/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/project/src/terminal.ts",
+  "/user/username/projects/project/src/common/input/keyboard.test.ts",
+  "/user/username/projects/project/src/common/input/keyboard.ts"
+ ],
+ "options": {
+  "composite": true,
+  "declarationMap": true,
+  "outDir": "/user/username/projects/project/out",
+  "baseUrl": "/user/username/projects/project/src",
+  "paths": {
+   "common/*": [
+    "./common/*"
+   ]
+  },
+  "tsBuildInfoFile": "/user/username/projects/project/out/src.tsconfig.tsbuildinfo",
+  "disableSourceOfProjectReferenceRedirect": true,
+  "pathsBasePath": "/user/username/projects/project/src",
+  "configFilePath": "/user/username/projects/project/src/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/project/src/common",
+   "originalPath": "./common"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src 1 undefined Config: /user/username/projects/project/src/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src 1 undefined Config: /user/username/projects/project/src/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/project/src/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/project/out/input/keyboard.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/project/src/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/project/src/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/project/out/input/keyboard.d.ts
+	/user/username/projects/project/src/terminal.ts
+	/user/username/projects/project/src/common/input/keyboard.test.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../out/input/keyboard.d.ts
+	  Imported via 'common/input/keyboard' from file 'terminal.ts'
+	  Imported via 'common/input/keyboard' from file 'common/input/keyboard.test.ts'
+	  Matched by include pattern './**/*' in 'tsconfig.json'
+	  File is output of project reference source 'common/input/keyboard.ts'
+	terminal.ts
+	  Matched by include pattern './**/*' in 'tsconfig.json'
+	common/input/keyboard.test.ts
+	  Matched by include pattern './**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/project/src
+For info: /user/username/projects/project/src/tsconfig.json :: No config files found.
+Project '/user/username/projects/project/src/common/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/project/src/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/project/src/common/input/keyboard.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/project/src/common/tsconfig.json,/user/username/projects/project/src/tsconfig.json
+	FileName: /user/username/projects/project/src/terminal.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/project/src/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/project/src/common/input/keyboard.ts","line":2,"offset":17},"seq":1,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/project/out/input/keyboard.d.ts.map 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/project/src/common/input
+For info: /user/username/projects/project/src/common/input/keyboard.ts :: Config file name: /user/username/projects/project/src/common/tsconfig.json
+Search path: /user/username/projects/project/src/common/input
+For info: /user/username/projects/project/src/common/input/keyboard.ts :: Config file name: /user/username/projects/project/src/common/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/project/src/common/input/keyboard.ts","start":{"line":2,"offset":17},"end":{"line":2,"offset":38},"contextStart":{"line":2,"offset":1},"contextEnd":{"line":2,"offset":44},"lineText":"export function evaluateKeyboardEvent() { }","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/project/src/common/input/keyboard.test.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":31},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":63},"lineText":"import { evaluateKeyboardEvent } from 'common/input/keyboard';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/project/src/common/input/keyboard.test.ts","start":{"line":3,"offset":12},"end":{"line":3,"offset":33},"lineText":"    return evaluateKeyboardEvent();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/project/src/terminal.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":31},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":63},"lineText":"import { evaluateKeyboardEvent } from 'common/input/keyboard';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/project/src/terminal.ts","start":{"line":3,"offset":12},"end":{"line":3,"offset":33},"lineText":"    return evaluateKeyboardEvent();","isWriteAccess":false,"isDefinition":false}],"symbolName":"evaluateKeyboardEvent","symbolStartOffset":17,"symbolDisplayString":"function evaluateKeyboardEvent(): void"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project-and-using-declaration-maps.js
+++ b/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project-and-using-declaration-maps.js
@@ -30,7 +30,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_m
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/project/src/common/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/project/src/common/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/project/src/common/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -106,7 +106,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_m
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/project/src/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/project/src/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/project/src/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project.js
@@ -1,0 +1,150 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/project/src/common/input/keyboard.ts"}}
+Search path: /user/username/projects/project/src/common/input
+For info: /user/username/projects/project/src/common/input/keyboard.ts :: Config file name: /user/username/projects/project/src/common/tsconfig.json
+Creating configuration project /user/username/projects/project/src/common/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common/tsconfig.json 2000 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Config file
+Config: /user/username/projects/project/src/common/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/project/src/common/input/keyboard.test.ts",
+  "/user/username/projects/project/src/common/input/keyboard.ts"
+ ],
+ "options": {
+  "composite": true,
+  "declarationMap": true,
+  "outDir": "/user/username/projects/project/out",
+  "baseUrl": "/user/username/projects/project/src",
+  "disableSourceOfProjectReferenceRedirect": false,
+  "configFilePath": "/user/username/projects/project/src/common/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common 1 undefined Config: /user/username/projects/project/src/common/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common 1 undefined Config: /user/username/projects/project/src/common/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common/input/keyboard.test.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/project/src/common/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/common/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/project/src/common/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/project/src/common/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/project/src/common/input/keyboard.ts
+	/user/username/projects/project/src/common/input/keyboard.test.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	input/keyboard.ts
+	  Imported via 'common/input/keyboard' from file 'input/keyboard.test.ts'
+	  Matched by include pattern './**/*' in 'tsconfig.json'
+	input/keyboard.test.ts
+	  Matched by include pattern './**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/project/src/common
+For info: /user/username/projects/project/src/common/tsconfig.json :: Config file name: /user/username/projects/project/src/tsconfig.json
+Creating configuration project /user/username/projects/project/src/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/project/src/tsconfig.json 2000 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/project/src
+For info: /user/username/projects/project/src/tsconfig.json :: No config files found.
+Project '/user/username/projects/project/src/common/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/project/src/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/project/src/common/input/keyboard.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/project/src/common/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/project/src/terminal.ts"}}
+Search path: /user/username/projects/project/src
+For info: /user/username/projects/project/src/terminal.ts :: Config file name: /user/username/projects/project/src/tsconfig.json
+Loading configured project /user/username/projects/project/src/tsconfig.json
+Config: /user/username/projects/project/src/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/project/src/terminal.ts",
+  "/user/username/projects/project/src/common/input/keyboard.test.ts",
+  "/user/username/projects/project/src/common/input/keyboard.ts"
+ ],
+ "options": {
+  "composite": true,
+  "declarationMap": true,
+  "outDir": "/user/username/projects/project/out",
+  "baseUrl": "/user/username/projects/project/src",
+  "paths": {
+   "common/*": [
+    "./common/*"
+   ]
+  },
+  "tsBuildInfoFile": "/user/username/projects/project/out/src.tsconfig.tsbuildinfo",
+  "disableSourceOfProjectReferenceRedirect": false,
+  "pathsBasePath": "/user/username/projects/project/src",
+  "configFilePath": "/user/username/projects/project/src/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/project/src/common",
+   "originalPath": "./common"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src 1 undefined Config: /user/username/projects/project/src/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src 1 undefined Config: /user/username/projects/project/src/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/project/src/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/project/src/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/project/src/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/project/src/common/input/keyboard.ts
+	/user/username/projects/project/src/terminal.ts
+	/user/username/projects/project/src/common/input/keyboard.test.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	common/input/keyboard.ts
+	  Imported via 'common/input/keyboard' from file 'terminal.ts'
+	  Imported via 'common/input/keyboard' from file 'common/input/keyboard.test.ts'
+	  Matched by include pattern './**/*' in 'tsconfig.json'
+	terminal.ts
+	  Matched by include pattern './**/*' in 'tsconfig.json'
+	common/input/keyboard.test.ts
+	  Matched by include pattern './**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/project/src
+For info: /user/username/projects/project/src/tsconfig.json :: No config files found.
+Project '/user/username/projects/project/src/common/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/project/src/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/project/src/common/input/keyboard.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/project/src/common/tsconfig.json,/user/username/projects/project/src/tsconfig.json
+	FileName: /user/username/projects/project/src/terminal.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/project/src/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/project/src/common/input/keyboard.ts","line":2,"offset":17},"seq":1,"type":"request"}
+Search path: /user/username/projects/project/src/common/input
+For info: /user/username/projects/project/src/common/input/keyboard.ts :: Config file name: /user/username/projects/project/src/common/tsconfig.json
+Search path: /user/username/projects/project/src/common/input
+For info: /user/username/projects/project/src/common/input/keyboard.test.ts :: Config file name: /user/username/projects/project/src/common/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/project/src/common/input/keyboard.ts","start":{"line":2,"offset":17},"end":{"line":2,"offset":38},"contextStart":{"line":2,"offset":1},"contextEnd":{"line":2,"offset":44},"lineText":"export function evaluateKeyboardEvent() { }","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/project/src/common/input/keyboard.test.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":31},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":63},"lineText":"import { evaluateKeyboardEvent } from 'common/input/keyboard';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/project/src/common/input/keyboard.test.ts","start":{"line":3,"offset":12},"end":{"line":3,"offset":33},"lineText":"    return evaluateKeyboardEvent();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/project/src/terminal.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":31},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":63},"lineText":"import { evaluateKeyboardEvent } from 'common/input/keyboard';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/project/src/terminal.ts","start":{"line":3,"offset":12},"end":{"line":3,"offset":33},"lineText":"    return evaluateKeyboardEvent();","isWriteAccess":false,"isDefinition":false}],"symbolName":"evaluateKeyboardEvent","symbolStartOffset":17,"symbolDisplayString":"function evaluateKeyboardEvent(): void"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/root-file-is-file-from-referenced-project.js
@@ -30,7 +30,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_m
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/common/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/project/src/common/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/project/src/common/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/project/src/common/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -105,7 +105,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_m
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/src/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/src/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/project/src/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/project/src/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/project/src/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
@@ -85,7 +85,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/f
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (5)
 	/a/lib/lib.d.ts
@@ -118,7 +118,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -162,7 +162,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -226,7 +226,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -384,7 +384,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/mai
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (5)
 	/a/lib/lib.d.ts
@@ -415,7 +415,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -545,8 +545,8 @@ Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
 }
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -560,8 +560,8 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
 event:
@@ -589,8 +589,8 @@ Open files:
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 After ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (5)

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-first-indirect-project-but-not-in-another-one.js
@@ -1,0 +1,611 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/indirect1",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":4,"tsSize":166,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"75d5ba36c0a162a329bf40235b10e96d2d129b95469e1f02c08da775fb38a2b4","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":77,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+
+getDefaultProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+findDefaultConfiguredProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/indirect1",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+reload projects.
+Scheduled: /dev/null/inferredProject1*
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: /user/username/projects/myproject/tsconfig-src.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig-src.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"User requested reload projects"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/indirect1",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig.json","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"User requested reload projects"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig-src.json","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
@@ -1,0 +1,552 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/indirect1",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":4,"tsSize":166,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"9ccc3aed1af08832ccb25ea453f7b771199f56af238b53cc428549dbd2d59246","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":"","disableReferencedProjectLoad":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-indirect1.json
+
+getDefaultProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig.json
+findDefaultConfiguredProject for /user/username/projects/myproject/src/main.ts: undefined
+
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-indirect1.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/indirect1",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-indirect1.json
+reload projects.
+Scheduled: /dev/null/inferredProject1*
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: /user/username/projects/myproject/tsconfig-indirect1.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig-indirect1.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig-indirect1.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"User requested reload projects"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/indirect1",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig.json","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig-indirect1.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json","reason":"User requested reload projects"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig-indirect1.json","configFile":"/user/username/projects/myproject/tsconfig-indirect1.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-indirect1.json
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-indirect1.json

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set-in-indirect-project.js
@@ -63,7 +63,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/f
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (5)
 	/a/lib/lib.d.ts
@@ -96,7 +96,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -142,7 +142,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -206,7 +206,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -343,7 +343,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/mai
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (5)
 	/a/lib/lib.d.ts
@@ -374,7 +374,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -486,8 +486,8 @@ Config: /user/username/projects/myproject/tsconfig-src.json : {
 }
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -501,8 +501,8 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
 event:
@@ -530,8 +530,8 @@ Open files:
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 After ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (5)

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
@@ -1,0 +1,359 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","baseUrl":"","disableReferencedProjectLoad":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json
+
+getDefaultProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig.json
+findDefaultConfiguredProject for /user/username/projects/myproject/src/main.ts: undefined
+
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json
+reload projects.
+Scheduled: /dev/null/inferredProject1*
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"User requested reload projects"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig.json","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-disables-looking-into-the-child-project-if-disableReferencedProjectLoad-is-set.js
@@ -44,7 +44,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/f
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -86,7 +86,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -138,7 +138,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -230,7 +230,7 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/mypr
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -316,8 +316,8 @@ Config: /user/username/projects/myproject/tsconfig-src.json : {
 }
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -341,8 +341,8 @@ Open files:
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 After ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-found-is-not-solution-but-references-open-file-through-project-reference.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-found-is-not-solution-but-references-open-file-through-project-reference.js
@@ -43,7 +43,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/f
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -73,7 +73,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -127,7 +127,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -191,7 +191,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -301,7 +301,7 @@ Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/mypr
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -329,7 +329,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -387,7 +387,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -466,8 +466,8 @@ Config: /user/username/projects/myproject/tsconfig-src.json : {
 }
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -481,8 +481,8 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
 event:
@@ -512,8 +512,8 @@ Open files:
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 After ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
@@ -602,7 +602,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -741,7 +741,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 un
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -769,7 +769,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-found-is-not-solution-but-references-open-file-through-project-reference.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-found-is-not-solution-but-references-open-file-through-project-reference.js
@@ -1,0 +1,803 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"75d5ba36c0a162a329bf40235b10e96d2d129b95469e1f02c08da775fb38a2b4","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":77,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+
+getDefaultProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+findDefaultConfiguredProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+reload projects.
+Scheduled: /dev/null/inferredProject1*
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: /user/username/projects/myproject/tsconfig-src.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig-src.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"User requested reload projects"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig.json","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"User requested reload projects"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig-src.json","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/src/main.ts","line":2,"offset":10},"seq":2,"type":"request"}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/helpers/functions.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/helpers/functions.d.ts.map 500 undefined WatchType: Closed Script info
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":41},"lineText":"import { foo } from 'helpers/functions';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":2,"offset":10},"end":{"line":2,"offset":13},"contextStart":{"line":2,"offset":1},"contextEnd":{"line":2,"offset":16},"lineText":"export { foo };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/helpers/functions.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":17},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":22},"lineText":"export const foo = 1;","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/own/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/own/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false}],"symbolName":"foo","symbolStartOffset":10,"symbolDisplayString":"(alias) const foo: 1\nexport foo"},"responseRequired":true}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+Search path: /user/username/projects/myproject/indirect3
+For info: /user/username/projects/myproject/indirect3/main.ts :: Config file name: /user/username/projects/myproject/indirect3/tsconfig.json
+Creating configuration project /user/username/projects/myproject/indirect3/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/indirect3/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/indirect3/main.ts to open"}}
+Config: /user/username/projects/myproject/indirect3/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect3/main.ts"
+ ],
+ "options": {
+  "baseUrl": "/user/username/projects/myproject/target/src",
+  "configFilePath": "/user/username/projects/myproject/indirect3/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3 1 undefined Config: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3 1 undefined Config: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/main.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/target/src/helpers/functions.d.ts
+	/user/username/projects/myproject/target/src/main.d.ts
+	/user/username/projects/myproject/indirect3/main.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../target/src/helpers/functions.d.ts
+	  Imported via 'helpers/functions' from file '../target/src/main.d.ts'
+	../target/src/main.d.ts
+	  Imported via 'main' from file 'main.ts'
+	main.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/indirect3/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"5b0817f69b6871821661b976aa73f4f2533b37c5f4b920541094c2d727d0dc39","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":57,"tsx":0,"tsxSize":0,"dts":3,"dtsSize":494,"deferred":0,"deferredSize":0},"compilerOptions":{"baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/indirect3/main.ts","configFile":"/user/username/projects/myproject/indirect3/tsconfig.json","diagnostics":[]}}
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+`remove Project::
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/indirect3/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/indirect3/tsconfig.json
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/indirect3/main.ts","line":1,"offset":10},"seq":3,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/main.d.ts.map 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating project for original file: /user/username/projects/myproject/src/main.ts for location: /user/username/projects/myproject/target/src/main.d.ts"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for original file: /user/username/projects/myproject/src/main.ts for location: /user/username/projects/myproject/target/src/main.d.ts"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/indirect3/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect3/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":41},"lineText":"import { foo } from 'helpers/functions';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":2,"offset":10},"end":{"line":2,"offset":13},"contextStart":{"line":2,"offset":1},"contextEnd":{"line":2,"offset":16},"lineText":"export { foo };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/helpers/functions.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":17},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":22},"lineText":"export const foo = 1;","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/own/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/own/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false}],"symbolName":"foo","symbolStartOffset":10,"symbolDisplayString":"(alias) const foo: 1\nimport foo"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-is-indirectly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-is-indirectly-referenced-by-solution.js
@@ -1,0 +1,1198 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/indirect1",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":4,"tsSize":166,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"75d5ba36c0a162a329bf40235b10e96d2d129b95469e1f02c08da775fb38a2b4","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":77,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+
+getDefaultProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+findDefaultConfiguredProject for /user/username/projects/myproject/src/main.ts: /user/username/projects/myproject/tsconfig-src.json
+
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/src/main.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/src/main.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/indirect1",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for /user/username/projects/myproject/src/main.ts to open"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/src/main.ts","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+reload projects.
+Scheduled: /dev/null/inferredProject1*
+Scheduled: /user/username/projects/myproject/tsconfig.json
+Scheduled: /user/username/projects/myproject/tsconfig-src.json
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig.json, Cancelled earlier one
+Scheduled: /user/username/projects/myproject/tsconfig-src.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"User requested reload projects"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/indirect1",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig.json","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[]}}
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Reloading configured project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"User requested reload projects"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/tsconfig-src.json","configFile":"/user/username/projects/myproject/tsconfig-src.json","diagnostics":[]}}
+Search path: /dummy
+For info: /dummy/dummy.ts :: No config files found.
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/src/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/tsconfig.json,/user/username/projects/myproject/tsconfig-src.json
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/src/main.ts","line":2,"offset":10},"seq":2,"type":"request"}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/indirect1
+For info: /user/username/projects/myproject/indirect1/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for original file: /user/username/projects/myproject/indirect1/main.ts"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"9ccc3aed1af08832ccb25ea453f7b771199f56af238b53cc428549dbd2d59246","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Search path: /user/username/projects/myproject/indirect1
+For info: /user/username/projects/myproject/indirect1/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/indirect1
+For info: /user/username/projects/myproject/indirect1/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect2.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect2.json","reason":"Creating project referenced by : /user/username/projects/myproject/tsconfig.json as it references project /user/username/projects/myproject/tsconfig-src.json"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect2/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect2/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect2/main.ts'
+	indirect2/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect2.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"d9a040bddd6b85b85abd507a988a4b809b1515b5e61257ea3f8263da59589565","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":3,"tsSize":134,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"composite":true,"outDir":"","baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":true,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"other","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/helpers/functions.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/helpers/functions.d.ts.map 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":41},"lineText":"import { foo } from 'helpers/functions';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":2,"offset":10},"end":{"line":2,"offset":13},"contextStart":{"line":2,"offset":1},"contextEnd":{"line":2,"offset":16},"lineText":"export { foo };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/helpers/functions.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":17},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":22},"lineText":"export const foo = 1;","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect1/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect1/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/indirect2/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect2/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false}],"symbolName":"foo","symbolStartOffset":10,"symbolDisplayString":"(alias) const foo: 1\nexport foo"},"responseRequired":true}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /dummy/dummy.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+Search path: /user/username/projects/myproject/indirect3
+For info: /user/username/projects/myproject/indirect3/main.ts :: Config file name: /user/username/projects/myproject/indirect3/tsconfig.json
+Creating configuration project /user/username/projects/myproject/indirect3/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/indirect3/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/indirect3/main.ts to open"}}
+Config: /user/username/projects/myproject/indirect3/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect3/main.ts"
+ ],
+ "options": {
+  "baseUrl": "/user/username/projects/myproject/target/src",
+  "configFilePath": "/user/username/projects/myproject/indirect3/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3 1 undefined Config: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3 1 undefined Config: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/main.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/target/src/helpers/functions.d.ts
+	/user/username/projects/myproject/target/src/main.d.ts
+	/user/username/projects/myproject/indirect3/main.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../target/src/helpers/functions.d.ts
+	  Imported via 'helpers/functions' from file '../target/src/main.d.ts'
+	../target/src/main.d.ts
+	  Imported via 'main' from file 'main.ts'
+	main.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/indirect3/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"5b0817f69b6871821661b976aa73f4f2533b37c5f4b920541094c2d727d0dc39","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":57,"tsx":0,"tsxSize":0,"dts":3,"dtsSize":494,"deferred":0,"deferredSize":0},"compilerOptions":{"baseUrl":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/indirect3/main.ts","configFile":"/user/username/projects/myproject/indirect3/tsconfig.json","diagnostics":[]}}
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+`remove Project::
+Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect2/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect2/main.ts'
+	indirect2/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+`remove Project::
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/dummy/dummy.ts
+
+
+	../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	dummy.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/indirect2/main.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/indirect3/main.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/indirect3/tsconfig.json
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/indirect3/main.ts","line":1,"offset":10},"seq":3,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/target/src/main.d.ts.map 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/main.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating project for original file: /user/username/projects/myproject/src/main.ts for location: /user/username/projects/myproject/target/src/main.d.ts"}}
+Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/own/main.ts"
+ ],
+ "options": {
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/indirect1",
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect1.json",
+   "originalPath": "./tsconfig-indirect1.json"
+  },
+  {
+   "path": "/user/username/projects/myproject/tsconfig-indirect2.json",
+   "originalPath": "./tsconfig-indirect2.json"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/own/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Config: /user/username/projects/myproject/tsconfig-indirect1.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect1/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect1.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect1.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/tsconfig-src.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/src/main.ts",
+  "/user/username/projects/myproject/src/helpers/functions.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-src.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-src.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 undefined Config: /user/username/projects/myproject/tsconfig-src.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect2/main.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/myproject/target",
+  "baseUrl": "/user/username/projects/myproject/src",
+  "configFilePath": "/user/username/projects/myproject/tsconfig-indirect2.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/tsconfig-src.json",
+   "originalPath": "./tsconfig-src.json"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indirect2.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+	Files (5)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+	/user/username/projects/myproject/own/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Imported via 'main' from file 'own/main.ts'
+	own/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-src.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json","reason":"Creating project referenced in solution /user/username/projects/myproject/tsconfig.json to find possible configured project for original file: /user/username/projects/myproject/src/main.ts for location: /user/username/projects/myproject/target/src/main.d.ts"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+	src/main.ts
+	  Matched by include pattern './src/**/*' in 'tsconfig-src.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect1.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json","reason":"Creating project referenced by : /user/username/projects/myproject/tsconfig.json as it references project /user/username/projects/myproject/tsconfig-src.json"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect1/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect1/main.ts'
+	indirect1/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect1.json"}}
+Creating configuration project /user/username/projects/myproject/tsconfig-indirect2.json
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect2.json","reason":"Creating project referenced by : /user/username/projects/myproject/tsconfig.json as it references project /user/username/projects/myproject/tsconfig-src.json"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect2/main.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/src/helpers/functions.ts
+	/user/username/projects/myproject/src/main.ts
+	/user/username/projects/myproject/indirect2/main.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	src/helpers/functions.ts
+	  Imported via 'helpers/functions' from file 'src/main.ts'
+	src/main.ts
+	  Imported via 'main' from file 'indirect2/main.ts'
+	indirect2/main.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-indirect2.json"}}
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src
+For info: /user/username/projects/myproject/src/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/src/helpers
+For info: /user/username/projects/myproject/src/helpers/functions.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+Search path: /user/username/projects/myproject/indirect1
+For info: /user/username/projects/myproject/indirect1/main.ts :: Config file name: /user/username/projects/myproject/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/indirect3/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect3/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":41},"lineText":"import { foo } from 'helpers/functions';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/main.ts","start":{"line":2,"offset":10},"end":{"line":2,"offset":13},"contextStart":{"line":2,"offset":1},"contextEnd":{"line":2,"offset":16},"lineText":"export { foo };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/src/helpers/functions.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":17},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":22},"lineText":"export const foo = 1;","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect1/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect1/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/indirect2/main.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":13},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":28},"lineText":"import { foo } from 'main';","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/indirect2/main.ts","start":{"line":2,"offset":1},"end":{"line":2,"offset":4},"lineText":"foo;","isWriteAccess":false,"isDefinition":false}],"symbolName":"foo","symbolStartOffset":10,"symbolDisplayString":"(alias) const foo: 1\nimport foo"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-is-indirectly-referenced-by-solution.js
+++ b/tests/baselines/reference/tsserver/projectReferences/solution-with-its-own-files-and-project-is-indirectly-referenced-by-solution.js
@@ -84,7 +84,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/f
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (5)
 	/a/lib/lib.d.ts
@@ -117,7 +117,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -171,7 +171,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -235,7 +235,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -392,7 +392,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/mai
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src/helpers/functions.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (5)
 	/a/lib/lib.d.ts
@@ -423,7 +423,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -481,7 +481,7 @@ FileWatcher:: Close:: WatchInfo: /dummy/dummy.ts 500 undefined WatchType: Closed
 Search path: /dummy
 For info: /dummy/dummy.ts :: No config files found.
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: false structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -600,8 +600,8 @@ Config: /user/username/projects/myproject/tsconfig-indirect2.json : {
 }
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
 event:
@@ -615,8 +615,8 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 event:
     {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig-src.json"}}
 event:
@@ -646,8 +646,8 @@ Open files:
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /dummy/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 4 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 After ensureProjectForOpenFiles:
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (5)
@@ -686,7 +686,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -725,7 +725,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect2/mai
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -831,7 +831,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect3/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect3/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/indirect3/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -1060,7 +1060,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig-indi
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect1/main.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig.json' (Configured)
 	Files (5)
 	/a/lib/lib.d.ts
@@ -1091,7 +1091,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-src.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-src.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-src.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -1125,7 +1125,7 @@ Plugins were requested but not running in environment that supports 'require'. N
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect1.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect1.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect1.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts
@@ -1154,7 +1154,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect2/mai
 Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig-indirect2.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig-indirect2.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/tsconfig-indirect2.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property-is-loaded-through-indirect-assignment-with-original-declaration-local-to-project-is-treated-as-local.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property-is-loaded-through-indirect-assignment-with-original-declaration-local-to-project-is-treated-as-local.js
@@ -1,0 +1,109 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/solution/api/src/server.ts"}}
+Search path: /user/username/projects/solution/api/src
+For info: /user/username/projects/solution/api/src/server.ts :: Config file name: /user/username/projects/solution/api/tsconfig.json
+Creating configuration project /user/username/projects/solution/api/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/tsconfig.json 2000 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Config file
+Config: /user/username/projects/solution/api/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/api/src/server.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/api/dist",
+  "rootDir": "/user/username/projects/solution/api/src",
+  "configFilePath": "/user/username/projects/solution/api/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/shared",
+   "originalPath": "../shared"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/src 1 undefined Config: /user/username/projects/solution/api/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/src 1 undefined Config: /user/username/projects/solution/api/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json
+Config: /user/username/projects/solution/shared/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/shared/src/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/shared/dist",
+  "rootDir": "/user/username/projects/solution/shared/src",
+  "configFilePath": "/user/username/projects/solution/shared/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/tsconfig.json 2000 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src 1 undefined Config: /user/username/projects/solution/shared/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src 1 undefined Config: /user/username/projects/solution/shared/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+	/user/username/projects/solution/api/src/server.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../shared/src/index.ts
+	  Imported via "../../shared/dist" from file 'src/server.ts'
+	src/server.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/api
+For info: /user/username/projects/solution/api/tsconfig.json :: Config file name: /user/username/projects/solution/tsconfig.json
+Creating configuration project /user/username/projects/solution/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/solution
+For info: /user/username/projects/solution/tsconfig.json :: No config files found.
+Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/solution/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/solution/api/src/server.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/solution/api/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/solution/api/src/server.ts","line":2,"offset":12},"seq":1,"type":"request"}
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+Creating configuration project /user/username/projects/solution/shared/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/shared/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/solution/shared/src/index.ts","start":{"line":1,"offset":17},"end":{"line":1,"offset":20},"contextStart":{"line":1,"offset":17},"contextEnd":{"line":1,"offset":31},"lineText":"const local = { bar: () => { } };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/solution/api/src/server.ts","start":{"line":2,"offset":12},"end":{"line":2,"offset":15},"lineText":"shared.foo.bar();","isWriteAccess":false,"isDefinition":false}],"symbolName":"bar","symbolStartOffset":12,"symbolDisplayString":"(property) bar: () => void"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property-is-loaded-through-indirect-assignment-with-original-declaration-local-to-project-is-treated-as-local.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property-is-loaded-through-indirect-assignment-with-original-declaration-local-to-project-is-treated-as-local.js
@@ -47,7 +47,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -91,7 +91,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/shared/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property.js
@@ -47,7 +47,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -91,7 +91,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/shared/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -147,8 +147,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Creating configuration project /user/username/projects/solution/app/tsconfig.json
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src/app.ts 500 undefined WatchType: Closed Script info
@@ -159,7 +159,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/app/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-as-object-literal-property.js
@@ -1,0 +1,180 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/solution/api/src/server.ts"}}
+Search path: /user/username/projects/solution/api/src
+For info: /user/username/projects/solution/api/src/server.ts :: Config file name: /user/username/projects/solution/api/tsconfig.json
+Creating configuration project /user/username/projects/solution/api/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/tsconfig.json 2000 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Config file
+Config: /user/username/projects/solution/api/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/api/src/server.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/api/dist",
+  "rootDir": "/user/username/projects/solution/api/src",
+  "configFilePath": "/user/username/projects/solution/api/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/shared",
+   "originalPath": "../shared"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/src 1 undefined Config: /user/username/projects/solution/api/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/src 1 undefined Config: /user/username/projects/solution/api/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json
+Config: /user/username/projects/solution/shared/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/shared/src/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/shared/dist",
+  "rootDir": "/user/username/projects/solution/shared/src",
+  "configFilePath": "/user/username/projects/solution/shared/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/tsconfig.json 2000 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src 1 undefined Config: /user/username/projects/solution/shared/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src 1 undefined Config: /user/username/projects/solution/shared/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+	/user/username/projects/solution/api/src/server.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../shared/src/index.ts
+	  Imported via "../../shared/dist" from file 'src/server.ts'
+	src/server.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/api
+For info: /user/username/projects/solution/api/tsconfig.json :: Config file name: /user/username/projects/solution/tsconfig.json
+Creating configuration project /user/username/projects/solution/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/solution
+For info: /user/username/projects/solution/tsconfig.json :: No config files found.
+Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/solution/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/solution/api/src/server.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/solution/api/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/solution/api/src/server.ts","line":2,"offset":12},"seq":1,"type":"request"}
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+Creating configuration project /user/username/projects/solution/shared/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/shared/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+Loading configured project /user/username/projects/solution/tsconfig.json
+Config: /user/username/projects/solution/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/solution/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/api",
+   "originalPath": "./api"
+  },
+  {
+   "path": "/user/username/projects/solution/app",
+   "originalPath": "./app"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json
+Config: /user/username/projects/solution/app/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/app/src/app.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/app/dist",
+  "rootDir": "/user/username/projects/solution/app/src",
+  "configFilePath": "/user/username/projects/solution/app/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/shared",
+   "originalPath": "../shared"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Creating configuration project /user/username/projects/solution/app/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src/app.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/app/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+	/user/username/projects/solution/app/src/app.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../shared/src/index.ts
+	  Imported via "../../shared/dist" from file 'src/app.ts'
+	src/app.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/solution/shared/src/index.ts","start":{"line":1,"offset":22},"end":{"line":1,"offset":25},"contextStart":{"line":1,"offset":22},"contextEnd":{"line":1,"offset":36},"lineText":"export const foo = { bar: () => { } };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/solution/api/src/server.ts","start":{"line":2,"offset":12},"end":{"line":2,"offset":15},"lineText":"shared.foo.bar();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/solution/app/src/app.ts","start":{"line":2,"offset":12},"end":{"line":2,"offset":15},"lineText":"shared.foo.bar();","isWriteAccess":false,"isDefinition":false}],"symbolName":"bar","symbolStartOffset":12,"symbolDisplayString":"(property) bar: () => void"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-assignment.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-assignment.js
@@ -47,7 +47,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -91,7 +91,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/shared/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -147,8 +147,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Creating configuration project /user/username/projects/solution/app/tsconfig.json
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src/app.ts 500 undefined WatchType: Closed Script info
@@ -159,7 +159,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/app/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-assignment.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-arrow-function-assignment.js
@@ -1,0 +1,180 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/solution/api/src/server.ts"}}
+Search path: /user/username/projects/solution/api/src
+For info: /user/username/projects/solution/api/src/server.ts :: Config file name: /user/username/projects/solution/api/tsconfig.json
+Creating configuration project /user/username/projects/solution/api/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/tsconfig.json 2000 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Config file
+Config: /user/username/projects/solution/api/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/api/src/server.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/api/dist",
+  "rootDir": "/user/username/projects/solution/api/src",
+  "configFilePath": "/user/username/projects/solution/api/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/shared",
+   "originalPath": "../shared"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/src 1 undefined Config: /user/username/projects/solution/api/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/src 1 undefined Config: /user/username/projects/solution/api/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json
+Config: /user/username/projects/solution/shared/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/shared/src/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/shared/dist",
+  "rootDir": "/user/username/projects/solution/shared/src",
+  "configFilePath": "/user/username/projects/solution/shared/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/tsconfig.json 2000 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src 1 undefined Config: /user/username/projects/solution/shared/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src 1 undefined Config: /user/username/projects/solution/shared/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+	/user/username/projects/solution/api/src/server.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../shared/src/index.ts
+	  Imported via "../../shared/dist" from file 'src/server.ts'
+	src/server.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/api
+For info: /user/username/projects/solution/api/tsconfig.json :: Config file name: /user/username/projects/solution/tsconfig.json
+Creating configuration project /user/username/projects/solution/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/solution
+For info: /user/username/projects/solution/tsconfig.json :: No config files found.
+Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/solution/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/solution/api/src/server.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/solution/api/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/solution/api/src/server.ts","line":2,"offset":8},"seq":1,"type":"request"}
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+Creating configuration project /user/username/projects/solution/shared/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/shared/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+Loading configured project /user/username/projects/solution/tsconfig.json
+Config: /user/username/projects/solution/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/solution/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/api",
+   "originalPath": "./api"
+  },
+  {
+   "path": "/user/username/projects/solution/app",
+   "originalPath": "./app"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json
+Config: /user/username/projects/solution/app/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/app/src/app.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/app/dist",
+  "rootDir": "/user/username/projects/solution/app/src",
+  "configFilePath": "/user/username/projects/solution/app/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/shared",
+   "originalPath": "../shared"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Creating configuration project /user/username/projects/solution/app/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src/app.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/app/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+	/user/username/projects/solution/app/src/app.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../shared/src/index.ts
+	  Imported via "../../shared/dist" from file 'src/app.ts'
+	src/app.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/solution/shared/src/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":17},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"export const dog = () => { };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/solution/api/src/server.ts","start":{"line":2,"offset":8},"end":{"line":2,"offset":11},"lineText":"shared.dog();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/solution/app/src/app.ts","start":{"line":2,"offset":8},"end":{"line":2,"offset":11},"lineText":"shared.dog();","isWriteAccess":false,"isDefinition":false}],"symbolName":"dog","symbolStartOffset":8,"symbolDisplayString":"const dog: () => void"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-method-of-class-expression.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-method-of-class-expression.js
@@ -47,7 +47,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -91,7 +91,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/shared/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -147,8 +147,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Creating configuration project /user/username/projects/solution/app/tsconfig.json
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src/app.ts 500 undefined WatchType: Closed Script info
@@ -159,7 +159,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/app/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-method-of-class-expression.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-method-of-class-expression.js
@@ -1,0 +1,180 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/solution/api/src/server.ts"}}
+Search path: /user/username/projects/solution/api/src
+For info: /user/username/projects/solution/api/src/server.ts :: Config file name: /user/username/projects/solution/api/tsconfig.json
+Creating configuration project /user/username/projects/solution/api/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/tsconfig.json 2000 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Config file
+Config: /user/username/projects/solution/api/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/api/src/server.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/api/dist",
+  "rootDir": "/user/username/projects/solution/api/src",
+  "configFilePath": "/user/username/projects/solution/api/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/shared",
+   "originalPath": "../shared"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/src 1 undefined Config: /user/username/projects/solution/api/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/src 1 undefined Config: /user/username/projects/solution/api/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json
+Config: /user/username/projects/solution/shared/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/shared/src/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/shared/dist",
+  "rootDir": "/user/username/projects/solution/shared/src",
+  "configFilePath": "/user/username/projects/solution/shared/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/tsconfig.json 2000 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src 1 undefined Config: /user/username/projects/solution/shared/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src 1 undefined Config: /user/username/projects/solution/shared/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+	/user/username/projects/solution/api/src/server.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../shared/src/index.ts
+	  Imported via "../../shared/dist" from file 'src/server.ts'
+	src/server.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/api
+For info: /user/username/projects/solution/api/tsconfig.json :: Config file name: /user/username/projects/solution/tsconfig.json
+Creating configuration project /user/username/projects/solution/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/solution
+For info: /user/username/projects/solution/tsconfig.json :: No config files found.
+Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/solution/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/solution/api/src/server.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/solution/api/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/solution/api/src/server.ts","line":3,"offset":10},"seq":1,"type":"request"}
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+Creating configuration project /user/username/projects/solution/shared/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/shared/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+Loading configured project /user/username/projects/solution/tsconfig.json
+Config: /user/username/projects/solution/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/solution/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/api",
+   "originalPath": "./api"
+  },
+  {
+   "path": "/user/username/projects/solution/app",
+   "originalPath": "./app"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json
+Config: /user/username/projects/solution/app/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/app/src/app.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/app/dist",
+  "rootDir": "/user/username/projects/solution/app/src",
+  "configFilePath": "/user/username/projects/solution/app/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/shared",
+   "originalPath": "../shared"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Creating configuration project /user/username/projects/solution/app/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src/app.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/app/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+	/user/username/projects/solution/app/src/app.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../shared/src/index.ts
+	  Imported via "../../shared/dist" from file 'src/app.ts'
+	src/app.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/solution/shared/src/index.ts","start":{"line":1,"offset":28},"end":{"line":1,"offset":31},"contextStart":{"line":1,"offset":28},"contextEnd":{"line":1,"offset":36},"lineText":"export const foo = class { fly() {} };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/solution/api/src/server.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":13},"lineText":"instance.fly();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/solution/app/src/app.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":13},"lineText":"instance.fly();","isWriteAccess":false,"isDefinition":false}],"symbolName":"fly","symbolStartOffset":10,"symbolDisplayString":"(method) foo.fly(): void"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-object-literal-property.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-object-literal-property.js
@@ -47,7 +47,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -91,7 +91,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/no
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/shared/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -147,8 +147,8 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
-Different program with same set of files:: structureIsReused:: 0
+Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Different program with same set of files
 Creating configuration project /user/username/projects/solution/app/tsconfig.json
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src/app.ts 500 undefined WatchType: Closed Script info
@@ -159,7 +159,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/app/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-object-literal-property.js
+++ b/tests/baselines/reference/tsserver/projectReferences/special-handling-of-localness-when-using-object-literal-property.js
@@ -1,0 +1,180 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/solution/api/src/server.ts"}}
+Search path: /user/username/projects/solution/api/src
+For info: /user/username/projects/solution/api/src/server.ts :: Config file name: /user/username/projects/solution/api/tsconfig.json
+Creating configuration project /user/username/projects/solution/api/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/tsconfig.json 2000 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Config file
+Config: /user/username/projects/solution/api/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/api/src/server.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/api/dist",
+  "rootDir": "/user/username/projects/solution/api/src",
+  "configFilePath": "/user/username/projects/solution/api/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/shared",
+   "originalPath": "../shared"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/src 1 undefined Config: /user/username/projects/solution/api/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/src 1 undefined Config: /user/username/projects/solution/api/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json
+Config: /user/username/projects/solution/shared/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/shared/src/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/shared/dist",
+  "rootDir": "/user/username/projects/solution/shared/src",
+  "configFilePath": "/user/username/projects/solution/shared/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/tsconfig.json 2000 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src 1 undefined Config: /user/username/projects/solution/shared/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src 1 undefined Config: /user/username/projects/solution/shared/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/src/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/api/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/api/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/api/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+	/user/username/projects/solution/api/src/server.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../shared/src/index.ts
+	  Imported via "../../shared/dist" from file 'src/server.ts'
+	src/server.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/api
+For info: /user/username/projects/solution/api/tsconfig.json :: Config file name: /user/username/projects/solution/tsconfig.json
+Creating configuration project /user/username/projects/solution/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+Search path: /user/username/projects/solution
+For info: /user/username/projects/solution/tsconfig.json :: No config files found.
+Project '/user/username/projects/solution/api/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/user/username/projects/solution/tsconfig.json' (Configured)
+	Files (0) InitialLoadPending
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/solution/api/src/server.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/solution/api/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/solution/api/src/server.ts","line":2,"offset":12},"seq":1,"type":"request"}
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+Creating configuration project /user/username/projects/solution/shared/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/shared/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/shared/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/shared/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+Loading configured project /user/username/projects/solution/tsconfig.json
+Config: /user/username/projects/solution/tsconfig.json : {
+ "rootNames": [],
+ "options": {
+  "configFilePath": "/user/username/projects/solution/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/api",
+   "originalPath": "./api"
+  },
+  {
+   "path": "/user/username/projects/solution/app",
+   "originalPath": "./app"
+  }
+ ]
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json
+Config: /user/username/projects/solution/app/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/app/src/app.ts"
+ ],
+ "options": {
+  "composite": true,
+  "outDir": "/user/username/projects/solution/app/dist",
+  "rootDir": "/user/username/projects/solution/app/src",
+  "configFilePath": "/user/username/projects/solution/app/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/solution/shared",
+   "originalPath": "../shared"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/tsconfig.json 2000 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src 1 undefined Config: /user/username/projects/solution/app/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Different program with same set of files:: structureIsReused:: 0
+Creating configuration project /user/username/projects/solution/app/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/src/app.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/shared 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/app/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/app/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/app/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/app/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/shared/src/index.ts
+	/user/username/projects/solution/app/src/app.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	../shared/src/index.ts
+	  Imported via "../../shared/dist" from file 'src/app.ts'
+	src/app.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/solution/shared/src
+For info: /user/username/projects/solution/shared/src/index.ts :: Config file name: /user/username/projects/solution/shared/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/solution/shared/src/index.ts","start":{"line":1,"offset":23},"end":{"line":1,"offset":26},"contextStart":{"line":1,"offset":23},"contextEnd":{"line":1,"offset":33},"lineText":"export const foo = {  baz: \"BAZ\" };","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/solution/api/src/server.ts","start":{"line":2,"offset":12},"end":{"line":2,"offset":15},"lineText":"shared.foo.baz;","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/solution/app/src/app.ts","start":{"line":2,"offset":12},"end":{"line":2,"offset":15},"lineText":"shared.foo.baz;","isWriteAccess":false,"isDefinition":false}],"symbolName":"baz","symbolStartOffset":12,"symbolDisplayString":"(property) baz: string"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/when-files-from-two-projects-are-open-and-one-project-references.js
+++ b/tests/baselines/reference/tsserver/projectReferences/when-files-from-two-projects-are-open-and-one-project-references.js
@@ -234,7 +234,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/main/nod
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/main/node_modules/@types 1 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/main/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/main/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/main/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -267,7 +267,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/core/nod
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/core/node_modules/@types 1 undefined Project: /user/username/projects/myproject/core/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/core/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/core/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/core/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/core/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/core/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -305,7 +305,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/indirect/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -326,7 +326,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef1
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef1/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef1/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef1/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef1/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/coreRef1/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/coreRef1/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/coreRef1/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -347,7 +347,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad1/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -368,7 +368,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -389,7 +389,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/refToCor
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/refToCoreRef3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/refToCoreRef3/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -410,7 +410,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef3
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef3/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef3/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef3/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/coreRef3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/coreRef3/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/coreRef3/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/when-files-from-two-projects-are-open-and-one-project-references.js
+++ b/tests/baselines/reference/tsserver/projectReferences/when-files-from-two-projects-are-open-and-one-project-references.js
@@ -1,0 +1,427 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/main/src/file1.ts"}}
+Search path: /user/username/projects/myproject/main/src
+For info: /user/username/projects/myproject/main/src/file1.ts :: Config file name: /user/username/projects/myproject/main/tsconfig.json
+Creating configuration project /user/username/projects/myproject/main/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/main/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/main/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/main/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/main/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/core",
+   "originalPath": "../core"
+  },
+  {
+   "path": "/user/username/projects/myproject/indirect",
+   "originalPath": "../indirect"
+  },
+  {
+   "path": "/user/username/projects/myproject/noCoreRef1",
+   "originalPath": "../noCoreRef1"
+  },
+  {
+   "path": "/user/username/projects/myproject/indirectDisabledChildLoad1",
+   "originalPath": "../indirectDisabledChildLoad1"
+  },
+  {
+   "path": "/user/username/projects/myproject/indirectDisabledChildLoad2",
+   "originalPath": "../indirectDisabledChildLoad2"
+  },
+  {
+   "path": "/user/username/projects/myproject/refToCoreRef3",
+   "originalPath": "../refToCoreRef3"
+  },
+  {
+   "path": "/user/username/projects/myproject/indirectNoCoreRef",
+   "originalPath": "../indirectNoCoreRef"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/main 1 undefined Config: /user/username/projects/myproject/main/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/main 1 undefined Config: /user/username/projects/myproject/main/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/main/tsconfig.json
+Config: /user/username/projects/myproject/core/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/core/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/core/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/core/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/core 1 undefined Config: /user/username/projects/myproject/core/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/core 1 undefined Config: /user/username/projects/myproject/core/tsconfig.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/indirect/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirect/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/indirect/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/coreRef1",
+   "originalPath": "../coreRef1"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect 1 undefined Config: /user/username/projects/myproject/indirect/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect 1 undefined Config: /user/username/projects/myproject/indirect/tsconfig.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/coreRef1/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/coreRef1/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/coreRef1/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/core",
+   "originalPath": "../core"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef1/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef1 1 undefined Config: /user/username/projects/myproject/coreRef1/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef1 1 undefined Config: /user/username/projects/myproject/coreRef1/tsconfig.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/noCoreRef1/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/noCoreRef1/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/noCoreRef1/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/noCoreRef1/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/noCoreRef1 1 undefined Config: /user/username/projects/myproject/noCoreRef1/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/noCoreRef1 1 undefined Config: /user/username/projects/myproject/noCoreRef1/tsconfig.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirectDisabledChildLoad1/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/coreRef2",
+   "originalPath": "../coreRef2"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad1 1 undefined Config: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad1 1 undefined Config: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/coreRef2/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/coreRef2/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/coreRef2/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/core",
+   "originalPath": "../core"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef2/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef2 1 undefined Config: /user/username/projects/myproject/coreRef2/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef2 1 undefined Config: /user/username/projects/myproject/coreRef2/tsconfig.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirectDisabledChildLoad2/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "disableReferencedProjectLoad": true,
+  "configFilePath": "/user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/coreRef3",
+   "originalPath": "../coreRef3"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad2 1 undefined Config: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad2 1 undefined Config: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/coreRef3/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/coreRef3/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/coreRef3/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/core",
+   "originalPath": "../core"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef3/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef3 1 undefined Config: /user/username/projects/myproject/coreRef3/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef3 1 undefined Config: /user/username/projects/myproject/coreRef3/tsconfig.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/refToCoreRef3/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/refToCoreRef3/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/refToCoreRef3/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/coreRef3",
+   "originalPath": "../coreRef3"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/refToCoreRef3/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/refToCoreRef3 1 undefined Config: /user/username/projects/myproject/refToCoreRef3/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/refToCoreRef3 1 undefined Config: /user/username/projects/myproject/refToCoreRef3/tsconfig.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/indirectNoCoreRef/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/indirectNoCoreRef/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/indirectNoCoreRef/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/noCoreRef2",
+   "originalPath": "../noCoreRef2"
+  }
+ ]
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectNoCoreRef/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectNoCoreRef 1 undefined Config: /user/username/projects/myproject/indirectNoCoreRef/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectNoCoreRef 1 undefined Config: /user/username/projects/myproject/indirectNoCoreRef/tsconfig.json WatchType: Wild card directory
+Config: /user/username/projects/myproject/noCoreRef2/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/noCoreRef2/src/file1.ts"
+ ],
+ "options": {
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/noCoreRef2/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/noCoreRef2/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/noCoreRef2 1 undefined Config: /user/username/projects/myproject/noCoreRef2/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/noCoreRef2 1 undefined Config: /user/username/projects/myproject/noCoreRef2/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/main/node_modules/@types 1 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/main/node_modules/@types 1 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/main/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/main/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/main/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/main/src/file1.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/main
+For info: /user/username/projects/myproject/main/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/main/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/main/src/file1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/main/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/core/src/file1.ts"}}
+Search path: /user/username/projects/myproject/core/src
+For info: /user/username/projects/myproject/core/src/file1.ts :: Config file name: /user/username/projects/myproject/core/tsconfig.json
+Creating configuration project /user/username/projects/myproject/core/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/core/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/core/node_modules/@types 1 undefined Project: /user/username/projects/myproject/core/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/core/node_modules/@types 1 undefined Project: /user/username/projects/myproject/core/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/core/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/core/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/core/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/core/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/core/src/file1.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/core
+For info: /user/username/projects/myproject/core/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/main/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/core/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/main/src/file1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/main/tsconfig.json
+	FileName: /user/username/projects/myproject/core/src/file1.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/core/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/core/src/file1.ts","line":1,"offset":14},"seq":1,"type":"request"}
+Creating configuration project /user/username/projects/myproject/indirect/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect/src/file1.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/indirect/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirect/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirect/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirect/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/indirect/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/indirect/src/file1.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Creating configuration project /user/username/projects/myproject/coreRef1/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef1/src/file1.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/coreRef1/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef1/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef1/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef1/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef1/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef1/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef1/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/coreRef1/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/coreRef1/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/coreRef1/src/file1.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Creating configuration project /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad1/src/file1.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad1/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad1/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/indirectDisabledChildLoad1/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/indirectDisabledChildLoad1/src/file1.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Creating configuration project /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad2/src/file1.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/indirectDisabledChildLoad2/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/indirectDisabledChildLoad2/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/indirectDisabledChildLoad2/src/file1.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Creating configuration project /user/username/projects/myproject/refToCoreRef3/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/refToCoreRef3/src/file1.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/refToCoreRef3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/refToCoreRef3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/refToCoreRef3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/refToCoreRef3/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/refToCoreRef3/src/file1.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Creating configuration project /user/username/projects/myproject/coreRef3/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef3/src/file1.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/coreRef3/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/coreRef3/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef3/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef3/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/coreRef3/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/coreRef3/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/coreRef3/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/coreRef3/src/file1.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	src/file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/core/src/file1.d.ts 2000 undefined Project: /user/username/projects/myproject/core/tsconfig.json WatchType: Missing generated file
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/core/src/file1.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":23},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":29},"lineText":"export const coreConst = 10;","isWriteAccess":true,"isDefinition":true}],"symbolName":"coreConst","symbolStartOffset":14,"symbolDisplayString":"const coreConst: 10"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/when-the-referenced-projects-have-allowJs-and-emitDeclarationOnly.js
+++ b/tests/baselines/reference/tsserver/projectReferences/when-the-referenced-projects-have-allowJs-and-emitDeclarationOnly.js
@@ -60,7 +60,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/consumer/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/consumer/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/myproject/packages/consumer/tsconfig.json' (Configured)
 	Files (4)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projectReferences/when-the-referenced-projects-have-allowJs-and-emitDeclarationOnly.js
+++ b/tests/baselines/reference/tsserver/projectReferences/when-the-referenced-projects-have-allowJs-and-emitDeclarationOnly.js
@@ -1,0 +1,105 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/packages/consumer/src/index.ts"}}
+Search path: /user/username/projects/myproject/packages/consumer/src
+For info: /user/username/projects/myproject/packages/consumer/src/index.ts :: Config file name: /user/username/projects/myproject/packages/consumer/tsconfig.json
+Creating configuration project /user/username/projects/myproject/packages/consumer/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/consumer/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/packages/consumer/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/packages/consumer/src/index.ts to open"}}
+Config: /user/username/projects/myproject/packages/consumer/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/consumer/src/index.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/packages/consumer/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/packages/emit-composite",
+   "originalPath": "../emit-composite"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/consumer/src 1 undefined Config: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/consumer/src 1 undefined Config: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/packages/consumer/tsconfig.json
+Config: /user/username/projects/myproject/packages/emit-composite/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/packages/emit-composite/src/index.js",
+  "/user/username/projects/myproject/packages/emit-composite/src/testModule.js"
+ ],
+ "options": {
+  "composite": true,
+  "allowJs": true,
+  "emitDeclarationOnly": true,
+  "outDir": "/user/username/projects/myproject/packages/emit-composite/lib",
+  "rootDir": "/user/username/projects/myproject/packages/emit-composite/src",
+  "configFilePath": "/user/username/projects/myproject/packages/emit-composite/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/emit-composite/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/emit-composite/src 1 undefined Config: /user/username/projects/myproject/packages/emit-composite/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/emit-composite/src 1 undefined Config: /user/username/projects/myproject/packages/emit-composite/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/emit-composite/src/index.js 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/emit-composite 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/emit-composite 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/emit-composite/src/testModule.js 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/consumer/src 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/consumer/src 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/consumer/node_modules 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/consumer/node_modules 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/consumer/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/consumer/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/packages/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/packages/consumer/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/packages/consumer/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/myproject/packages/consumer/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/packages/emit-composite/src/testModule.js
+	/user/username/projects/myproject/packages/emit-composite/src/index.js
+	/user/username/projects/myproject/packages/consumer/src/index.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library
+	../emit-composite/src/testModule.js
+	  Imported via './testModule' from file '../emit-composite/src/index.js'
+	../emit-composite/src/index.js
+	  Imported via 'emit-composite' from file 'src/index.ts' with packageId 'emit-composite/lib/index.d.ts@1.0.0'
+	src/index.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/packages/consumer/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"f6f890b868ee990140855d3b392e7be25cc511c224e307bfaf73c9f27a024a79","fileStats":{"js":2,"jsSize":203,"jsx":0,"jsxSize":0,"ts":1,"tsSize":143,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/packages/consumer/src/index.ts","configFile":"/user/username/projects/myproject/packages/consumer/tsconfig.json","diagnostics":[]}}
+Project '/user/username/projects/myproject/packages/consumer/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/packages/consumer/src/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/packages/consumer/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/packages/consumer/src/index.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/packages/consumer/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/user/username/projects/myproject/packages/consumer/src/index.ts","diagnostics":[{"start":{"line":3,"offset":42},"end":{"line":3,"offset":44},"text":"Expected 1 arguments, but got 2.","code":2554,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/user/username/projects/myproject/packages/consumer/src/index.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projectReferences/with-disableSolutionSearching-solution-and-siblings-are-not-loaded.js
+++ b/tests/baselines/reference/tsserver/projectReferences/with-disableSolutionSearching-solution-and-siblings-are-not-loaded.js
@@ -1,0 +1,52 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/solution/compiler/program.ts"}}
+Search path: /user/username/projects/solution/compiler
+For info: /user/username/projects/solution/compiler/program.ts :: Config file name: /user/username/projects/solution/compiler/tsconfig.json
+Creating configuration project /user/username/projects/solution/compiler/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/tsconfig.json 2000 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Config file
+Config: /user/username/projects/solution/compiler/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/solution/compiler/types.ts",
+  "/user/username/projects/solution/compiler/program.ts"
+ ],
+ "options": {
+  "composite": true,
+  "module": 0,
+  "disableSolutionSearching": true,
+  "configFilePath": "/user/username/projects/solution/compiler/tsconfig.json"
+ }
+}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/types.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/solution/compiler/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/solution/compiler/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/user/username/projects/solution/compiler/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/solution/compiler/types.ts
+	/user/username/projects/solution/compiler/program.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library
+	types.ts
+	  Part of 'files' list in tsconfig.json
+	program.ts
+	  Part of 'files' list in tsconfig.json
+
+-----------------------------------------------
+Project '/user/username/projects/solution/compiler/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/solution/compiler/program.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/solution/compiler/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/solution/compiler/program.ts","line":4,"offset":25},"seq":1,"type":"request"}
+response:{"response":{"refs":[{"file":"/user/username/projects/solution/compiler/types.ts","start":{"line":4,"offset":25},"end":{"line":4,"offset":39},"contextStart":{"line":4,"offset":25},"contextEnd":{"line":4,"offset":52},"lineText":"                        getSourceFiles(): string[];","isWriteAccess":false,"isDefinition":true},{"file":"/user/username/projects/solution/compiler/program.ts","start":{"line":4,"offset":25},"end":{"line":4,"offset":39},"contextStart":{"line":4,"offset":25},"contextEnd":{"line":4,"offset":64},"lineText":"                        getSourceFiles: () => [getSourceFile()]","isWriteAccess":true,"isDefinition":true}],"symbolName":"getSourceFiles","symbolStartOffset":25,"symbolDisplayString":"(method) ts.Program.getSourceFiles(): string[]"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/with-disableSolutionSearching-solution-and-siblings-are-not-loaded.js
+++ b/tests/baselines/reference/tsserver/projectReferences/with-disableSolutionSearching-solution-and-siblings-are-not-loaded.js
@@ -24,7 +24,7 @@ DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/compiler/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/solution/node_modules/@types 1 undefined Project: /user/username/projects/solution/compiler/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /user/username/projects/solution/compiler/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /user/username/projects/solution/compiler/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/user/username/projects/solution/compiler/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projects/getting-errors-from-closed-script-info-does-not-throw-exception-because-of-getting-project-from-orphan-script-info.js
+++ b/tests/baselines/reference/tsserver/projects/getting-errors-from-closed-script-info-does-not-throw-exception-because-of-getting-project-from-orphan-script-info.js
@@ -19,7 +19,7 @@ Starting updateGraphWorker: Project: /a/b/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/a/b/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projects/getting-errors-from-closed-script-info-does-not-throw-exception-because-of-getting-project-from-orphan-script-info.js
+++ b/tests/baselines/reference/tsserver/projects/getting-errors-from-closed-script-info-does-not-throw-exception-because-of-getting-project-from-orphan-script-info.js
@@ -1,0 +1,52 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/a/b/app.ts"},"seq":1,"type":"request"}
+Search path: /a/b
+For info: /a/b/app.ts :: Config file name: /a/b/tsconfig.json
+Creating configuration project /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/app.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/app.ts
+
+
+	../lib/lib.d.ts
+	  Default library
+	app.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/app.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"close","arguments":{"file":"/a/b/app.ts"},"seq":2,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /a/b/app.ts 500 undefined WatchType: Closed Script info
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/a/b/app.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}

--- a/tests/baselines/reference/tsserver/projects/handles-delayed-directory-watch-invoke-on-file-creation.js
+++ b/tests/baselines/reference/tsserver/projects/handles-delayed-directory-watch-invoke-on-file-creation.js
@@ -23,7 +23,7 @@ Starting updateGraphWorker: Project: /users/username/projects/project/tsconfig.j
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/node_modules/@types 1 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/node_modules/@types 1 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/project/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -92,7 +92,7 @@ request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/users/u
 Search path: /users/username/projects/project
 For info: /users/username/projects/project/a.ts :: Config file name: /users/username/projects/project/tsconfig.json
 Starting updateGraphWorker: Project: /users/username/projects/project/tsconfig.json
-Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/project/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -159,7 +159,7 @@ Search path: /users/username/projects/project/sub
 For info: /users/username/projects/project/sub/a.ts :: Config file name: /users/username/projects/project/tsconfig.json
 Starting updateGraphWorker: Project: /users/username/projects/project/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /users/username/projects/project/a.ts 500 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Missing file
-Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/project/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -183,7 +183,7 @@ DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/node_
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -264,7 +264,7 @@ FileWatcher:: Close:: WatchInfo: /users/username/projects/project/sub/jsconfig.j
 FileWatcher:: Close:: WatchInfo: /users/username/projects/project/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
 Starting updateGraphWorker: Project: /users/username/projects/project/tsconfig.json
 FileWatcher:: Close:: WatchInfo: /users/username/projects/project/a.ts 500 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Missing file
-Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 4 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 4 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/project/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/projects/handles-delayed-directory-watch-invoke-on-file-creation.js
+++ b/tests/baselines/reference/tsserver/projects/handles-delayed-directory-watch-invoke-on-file-creation.js
@@ -1,0 +1,296 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/users/username/projects/project/b.ts","projectRootPath":"/users/username/projects/project"}}
+Search path: /users/username/projects/project
+For info: /users/username/projects/project/b.ts :: Config file name: /users/username/projects/project/tsconfig.json
+Creating configuration project /users/username/projects/project/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/project/tsconfig.json 2000 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/users/username/projects/project/tsconfig.json","reason":"Creating possible configured project for /users/username/projects/project/b.ts to open"}}
+Config: /users/username/projects/project/tsconfig.json : {
+ "rootNames": [
+  "/users/username/projects/project/b.ts",
+  "/users/username/projects/project/sub/a.ts"
+ ],
+ "options": {
+  "configFilePath": "/users/username/projects/project/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/a.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /users/username/projects/project/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/node_modules/@types 1 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/node_modules/@types 1 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/project/b.ts
+	/users/username/projects/project/sub/a.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	b.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	sub/a.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/users/username/projects/project/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"5b0be5fc7f7235edf5a31bffe614b4e0819e55ec5f118558864b1f882e283c0d","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":2,"tsSize":40,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/users/username/projects/project/b.ts","configFile":"/users/username/projects/project/tsconfig.json","diagnostics":[]}}
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/users/username/projects/project/sub/a.ts","projectRootPath":"/users/username/projects/project"}}
+FileWatcher:: Close:: WatchInfo: /users/username/projects/project/sub/a.ts 500 undefined WatchType: Closed Script info
+Search path: /users/username/projects/project/sub
+For info: /users/username/projects/project/sub/a.ts :: Config file name: /users/username/projects/project/tsconfig.json
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+	FileName: /users/username/projects/project/sub/a.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+response:{"responseRequired":false}
+DirectoryWatcher:: Triggered with /users/username/projects/project/sub/a.ts :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/project/sub/a.ts :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /users/username/projects/project/sub :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+Scheduled: /users/username/projects/project/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/project/sub :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /users/username/projects/project/a.ts :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+Scheduled: /users/username/projects/project/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/project/a.ts :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+request:{"seq":0,"type":"request","command":"close","arguments":{"file":"/users/username/projects/project/sub/a.ts"}}
+Scheduled: /users/username/projects/project/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/users/username/projects/project/a.ts","projectRootPath":"/users/username/projects/project"}}
+Search path: /users/username/projects/project
+For info: /users/username/projects/project/a.ts :: Config file name: /users/username/projects/project/tsconfig.json
+Starting updateGraphWorker: Project: /users/username/projects/project/tsconfig.json
+Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/project/b.ts
+	/users/username/projects/project/a.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	b.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	a.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+	FileName: /users/username/projects/project/a.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+response:{"responseRequired":false}
+Running: /users/username/projects/project/tsconfig.json
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+	FileName: /users/username/projects/project/a.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+	FileName: /users/username/projects/project/a.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+got projects updated in background, updating diagnostics for /users/username/projects/project/b.ts,/users/username/projects/project/a.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/users/username/projects/project/b.ts","/users/username/projects/project/a.ts"]}}
+request:{"seq":0,"type":"request","command":"close","arguments":{"file":"/users/username/projects/project/a.ts"}}
+Scheduled: /users/username/projects/project/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/users/username/projects/project/sub/a.ts","projectRootPath":"/users/username/projects/project"}}
+Search path: /users/username/projects/project/sub
+For info: /users/username/projects/project/sub/a.ts :: Config file name: /users/username/projects/project/tsconfig.json
+Starting updateGraphWorker: Project: /users/username/projects/project/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/project/a.ts 500 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Missing file
+Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/users/username/projects/project/b.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	b.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/users/username/projects/project/sub/a.ts","configFile":"/users/username/projects/project/tsconfig.json","diagnostics":[{"text":"File '/users/username/projects/project/a.ts' not found.\n  The file is in the program because:\n    Matched by include pattern '**/*' in '/users/username/projects/project/tsconfig.json'","code":6053,"category":"error"}]}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /users/username/projects/project/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/sub/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/users/username/projects/project/sub/a.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	a.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+	FileName: /users/username/projects/project/sub/a.ts ProjectRootPath: /users/username/projects/project
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+Running: /users/username/projects/project/tsconfig.json
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+	FileName: /users/username/projects/project/sub/a.ts ProjectRootPath: /users/username/projects/project
+		Projects: /dev/null/inferredProject1*
+After ensureProjectForOpenFiles:
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/project/b.ts ProjectRootPath: /users/username/projects/project
+		Projects: /users/username/projects/project/tsconfig.json
+	FileName: /users/username/projects/project/sub/a.ts ProjectRootPath: /users/username/projects/project
+		Projects: /dev/null/inferredProject1*
+got projects updated in background, updating diagnostics for /users/username/projects/project/b.ts,/users/username/projects/project/sub/a.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/users/username/projects/project/b.ts","/users/username/projects/project/sub/a.ts"]}}
+FileWatcher:: Triggered with /users/username/projects/project/a.ts 2:: WatchInfo: /users/username/projects/project/a.ts 500 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Missing file
+Elapsed:: *ms FileWatcher:: Triggered with /users/username/projects/project/a.ts 2:: WatchInfo: /users/username/projects/project/a.ts 500 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Triggered with /users/username/projects/project/a.ts :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+Scheduled: /users/username/projects/project/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/project/a.ts :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /users/username/projects/project/sub :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+Scheduled: /users/username/projects/project/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/project/sub :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /users/username/projects/project/sub/a.ts :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+Scheduled: /users/username/projects/project/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/project/sub/a.ts :: WatchInfo: /users/username/projects/project 1 undefined Config: /users/username/projects/project/tsconfig.json WatchType: Wild card directory
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/project/b.ts","/users/username/projects/project/sub/a.ts"]},"seq":1,"type":"request"}
+response:{"responseRequired":false}
+FileWatcher:: Close:: WatchInfo: /users/username/projects/project/sub/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /users/username/projects/project/sub/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Close:: WatchInfo: /users/username/projects/project/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /users/username/projects/project/tsconfig.json
+FileWatcher:: Close:: WatchInfo: /users/username/projects/project/a.ts 500 undefined Project: /users/username/projects/project/tsconfig.json WatchType: Missing file
+Finishing updateGraphWorker: Project: /users/username/projects/project/tsconfig.json Version: 4 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/project/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/project/b.ts
+	/users/username/projects/project/sub/a.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	b.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	sub/a.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/project/b.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/project/b.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/project/b.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/project/sub/a.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/project/sub/a.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/project/sub/a.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":1}}

--- a/tests/baselines/reference/tsserver/projects/handles-the-missing-files-added-with-tripleslash-ref.js
+++ b/tests/baselines/reference/tsserver/projects/handles-the-missing-files-added-with-tripleslash-ref.js
@@ -1,0 +1,76 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/commonFile1.ts"}}
+Search path: /a/b
+For info: /a/b/commonFile1.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/b/commonfile2.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/commonFile1.ts
+
+
+	../lib/lib.d.ts
+	  Default library for target 'es5'
+	commonFile1.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/commonFile1.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"semanticDiagnosticsSync","arguments":{"file":"/a/b/commonFile1.ts"}}
+response:{"response":[{"start":{"line":2,"offset":29},"end":{"line":2,"offset":30},"text":"Cannot find name 'y'.","code":2304,"category":"error"},{"start":{"line":1,"offset":22},"end":{"line":1,"offset":36},"text":"File '/a/b/commonFile2.ts' not found.","code":6053,"category":"error"}],"responseRequired":true}
+FileWatcher:: Triggered with /a/b/commonFile2.ts 0:: WatchInfo: /a/b/commonfile2.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+FileWatcher:: Close:: WatchInfo: /a/b/commonfile2.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+Scheduled: /dev/null/inferredProject1*
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /a/b/commonFile2.ts 0:: WatchInfo: /a/b/commonfile2.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+Running: /dev/null/inferredProject1*
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/b/commonFile2.ts 500 undefined WatchType: Closed Script info
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (3)
+	/a/lib/lib.d.ts
+	/a/b/commonFile2.ts
+	/a/b/commonFile1.ts
+
+
+	../lib/lib.d.ts
+	  Default library for target 'es5'
+	commonFile2.ts
+	  Referenced via 'commonFile2.ts' from file 'commonFile1.ts'
+	commonFile1.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/commonFile1.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+After ensureProjectForOpenFiles:
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/commonFile1.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+request:{"seq":0,"type":"request","command":"semanticDiagnosticsSync","arguments":{"file":"/a/b/commonFile1.ts"}}
+response:{"response":[],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/resolutionCache/disable-suggestion-diagnostics.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/disable-suggestion-diagnostics.js
@@ -7,7 +7,7 @@ Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (1)
 	/a.js

--- a/tests/baselines/reference/tsserver/resolutionCache/disable-suggestion-diagnostics.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/disable-suggestion-diagnostics.js
@@ -1,0 +1,39 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/a.js","fileContent":"require(\"b\")"},"seq":1,"type":"request"}
+Search path: /
+For info: /a.js :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+	/a.js
+
+
+	a.js
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a.js ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"configure","arguments":{"preferences":{"disableSuggestions":true}},"seq":2,"type":"request"}
+response:
+    {"seq":0,"type":"response","command":"configure","request_seq":2,"success":true,"performanceData":{"updateGraphDurationMs":*}}
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/a.js"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/a.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/a.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/resolutionCache/npm-install-@types-works.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/npm-install-@types-works.js
@@ -1,0 +1,109 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/a/b/projects/temp/a.ts","fileContent":"import f = require(\"pad\"); f;","scriptKindName":"TS","projectRootPath":"/a/b/projects/temp"},"seq":1,"type":"request"}
+Search path: /a/b/projects/temp
+For info: /a/b/projects/temp/a.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /a/b/projects/temp/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /a/b/projects/temp/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/projects/temp/a.ts
+
+
+	../../../lib/lib.d.ts
+	  Default library for target 'es5'
+	a.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/temp/a.ts ProjectRootPath: /a/b/projects/temp
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/a/b/projects/temp/a.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/a/b/projects/temp/a.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/a/b/projects/temp/a.ts","diagnostics":[{"start":{"line":1,"offset":20},"end":{"line":1,"offset":25},"text":"Cannot find module 'pad' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/a/b/projects/temp/a.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+DirectoryWatcher:: Triggered with /a/b/projects/temp/node_modules :: WatchInfo: /a/b/projects/temp/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Scheduled: /dev/null/inferredProject1*FailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/temp/node_modules :: WatchInfo: /a/b/projects/temp/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /a/b/projects/temp/node_modules/@types :: WatchInfo: /a/b/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Scheduled: /dev/null/inferredProject1*
+Scheduled: *ensureProjectForOpenFiles*
+Scheduled: /dev/null/inferredProject1*FailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/temp/node_modules/@types :: WatchInfo: /a/b/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Triggered with /a/b/projects/temp/node_modules/@types :: WatchInfo: /a/b/projects/temp/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Scheduled: /dev/null/inferredProject1*FailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/temp/node_modules/@types :: WatchInfo: /a/b/projects/temp/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /a/b/projects/temp/node_modules/@types/pad :: WatchInfo: /a/b/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Scheduled: /dev/null/inferredProject1*, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Scheduled: /dev/null/inferredProject1*FailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/temp/node_modules/@types/pad :: WatchInfo: /a/b/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Triggered with /a/b/projects/temp/node_modules/@types/pad :: WatchInfo: /a/b/projects/temp/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Scheduled: /dev/null/inferredProject1*FailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/projects/temp/node_modules/@types/pad :: WatchInfo: /a/b/projects/temp/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Running: /dev/null/inferredProject1*
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules 1 undefined WatchType: node_modules for closed script infos in them
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules 1 undefined WatchType: node_modules for closed script infos in them
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (3)
+	/a/lib/lib.d.ts
+	/a/b/projects/temp/node_modules/@types/pad/index.d.ts
+	/a/b/projects/temp/a.ts
+
+
+	../../../lib/lib.d.ts
+	  Default library for target 'es5'
+	node_modules/@types/pad/index.d.ts
+	  Imported via "pad" from file 'a.ts'
+	  Entry point for implicit type library 'pad'
+	a.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/temp/a.ts ProjectRootPath: /a/b/projects/temp
+		Projects: /dev/null/inferredProject1*
+After ensureProjectForOpenFiles:
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/temp/a.ts ProjectRootPath: /a/b/projects/temp
+		Projects: /dev/null/inferredProject1*
+got projects updated in background, updating diagnostics for /a/b/projects/temp/a.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/a/b/projects/temp/a.ts"]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/a/b/projects/temp/a.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/a/b/projects/temp/a.ts","diagnostics":[]}}

--- a/tests/baselines/reference/tsserver/resolutionCache/npm-install-@types-works.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/npm-install-@types-works.js
@@ -11,7 +11,7 @@ DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules 1 undefine
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
 DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -66,7 +66,7 @@ Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules 1 undefined WatchType: node_modules for closed script infos in them
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/temp/node_modules 1 undefined WatchType: node_modules for closed script infos in them
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/resolutionCache/renaming-module-should-restore-the-states-for-configured-projects.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/renaming-module-should-restore-the-states-for-configured-projects.js
@@ -1,0 +1,143 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/file1.ts"}}
+Search path: /a/b
+For info: /a/b/file1.ts :: Config file name: /a/b/tsconfig.json
+Creating configuration project /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/tsconfig.json 2000 undefined Project: /a/b/tsconfig.json WatchType: Config file
+Config: /a/b/tsconfig.json : {
+ "rootNames": [
+  "/a/b/file1.ts",
+  "/a/b/moduleFile.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /a/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /a/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/b/moduleFile.ts
+	/a/b/file1.ts
+
+
+	moduleFile.ts
+	  Imported via './moduleFile' from file 'file1.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/file1.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"semanticDiagnosticsSync","arguments":{"file":"/a/b/file1.ts"}}
+response:{"response":[],"responseRequired":true}
+FileWatcher:: Triggered with /a/b/moduleFile.ts 2:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+Scheduled: /a/b/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /a/b/moduleFile.ts 2:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Triggered with /a/b/moduleFile.ts :: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Scheduled: /a/b/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/moduleFile.ts :: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /a/b/moduleFile1.ts :: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Scheduled: /a/b/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/moduleFile1.ts :: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Running: /a/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/moduleFile1.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /a/b/moduleFile 1 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/moduleFile 1 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /a/b 0 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b 0 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/b/file1.ts
+	/a/b/moduleFile1.ts
+
+
+	file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	moduleFile1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/file1.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/file1.ts ProjectRootPath: undefined
+		Projects: /a/b/tsconfig.json
+request:{"seq":0,"type":"request","command":"semanticDiagnosticsSync","arguments":{"file":"/a/b/file1.ts"}}
+response:{"response":[{"start":{"line":1,"offset":20},"end":{"line":1,"offset":34},"text":"Cannot find module './moduleFile' or its corresponding type declarations.","code":2307,"category":"error"}],"responseRequired":true}
+FileWatcher:: Triggered with /a/b/moduleFile1.ts 2:: WatchInfo: /a/b/moduleFile1.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /a/b/moduleFile1.ts 500 undefined WatchType: Closed Script info
+Scheduled: /a/b/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /a/b/moduleFile1.ts 2:: WatchInfo: /a/b/moduleFile1.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Triggered with /a/b/moduleFile1.ts :: WatchInfo: /a/b 0 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /a/b/tsconfig.jsonFailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/moduleFile1.ts :: WatchInfo: /a/b 0 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /a/b/moduleFile1.ts :: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Scheduled: /a/b/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/moduleFile1.ts :: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Triggered with /a/b/moduleFile.ts :: WatchInfo: /a/b 0 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /a/b/tsconfig.jsonFailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/moduleFile.ts :: WatchInfo: /a/b 0 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /a/b/moduleFile.ts :: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Scheduled: /a/b/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/moduleFile.ts :: WatchInfo: /a/b 1 undefined Config: /a/b/tsconfig.json WatchType: Wild card directory
+Running: /a/b/tsconfig.jsonFailedLookupInvalidation
+Scheduled: /a/b/tsconfig.json, Cancelled earlier one
+Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
+request:{"seq":0,"type":"request","command":"semanticDiagnosticsSync","arguments":{"file":"/a/b/file1.ts"}}
+FileWatcher:: Added:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /a/b/tsconfig.json
+DirectoryWatcher:: Close:: WatchInfo: /a/b/moduleFile 1 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a/b/moduleFile 1 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /a/b 0 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a/b 0 undefined Project: /a/b/tsconfig.json WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /a/b/tsconfig.json Version: 3 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/a/b/tsconfig.json' (Configured)
+	Files (2)
+	/a/b/moduleFile.ts
+	/a/b/file1.ts
+
+
+	moduleFile.ts
+	  Imported via './moduleFile' from file 'file1.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	file1.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+response:{"response":[],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/resolutionCache/renaming-module-should-restore-the-states-for-inferred-projects.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/renaming-module-should-restore-the-states-for-inferred-projects.js
@@ -1,0 +1,123 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/file1.ts"}}
+Search path: /a/b
+For info: /a/b/file1.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/b/moduleFile.ts
+	/a/b/file1.ts
+
+
+	moduleFile.ts
+	  Imported via './moduleFile' from file 'file1.ts'
+	file1.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/file1.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"semanticDiagnosticsSync","arguments":{"file":"/a/b/file1.ts"}}
+response:{"response":[],"responseRequired":true}
+FileWatcher:: Triggered with /a/b/moduleFile.ts 2:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+Scheduled: /dev/null/inferredProject1*
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /a/b/moduleFile.ts 2:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+Running: /dev/null/inferredProject1*
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /a/b/moduleFile 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/moduleFile 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+	/a/b/file1.ts
+
+
+	file1.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/file1.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+After ensureProjectForOpenFiles:
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/file1.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+request:{"seq":0,"type":"request","command":"semanticDiagnosticsSync","arguments":{"file":"/a/b/file1.ts"}}
+response:{"response":[{"start":{"line":1,"offset":20},"end":{"line":1,"offset":34},"text":"Cannot find module './moduleFile' or its corresponding type declarations.","code":2307,"category":"error"}],"responseRequired":true}
+DirectoryWatcher:: Triggered with /a/b/moduleFile1.ts :: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Scheduled: /dev/null/inferredProject1*FailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/moduleFile1.ts :: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /a/b/moduleFile.ts :: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Scheduled: /dev/null/inferredProject1*FailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/moduleFile.ts :: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Running: /dev/null/inferredProject1*FailedLookupInvalidation
+Scheduled: /dev/null/inferredProject1*
+Scheduled: *ensureProjectForOpenFiles*
+request:{"seq":0,"type":"request","command":"change","arguments":{"file":"/a/b/file1.ts","line":1,"offset":44,"endLine":1,"endOffset":44,"insertString":"\n"}}
+response:{"responseRequired":false}
+Running: /dev/null/inferredProject1*
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Close:: WatchInfo: /a/b/moduleFile 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a/b/moduleFile 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/b/moduleFile.ts
+	/a/b/file1.ts
+
+
+	moduleFile.ts
+	  Imported via './moduleFile' from file 'file1.ts'
+	file1.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/file1.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+After ensureProjectForOpenFiles:
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/file1.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+request:{"seq":0,"type":"request","command":"semanticDiagnosticsSync","arguments":{"file":"/a/b/file1.ts"}}
+response:{"response":[],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/resolutionCache/should-remove-the-module-not-found-error.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/should-remove-the-module-not-found-error.js
@@ -1,0 +1,62 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/a/b/file1.ts"}}
+Search path: /a/b
+For info: /a/b/file1.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /a/b/moduleFile 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/moduleFile 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+	/a/b/file1.ts
+
+
+	file1.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/file1.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"semanticDiagnosticsSync","arguments":{"file":"/a/b/file1.ts"}}
+response:{"response":[{"start":{"line":1,"offset":20},"end":{"line":1,"offset":34},"text":"Cannot find module './moduleFile' or its corresponding type declarations.","code":2307,"category":"error"}],"responseRequired":true}
+DirectoryWatcher:: Triggered with /a/b/moduleFile.ts :: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Scheduled: /dev/null/inferredProject1*FailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /a/b/moduleFile.ts :: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Running: /dev/null/inferredProject1*FailedLookupInvalidation
+Scheduled: /dev/null/inferredProject1*
+Scheduled: *ensureProjectForOpenFiles*
+request:{"seq":0,"type":"request","command":"change","arguments":{"file":"/a/b/file1.ts","line":1,"offset":44,"endLine":1,"endOffset":44,"insertString":"\n"}}
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"semanticDiagnosticsSync","arguments":{"file":"/a/b/file1.ts"}}
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/b/moduleFile.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Close:: WatchInfo: /a/b/moduleFile 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a/b/moduleFile 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a/b 0 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/b/moduleFile.ts
+	/a/b/file1.ts
+
+
+	moduleFile.ts
+	  Imported via './moduleFile' from file 'file1.ts'
+	file1.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+response:{"response":[],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/resolutionCache/suggestion-diagnostics.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/suggestion-diagnostics.js
@@ -1,0 +1,35 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/a.js","fileContent":"function f(p) {}"},"seq":1,"type":"request"}
+Search path: /
+For info: /a.js :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+	/a.js
+
+
+	a.js
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a.js ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/a.js"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/a.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/a.js","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/a.js","diagnostics":[{"start":{"line":1,"offset":12},"end":{"line":1,"offset":13},"text":"'p' is declared but its value is never read.","code":6133,"category":"suggestion","reportsUnnecessary":true}]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}

--- a/tests/baselines/reference/tsserver/resolutionCache/suggestion-diagnostics.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/suggestion-diagnostics.js
@@ -5,7 +5,7 @@ For info: /a.js :: No config files found.
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (1)
 	/a.js

--- a/tests/baselines/reference/tsserver/resolutionCache/suppressed-diagnostic-events.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/suppressed-diagnostic-events.js
@@ -1,0 +1,33 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/a.ts","fileContent":"1 = 2;"},"seq":1,"type":"request"}
+Search path: /
+For info: /a.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+	/a.ts
+
+
+	a.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (1)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/a.ts"]},"seq":2,"type":"request"}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"file":"/a.ts"},"seq":3,"type":"request"}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}
+response:{"responseRequired":false}

--- a/tests/baselines/reference/tsserver/resolutionCache/suppressed-diagnostic-events.js
+++ b/tests/baselines/reference/tsserver/resolutionCache/suppressed-diagnostic-events.js
@@ -5,7 +5,7 @@ For info: /a.ts :: No config files found.
 Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
 Starting updateGraphWorker: Project: /dev/null/inferredProject1*
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
-Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/dev/null/inferredProject1*' (Inferred)
 	Files (1)
 	/a.ts

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-compiles-from-sources.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-compiles-from-sources.js
@@ -37,7 +37,7 @@ DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -94,7 +94,7 @@ DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-compiles-from-sources.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-compiles-from-sources.js
@@ -1,0 +1,142 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","projectRootPath":"/users/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime
+For info: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts :: Config file name: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Creating configuration project /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json 2000 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","reason":"Creating possible configured project for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts to open"}}
+Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json : {
+ "rootNames": [
+  "/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"
+ ],
+ "options": {
+  "configFilePath": "/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"a6bd830f3b019a6f703b938422f5798726d0914f0d6f67c2539798ea5e66fed2","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":55,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","configFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","diagnostics":[]}}
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[{"start":{"line":1,"offset":17},"end":{"line":1,"offset":46},"text":"Cannot find module '@microsoft/recognizers-text' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@microsoft :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@microsoft :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@microsoft/recognizers-text :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@microsoft/recognizers-text :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	../recognizers-text/dist/types/recognizers-text.d.ts
+	  Imported via "@microsoft/recognizers-text" from file 'src/datetime/baseDate.ts'
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+got projects updated in background, updating diagnostics for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
@@ -37,7 +37,7 @@ DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
@@ -1,0 +1,86 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","projectRootPath":"/users/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime
+For info: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts :: Config file name: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Creating configuration project /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json 2000 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","reason":"Creating possible configured project for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts to open"}}
+Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json : {
+ "rootNames": [
+  "/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"
+ ],
+ "options": {
+  "configFilePath": "/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"a6bd830f3b019a6f703b938422f5798726d0914f0d6f67c2539798ea5e66fed2","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":55,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","configFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","diagnostics":[]}}
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[{"start":{"line":1,"offset":17},"end":{"line":1,"offset":46},"text":"Cannot find module '@microsoft/recognizers-text' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[{"start":{"line":1,"offset":17},"end":{"line":1,"offset":46},"text":"Cannot find module '@microsoft/recognizers-text' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-recompiles-after-deleting-generated-folders.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-recompiles-after-deleting-generated-folders.js
@@ -1,0 +1,142 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","projectRootPath":"/users/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime
+For info: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts :: Config file name: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Creating configuration project /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json 2000 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","reason":"Creating possible configured project for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts to open"}}
+Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json : {
+ "rootNames": [
+  "/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"
+ ],
+ "options": {
+  "configFilePath": "/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	../recognizers-text/dist/types/recognizers-text.d.ts
+	  Imported via "@microsoft/recognizers-text" from file 'src/datetime/baseDate.ts'
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"a6bd830f3b019a6f703b938422f5798726d0914f0d6f67c2539798ea5e66fed2","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":55,"tsx":0,"tsxSize":0,"dts":2,"dtsSize":370,"deferred":0,"deferredSize":0},"compilerOptions":{},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","configFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","diagnostics":[]}}
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+FileWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 2:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 2:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+got projects updated in background, updating diagnostics for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[{"start":{"line":1,"offset":17},"end":{"line":1,"offset":46},"text":"Cannot find module '@microsoft/recognizers-text' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":4,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[{"start":{"line":1,"offset":17},"end":{"line":1,"offset":46},"text":"Cannot find module '@microsoft/recognizers-text' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":4}}

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-recompiles-after-deleting-generated-folders.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-when-project-recompiles-after-deleting-generated-folders.js
@@ -32,7 +32,7 @@ DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -85,7 +85,7 @@ DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-compiles-from-sources.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-compiles-from-sources.js
@@ -49,7 +49,7 @@ DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -119,7 +119,7 @@ DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-compiles-from-sources.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-compiles-from-sources.js
@@ -1,0 +1,167 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","projectRootPath":"/users/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime
+For info: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts :: Config file name: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Creating configuration project /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json 2000 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","reason":"Creating possible configured project for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts to open"}}
+Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json : {
+ "rootNames": [
+  "/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"
+ ],
+ "options": {
+  "rootDir": "/users/username/projects/myproject/javascript/packages/recognizers-date-time/src",
+  "baseUrl": "/users/username/projects/myproject/javascript/packages/recognizers-date-time",
+  "paths": {
+   "@microsoft/*": [
+    "../*"
+   ]
+  },
+  "pathsBasePath": "/users/username/projects/myproject/javascript/packages/recognizers-date-time",
+  "configFilePath": "/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages 0 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages 0 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"a6bd830f3b019a6f703b938422f5798726d0914f0d6f67c2539798ea5e66fed2","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":55,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"rootDir":"","baseUrl":"","paths":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","configFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","diagnostics":[]}}
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[{"start":{"line":1,"offset":17},"end":{"line":1,"offset":46},"text":"Cannot find module '@microsoft/recognizers-text' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@microsoft :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@microsoft :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@microsoft/recognizers-text :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@microsoft/recognizers-text :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	../recognizers-text/dist/types/recognizers-text.d.ts
+	  Imported via "@microsoft/recognizers-text" from file 'src/datetime/baseDate.ts'
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+got projects updated in background, updating diagnostics for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
@@ -49,7 +49,7 @@ DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -111,7 +111,7 @@ DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-has-node_modules-setup-but-doesnt-have-modules-in-typings-folder-and-then-recompiles.js
@@ -1,0 +1,159 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","projectRootPath":"/users/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime
+For info: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts :: Config file name: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Creating configuration project /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json 2000 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","reason":"Creating possible configured project for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts to open"}}
+Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json : {
+ "rootNames": [
+  "/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"
+ ],
+ "options": {
+  "rootDir": "/users/username/projects/myproject/javascript/packages/recognizers-date-time/src",
+  "baseUrl": "/users/username/projects/myproject/javascript/packages/recognizers-date-time",
+  "paths": {
+   "@microsoft/*": [
+    "../*"
+   ]
+  },
+  "pathsBasePath": "/users/username/projects/myproject/javascript/packages/recognizers-date-time",
+  "configFilePath": "/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages 0 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages 0 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"a6bd830f3b019a6f703b938422f5798726d0914f0d6f67c2539798ea5e66fed2","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":55,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"rootDir":"","baseUrl":"","paths":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","configFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","diagnostics":[]}}
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[{"start":{"line":1,"offset":17},"end":{"line":1,"offset":46},"text":"Cannot find module '@microsoft/recognizers-text' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	../recognizers-text/dist/types/recognizers-text.d.ts
+	  Imported via "@microsoft/recognizers-text" from file 'src/datetime/baseDate.ts'
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+got projects updated in background, updating diagnostics for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-recompiles-after-deleting-generated-folders.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-recompiles-after-deleting-generated-folders.js
@@ -38,7 +38,7 @@ DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -97,7 +97,7 @@ DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (2)
 	/a/lib/lib.d.ts
@@ -167,7 +167,7 @@ DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascr
 Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
-Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 3 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts

--- a/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-recompiles-after-deleting-generated-folders.js
+++ b/tests/baselines/reference/tsserver/symLinks/module-resolution-with-path-mapping-when-project-recompiles-after-deleting-generated-folders.js
@@ -1,0 +1,215 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","projectRootPath":"/users/username/projects/myproject"},"seq":1,"type":"request"}
+Search path: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime
+For info: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts :: Config file name: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Creating configuration project /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json 2000 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Config file
+event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","reason":"Creating possible configured project for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts to open"}}
+Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json : {
+ "rootNames": [
+  "/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"
+ ],
+ "options": {
+  "rootDir": "/users/username/projects/myproject/javascript/packages/recognizers-date-time/src",
+  "baseUrl": "/users/username/projects/myproject/javascript/packages/recognizers-date-time",
+  "paths": {
+   "@microsoft/*": [
+    "../*"
+   ]
+  },
+  "pathsBasePath": "/users/username/projects/myproject/javascript/packages/recognizers-date-time",
+  "configFilePath": "/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Config: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages 0 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages 0 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules/@types 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	../recognizers-text/dist/types/recognizers-text.d.ts
+	  Imported via "@microsoft/recognizers-text" from file 'src/datetime/baseDate.ts'
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json"}}
+event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"a6bd830f3b019a6f703b938422f5798726d0914f0d6f67c2539798ea5e66fed2","fileStats":{"js":0,"jsSize":0,"jsx":0,"jsxSize":0,"ts":1,"tsSize":55,"tsx":0,"tsxSize":0,"dts":2,"dtsSize":370,"deferred":0,"deferredSize":0},"compilerOptions":{"rootDir":"","baseUrl":"","paths":""},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"4.4.0-dev"}}}
+event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","configFile":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json","diagnostics":[]}}
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}
+FileWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 2:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Elapsed:: *ms FileWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 2:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 2 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+got projects updated in background, updating diagnostics for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]}}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":3,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[{"start":{"line":1,"offset":17},"end":{"line":1,"offset":46},"text":"Cannot find module '@microsoft/recognizers-text' or its corresponding type declarations.","code":2307,"category":"error"}]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation
+Elapsed:: *ms DirectoryWatcher:: Triggered with /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts :: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.jsonFailedLookupInvalidation
+Scheduled: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Scheduled: *ensureProjectForOpenFiles*
+Running: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+Starting updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-text 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/recognizers-date-time/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/packages/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/javascript/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /users/username/projects/myproject/node_modules 1 undefined Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json WatchType: Failed Lookup Locations
+Finishing updateGraphWorker: Project: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json Version: 3 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-text/dist/types/recognizers-text.d.ts
+	/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library
+	../recognizers-text/dist/types/recognizers-text.d.ts
+	  Imported via "@microsoft/recognizers-text" from file 'src/datetime/baseDate.ts'
+	src/datetime/baseDate.ts
+	  Matched by include pattern 'src' in 'tsconfig.json'
+
+-----------------------------------------------
+Running: *ensureProjectForOpenFiles*
+Before ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+After ensureProjectForOpenFiles:
+Project '/users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts ProjectRootPath: /users/username/projects/myproject
+		Projects: /users/username/projects/myproject/javascript/packages/recognizers-date-time/tsconfig.json
+got projects updated in background, updating diagnostics for /users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts
+event:
+    {"seq":0,"type":"event","event":"projectsUpdatedInBackground","body":{"openFiles":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]}}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts"]},"seq":4,"type":"request"}
+response:{"responseRequired":false}
+event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"/users/username/projects/myproject/javascript/packages/recognizers-date-time/src/datetime/baseDate.ts","diagnostics":[]}}
+event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":4}}

--- a/tests/baselines/reference/tsserver/symLinks/rename-in-common-file-renames-all-project.js
+++ b/tests/baselines/reference/tsserver/symLinks/rename-in-common-file-renames-all-project.js
@@ -1,0 +1,146 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/users/username/projects/a/a.ts","projectRootPath":"/users/username/projects/a"}}
+Search path: /users/username/projects/a
+For info: /users/username/projects/a/a.ts :: Config file name: /users/username/projects/a/tsconfig.json
+Creating configuration project /users/username/projects/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/a/tsconfig.json 2000 undefined Project: /users/username/projects/a/tsconfig.json WatchType: Config file
+Config: /users/username/projects/a/tsconfig.json : {
+ "rootNames": [
+  "/users/username/projects/a/a.ts",
+  "/users/username/projects/a/c/fc.ts"
+ ],
+ "options": {
+  "module": 1,
+  "configFilePath": "/users/username/projects/a/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/a 1 undefined Config: /users/username/projects/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/a 1 undefined Config: /users/username/projects/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /users/username/projects/a/c/fc.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /users/username/projects/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/a/node_modules/@types 1 undefined Project: /users/username/projects/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/a/node_modules/@types 1 undefined Project: /users/username/projects/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /users/username/projects/a/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/a/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/a/c/fc.ts
+	/users/username/projects/a/a.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	c/fc.ts
+	  Imported via "./c/fc" from file 'a.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	a.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Project '/users/username/projects/a/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/a/a.ts ProjectRootPath: /users/username/projects/a
+		Projects: /users/username/projects/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/users/username/projects/b/b.ts","projectRootPath":"/users/username/projects/b"}}
+Search path: /users/username/projects/b
+For info: /users/username/projects/b/b.ts :: Config file name: /users/username/projects/b/tsconfig.json
+Creating configuration project /users/username/projects/b/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /users/username/projects/b/tsconfig.json 2000 undefined Project: /users/username/projects/b/tsconfig.json WatchType: Config file
+Config: /users/username/projects/b/tsconfig.json : {
+ "rootNames": [
+  "/users/username/projects/b/b.ts",
+  "/users/username/projects/b/c/fc.ts"
+ ],
+ "options": {
+  "module": 1,
+  "configFilePath": "/users/username/projects/b/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/b 1 undefined Config: /users/username/projects/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/b 1 undefined Config: /users/username/projects/b/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /users/username/projects/b/c/fc.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /users/username/projects/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/b/node_modules/@types 1 undefined Project: /users/username/projects/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/b/node_modules/@types 1 undefined Project: /users/username/projects/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /users/username/projects/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Project '/users/username/projects/b/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/users/username/projects/b/c/fc.ts
+	/users/username/projects/b/b.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library
+	c/fc.ts
+	  Imported via "./c/fc" from file 'b.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	b.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Project '/users/username/projects/a/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/users/username/projects/b/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/a/a.ts ProjectRootPath: /users/username/projects/a
+		Projects: /users/username/projects/a/tsconfig.json
+	FileName: /users/username/projects/b/b.ts ProjectRootPath: /users/username/projects/b
+		Projects: /users/username/projects/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/users/username/projects/a/c/fc.ts","projectRootPath":"/users/username/projects/a"}}
+FileWatcher:: Close:: WatchInfo: /users/username/projects/a/c/fc.ts 500 undefined WatchType: Closed Script info
+Search path: /users/username/projects/a/c
+For info: /users/username/projects/a/c/fc.ts :: Config file name: /users/username/projects/a/tsconfig.json
+Project '/users/username/projects/a/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/users/username/projects/b/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/a/a.ts ProjectRootPath: /users/username/projects/a
+		Projects: /users/username/projects/a/tsconfig.json
+	FileName: /users/username/projects/b/b.ts ProjectRootPath: /users/username/projects/b
+		Projects: /users/username/projects/b/tsconfig.json
+	FileName: /users/username/projects/a/c/fc.ts ProjectRootPath: /users/username/projects/a
+		Projects: /users/username/projects/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/users/username/projects/b/c/fc.ts","projectRootPath":"/users/username/projects/b"}}
+FileWatcher:: Close:: WatchInfo: /users/username/projects/b/c/fc.ts 500 undefined WatchType: Closed Script info
+Search path: /users/username/projects/b/c
+For info: /users/username/projects/b/c/fc.ts :: Config file name: /users/username/projects/b/tsconfig.json
+Project '/users/username/projects/a/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Project '/users/username/projects/b/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /users/username/projects/a/a.ts ProjectRootPath: /users/username/projects/a
+		Projects: /users/username/projects/a/tsconfig.json
+	FileName: /users/username/projects/b/b.ts ProjectRootPath: /users/username/projects/b
+		Projects: /users/username/projects/b/tsconfig.json
+	FileName: /users/username/projects/a/c/fc.ts ProjectRootPath: /users/username/projects/a
+		Projects: /users/username/projects/a/tsconfig.json
+	FileName: /users/username/projects/b/c/fc.ts ProjectRootPath: /users/username/projects/b
+		Projects: /users/username/projects/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"rename","arguments":{"file":"/users/username/projects/a/c/fc.ts","line":1,"offset":14}}
+response:{"response":{"info":{"canRename":true,"displayName":"C","fullDisplayName":"\"/users/username/projects/a/c/fc\".C","kind":"const","kindModifiers":"export","triggerSpan":{"start":{"line":1,"offset":14},"end":{"line":1,"offset":15}}},"locs":[{"file":"/users/username/projects/a/c/fc.ts","locs":[{"start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":19}}]},{"file":"/users/username/projects/a/a.ts","locs":[{"start":{"line":1,"offset":9},"end":{"line":1,"offset":10},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":26}},{"start":{"line":1,"offset":39},"end":{"line":1,"offset":40}}]},{"file":"/users/username/projects/b/c/fc.ts","locs":[{"start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":19}}]},{"file":"/users/username/projects/b/b.ts","locs":[{"start":{"line":1,"offset":9},"end":{"line":1,"offset":10},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":26}},{"start":{"line":1,"offset":39},"end":{"line":1,"offset":40}}]}]},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/symLinks/rename-in-common-file-renames-all-project.js
+++ b/tests/baselines/reference/tsserver/symLinks/rename-in-common-file-renames-all-project.js
@@ -22,7 +22,7 @@ Starting updateGraphWorker: Project: /users/username/projects/a/tsconfig.json
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/a/node_modules/@types 1 undefined Project: /users/username/projects/a/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/a/node_modules/@types 1 undefined Project: /users/username/projects/a/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /users/username/projects/a/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/a/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts
@@ -69,7 +69,7 @@ FileWatcher:: Added:: WatchInfo: /users/username/projects/b/c/fc.ts 500 undefine
 Starting updateGraphWorker: Project: /users/username/projects/b/tsconfig.json
 DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/b/node_modules/@types 1 undefined Project: /users/username/projects/b/tsconfig.json WatchType: Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/username/projects/b/node_modules/@types 1 undefined Project: /users/username/projects/b/tsconfig.json WatchType: Type roots
-Finishing updateGraphWorker: Project: /users/username/projects/b/tsconfig.json Version: 1 structureChanged: true Elapsed:: *ms
+Finishing updateGraphWorker: Project: /users/username/projects/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Project '/users/username/projects/b/tsconfig.json' (Configured)
 	Files (3)
 	/a/lib/lib.d.ts


### PR DESCRIPTION
Also ensures inferred and auto import projects have name per project service so they are same across any type of runs
This is the PR I had started as part of #41004 and is partially done but nothing wrong with merging this without converting many more tests to baselines. That can be done as and when needed.
