### PR TITLE
`getEditsForFileRename`: fix `updateTsconfigFiles` w/ empty `include`

### DIFF
--- a/tests/cases/fourslash/getEditsForFileRename_tsconfig_empty_include.ts
+++ b/tests/cases/fourslash/getEditsForFileRename_tsconfig_empty_include.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a/foo.ts
+////const x = 1
+
+// @Filename: /a/tsconfig.json
+////{ "include": [] }
+
+verify.getEditsForFileRename({
+  oldPath: "/a/foo.ts",
+  newPath: "/a/bar.ts",
+  newFileContents: {
+  }
+});


### PR DESCRIPTION
Avoid the assumption that there are always include patterns: when there
are none (and therefore the renamed file didn't match anyway), just skip
the test for added include.

Also change the code to use `return` to make it flatter.

(Also get rid of a redundant type.)

Fixes #40386.
