### PR TITLE
Update RequestInfo to accept a URL class.

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -19647,7 +19647,7 @@ declare function removeEventListener<K extends keyof WindowEventMap>(type: K, li
 declare function removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 type HeadersInit = Headers | string[][] | Record<string, string>;
 type BodyInit = Blob | BufferSource | FormData | URLSearchParams | ReadableStream<Uint8Array> | string;
-type RequestInfo = Request | string;
+type RequestInfo = Request | string | URL;
 type BlobPart = BufferSource | Blob | string;
 type DOMHighResTimeStamp = number;
 type RenderingContext = CanvasRenderingContext2D | ImageBitmapRenderingContext | WebGLRenderingContext | WebGL2RenderingContext;


### PR DESCRIPTION
When creating a new `Request` Object with `RequestInfo`, `RequestInfo` can be one of `string`, `URL`, or `Request`

```js
new Request("https://example.com")
new Request(new URL("https://example.com"))
new Request(new Request("https://example.com"))
```

The above are all valid ways to create a Request.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #
