### PR TITLE
Make export-module and reference maps invertible

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -388,7 +388,7 @@ namespace ts {
             if (state.exportedModulesMap) {
                 if (!state.currentAffectedFilesExportedModulesMap) {
                     state.currentAffectedFilesExportedModulesMap = {
-                        exporting: BuilderState.createTwoWayMap<Path, Path>(),
+                        exporting: BuilderState.createManyToManyPathMap(),
                         nonExporting: new Set<Path>(),
                     };
                 }
@@ -1263,8 +1263,8 @@ namespace ts {
         const state: ReusableBuilderProgramState = {
             fileInfos,
             compilerOptions: program.options ? convertToOptionsWithAbsolutePaths(program.options, toAbsolutePath) : {},
-            referencedMap: toTwoWayMap(program.referencedMap),
-            exportedModulesMap: toTwoWayMap(program.exportedModulesMap),
+            referencedMap: toManyToManyPathMap(program.referencedMap),
+            exportedModulesMap: toManyToManyPathMap(program.exportedModulesMap),
             semanticDiagnosticsPerFile: program.semanticDiagnosticsPerFile && arrayToMap(program.semanticDiagnosticsPerFile, value => toFilePath(isNumber(value) ? value : value[0]), value => isNumber(value) ? emptyArray : value[1]),
             hasReusableDiagnostic: true,
             affectedFilesPendingEmit: map(program.affectedFilesPendingEmit, value => toFilePath(value[0])),
@@ -1312,12 +1312,12 @@ namespace ts {
             return filePathsSetList![fileIdsListId - 1];
         }
 
-        function toTwoWayMap(referenceMap: ProgramBuildInfoReferencedMap | undefined): BuilderState.TwoWayMap<Path, Path> | undefined {
+        function toManyToManyPathMap(referenceMap: ProgramBuildInfoReferencedMap | undefined): BuilderState.ManyToManyPathMap | undefined {
             if (!referenceMap) {
                 return undefined;
             }
 
-            const map = BuilderState.createTwoWayMap<Path, Path>();
+            const map = BuilderState.createManyToManyPathMap();
             referenceMap.forEach(([fileId, fileIdListId]) =>
                 map.set(toFilePath(fileId), toFilePathsSet(fileIdListId))
             );

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -113,6 +113,8 @@ namespace ts {
         currentAffectedFilesSignatures: ESMap<Path, string> | undefined;
         /**
          * Newly computed visible to outside referencedSet
+         * We need to store the updates separately in case the in-progress build is cancelled
+         * and we need to roll back.
          */
         currentAffectedFilesExportedModulesMap: BuilderState.ComputingExportedModulesMap | undefined;
         /**

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -223,7 +223,7 @@ namespace ts {
                 // versions dont match
                 oldInfo.version !== info.version ||
                 // Referenced files changed
-                !hasSameKeys(newReferences = referencedMap && referencedMap.get(sourceFilePath), oldReferencedMap && oldReferencedMap.get(sourceFilePath)) ||
+                !hasSameKeys(newReferences = referencedMap && referencedMap.getValues(sourceFilePath), oldReferencedMap && oldReferencedMap.getValues(sourceFilePath)) ||
                 // Referenced file was deleted in the new program
                 newReferences && forEachKey(newReferences, path => !state.fileInfos.has(path) && oldState!.fileInfos.has(path))) {
                 // Register file as changed file and do not copy semantic diagnostics, since all changed files need to be re-evaluated
@@ -562,7 +562,7 @@ namespace ts {
         // If exported from path is not from cache and exported modules has path, all files referencing file exported from are affected
         state.exportedModulesMap.getKeys(affectedFile.resolvedPath)?.forEach(exportedFromPath =>
             // If the cache had an updated value, skip
-            !state.currentAffectedFilesExportedModulesMap!.exporting.has(exportedFromPath) &&
+            !state.currentAffectedFilesExportedModulesMap!.exporting.hasKey(exportedFromPath) &&
             !state.currentAffectedFilesExportedModulesMap!.nonExporting.has(exportedFromPath) &&
             forEachFilesReferencingPath(state, exportedFromPath, seenFileAndExportsOfFile, fn)
         );
@@ -597,7 +597,7 @@ namespace ts {
         // If exported from path is not from cache and exported modules has path, all files referencing file exported from are affected
         state.exportedModulesMap!.getKeys(filePath)?.forEach(exportedFromPath =>
             // If the cache had an updated value, skip
-            !state.currentAffectedFilesExportedModulesMap!.exporting.has(exportedFromPath) &&
+            !state.currentAffectedFilesExportedModulesMap!.exporting.hasKey(exportedFromPath) &&
             !state.currentAffectedFilesExportedModulesMap!.nonExporting.has(exportedFromPath) &&
             forEachFileAndExportsOfFile(state, exportedFromPath, seenFileAndExportsOfFile, fn)
         );
@@ -760,7 +760,7 @@ namespace ts {
         if (state.referencedMap) {
             referencedMap = arrayFrom(state.referencedMap.keys()).sort(compareStringsCaseSensitive).map(key => [
                 toFileId(key),
-                toFileIdListId(state.referencedMap!.get(key)!)
+                toFileIdListId(state.referencedMap!.getValues(key)!)
             ]);
         }
 
@@ -772,14 +772,14 @@ namespace ts {
                         return undefined;
                     }
 
-                    const newValue = state.currentAffectedFilesExportedModulesMap.exporting.get(key);
+                    const newValue = state.currentAffectedFilesExportedModulesMap.exporting.getValues(key);
                     if (newValue) {
                         return [toFileId(key), toFileIdListId(newValue)];
                     }
                 }
 
                 // Not in temporary cache, use existing value
-                return [toFileId(key), toFileIdListId(state.exportedModulesMap!.get(key)!)];
+                return [toFileId(key), toFileIdListId(state.exportedModulesMap!.getValues(key)!)];
             });
         }
 

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -212,7 +212,7 @@ namespace ts {
         const copyLibFileDiagnostics = copyDeclarationFileDiagnostics && !compilerOptions.skipDefaultLibCheck === !oldCompilerOptions!.skipDefaultLibCheck;
         state.fileInfos.forEach((info, sourceFilePath) => {
             let oldInfo: Readonly<BuilderState.FileInfo> | undefined;
-            let newReferences: BuilderState.ReferencedSet | undefined;
+            let newReferences: ReadonlySet<Path> | undefined;
 
             // if not using old state, every file is changed
             if (!useOldState ||
@@ -311,7 +311,7 @@ namespace ts {
         newState.affectedFilesIndex = state.affectedFilesIndex;
         newState.currentChangedFilePath = state.currentChangedFilePath;
         newState.currentAffectedFilesSignatures = state.currentAffectedFilesSignatures && new Map(state.currentAffectedFilesSignatures);
-        newState.currentAffectedFilesExportedModulesMap = state.currentAffectedFilesExportedModulesMap && new Map(state.currentAffectedFilesExportedModulesMap);
+        newState.currentAffectedFilesExportedModulesMap = state.currentAffectedFilesExportedModulesMap && { exporting: state.currentAffectedFilesExportedModulesMap.exporting.clone(), nonExporting: new Set(state.currentAffectedFilesExportedModulesMap.nonExporting) };
         newState.seenAffectedFiles = state.seenAffectedFiles && new Set(state.seenAffectedFiles);
         newState.cleanedDiagnosticsOfLibFiles = state.cleanedDiagnosticsOfLibFiles;
         newState.semanticDiagnosticsFromOldState = state.semanticDiagnosticsFromOldState && new Set(state.semanticDiagnosticsFromOldState);
@@ -384,7 +384,12 @@ namespace ts {
             // Get next batch of affected files
             if (!state.currentAffectedFilesSignatures) state.currentAffectedFilesSignatures = new Map();
             if (state.exportedModulesMap) {
-                if (!state.currentAffectedFilesExportedModulesMap) state.currentAffectedFilesExportedModulesMap = new Map();
+                if (!state.currentAffectedFilesExportedModulesMap) {
+                    state.currentAffectedFilesExportedModulesMap = {
+                        exporting: BuilderState.createTwoWayMap<Path, Path>(),
+                        nonExporting: new Set<Path>(),
+                    };
+                }
             }
             state.affectedFiles = BuilderState.getFilesAffectedBy(state, program, nextKey.value, cancellationToken, computeHash, state.currentAffectedFilesSignatures, state.currentAffectedFilesExportedModulesMap);
             state.currentChangedFilePath = nextKey.value;
@@ -465,7 +470,7 @@ namespace ts {
      * Handle the dts may change, so they need to be added to pending emit if dts emit is enabled,
      * Also we need to make sure signature is updated for these files
      */
-    function handleDtsMayChangeOf(state: BuilderProgramState, path: Path, cancellationToken: CancellationToken | undefined, computeHash: BuilderState.ComputeHash) {
+    function handleDtsMayChangeOf(state: BuilderProgramState, path: Path, cancellationToken: CancellationToken | undefined, computeHash: BuilderState.ComputeHash): void {
         removeSemanticDiagnosticsOf(state, path);
 
         if (!state.changedFilesSet.has(path)) {
@@ -544,19 +549,19 @@ namespace ts {
         }
 
         Debug.assert(!!state.currentAffectedFilesExportedModulesMap);
+
         const seenFileAndExportsOfFile = new Set<string>();
         // Go through exported modules from cache first
         // If exported modules has path, all files referencing file exported from are affected
-        forEachEntry(state.currentAffectedFilesExportedModulesMap, (exportedModules, exportedFromPath) =>
-            exportedModules &&
-            exportedModules.has(affectedFile.resolvedPath) &&
+        state.currentAffectedFilesExportedModulesMap.exporting.getKeys(affectedFile.resolvedPath)?.forEach(exportedFromPath =>
             forEachFilesReferencingPath(state, exportedFromPath, seenFileAndExportsOfFile, fn)
         );
 
         // If exported from path is not from cache and exported modules has path, all files referencing file exported from are affected
-        forEachEntry(state.exportedModulesMap, (exportedModules, exportedFromPath) =>
-            !state.currentAffectedFilesExportedModulesMap!.has(exportedFromPath) && // If we already iterated this through cache, ignore it
-            exportedModules.has(affectedFile.resolvedPath) &&
+        state.exportedModulesMap.getKeys(affectedFile.resolvedPath)?.forEach(exportedFromPath =>
+            // If the cache had an updated value, skip
+            !state.currentAffectedFilesExportedModulesMap!.exporting.has(exportedFromPath) &&
+            !state.currentAffectedFilesExportedModulesMap!.nonExporting.has(exportedFromPath) &&
             forEachFilesReferencingPath(state, exportedFromPath, seenFileAndExportsOfFile, fn)
         );
     }
@@ -564,16 +569,16 @@ namespace ts {
     /**
      * Iterate on files referencing referencedPath
      */
-    function forEachFilesReferencingPath(state: BuilderProgramState, referencedPath: Path, seenFileAndExportsOfFile: Set<string>, fn: (state: BuilderProgramState, filePath: Path) => void) {
-        forEachEntry(state.referencedMap!, (referencesInFile, filePath) =>
-            referencesInFile.has(referencedPath) && forEachFileAndExportsOfFile(state, filePath, seenFileAndExportsOfFile, fn)
+    function forEachFilesReferencingPath(state: BuilderProgramState, referencedPath: Path, seenFileAndExportsOfFile: Set<string>, fn: (state: BuilderProgramState, filePath: Path) => void): void {
+        state.referencedMap!.getKeys(referencedPath)?.forEach(filePath =>
+            forEachFileAndExportsOfFile(state, filePath, seenFileAndExportsOfFile, fn)
         );
     }
 
     /**
      * fn on file and iterate on anything that exports this file
      */
-    function forEachFileAndExportsOfFile(state: BuilderProgramState, filePath: Path, seenFileAndExportsOfFile: Set<string>, fn: (state: BuilderProgramState, filePath: Path) => void) {
+    function forEachFileAndExportsOfFile(state: BuilderProgramState, filePath: Path, seenFileAndExportsOfFile: Set<string>, fn: (state: BuilderProgramState, filePath: Path) => void): void {
         if (!tryAddToSet(seenFileAndExportsOfFile, filePath)) {
             return;
         }
@@ -583,23 +588,20 @@ namespace ts {
         Debug.assert(!!state.currentAffectedFilesExportedModulesMap);
         // Go through exported modules from cache first
         // If exported modules has path, all files referencing file exported from are affected
-        forEachEntry(state.currentAffectedFilesExportedModulesMap, (exportedModules, exportedFromPath) =>
-            exportedModules &&
-            exportedModules.has(filePath) &&
+        state.currentAffectedFilesExportedModulesMap.exporting.getKeys(filePath)?.forEach(exportedFromPath =>
             forEachFileAndExportsOfFile(state, exportedFromPath, seenFileAndExportsOfFile, fn)
         );
 
         // If exported from path is not from cache and exported modules has path, all files referencing file exported from are affected
-        forEachEntry(state.exportedModulesMap!, (exportedModules, exportedFromPath) =>
-            !state.currentAffectedFilesExportedModulesMap!.has(exportedFromPath) && // If we already iterated this through cache, ignore it
-            exportedModules.has(filePath) &&
+        state.exportedModulesMap!.getKeys(filePath)?.forEach(exportedFromPath =>
+            // If the cache had an updated value, skip
+            !state.currentAffectedFilesExportedModulesMap!.exporting.has(exportedFromPath) &&
+            !state.currentAffectedFilesExportedModulesMap!.nonExporting.has(exportedFromPath) &&
             forEachFileAndExportsOfFile(state, exportedFromPath, seenFileAndExportsOfFile, fn)
         );
 
         // Remove diagnostics of files that import this file (without going to exports of referencing files)
-
-        forEachEntry(state.referencedMap!, (referencesInFile, referencingFilePath) =>
-            referencesInFile.has(filePath) &&
+        state.referencedMap!.getKeys(filePath)?.forEach(referencingFilePath =>
             !seenFileAndExportsOfFile.has(referencingFilePath) && // Not already removed diagnostic file
             fn(state, referencingFilePath) // Dont add to seen since this is not yet done with the export removal
         );
@@ -763,11 +765,19 @@ namespace ts {
         let exportedModulesMap: ProgramBuildInfoReferencedMap | undefined;
         if (state.exportedModulesMap) {
             exportedModulesMap = mapDefined(arrayFrom(state.exportedModulesMap.keys()).sort(compareStringsCaseSensitive), key => {
-                const newValue = state.currentAffectedFilesExportedModulesMap && state.currentAffectedFilesExportedModulesMap.get(key);
+                if (state.currentAffectedFilesExportedModulesMap) {
+                    if (state.currentAffectedFilesExportedModulesMap.nonExporting.has(key)) {
+                        return undefined;
+                    }
+
+                    const newValue = state.currentAffectedFilesExportedModulesMap.exporting.get(key);
+                    if (newValue) {
+                        return [toFileId(key), toFileIdListId(newValue)];
+                    }
+                }
+
                 // Not in temporary cache, use existing value
-                if (newValue === undefined) return [toFileId(key), toFileIdListId(state.exportedModulesMap!.get(key)!)];
-                // Value in cache and has updated value map, use that
-                else if (newValue) return [toFileId(key), toFileIdListId(newValue)];
+                return [toFileId(key), toFileIdListId(state.exportedModulesMap!.get(key)!)];
             });
         }
 
@@ -1251,8 +1261,8 @@ namespace ts {
         const state: ReusableBuilderProgramState = {
             fileInfos,
             compilerOptions: program.options ? convertToOptionsWithAbsolutePaths(program.options, toAbsolutePath) : {},
-            referencedMap: toMapOfReferencedSet(program.referencedMap),
-            exportedModulesMap: toMapOfReferencedSet(program.exportedModulesMap),
+            referencedMap: toTwoWayMap(program.referencedMap),
+            exportedModulesMap: toTwoWayMap(program.exportedModulesMap),
             semanticDiagnosticsPerFile: program.semanticDiagnosticsPerFile && arrayToMap(program.semanticDiagnosticsPerFile, value => toFilePath(isNumber(value) ? value : value[0]), value => isNumber(value) ? emptyArray : value[1]),
             hasReusableDiagnostic: true,
             affectedFilesPendingEmit: map(program.affectedFilesPendingEmit, value => toFilePath(value[0])),
@@ -1300,8 +1310,16 @@ namespace ts {
             return filePathsSetList![fileIdsListId - 1];
         }
 
-        function toMapOfReferencedSet(referenceMap: ProgramBuildInfoReferencedMap | undefined): ReadonlyESMap<Path, BuilderState.ReferencedSet> | undefined {
-            return referenceMap && arrayToMap(referenceMap, value => toFilePath(value[0]), value => toFilePathsSet(value[1]));
+        function toTwoWayMap(referenceMap: ProgramBuildInfoReferencedMap | undefined): BuilderState.TwoWayMap<Path, Path> | undefined {
+            if (!referenceMap) {
+                return undefined;
+            }
+
+            const map = BuilderState.createTwoWayMap<Path, Path>();
+            referenceMap.forEach(([fileId, fileIdListId]) =>
+                map.set(toFilePath(fileId), toFilePathsSet(fileIdListId))
+            );
+            return map;
         }
     }
 

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -259,7 +259,7 @@ namespace ts {
         /**
          * Returns true if oldState is reusable, that is the emitKind = module/non module has not changed
          */
-        export function canReuseOldState(newReferencedMap: BuilderState.TwoWayMap<Path, Path> | undefined, oldState: Readonly<ReusableBuilderState> | undefined) {
+        export function canReuseOldState(newReferencedMap: TwoWayMap<Path, Path> | undefined, oldState: Readonly<ReusableBuilderState> | undefined) {
             return oldState && !oldState.referencedMap === !newReferencedMap;
         }
 

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -43,6 +43,8 @@ namespace ts {
         /**
          * Contains the map of exported modules ReferencedSet=exported module files from the file if module emit is enabled
          * Otherwise undefined
+         *
+         * This is equivalent to referencedMap, but for the emitted .d.ts file.
          */
         readonly exportedModulesMap: BuilderState.TwoWayMap<Path, Path> | undefined;
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7284,26 +7284,4 @@ namespace ts {
                 return (parent as SourceFile).statements;
         }
     }
-
-    export function addToMultimap<K, V>(map: ESMap<K, Set<V>>, k: K, v: V): void {
-        let set = map.get(k);
-        if (!set) {
-            set = new Set<V>();
-            map.set(k, set);
-        }
-        set.add(v);
-    }
-
-    export function deleteFromMultimap<K, V>(map: ESMap<K, Set<V>>, k: K, v: V, removeEmpty = true): boolean {
-        const set = map.get(k);
-
-        if (set?.delete(v)) {
-            if (removeEmpty && !set.size) {
-                map.delete(k);
-            }
-            return true;
-        }
-
-        return false;
-    }
 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7284,4 +7284,26 @@ namespace ts {
                 return (parent as SourceFile).statements;
         }
     }
+
+    export function addToMultimap<K, V>(map: ESMap<K, Set<V>>, k: K, v: V): void {
+        let set = map.get(k);
+        if (!set) {
+            set = new Set<V>();
+            map.set(k, set);
+        }
+        set.add(v);
+    }
+
+    export function deleteFromMultimap<K, V>(map: ESMap<K, Set<V>>, k: K, v: V, removeEmpty = true): boolean {
+        const set = map.get(k);
+
+        if (set?.delete(v)) {
+            if (removeEmpty && !set.size) {
+                map.delete(k);
+            }
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/testRunner/unittests/tscWatch/incremental.ts
+++ b/src/testRunner/unittests/tscWatch/incremental.ts
@@ -181,8 +181,8 @@ namespace ts.tscWatch {
                         configFilePath: config.path
                     });
 
-                    assert.equal(state.referencedMap!.size, 0);
-                    assert.equal(state.exportedModulesMap!.size, 0);
+                    assert.equal(arrayFrom(state.referencedMap!.keys()).length, 0);
+                    assert.equal(arrayFrom(state.exportedModulesMap!.keys()).length, 0);
 
                     assert.equal(state.semanticDiagnosticsPerFile!.size, 3);
                     assert.deepEqual(state.semanticDiagnosticsPerFile!.get(libFile.path as Path), emptyArray);


### PR DESCRIPTION
Right now, we're enumerating all the entries to find out which keys map
to a corresponding value.  By maintaining a two-way map, we can convert
this linear search into a map lookup and skip allocation of many, many
iterator results.