### PR TITLE
fix(#20846 lib/es2015): override new Proxy<T, U>

### DIFF
--- a/src/lib/es2015.proxy.d.ts
+++ b/src/lib/es2015.proxy.d.ts
@@ -1,21 +1,23 @@
-interface ProxyHandler<T extends object> {
+interface ProxyHandler<T extends object, U extends object> {
     apply?(target: T, thisArg: any, argArray: any[]): any;
     construct?(target: T, argArray: any[], newTarget: Function): object;
     defineProperty?(target: T, p: string | symbol, attributes: PropertyDescriptor): boolean;
     deleteProperty?(target: T, p: string | symbol): boolean;
-    get?(target: T, p: string | symbol, receiver: any): any;
+    get?<K extends keyof U>(target: T, p: K, receiver: U): U[K];
     getOwnPropertyDescriptor?(target: T, p: string | symbol): PropertyDescriptor | undefined;
     getPrototypeOf?(target: T): object | null;
     has?(target: T, p: string | symbol): boolean;
     isExtensible?(target: T): boolean;
     ownKeys?(target: T): ArrayLike<string | symbol>;
     preventExtensions?(target: T): boolean;
-    set?(target: T, p: string | symbol, value: any, receiver: any): boolean;
+    set?<K extends keyof U>(target: T, p: K, value: U[K], receiver: U): boolean;
     setPrototypeOf?(target: T, v: object | null): boolean;
 }
 
 interface ProxyConstructor {
-    revocable<T extends object>(target: T, handler: ProxyHandler<T>): { proxy: T; revoke: () => void; };
-    new <T extends object>(target: T, handler: ProxyHandler<T>): T;
+    revocable<T extends object>(target: T, handler: ProxyHandler<T, any>): { proxy: T; revoke: () => void; };
+    revocable<T extends object, U extends object>(target: T, handler: ProxyHandler<T, U>): { proxy: U; revoke: () => void; };
+    new <T extends object>(target: T, handler: ProxyHandler<T, any>): T;
+    new <T extends object, U extends object>(target: T, handler: ProxyHandler<T, U>): U;
 }
 declare var Proxy: ProxyConstructor;


### PR DESCRIPTION
Fixes #20846

Faced with the need to definition type the Proxy output in my project, I got acquainted with the problem #20846.
I suggest the following solution using overloads, preserving the health of the current behavior and backward compatibility with the current definition format

example:
```ts
interface XProxyConstructor {
  revocable<T extends object>(target: T, handler: XProxyHandler<T, any>): { proxy: T; revoke: () => void; };
  revocable<T extends object, U extends object>(target: T, handler: XProxyHandler<T, U>): { proxy: U; revoke: () => void; };
  new <T extends object>(target: T, handler: XProxyHandler<T, any>): T;
  new <T extends object, U extends object>(target: T, handler: XProxyHandler<T, U>): U;
}
declare var XProxy: XProxyConstructor;


interface A { a: string }
interface B { b: number }

const a: A = { a: '' }

var b = new XProxy<A, B>(a, {})
```

in VSCode

![Снимок экрана от 2021-06-06 13-55-37](https://user-images.githubusercontent.com/3082812/120922114-fcfe8280-c6cf-11eb-9017-20fe480ba9b3.png)

![Снимок экрана от 2021-06-06 13-57-44](https://user-images.githubusercontent.com/3082812/120922210-77c79d80-c6d0-11eb-8ae1-13cd2737db12.png)

