### PR TITLE
Add SolutionBuilderHostBase.getCustomTransformers to be used when emitting.

### DIFF
--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -85,6 +85,7 @@ namespace ts {
          * writeFileCallback
          */
         writeFile?(path: string, data: string, writeByteOrderMark?: boolean): void;
+        getCustomTransformers?: (project: string) => CustomTransformers | undefined;
 
         getModifiedTime(fileName: string): Date | undefined;
         setModifiedTime(fileName: string, date: Date): void;
@@ -785,7 +786,7 @@ namespace ts {
                 emit: (targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers) => {
                     if (targetSourceFile || emitOnlyDtsFiles) {
                         return withProgramOrUndefined(
-                            program => program.emit(targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers)
+                            program => program.emit(targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers || state.host.getCustomTransformers?.(project))
                         );
                     }
                     executeSteps(BuildStep.SemanticDiagnostics, cancellationToken);
@@ -921,7 +922,7 @@ namespace ts {
                 (name, text, writeByteOrderMark) => outputFiles.push({ name, text, writeByteOrderMark }),
                 cancellationToken,
                 /*emitOnlyDts*/ false,
-                customTransformers
+                customTransformers || state.host.getCustomTransformers?.(project)
             );
             // Don't emit .d.ts if there are decl file errors
             if (declDiagnostics) {
@@ -1060,7 +1061,7 @@ namespace ts {
                     const refName = resolveProjectName(state, ref.path);
                     return parseConfigFile(state, refName, toResolvedConfigFilePath(state, refName));
                 },
-                customTransformers
+                customTransformers || state.host.getCustomTransformers?.(project)
             );
 
             if (isString(outputFiles)) {

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -141,6 +141,7 @@
         "unittests/tsbuildWatch/noEmit.ts",
         "unittests/tsbuildWatch/noEmitOnError.ts",
         "unittests/tsbuildWatch/programUpdates.ts",
+        "unittests/tsbuildWatch/publicApi.ts",
         "unittests/tsbuildWatch/reexport.ts",
         "unittests/tsbuildWatch/watchEnvironment.ts",
         "unittests/tsc/composite.ts",

--- a/src/testRunner/unittests/tsbuildWatch/publicApi.ts
+++ b/src/testRunner/unittests/tsbuildWatch/publicApi.ts
@@ -1,0 +1,115 @@
+namespace ts.tscWatch {
+    it("unittests:: tsbuildWatch:: watchMode:: Public API with custom transformers", () => {
+        const solution: File = {
+            path: `${projectRoot}/tsconfig.json`,
+            content: JSON.stringify({
+                references: [
+                    { path: "./shared/tsconfig.json" },
+                    { path: "./webpack/tsconfig.json" }
+                ],
+                files: []
+            })
+        };
+        const sharedConfig: File = {
+            path: `${projectRoot}/shared/tsconfig.json`,
+            content: JSON.stringify({
+                compilerOptions: { composite: true },
+            })
+        };
+        const sharedIndex: File = {
+            path: `${projectRoot}/shared/index.ts`,
+            content: `export function f1() { }
+export class c { }
+export enum e { }
+// leading
+export function f2() { } // trailing`
+        };
+        const webpackConfig: File = {
+            path: `${projectRoot}/webpack/tsconfig.json`,
+            content: JSON.stringify({
+                compilerOptions: { composite: true, },
+                references: [{ path: "../shared/tsconfig.json" }]
+            })
+        };
+        const webpackIndex: File = {
+            path: `${projectRoot}/webpack/index.ts`,
+            content: `export function f2() { }
+export class c2 { }
+export enum e2 { }
+// leading
+export function f22() { } // trailing`
+        };
+        const commandLineArgs = ["--b", "--w"];
+        const { sys, baseline, oldSnap } = createBaseline(createWatchedSystem([libFile, solution, sharedConfig, sharedIndex, webpackConfig, webpackIndex], { currentDirectory: projectRoot }));
+        const { cb, getPrograms } = commandLineCallbacks(sys);
+        const buildHost = createSolutionBuilderWithWatchHost(
+            sys,
+            /*createProgram*/ undefined,
+            createDiagnosticReporter(sys, /*pretty*/ true),
+            createBuilderStatusReporter(sys, /*pretty*/ true),
+            createWatchStatusReporter(sys, /*pretty*/ true)
+        );
+        buildHost.afterProgramEmitAndDiagnostics = cb;
+        buildHost.afterEmitBundle = cb;
+        buildHost.getCustomTransformers = getCustomTransformers;
+        const builder = createSolutionBuilderWithWatch(buildHost, [solution.path], { verbose: true });
+        builder.build();
+        runWatchBaseline({
+            scenario: "publicApi",
+            subScenario: "with custom transformers",
+            commandLineArgs,
+            sys,
+            baseline,
+            oldSnap,
+            getPrograms,
+            changes: [
+                {
+                    caption: "change to shared",
+                    change: sys => sys.prependFile(sharedIndex.path, "export function fooBar() {}"),
+                    timeouts: sys => {
+                        sys.checkTimeoutQueueLengthAndRun(1); // Shared
+                        sys.checkTimeoutQueueLengthAndRun(1); // webpack
+                        sys.checkTimeoutQueueLengthAndRun(1); // solution
+                        sys.checkTimeoutQueueLength(0);
+                    }
+                }
+            ],
+            watchOrSolution: builder
+        });
+
+        function getCustomTransformers(project: string): CustomTransformers {
+            const before: TransformerFactory<SourceFile> = context => {
+                return file => visitEachChild(file, visit, context);
+                function visit(node: Node): VisitResult<Node> {
+                    switch (node.kind) {
+                        case SyntaxKind.FunctionDeclaration:
+                            return visitFunction(node as FunctionDeclaration);
+                        default:
+                            return visitEachChild(node, visit, context);
+                    }
+                }
+                function visitFunction(node: FunctionDeclaration) {
+                    addSyntheticLeadingComment(node, SyntaxKind.MultiLineCommentTrivia, `@before${project}`, /*hasTrailingNewLine*/ true);
+                    return node;
+                }
+            };
+
+            const after: TransformerFactory<SourceFile> = context => {
+                return file => visitEachChild(file, visit, context);
+                function visit(node: Node): VisitResult<Node> {
+                    switch (node.kind) {
+                        case SyntaxKind.VariableStatement:
+                            return visitVariableStatement(node as VariableStatement);
+                        default:
+                            return visitEachChild(node, visit, context);
+                    }
+                }
+                function visitVariableStatement(node: VariableStatement) {
+                    addSyntheticLeadingComment(node, SyntaxKind.SingleLineCommentTrivia, `@after${project}`);
+                    return node;
+                }
+            };
+            return { before: [before], after: [after] };
+        }
+    });
+}

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5240,6 +5240,7 @@ declare namespace ts {
          * writeFileCallback
          */
         writeFile?(path: string, data: string, writeByteOrderMark?: boolean): void;
+        getCustomTransformers?: (project: string) => CustomTransformers | undefined;
         getModifiedTime(fileName: string): Date | undefined;
         setModifiedTime(fileName: string, date: Date): void;
         deleteFile(fileName: string): void;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5240,6 +5240,7 @@ declare namespace ts {
          * writeFileCallback
          */
         writeFile?(path: string, data: string, writeByteOrderMark?: boolean): void;
+        getCustomTransformers?: (project: string) => CustomTransformers | undefined;
         getModifiedTime(fileName: string): Date | undefined;
         setModifiedTime(fileName: string, date: Date): void;
         deleteFile(fileName: string): void;

--- a/tests/baselines/reference/tsbuild/watchMode/publicApi/with-custom-transformers.js
+++ b/tests/baselines/reference/tsbuild/watchMode/publicApi/with-custom-transformers.js
@@ -1,0 +1,383 @@
+Input::
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"references":[{"path":"./shared/tsconfig.json"},{"path":"./webpack/tsconfig.json"}],"files":[]}
+
+//// [/user/username/projects/myproject/shared/tsconfig.json]
+{"compilerOptions":{"composite":true}}
+
+//// [/user/username/projects/myproject/shared/index.ts]
+export function f1() { }
+export class c { }
+export enum e { }
+// leading
+export function f2() { } // trailing
+
+//// [/user/username/projects/myproject/webpack/tsconfig.json]
+{"compilerOptions":{"composite":true},"references":[{"path":"../shared/tsconfig.json"}]}
+
+//// [/user/username/projects/myproject/webpack/index.ts]
+export function f2() { }
+export class c2 { }
+export enum e2 { }
+// leading
+export function f22() { } // trailing
+
+
+/a/lib/tsc.js --b --w
+Output::
+[[90m12:00:31 AM[0m] Projects in this build: 
+    * shared/tsconfig.json
+    * webpack/tsconfig.json
+    * tsconfig.json
+
+[[90m12:00:32 AM[0m] Project 'shared/tsconfig.json' is out of date because output file 'shared/index.js' does not exist
+
+[[90m12:00:33 AM[0m] Building project '/user/username/projects/myproject/shared/tsconfig.json'...
+
+[[90m12:00:42 AM[0m] Project 'webpack/tsconfig.json' is out of date because output file 'webpack/index.js' does not exist
+
+[[90m12:00:43 AM[0m] Building project '/user/username/projects/myproject/webpack/tsconfig.json'...
+
+[[90m12:00:52 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/shared/index.ts"]
+Program options: {"composite":true,"configFilePath":"/user/username/projects/myproject/shared/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/shared/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/shared/index.ts
+
+Program root files: ["/user/username/projects/myproject/webpack/index.ts"]
+Program options: {"composite":true,"configFilePath":"/user/username/projects/myproject/webpack/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/webpack/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/webpack/index.ts
+
+WatchedFiles::
+/user/username/projects/myproject/shared/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/shared/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/shared/index.ts:
+  {"fileName":"/user/username/projects/myproject/shared/index.ts","pollingInterval":250}
+/user/username/projects/myproject/webpack/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/webpack/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/webpack/index.ts:
+  {"fileName":"/user/username/projects/myproject/webpack/index.ts","pollingInterval":250}
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/shared:
+  {"directoryName":"/user/username/projects/myproject/shared","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/webpack:
+  {"directoryName":"/user/username/projects/myproject/webpack","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/shared/index.js]
+"use strict";
+exports.__esModule = true;
+exports.f2 = exports.e = exports.c = exports.f1 = void 0;
+/*@before/user/username/projects/myproject/shared/tsconfig.json*/
+function f1() { }
+exports.f1 = f1;
+//@after/user/username/projects/myproject/shared/tsconfig.json
+var c = /** @class */ (function () {
+    function c() {
+    }
+    return c;
+}());
+exports.c = c;
+//@after/user/username/projects/myproject/shared/tsconfig.json
+var e;
+(function (e) {
+})(e = exports.e || (exports.e = {}));
+// leading
+/*@before/user/username/projects/myproject/shared/tsconfig.json*/
+function f2() { } // trailing
+exports.f2 = f2;
+
+
+//// [/user/username/projects/myproject/shared/index.d.ts]
+export declare function f1(): void;
+export declare class c {
+}
+export declare enum e {
+}
+export declare function f2(): void;
+
+
+//// [/user/username/projects/myproject/shared/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../../../../a/lib/lib.d.ts","./index.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true},"8649344783-export function f1() { }\nexport class c { }\nexport enum e { }\n// leading\nexport function f2() { } // trailing"],"options":{"composite":true},"referencedMap":[],"exportedModulesMap":[],"semanticDiagnosticsPerFile":[1,2]},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/myproject/shared/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../../../a/lib/lib.d.ts",
+      "./index.ts"
+    ],
+    "fileInfos": {
+      "../../../../../a/lib/lib.d.ts": {
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "signature": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "8649344783-export function f1() { }\nexport class c { }\nexport enum e { }\n// leading\nexport function f2() { } // trailing",
+        "signature": "8649344783-export function f1() { }\nexport class c { }\nexport enum e { }\n// leading\nexport function f2() { } // trailing"
+      }
+    },
+    "options": {
+      "composite": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../../../../a/lib/lib.d.ts",
+      "./index.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 745
+}
+
+//// [/user/username/projects/myproject/webpack/index.js]
+"use strict";
+exports.__esModule = true;
+exports.f22 = exports.e2 = exports.c2 = exports.f2 = void 0;
+/*@before/user/username/projects/myproject/webpack/tsconfig.json*/
+function f2() { }
+exports.f2 = f2;
+//@after/user/username/projects/myproject/webpack/tsconfig.json
+var c2 = /** @class */ (function () {
+    function c2() {
+    }
+    return c2;
+}());
+exports.c2 = c2;
+//@after/user/username/projects/myproject/webpack/tsconfig.json
+var e2;
+(function (e2) {
+})(e2 = exports.e2 || (exports.e2 = {}));
+// leading
+/*@before/user/username/projects/myproject/webpack/tsconfig.json*/
+function f22() { } // trailing
+exports.f22 = f22;
+
+
+//// [/user/username/projects/myproject/webpack/index.d.ts]
+export declare function f2(): void;
+export declare class c2 {
+}
+export declare enum e2 {
+}
+export declare function f22(): void;
+
+
+//// [/user/username/projects/myproject/webpack/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../../../../a/lib/lib.d.ts","./index.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true},"20140662566-export function f2() { }\nexport class c2 { }\nexport enum e2 { }\n// leading\nexport function f22() { } // trailing"],"options":{"composite":true},"referencedMap":[],"exportedModulesMap":[],"semanticDiagnosticsPerFile":[1,2]},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/myproject/webpack/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../../../a/lib/lib.d.ts",
+      "./index.ts"
+    ],
+    "fileInfos": {
+      "../../../../../a/lib/lib.d.ts": {
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "signature": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "20140662566-export function f2() { }\nexport class c2 { }\nexport enum e2 { }\n// leading\nexport function f22() { } // trailing",
+        "signature": "20140662566-export function f2() { }\nexport class c2 { }\nexport enum e2 { }\n// leading\nexport function f22() { } // trailing"
+      }
+    },
+    "options": {
+      "composite": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../../../../a/lib/lib.d.ts",
+      "./index.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 749
+}
+
+
+Change:: change to shared
+
+Input::
+//// [/user/username/projects/myproject/shared/index.ts]
+export function fooBar() {}export function f1() { }
+export class c { }
+export enum e { }
+// leading
+export function f2() { } // trailing
+
+
+Output::
+>> Screen clear
+[[90m12:00:55 AM[0m] File change detected. Starting incremental compilation...
+
+[[90m12:00:56 AM[0m] Project 'shared/tsconfig.json' is out of date because oldest output 'shared/index.js' is older than newest input 'shared/index.ts'
+
+[[90m12:00:57 AM[0m] Building project '/user/username/projects/myproject/shared/tsconfig.json'...
+
+[[90m12:01:10 AM[0m] Project 'webpack/tsconfig.json' is out of date because oldest output 'webpack/index.js' is older than newest input 'shared/tsconfig.json'
+
+[[90m12:01:11 AM[0m] Building project '/user/username/projects/myproject/webpack/tsconfig.json'...
+
+[[90m12:01:13 AM[0m] Updating unchanged output timestamps of project '/user/username/projects/myproject/webpack/tsconfig.json'...
+
+[[90m12:01:14 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/shared/index.ts"]
+Program options: {"composite":true,"configFilePath":"/user/username/projects/myproject/shared/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/shared/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/shared/index.ts
+
+Program root files: ["/user/username/projects/myproject/webpack/index.ts"]
+Program options: {"composite":true,"configFilePath":"/user/username/projects/myproject/webpack/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/webpack/index.ts
+
+Semantic diagnostics in builder refreshed for::
+
+WatchedFiles::
+/user/username/projects/myproject/shared/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/shared/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/shared/index.ts:
+  {"fileName":"/user/username/projects/myproject/shared/index.ts","pollingInterval":250}
+/user/username/projects/myproject/webpack/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/webpack/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/webpack/index.ts:
+  {"fileName":"/user/username/projects/myproject/webpack/index.ts","pollingInterval":250}
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/shared:
+  {"directoryName":"/user/username/projects/myproject/shared","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/webpack:
+  {"directoryName":"/user/username/projects/myproject/webpack","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/shared/index.js]
+"use strict";
+exports.__esModule = true;
+exports.f2 = exports.e = exports.c = exports.f1 = exports.fooBar = void 0;
+/*@before/user/username/projects/myproject/shared/tsconfig.json*/
+function fooBar() { }
+exports.fooBar = fooBar;
+/*@before/user/username/projects/myproject/shared/tsconfig.json*/
+function f1() { }
+exports.f1 = f1;
+//@after/user/username/projects/myproject/shared/tsconfig.json
+var c = /** @class */ (function () {
+    function c() {
+    }
+    return c;
+}());
+exports.c = c;
+//@after/user/username/projects/myproject/shared/tsconfig.json
+var e;
+(function (e) {
+})(e = exports.e || (exports.e = {}));
+// leading
+/*@before/user/username/projects/myproject/shared/tsconfig.json*/
+function f2() { } // trailing
+exports.f2 = f2;
+
+
+//// [/user/username/projects/myproject/shared/index.d.ts]
+export declare function fooBar(): void;
+export declare function f1(): void;
+export declare class c {
+}
+export declare enum e {
+}
+export declare function f2(): void;
+
+
+//// [/user/username/projects/myproject/shared/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../../../../a/lib/lib.d.ts","./index.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true},{"version":"14127205977-export function fooBar() {}export function f1() { }\nexport class c { }\nexport enum e { }\n// leading\nexport function f2() { } // trailing","signature":"1966424426-export declare function fooBar(): void;\nexport declare function f1(): void;\nexport declare class c {\n}\nexport declare enum e {\n}\nexport declare function f2(): void;\n"}],"options":{"composite":true},"referencedMap":[],"exportedModulesMap":[],"semanticDiagnosticsPerFile":[1,2]},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/myproject/shared/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../../../a/lib/lib.d.ts",
+      "./index.ts"
+    ],
+    "fileInfos": {
+      "../../../../../a/lib/lib.d.ts": {
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "signature": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "14127205977-export function fooBar() {}export function f1() { }\nexport class c { }\nexport enum e { }\n// leading\nexport function f2() { } // trailing",
+        "signature": "1966424426-export declare function fooBar(): void;\nexport declare function f1(): void;\nexport declare class c {\n}\nexport declare enum e {\n}\nexport declare function f2(): void;\n"
+      }
+    },
+    "options": {
+      "composite": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../../../../a/lib/lib.d.ts",
+      "./index.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 983
+}
+
+//// [/user/username/projects/myproject/webpack/index.js] file changed its modified time
+//// [/user/username/projects/myproject/webpack/index.d.ts] file changed its modified time
+//// [/user/username/projects/myproject/webpack/tsconfig.tsbuildinfo] file changed its modified time


### PR DESCRIPTION
This allows not having to specify the transformers during normal watch scneario
Builds on top of #43984
This is in response to https://github.com/microsoft/TypeScript/pull/43984#issuecomment-855279396