### PR TITLE
Switch references to master to main in the codebase + validating infra post-main migration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,12 +3,12 @@ Thank you for submitting a pull request!
 
 Please verify that:
 * [ ] There is an associated issue in the `Backlog` milestone (**required**)
-* [ ] Code is up-to-date with the `master` branch
+* [ ] Code is up-to-date with the `main` branch
 * [ ] You've successfully run `gulp runtests` locally
 * [ ] There are new or updated unit tests validating the change
 
 Refer to CONTRIBUTING.MD for more details.
-  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
+  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
 -->
 
 Fixes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - release-*
   pull_request:
     branches:
-      - master
+      - main
       - release-*
 
 jobs:

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -28,8 +28,8 @@ jobs:
     - run: |
         git config user.email "typescriptbot@microsoft.com"
         git config user.name "TypeScript Bot"
-        git fetch origin master
-        git merge origin/master --no-ff
+        git fetch origin main
+        git merge origin/main --no-ff
         npm ci
         npm test
         git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ You will need to complete a Contributor License Agreement (CLA). Briefly, this a
 Your pull request should:
 
 * Include a description of what your change intends to do
-* Be based on reasonably recent commit in the **master** branch
+* Be based on reasonably recent commit in the **main** branch
 * Include adequate tests
     * At least one test should fail in the absence of your non-test code changes. If your PR does not match this criteria, please specify why
     * Tests should include reasonable permutations of the target fix/change
@@ -118,7 +118,7 @@ There are three relevant locations to be aware of when it comes to TypeScript's 
 * `lib`: the location of the last-known-good (LKG) versions of the files which are updated periodically.
 * `built/local`: the build output location, including where `src/lib` files will be copied to.
 
-Any changes should be made to [src/lib](https://github.com/Microsoft/TypeScript/tree/master/src/lib). **Most** of these files can be updated by hand, with the exception of any generated files (see below).
+Any changes should be made to [src/lib](https://github.com/Microsoft/TypeScript/tree/main/src/lib). **Most** of these files can be updated by hand, with the exception of any generated files (see below).
 
 Library files in `built/local/` are updated automatically by running the standard build task:
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ npm install -g typescript@next
 
 ## Contribute
 
-There are many ways to [contribute](https://github.com/microsoft/TypeScript/blob/master/CONTRIBUTING.md) to TypeScript.
+There are many ways to [contribute](https://github.com/microsoft/TypeScript/blob/main/CONTRIBUTING.md) to TypeScript.
 * [Submit bugs](https://github.com/microsoft/TypeScript/issues) and help us verify fixes as they are checked in.
 * Review the [source code changes](https://github.com/microsoft/TypeScript/pulls).
 * Engage with other TypeScript users and developers on [StackOverflow](https://stackoverflow.com/questions/tagged/typescript).
 * Help each other in the [TypeScript Community Discord](https://discord.gg/typescript).
 * Join the [#typescript](https://twitter.com/search?q=%23TypeScript) discussion on Twitter.
-* [Contribute bug fixes](https://github.com/microsoft/TypeScript/blob/master/CONTRIBUTING.md).
-* Read the archived language specification ([docx](https://github.com/microsoft/TypeScript/blob/master/doc/TypeScript%20Language%20Specification%20-%20ARCHIVED.docx?raw=true),
- [pdf](https://github.com/microsoft/TypeScript/blob/master/doc/TypeScript%20Language%20Specification%20-%20ARCHIVED.pdf?raw=true), [md](https://github.com/microsoft/TypeScript/blob/master/doc/spec-ARCHIVED.md)).
+* [Contribute bug fixes](https://github.com/microsoft/TypeScript/blob/main/CONTRIBUTING.md).
+* Read the archived language specification ([docx](https://github.com/microsoft/TypeScript/blob/main/doc/TypeScript%20Language%20Specification%20-%20ARCHIVED.docx?raw=true),
+ [pdf](https://github.com/microsoft/TypeScript/blob/main/doc/TypeScript%20Language%20Specification%20-%20ARCHIVED.pdf?raw=true), [md](https://github.com/microsoft/TypeScript/blob/main/doc/spec-ARCHIVED.md)).
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see
 the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "TyPesScRiPt",
+    "name": "typescript",
     "author": "Microsoft Corp.",
     "homepage": "https://www.typescriptlang.org/",
     "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "typescript",
+    "name": "TyPesScRiPt",
     "author": "Microsoft Corp.",
     "homepage": "https://www.typescriptlang.org/",
     "version": "4.4.0",

--- a/scripts/open-user-pr.ts
+++ b/scripts/open-user-pr.ts
@@ -8,16 +8,16 @@ const userName = process.env.GH_USERNAME || "typescript-bot";
 const reviewers = process.env.REQUESTING_USER ? [process.env.REQUESTING_USER] : ["weswigham", "sandersn", "RyanCavanaugh"];
 const now = new Date();
 const masterBranchname = `user-baseline-updates`;
-const targetBranch = process.env.TARGET_BRANCH || "master";
-const branchName = process.env.TARGET_FORK?.toLowerCase() === "microsoft" && (targetBranch === "master" || targetBranch === "refs/heads/master")
+const targetBranch = process.env.TARGET_BRANCH || "main";
+const branchName = process.env.TARGET_FORK?.toLowerCase() === "microsoft" && (targetBranch === "main" || targetBranch === "refs/heads/main")
     ? masterBranchname
     : `user-update-${process.env.TARGET_FORK}-${process.env.TARGET_BRANCH ? "-" + process.env.TARGET_BRANCH : ""}`;
 const remoteUrl = `https://${process.argv[2]}@github.com/${userName}/TypeScript.git`;
-const baseRef = branchName === masterBranchname ? "master" : masterBranchname;
+const baseRef = branchName === masterBranchname ? "main" : masterBranchname;
 runSequence([
     ["git", ["remote", "add", "fork", remoteUrl]], // Add the remote fork
     ["git", ["checkout", "."]], // reset any changes
-    ["git", ["fetch", baseRef === "master" ? "origin" : "fork", baseRef]], // fetch target ref in case it's not present locally
+    ["git", ["fetch", baseRef === "main" ? "origin" : "fork", baseRef]], // fetch target ref in case it's not present locally
     ["git", ["checkout", baseRef]], // move head to target
     ["node", ["./node_modules/gulp/bin/gulp.js", "baseline-accept"]], // accept baselines
     ["git", ["checkout", "-b", branchName]], // create a branch
@@ -36,7 +36,7 @@ gh.pulls.create({
     maintainer_can_modify: true,
     title: `🤖 User test baselines have changed` + (process.env.TARGET_BRANCH ? ` for ${process.env.TARGET_BRANCH}` : ""),
     head: `${userName}:${branchName}`,
-    base: branchName === masterBranchname ? "master" : masterBranchname,
+    base: branchName === masterBranchname ? "main" : masterBranchname,
     body:
 `${process.env.SOURCE_ISSUE ? `This test run was triggerd by a request on https://github.com/Microsoft/TypeScript/pull/${process.env.SOURCE_ISSUE} `+"\n" : ""}Please review the diff and merge if no changes are unexpected.
 You can view the build log [here](https://typescript.visualstudio.com/TypeScript/_build/index?buildId=${process.env.BUILD_BUILDID}&_a=summary).

--- a/scripts/update-experimental-branches.js
+++ b/scripts/update-experimental-branches.js
@@ -34,8 +34,8 @@ async function main() {
     // Forcibly cleanup workspace
     runSequence([
         ["git", ["checkout", "."]],
-        ["git", ["fetch", "-fu", "origin", "master:master"]],
-        ["git", ["checkout", "master"]],
+        ["git", ["fetch", "-fu", "origin", "main:main"]],
+        ["git", ["checkout", "main"]],
         ["git", ["remote", "add", "fork", remoteUrl]], // Add the remote fork
     ]);
 
@@ -51,15 +51,15 @@ async function main() {
                         owner: "Microsoft",
                         repo: "TypeScript",
                         issue_number: num,
-                        body: `This PR is configured as an experiment, and currently has rebase conflicts with master - please rebase onto master and fix the conflicts.`
+                        body: `This PR is configured as an experiment, and currently has rebase conflicts with main - please rebase onto main and fix the conflicts.`
                     });
                 }
-                throw new Error(`Rebase conflict detected in PR ${num} with master`); // A PR is currently in conflict, give up
+                throw new Error(`Rebase conflict detected in PR ${num} with main`); // A PR is currently in conflict, give up
             }
             runSequence([
                 ["git", ["fetch", "origin", `pull/${num}/head:${num}`]],
                 ["git", ["checkout", `${num}`]],
-                ["git", ["rebase", "master"]],
+                ["git", ["rebase", "main"]],
                 ["git", ["push", "-f", "-u", "fork", `${num}`]], // Keep a rebased copy of this branch in our fork
             ]);
 
@@ -71,7 +71,7 @@ async function main() {
 
     // Return to `master` and make a new `experimental` branch
     runSequence([
-        ["git", ["checkout", "master"]],
+        ["git", ["checkout", "main"]],
         ["git", ["checkout", "-b", "experimental"]],
     ]);
 


### PR DESCRIPTION
This PR is so I can run some of the checking infra without affecting existing PRs. - https://github.com/microsoft/TypeScript/issues/44323

But it does actually solve a real problem, so I'm going to ask someone to review it