### PR TITLE
fix: "Convert named imports to namespace import" adds redundant underscore suffix

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1313,7 +1313,7 @@ namespace ts.FindAllReferences {
             if (!symbol) return undefined;
             for (const token of getPossibleSymbolReferenceNodes(sourceFile, symbol.name, searchContainer)) {
                 if (!isIdentifier(token) || token === definition || token.escapedText !== definition.escapedText) continue;
-                const referenceSymbol: Symbol = checker.getSymbolAtLocation(token)!; // See GH#19955 for why the type annotation is necessary
+                const referenceSymbol = checker.getSymbolAtLocation(token)!;
                 if (referenceSymbol === symbol
                     || checker.getShorthandAssignmentValueSymbol(token.parent) === symbol
                     || isExportSpecifier(token.parent) && getLocalSymbolForExportSpecifier(token, referenceSymbol, token.parent, checker) === symbol) {

--- a/src/services/refactors/convertImport.ts
+++ b/src/services/refactors/convertImport.ts
@@ -141,7 +141,7 @@ namespace ts.refactor {
         const preferredName = moduleSpecifier && isStringLiteral(moduleSpecifier) ? codefix.moduleSpecifierToValidIdentifier(moduleSpecifier.text, ScriptTarget.ESNext) : "module";
         const namespaceNameConflicts = toConvert.elements.some(element =>
             FindAllReferences.Core.eachSymbolReferenceInFile(element.name, checker, sourceFile, id =>
-                !!checker.resolveName(preferredName, id, SymbolFlags.All, /*excludeGlobals*/ true)) || false);
+                !!checker.resolveName(preferredName, id, SymbolFlags.All, /*excludeGlobals*/ true) && checker.getSymbolAtLocation(element.name) !== checker.getSymbolAtLocation(id)) || false);
         const namespaceImportName = namespaceNameConflicts ? getUniqueName(preferredName, sourceFile) : preferredName;
 
         const neededNamedImports: ImportSpecifier[] = [];

--- a/tests/cases/fourslash/refactorConvertImport_namedToNamespace1.ts
+++ b/tests/cases/fourslash/refactorConvertImport_namedToNamespace1.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+/////*a*/import { Foo } from "./Foo";/*b*/
+////Foo;
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert import",
+    actionName: "Convert named imports to namespace import",
+    actionDescription: "Convert named imports to namespace import",
+    newContent:
+`import * as Foo from "./Foo";
+Foo.Foo;`,
+});


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #44267 
