### PR TITLE
Update to CONTRIBUTING.md with a tip on avoiding problems with long paths of baseline tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Run `gulp` to build a version of the compiler/language service that reflects cha
 
 ### Avoiding problems with long paths
 
-Some of the baseline test files have very long names. If your repository is cloned to a directory with a long path, the total path might exceed 260 characters and not function properly on Windows. It is therefore recommended to clone into a location with short path such as `D:\TypeScript`.
+Some of the baseline test files have very long names. If your repository is cloned to a directory with a long path, the total path might exceed 260 characters and not function properly on Windows. It is therefore recommended to keep the code in a location with a short path, such as `D:\TypeScript`.
 
 ## Contributing bug fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,10 @@ The TypeScript repository is relatively large. To save some time, you might want
 
 Run `gulp` to build a version of the compiler/language service that reflects changes you've made. You can then run `node <repo-root>/built/local/tsc.js` in place of `tsc` in your project. For example, to run `tsc --watch` from within the root of the repository on a file called `test.ts`, you can run `node ./built/local/tsc.js --watch test.ts`.
 
+### Avoiding problems with long paths
+
+Some of the baseline test files have very long names. If your repository is cloned to a directory with a long path, the total path might exceed 260 characters and not function properly on Windows. It is therefore recommended to clone into a location with short path such as `D:\TypeScript`.
+
 ## Contributing bug fixes
 
 TypeScript is currently accepting contributions in the form of bug fixes. A bug must have an issue tracking it in the issue tracker that has been approved (labelled ["help wanted"](https://github.com/Microsoft/TypeScript/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or in the "Backlog milestone") by the TypeScript team. Your pull request should include a link to the bug that you are fixing. If you've submitted a PR for a bug, please post a comment in the bug to avoid duplication of effort.


### PR DESCRIPTION
Some test files have extremely long paths, for example: `\tests\baselines\reference\tsserver\projectReferences\special-handling-of-localness-when-using-arrow-function-as-object-literal-property-is-loaded-through-indirect-assignment-with-original-declaration-local-to-project-is-treated-as-local.js`. 

With such long names it is quite likely to reach the limit of 260 characters unless the repository is cloned into a folder with short path. When that happens, running `gulp runtests-parallel` leads to failed tests!

I've just faced such problem on my Windows 10 Home 10.0.19041 when I've cloned to location I use for most projects (24 characters long path). After cloning to `D:\TypeScript` all tests pass just fine.

I hope this addition will save people some time.
