### PR TITLE
Fix bug due to sharing of `.type.members`

### DIFF
--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -127,7 +127,7 @@ namespace ts.codefix {
                 }
 
                 for (const signature of signatures) {
-                    // Need to ensure nodes are fresh each time so they can have different positions.
+                    // Ensure nodes are fresh so they can have different positions when going through formatting.
                     outputMethod(quotePreference, signature, getSynthesizedDeepClones(modifiers, /*includeTrivia*/ false), getSynthesizedDeepClone(name, /*includeTrivia*/ false));
                 }
 
@@ -310,15 +310,16 @@ namespace ts.codefix {
     }
 
     export function typeToAutoImportableTypeNode(checker: TypeChecker, importAdder: ImportAdder, type: Type, contextNode: Node | undefined, scriptTarget: ScriptTarget, flags?: NodeBuilderFlags, tracker?: SymbolTracker): TypeNode | undefined {
-        const typeNode = checker.typeToTypeNode(type, contextNode, flags, tracker);
+        let typeNode = checker.typeToTypeNode(type, contextNode, flags, tracker);
         if (typeNode && isImportTypeNode(typeNode)) {
             const importableReference = tryGetAutoImportableReferenceFromTypeNode(typeNode, scriptTarget);
             if (importableReference) {
                 importSymbols(importAdder, importableReference.symbols);
-                return importableReference.typeNode;
+                typeNode = importableReference.typeNode;
             }
         }
-        return typeNode;
+        // Ensure nodes are fresh so they can have different positions when going through formatting.
+        return getSynthesizedDeepClone(typeNode);
     }
 
     function createDummyParameters(argCount: number, names: (string | undefined)[] | undefined, types: (TypeNode | undefined)[] | undefined, minArgumentCount: number | undefined, inJs: boolean): ParameterDeclaration[] {

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -991,7 +991,7 @@ namespace ts.textChanges {
             const { options = {}, range: { pos } } = change;
             const format = (n: Node) => getFormattedTextOfNode(n, sourceFile, pos, options, newLineCharacter, formatContext, validate);
             const text = change.kind === ChangeKind.ReplaceWithMultipleNodes
-                ? change.nodes.map(n => removeSuffix(format(n), newLineCharacter)).join(change.options!.joiner || newLineCharacter) // TODO: GH#18217
+                ? change.nodes.map(n => removeSuffix(format(n), newLineCharacter)).join(change.options?.joiner || newLineCharacter)
                 : format(change.node);
             // strip initial indentation (spaces or tabs) if text will be inserted in the middle of the line
             const noIndent = (options.preserveLeadingWhitespace || options.indentation !== undefined || getLineStartPositionForPosition(pos, sourceFile) === pos) ? text : text.replace(/^\s+/, "");
@@ -1054,7 +1054,7 @@ namespace ts.textChanges {
     }
 
     function assignPositionsToNode(node: Node): Node {
-        const visited = visitEachChild(node, assignPositionsToNode, nullTransformationContext, assignPositionsToNodeArray, assignPositionsToNode)!; // TODO: GH#18217
+        const visited = visitEachChild(node, assignPositionsToNode, nullTransformationContext, assignPositionsToNodeArray, assignPositionsToNode);
         // create proxy node for non synthesized nodes
         const newNode = nodeIsSynthesized(visited) ? visited : Object.create(visited) as Node;
         setTextRangePosEnd(newNode, getPos(node), getEnd(node));

--- a/tests/cases/fourslash/extract-method-two-type-literals.ts
+++ b/tests/cases/fourslash/extract-method-two-type-literals.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+////(x: {}, y: {}) => (/*1*/x + y/*2*/);
+
+goTo.select("1", "2");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "function_scope_1",
+    actionDescription: "Extract to function in global scope",
+    newContent:
+`(x: {}, y: {}) => (/*RENAME*/newFunction(x, y));
+
+function newFunction(x: {}, y: {}) {
+    return x + y;
+}
+`
+});


### PR DESCRIPTION
Function extraction failed when using two identical `TypeLiteral`s ---
the problem is that the parameters' `.type.members` are shared in their
two occurences in the resulting code, and when the formatter bangs
position properties on the second, it's actually changing the first too.

* `typeToAutoImportableTypeNode`: wrap in `getSynthesizedDeepClone` to
  avoid the offeding sharing.

* `getSynthesizedDeepCloneWorker`: add optional nodes/token visitors so
  it doesn't skip cloning the above.

* A few very minor tweaks which I saw when tracing this (comment update,
  two `!`s).

Fixes #44301
