### PR TITLE
Improve __spreadArray perf, and other fixes related to SpreadElement

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40726,6 +40726,11 @@ namespace ts {
                                         error(location, Diagnostics.This_syntax_requires_an_imported_helper_named_1_with_2_parameters_which_is_not_compatible_with_the_one_in_0_Consider_upgrading_your_version_of_0, externalHelpersModuleNameText, name, 5);
                                     }
                                 }
+                                else if (helper & ExternalEmitHelpers.SpreadArray) {
+                                    if (!some(getSignaturesOfSymbol(symbol), signature => getParameterCount(signature) > 2)) {
+                                        error(location, Diagnostics.This_syntax_requires_an_imported_helper_named_1_with_2_parameters_which_is_not_compatible_with_the_one_in_0_Consider_upgrading_your_version_of_0, externalHelpersModuleNameText, name, 3);
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/compiler/factory/emitHelpers.ts
+++ b/src/compiler/factory/emitHelpers.ts
@@ -287,7 +287,7 @@ namespace ts {
             return factory.createCallExpression(
                 getUnscopedHelperName("__spreadArray"),
                 /*typeArguments*/ undefined,
-                packFrom ? [to, from, factory.createTrue()] : [to, from]
+                [to, from, packFrom ? factory.createTrue() : factory.createFalse()]
             );
         }
 
@@ -638,7 +638,7 @@ namespace ts {
         scoped: false,
         text: `
             var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-                if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+                if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
                     if (ar || !(i in from)) {
                         if (!ar) ar = Array.prototype.slice.call(from, 0, i);
                         ar[i] = from[i];

--- a/src/compiler/factory/emitHelpers.ts
+++ b/src/compiler/factory/emitHelpers.ts
@@ -38,6 +38,9 @@ namespace ts {
 
     export function createEmitHelperFactory(context: TransformationContext): EmitHelperFactory {
         const factory = context.factory;
+        const immutableTrue = memoize(() => setEmitFlags(factory.createTrue(), EmitFlags.Immutable));
+        const immutableFalse = memoize(() => setEmitFlags(factory.createFalse(), EmitFlags.Immutable));
+
         return {
             getUnscopedHelperName,
             // TypeScript Helpers
@@ -287,7 +290,7 @@ namespace ts {
             return factory.createCallExpression(
                 getUnscopedHelperName("__spreadArray"),
                 /*typeArguments*/ undefined,
-                [to, from, packFrom ? factory.createTrue() : factory.createFalse()]
+                [to, from, packFrom ? immutableTrue() : immutableFalse()]
             );
         }
 

--- a/src/compiler/factory/emitNode.ts
+++ b/src/compiler/factory/emitNode.ts
@@ -20,7 +20,9 @@ namespace ts {
 
             node.emitNode = {} as EmitNode;
         }
-
+        else {
+            Debug.assert(!(node.emitNode.flags & EmitFlags.Immutable), "Invalid attempt to mutate an immutable node.");
+        }
         return node.emitNode;
     }
 

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -525,12 +525,25 @@ namespace ts {
                 elements = [];
             }
             else if (isNodeArray(elements)) {
-                // Ensure the transform flags have been aggregated for this NodeArray
-                if (elements.transformFlags === undefined) {
-                    aggregateChildrenFlags(elements as MutableNodeArray<T>);
+                if (hasTrailingComma === undefined || elements.hasTrailingComma === hasTrailingComma) {
+                    // Ensure the transform flags have been aggregated for this NodeArray
+                    if (elements.transformFlags === undefined) {
+                        aggregateChildrenFlags(elements as MutableNodeArray<T>);
+                    }
+                    Debug.attachNodeArrayDebugInfo(elements);
+                    return elements;
                 }
-                Debug.attachNodeArrayDebugInfo(elements);
-                return elements;
+
+                // This *was* a `NodeArray`, but the `hasTrailingComma` option differs. Recreate the
+                // array with the same elements, text range, and transform flags but with the updated
+                // value for `hasTrailingComma`
+                const array = elements.slice() as MutableNodeArray<T>;
+                array.pos = elements.pos;
+                array.end = elements.end;
+                array.hasTrailingComma = hasTrailingComma;
+                array.transformFlags = elements.transformFlags;
+                Debug.attachNodeArrayDebugInfo(array);
+                return array;
             }
 
             // Since the element list of a node array is typically created by starting with an empty array and
@@ -2184,7 +2197,12 @@ namespace ts {
         // @api
         function createArrayLiteralExpression(elements?: readonly Expression[], multiLine?: boolean) {
             const node = createBaseExpression<ArrayLiteralExpression>(SyntaxKind.ArrayLiteralExpression);
-            node.elements = parenthesizerRules().parenthesizeExpressionsOfCommaDelimitedList(createNodeArray(elements));
+            // Ensure we add a trailing comma for something like `[NumericLiteral(1), NumericLiteral(2), OmittedExpresion]` so that
+            // we end up with `[1, 2, ,]` instead of `[1, 2, ]` otherwise the `OmittedExpression` will just end up being treated like
+            // a trailing comma.
+            const lastElement = elements && lastOrUndefined(elements);
+            const elementsArray = createNodeArray(elements, lastElement && isOmittedExpression(lastElement) ? true : undefined);
+            node.elements = parenthesizerRules().parenthesizeExpressionsOfCommaDelimitedList(elementsArray);
             node.multiLine = multiLine;
             node.transformFlags |= propagateChildrenFlags(node.elements);
             return node;

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -6497,7 +6497,7 @@ namespace ts {
         // We are using `.slice()` here in case `destEmitNode.leadingComments` is pushed to later.
         if (leadingComments) destEmitNode.leadingComments = addRange(leadingComments.slice(), destEmitNode.leadingComments);
         if (trailingComments) destEmitNode.trailingComments = addRange(trailingComments.slice(), destEmitNode.trailingComments);
-        if (flags) destEmitNode.flags = flags;
+        if (flags) destEmitNode.flags = flags & ~EmitFlags.Immutable;
         if (commentRange) destEmitNode.commentRange = commentRange;
         if (sourceMapRange) destEmitNode.sourceMapRange = sourceMapRange;
         if (tokenSourceMapRanges) destEmitNode.tokenSourceMapRanges = mergeTokenSourceMapRanges(tokenSourceMapRanges, destEmitNode.tokenSourceMapRanges!);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6727,6 +6727,7 @@ namespace ts {
         /*@internal*/ TypeScriptClassWrapper = 1 << 25, // The node is an IIFE class wrapper created by the ts transform.
         /*@internal*/ NeverApplyImportHelper = 1 << 26, // Indicates the node should never be wrapped with an import star helper (because, for example, it imports tslib itself)
         /*@internal*/ IgnoreSourceNewlines = 1 << 27,   // Overrides `printerOptions.preserveSourceNewlines` to print this node (and all descendants) with default whitespace.
+        /*@internal*/ Immutable = 1 << 28,      // Indicates a node is a singleton intended to be reused in multiple locations. Any attempt to make further changes to the node will result in an error.
     }
 
     export interface EmitHelperBase {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -999,10 +999,13 @@ namespace ts {
         ;
 
     /* @internal */
-    export type MutableNodeArray<T extends Node> = NodeArray<T> & T[];
+    export interface MutableNodeArray<T extends Node> extends Array<T>, TextRange {
+        hasTrailingComma: boolean;
+        /* @internal */ transformFlags: TransformFlags;   // Flags for transforms, possibly undefined
+    }
 
     export interface NodeArray<T extends Node> extends ReadonlyArray<T>, ReadonlyTextRange {
-        hasTrailingComma?: boolean;
+        readonly hasTrailingComma: boolean;
         /* @internal */ transformFlags: TransformFlags;   // Flags for transforms, possibly undefined
     }
 

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -88,6 +88,7 @@
         "unittests/config/showConfig.ts",
         "unittests/config/tsconfigParsing.ts",
         "unittests/config/tsconfigParsingWatchOptions.ts",
+        "unittests/evaluation/arraySpread.ts",
         "unittests/evaluation/asyncArrow.ts",
         "unittests/evaluation/asyncGenerator.ts",
         "unittests/evaluation/awaiter.ts",

--- a/src/testRunner/unittests/evaluation/arraySpread.ts
+++ b/src/testRunner/unittests/evaluation/arraySpread.ts
@@ -1,0 +1,39 @@
+describe("unittests:: evaluation:: arraySpread", () => {
+    it("array spread preserves side-effects", async () => {
+        const result = evaluator.evaluateTypeScript(`
+            const k = [1, 2];
+            const o = [3, ...k, k[0]++];
+            export const output = o;
+        `);
+        assert.deepEqual(result.output, [3, 1, 2, 1]);
+    });
+    it("array spread packs spread elements", async () => {
+        const result = evaluator.evaluateTypeScript(`
+            const k = [1, , 2];
+            const o = [3, ...k, 4];
+            export const output = o;
+        `);
+        assert.deepEqual(result.output, [3, 1, undefined, 2, 4]);
+        assert.hasAllKeys(result.output, ["0", "1", "2", "3", "4"]);
+    });
+    it("array spread does not pack non-spread elements", async () => {
+        const result = evaluator.evaluateTypeScript(`
+            const k = [1, 2];
+            const o = [3, , ...k, , 4];
+            export const output = o;
+        `);
+        assert.deepEqual(result.output, [3, , 1, 2, , 4]); // eslint-disable-line no-sparse-arrays
+        assert.hasAllKeys(result.output, ["0", "2", "3", "5"]);
+        assert.doesNotHaveAllKeys(result.output, ["1", "4"]);
+    });
+    it("argument spread pack does not matter", async () => {
+        const result = evaluator.evaluateTypeScript(`
+            const f = (...args) => args;
+            const k = [1, , 2];
+            const o = f(3, ...k, 4);
+            export const output = o;
+        `);
+        assert.deepEqual(result.output, [3, 1, undefined, 2,4]);
+        assert.hasAllKeys(result.output, ["0", "1", "2", "3", "4"]);
+    });
+});

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -574,7 +574,7 @@ declare namespace ts {
     export type HasInitializer = HasExpressionInitializer | ForStatement | ForInStatement | ForOfStatement | JsxAttribute;
     export type HasExpressionInitializer = VariableDeclaration | ParameterDeclaration | BindingElement | PropertySignature | PropertyDeclaration | PropertyAssignment | EnumMember;
     export interface NodeArray<T extends Node> extends ReadonlyArray<T>, ReadonlyTextRange {
-        hasTrailingComma?: boolean;
+        readonly hasTrailingComma: boolean;
     }
     export interface Token<TKind extends SyntaxKind> extends Node {
         readonly kind: TKind;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -574,7 +574,7 @@ declare namespace ts {
     export type HasInitializer = HasExpressionInitializer | ForStatement | ForInStatement | ForOfStatement | JsxAttribute;
     export type HasExpressionInitializer = VariableDeclaration | ParameterDeclaration | BindingElement | PropertySignature | PropertyDeclaration | PropertyAssignment | EnumMember;
     export interface NodeArray<T extends Node> extends ReadonlyArray<T>, ReadonlyTextRange {
-        hasTrailingComma?: boolean;
+        readonly hasTrailingComma: boolean;
     }
     export interface Token<TKind extends SyntaxKind> extends Node {
         readonly kind: TKind;

--- a/tests/baselines/reference/argumentExpressionContextualTyping.js
+++ b/tests/baselines/reference/argumentExpressionContextualTyping.js
@@ -19,10 +19,14 @@ baz(["string", 1, true, ...array]);  // Error
 foo(o);                              // Error because x has an array type namely (string|number)[]
 
 //// [argumentExpressionContextualTyping.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // In a typed function call, argument expressions are contextually typed by their corresponding parameter types.
 function foo(_a) {
@@ -41,5 +45,5 @@ var tuple = ["string", 1, true];
 baz(tuple);
 baz(["string", 1, true]);
 baz(array); // Error
-baz(__spreadArray(["string", 1, true], array)); // Error
+baz(__spreadArray(["string", 1, true], array, true)); // Error
 foo(o); // Error because x has an array type namely (string|number)[]

--- a/tests/baselines/reference/argumentExpressionContextualTyping.js
+++ b/tests/baselines/reference/argumentExpressionContextualTyping.js
@@ -20,7 +20,7 @@ foo(o);                              // Error because x has an array type namely
 
 //// [argumentExpressionContextualTyping.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/arrayLiteralExpressionContextualTyping.js
+++ b/tests/baselines/reference/arrayLiteralExpressionContextualTyping.js
@@ -16,10 +16,14 @@ var spr2:[number, number, number] = [1, 2, 3, ...tup];  // Error
 
 
 //// [arrayLiteralExpressionContextualTyping.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // In a contextually typed array literal expression containing no spread elements, an element expression at index N is contextually typed by
 //      the type of the property with the numeric name N in the contextual type, if any, or otherwise
@@ -31,6 +35,6 @@ var tup1 = [1, 2, 3, "string"];
 var tup2 = [1, 2, 3, "string"]; // Error
 // In a contextually typed array literal expression containing one or more spread elements,
 // an element expression at index N is contextually typed by the numeric index type of the contextual type, if any.
-var spr = __spreadArray([1, 2, 3], array);
-var spr1 = __spreadArray([1, 2, 3], tup);
-var spr2 = __spreadArray([1, 2, 3], tup); // Error
+var spr = __spreadArray([1, 2, 3], array, true);
+var spr1 = __spreadArray([1, 2, 3], tup, true);
+var spr2 = __spreadArray([1, 2, 3], tup, true); // Error

--- a/tests/baselines/reference/arrayLiteralExpressionContextualTyping.js
+++ b/tests/baselines/reference/arrayLiteralExpressionContextualTyping.js
@@ -17,7 +17,7 @@ var spr2:[number, number, number] = [1, 2, 3, ...tup];  // Error
 
 //// [arrayLiteralExpressionContextualTyping.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/arrayLiteralSpread.js
+++ b/tests/baselines/reference/arrayLiteralSpread.js
@@ -24,25 +24,29 @@ function f2() {
 
 
 //// [arrayLiteralSpread.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 function f0() {
     var a = [1, 2, 3];
-    var a1 = __spreadArray([], a);
-    var a2 = __spreadArray([1], a);
-    var a3 = __spreadArray([1, 2], a);
-    var a4 = __spreadArray(__spreadArray([], a), [1]);
-    var a5 = __spreadArray(__spreadArray([], a), [1, 2]);
-    var a6 = __spreadArray(__spreadArray([1, 2], a), [1, 2]);
-    var a7 = __spreadArray(__spreadArray(__spreadArray([1], a), [2]), a);
-    var a8 = __spreadArray(__spreadArray(__spreadArray([], a), a), a);
+    var a1 = __spreadArray([], a, true);
+    var a2 = __spreadArray([1], a, true);
+    var a3 = __spreadArray([1, 2], a, true);
+    var a4 = __spreadArray(__spreadArray([], a, true), [1]);
+    var a5 = __spreadArray(__spreadArray([], a, true), [1, 2]);
+    var a6 = __spreadArray(__spreadArray([1, 2], a, true), [1, 2]);
+    var a7 = __spreadArray(__spreadArray(__spreadArray([1], a, true), [2]), a, true);
+    var a8 = __spreadArray(__spreadArray(__spreadArray([], a, true), a, true), a, true);
 }
 function f1() {
     var a = [1, 2, 3];
-    var b = __spreadArray(__spreadArray(["hello"], a), [true]);
+    var b = __spreadArray(__spreadArray(["hello"], a, true), [true]);
     var b;
 }
 function f2() {

--- a/tests/baselines/reference/arrayLiteralSpread.js
+++ b/tests/baselines/reference/arrayLiteralSpread.js
@@ -25,7 +25,7 @@ function f2() {
 
 //// [arrayLiteralSpread.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -38,15 +38,15 @@ function f0() {
     var a1 = __spreadArray([], a, true);
     var a2 = __spreadArray([1], a, true);
     var a3 = __spreadArray([1, 2], a, true);
-    var a4 = __spreadArray(__spreadArray([], a, true), [1]);
-    var a5 = __spreadArray(__spreadArray([], a, true), [1, 2]);
-    var a6 = __spreadArray(__spreadArray([1, 2], a, true), [1, 2]);
-    var a7 = __spreadArray(__spreadArray(__spreadArray([1], a, true), [2]), a, true);
+    var a4 = __spreadArray(__spreadArray([], a, true), [1], false);
+    var a5 = __spreadArray(__spreadArray([], a, true), [1, 2], false);
+    var a6 = __spreadArray(__spreadArray([1, 2], a, true), [1, 2], false);
+    var a7 = __spreadArray(__spreadArray(__spreadArray([1], a, true), [2], false), a, true);
     var a8 = __spreadArray(__spreadArray(__spreadArray([], a, true), a, true), a, true);
 }
 function f1() {
     var a = [1, 2, 3];
-    var b = __spreadArray(__spreadArray(["hello"], a, true), [true]);
+    var b = __spreadArray(__spreadArray(["hello"], a, true), [true], false);
     var b;
 }
 function f2() {

--- a/tests/baselines/reference/arrayLiteralSpreadES5iterable.js
+++ b/tests/baselines/reference/arrayLiteralSpreadES5iterable.js
@@ -40,10 +40,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 function f0() {
     var a = [1, 2, 3];

--- a/tests/baselines/reference/arrayLiteralSpreadES5iterable.js
+++ b/tests/baselines/reference/arrayLiteralSpreadES5iterable.js
@@ -41,7 +41,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -51,18 +51,18 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
 };
 function f0() {
     var a = [1, 2, 3];
-    var a1 = __spreadArray([], __read(a));
-    var a2 = __spreadArray([1], __read(a));
-    var a3 = __spreadArray([1, 2], __read(a));
-    var a4 = __spreadArray(__spreadArray([], __read(a)), [1]);
-    var a5 = __spreadArray(__spreadArray([], __read(a)), [1, 2]);
-    var a6 = __spreadArray(__spreadArray([1, 2], __read(a)), [1, 2]);
-    var a7 = __spreadArray(__spreadArray(__spreadArray([1], __read(a)), [2]), __read(a));
-    var a8 = __spreadArray(__spreadArray(__spreadArray([], __read(a)), __read(a)), __read(a));
+    var a1 = __spreadArray([], __read(a), false);
+    var a2 = __spreadArray([1], __read(a), false);
+    var a3 = __spreadArray([1, 2], __read(a), false);
+    var a4 = __spreadArray(__spreadArray([], __read(a), false), [1], false);
+    var a5 = __spreadArray(__spreadArray([], __read(a), false), [1, 2], false);
+    var a6 = __spreadArray(__spreadArray([1, 2], __read(a), false), [1, 2], false);
+    var a7 = __spreadArray(__spreadArray(__spreadArray([1], __read(a), false), [2], false), __read(a), false);
+    var a8 = __spreadArray(__spreadArray(__spreadArray([], __read(a), false), __read(a), false), __read(a), false);
 }
 function f1() {
     var a = [1, 2, 3];
-    var b = __spreadArray(__spreadArray(["hello"], __read(a)), [true]);
+    var b = __spreadArray(__spreadArray(["hello"], __read(a), false), [true], false);
     var b;
 }
 function f2() {

--- a/tests/baselines/reference/arrayLiterals2ES5.js
+++ b/tests/baselines/reference/arrayLiterals2ES5.js
@@ -63,7 +63,7 @@ var d9 = [[...temp1], ...["hello"]];
 //      ElementList, Elisionopt   AssignmentExpression
 //      ElementList, Elisionopt   SpreadElement
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -75,10 +75,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
 //      ...   AssignmentExpression
 var a0 = [, , 2, 3, 4];
 var a1 = ["hello", "world"];
-var a2 = __spreadArray(__spreadArray([, , ,], a0, true), ["hello"]);
+var a2 = __spreadArray(__spreadArray([, , ,], a0, true), ["hello"], false);
 var a3 = __spreadArray([, ,], a0, true);
 var a4 = [function () { return 1; },];
-var a5 = __spreadArray(__spreadArray([], a0, true), [,]);
+var a5 = __spreadArray(__spreadArray([], a0, true), [,], false);
 // Each element expression in a non-empty array literal is processed as follows:
 //    - If the array literal contains no spread elements, and if the array literal is contextually typed (section 4.19)
 //      by a type T and T has a property with the numeric name N, where N is the index of the element expression in the array literal,
@@ -110,4 +110,4 @@ var d5 = __spreadArray([], temp3, true);
 var d6 = __spreadArray([], temp4, true);
 var d7 = __spreadArray([], temp1, true);
 var d8 = [__spreadArray([], temp1, true)];
-var d9 = __spreadArray([__spreadArray([], temp1, true)], ["hello"]);
+var d9 = __spreadArray([__spreadArray([], temp1, true)], ["hello"], false);

--- a/tests/baselines/reference/arrayLiterals2ES5.js
+++ b/tests/baselines/reference/arrayLiterals2ES5.js
@@ -62,19 +62,23 @@ var d9 = [[...temp1], ...["hello"]];
 //      Elisionopt   SpreadElement
 //      ElementList, Elisionopt   AssignmentExpression
 //      ElementList, Elisionopt   SpreadElement
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // SpreadElement:
 //      ...   AssignmentExpression
 var a0 = [, , 2, 3, 4];
 var a1 = ["hello", "world"];
-var a2 = __spreadArray(__spreadArray([, , ], a0), ["hello"]);
-var a3 = __spreadArray([, ], a0);
+var a2 = __spreadArray(__spreadArray([, , ,], a0, true), ["hello"]);
+var a3 = __spreadArray([, ,], a0, true);
 var a4 = [function () { return 1; },];
-var a5 = __spreadArray(__spreadArray([], a0), [,]);
+var a5 = __spreadArray(__spreadArray([], a0, true), [,]);
 // Each element expression in a non-empty array literal is processed as follows:
 //    - If the array literal contains no spread elements, and if the array literal is contextually typed (section 4.19)
 //      by a type T and T has a property with the numeric name N, where N is the index of the element expression in the array literal,
@@ -97,13 +101,13 @@ var temp1 = [1, 2, 3];
 var temp2 = [[1, 2, 3], ["hello", "string"]];
 var temp3 = [undefined, null, undefined];
 var temp4 = [];
-var d0 = __spreadArray([1, true], temp); // has type (string|number|boolean)[]
-var d1 = __spreadArray([], temp); // has type string[]
-var d2 = __spreadArray([], temp1);
-var d3 = __spreadArray([], temp1);
-var d4 = __spreadArray(__spreadArray([], temp), temp1);
-var d5 = __spreadArray([], temp3);
-var d6 = __spreadArray([], temp4);
-var d7 = __spreadArray([], temp1);
-var d8 = [__spreadArray([], temp1)];
-var d9 = __spreadArray([__spreadArray([], temp1)], ["hello"]);
+var d0 = __spreadArray([1, true], temp, true); // has type (string|number|boolean)[]
+var d1 = __spreadArray([], temp, true); // has type string[]
+var d2 = __spreadArray([], temp1, true);
+var d3 = __spreadArray([], temp1, true);
+var d4 = __spreadArray(__spreadArray([], temp, true), temp1, true);
+var d5 = __spreadArray([], temp3, true);
+var d6 = __spreadArray([], temp4, true);
+var d7 = __spreadArray([], temp1, true);
+var d8 = [__spreadArray([], temp1, true)];
+var d9 = __spreadArray([__spreadArray([], temp1, true)], ["hello"]);

--- a/tests/baselines/reference/arrayLiterals3.js
+++ b/tests/baselines/reference/arrayLiterals3.js
@@ -41,7 +41,7 @@ var c2: myArray = [...temp1, ...temp];            // Error cannot assign (number
 //      by a type T and T has a property with the numeric name N, where N is the index of the element expression in the array literal,
 //      the element expression is contextually typed by the type of that property.
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/arrayLiterals3.js
+++ b/tests/baselines/reference/arrayLiterals3.js
@@ -40,10 +40,14 @@ var c2: myArray = [...temp1, ...temp];            // Error cannot assign (number
 //    - If the array literal contains no spread elements, and if the array literal is contextually typed (section 4.19)
 //      by a type T and T has a property with the numeric name N, where N is the index of the element expression in the array literal,
 //      the element expression is contextually typed by the type of that property.
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // The resulting type an array literal expression is determined as follows:
 //     - If the array literal contains no spread elements and is contextually typed by a tuple-like type,
@@ -60,6 +64,6 @@ var _a = [1, 2, "string", true], b1 = _a[0], b2 = _a[1];
 var temp = ["s", "t", "r"];
 var temp1 = [1, 2, 3];
 var temp2 = [[1, 2, 3], ["hello", "string"]];
-var c0 = __spreadArray([], temp2); // Error
-var c1 = __spreadArray([], temp1); // Error cannot assign number[] to [number, number, number]
-var c2 = __spreadArray(__spreadArray([], temp1), temp); // Error cannot assign (number|string)[] to number[]
+var c0 = __spreadArray([], temp2, true); // Error
+var c1 = __spreadArray([], temp1, true); // Error cannot assign number[] to [number, number, number]
+var c2 = __spreadArray(__spreadArray([], temp1, true), temp, true); // Error cannot assign (number|string)[] to number[]

--- a/tests/baselines/reference/arraySpreadImportHelpers.errors.txt
+++ b/tests/baselines/reference/arraySpreadImportHelpers.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/conformance/es6/spread/main.ts(3,15): error TS2807: This syntax requires an imported helper named '__spreadArray' with 3 parameters, which is not compatible with the one in 'tslib'. Consider upgrading your version of 'tslib'.
+
+
+==== tests/cases/conformance/es6/spread/main.ts (1 errors) ====
+    export {};
+    const k = [1, , 2];
+    const o = [3, ...k, 4];
+                  ~~~~
+!!! error TS2807: This syntax requires an imported helper named '__spreadArray' with 3 parameters, which is not compatible with the one in 'tslib'. Consider upgrading your version of 'tslib'.
+    
+==== tests/cases/conformance/es6/spread/tslib.d.ts (0 errors) ====
+    // this is a pre-TS4.4 versions of emit helper, which always forced array packing
+    declare module "tslib" {
+        function __spreadArray(to: any[], from: any[]): any[];
+    }
+    

--- a/tests/baselines/reference/callChain.js
+++ b/tests/baselines/reference/callChain.js
@@ -44,7 +44,7 @@ o2?.b()!.toString!;
 //// [callChain.js]
 "use strict";
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -56,27 +56,27 @@ var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o;
 o1 === null || o1 === void 0 ? void 0 : o1();
 o1 === null || o1 === void 0 ? void 0 : o1(1);
 o1 === null || o1 === void 0 ? void 0 : o1.apply(void 0, [1, 2]);
-o1 === null || o1 === void 0 ? void 0 : o1.apply(void 0, __spreadArray(__spreadArray([1], [2, 3]), [4]));
+o1 === null || o1 === void 0 ? void 0 : o1.apply(void 0, __spreadArray(__spreadArray([1], [2, 3], false), [4], false));
 o2 === null || o2 === void 0 ? void 0 : o2.b();
 o2 === null || o2 === void 0 ? void 0 : o2.b(1);
 o2 === null || o2 === void 0 ? void 0 : o2.b.apply(o2, [1, 2]);
-o2 === null || o2 === void 0 ? void 0 : o2.b.apply(o2, __spreadArray(__spreadArray([1], [2, 3]), [4]));
+o2 === null || o2 === void 0 ? void 0 : o2.b.apply(o2, __spreadArray(__spreadArray([1], [2, 3], false), [4], false));
 o2 === null || o2 === void 0 ? void 0 : o2["b"]();
 o2 === null || o2 === void 0 ? void 0 : o2["b"](1);
 o2 === null || o2 === void 0 ? void 0 : o2["b"].apply(o2, [1, 2]);
-o2 === null || o2 === void 0 ? void 0 : o2["b"].apply(o2, __spreadArray(__spreadArray([1], [2, 3]), [4]));
+o2 === null || o2 === void 0 ? void 0 : o2["b"].apply(o2, __spreadArray(__spreadArray([1], [2, 3], false), [4], false));
 (_a = o3.b) === null || _a === void 0 ? void 0 : _a.call(o3).c;
 (_b = o3.b) === null || _b === void 0 ? void 0 : _b.call(o3, 1).c;
-(_c = o3.b) === null || _c === void 0 ? void 0 : _c.call.apply(_c, __spreadArray([o3], [1, 2])).c;
-(_d = o3.b) === null || _d === void 0 ? void 0 : _d.call.apply(_d, __spreadArray(__spreadArray([o3, 1], [2, 3]), [4])).c;
+(_c = o3.b) === null || _c === void 0 ? void 0 : _c.call.apply(_c, __spreadArray([o3], [1, 2], false)).c;
+(_d = o3.b) === null || _d === void 0 ? void 0 : _d.call.apply(_d, __spreadArray(__spreadArray([o3, 1], [2, 3], false), [4], false)).c;
 (_e = o3.b) === null || _e === void 0 ? void 0 : _e.call(o3)["c"];
 (_f = o3.b) === null || _f === void 0 ? void 0 : _f.call(o3, 1)["c"];
-(_g = o3.b) === null || _g === void 0 ? void 0 : _g.call.apply(_g, __spreadArray([o3], [1, 2]))["c"];
-(_h = o3.b) === null || _h === void 0 ? void 0 : _h.call.apply(_h, __spreadArray(__spreadArray([o3, 1], [2, 3]), [4]))["c"];
+(_g = o3.b) === null || _g === void 0 ? void 0 : _g.call.apply(_g, __spreadArray([o3], [1, 2], false))["c"];
+(_h = o3.b) === null || _h === void 0 ? void 0 : _h.call.apply(_h, __spreadArray(__spreadArray([o3, 1], [2, 3], false), [4], false))["c"];
 (_j = o3["b"]) === null || _j === void 0 ? void 0 : _j.call(o3).c;
 (_k = o3["b"]) === null || _k === void 0 ? void 0 : _k.call(o3, 1).c;
-(_l = o3["b"]) === null || _l === void 0 ? void 0 : _l.call.apply(_l, __spreadArray([o3], [1, 2])).c;
-(_m = o3["b"]) === null || _m === void 0 ? void 0 : _m.call.apply(_m, __spreadArray(__spreadArray([o3, 1], [2, 3]), [4])).c;
+(_l = o3["b"]) === null || _l === void 0 ? void 0 : _l.call.apply(_l, __spreadArray([o3], [1, 2], false)).c;
+(_m = o3["b"]) === null || _m === void 0 ? void 0 : _m.call.apply(_m, __spreadArray(__spreadArray([o3, 1], [2, 3], false), [4], false)).c;
 var v = o4 === null || o4 === void 0 ? void 0 : o4(incr);
 (_o = o5()) === null || _o === void 0 ? void 0 : _o();
 // GH#36031

--- a/tests/baselines/reference/callChain.js
+++ b/tests/baselines/reference/callChain.js
@@ -43,10 +43,14 @@ o2?.b()!.toString!;
 
 //// [callChain.js]
 "use strict";
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o;
 o1 === null || o1 === void 0 ? void 0 : o1();

--- a/tests/baselines/reference/callOverload.js
+++ b/tests/baselines/reference/callOverload.js
@@ -13,7 +13,7 @@ withRest(...n);
 
 //// [callOverload.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -25,6 +25,6 @@ var n;
 fn(1); // no error
 fn(1, 2, 3, 4);
 takeTwo(1, 2, 3, 4);
-withRest.apply(void 0, __spreadArray(['a'], n)); // no error
+withRest.apply(void 0, __spreadArray(['a'], n, false)); // no error
 withRest();
 withRest.apply(void 0, n);

--- a/tests/baselines/reference/callOverload.js
+++ b/tests/baselines/reference/callOverload.js
@@ -12,10 +12,14 @@ withRest();
 withRest(...n); 
 
 //// [callOverload.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var n;
 fn(1); // no error

--- a/tests/baselines/reference/callWithSpread.js
+++ b/tests/baselines/reference/callWithSpread.js
@@ -75,7 +75,7 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -95,23 +95,23 @@ var z;
 var obj;
 var xa;
 foo(1, 2, "abc");
-foo.apply(void 0, __spreadArray([1, 2], a));
-foo.apply(void 0, __spreadArray(__spreadArray([1, 2], a), ["abc"]));
+foo.apply(void 0, __spreadArray([1, 2], a, false));
+foo.apply(void 0, __spreadArray(__spreadArray([1, 2], a, false), ["abc"], false));
 obj.foo(1, 2, "abc");
-obj.foo.apply(obj, __spreadArray([1, 2], a));
-obj.foo.apply(obj, __spreadArray(__spreadArray([1, 2], a), ["abc"]));
-obj.foo.apply(obj, __spreadArray([1, 2], a)).foo(1, 2, "abc");
-(_a = obj.foo.apply(obj, __spreadArray([1, 2], a))).foo.apply(_a, __spreadArray([1, 2], a));
-(_b = obj.foo.apply(obj, __spreadArray([1, 2], a))).foo.apply(_b, __spreadArray(__spreadArray([1, 2], a), ["abc"]));
+obj.foo.apply(obj, __spreadArray([1, 2], a, false));
+obj.foo.apply(obj, __spreadArray(__spreadArray([1, 2], a, false), ["abc"], false));
+obj.foo.apply(obj, __spreadArray([1, 2], a, false)).foo(1, 2, "abc");
+(_a = obj.foo.apply(obj, __spreadArray([1, 2], a, false))).foo.apply(_a, __spreadArray([1, 2], a, false));
+(_b = obj.foo.apply(obj, __spreadArray([1, 2], a, false))).foo.apply(_b, __spreadArray(__spreadArray([1, 2], a, false), ["abc"], false));
 (obj.foo)(1, 2, "abc");
-obj.foo.apply(obj, __spreadArray([1, 2], a));
-obj.foo.apply(obj, __spreadArray(__spreadArray([1, 2], a), ["abc"]));
-(obj.foo.apply(obj, __spreadArray([1, 2], a)).foo)(1, 2, "abc");
-(_c = obj.foo.apply(obj, __spreadArray([1, 2], a))).foo.apply(_c, __spreadArray([1, 2], a));
-(_d = obj.foo.apply(obj, __spreadArray([1, 2], a))).foo.apply(_d, __spreadArray(__spreadArray([1, 2], a), ["abc"]));
+obj.foo.apply(obj, __spreadArray([1, 2], a, false));
+obj.foo.apply(obj, __spreadArray(__spreadArray([1, 2], a, false), ["abc"], false));
+(obj.foo.apply(obj, __spreadArray([1, 2], a, false)).foo)(1, 2, "abc");
+(_c = obj.foo.apply(obj, __spreadArray([1, 2], a, false))).foo.apply(_c, __spreadArray([1, 2], a, false));
+(_d = obj.foo.apply(obj, __spreadArray([1, 2], a, false))).foo.apply(_d, __spreadArray(__spreadArray([1, 2], a, false), ["abc"], false));
 xa[1].foo(1, 2, "abc");
-(_e = xa[1]).foo.apply(_e, __spreadArray([1, 2], a));
-(_f = xa[1]).foo.apply(_f, __spreadArray(__spreadArray([1, 2], a), ["abc"]));
+(_e = xa[1]).foo.apply(_e, __spreadArray([1, 2], a, false));
+(_f = xa[1]).foo.apply(_f, __spreadArray(__spreadArray([1, 2], a, false), ["abc"], false));
 (_g = xa[1]).foo.apply(_g, [1, 2, "abc"]);
 var C = /** @class */ (function () {
     function C(x, y) {
@@ -120,7 +120,7 @@ var C = /** @class */ (function () {
             z[_i - 2] = arguments[_i];
         }
         this.foo(x, y);
-        this.foo.apply(this, __spreadArray([x, y], z));
+        this.foo.apply(this, __spreadArray([x, y], z, false));
     }
     C.prototype.foo = function (x, y) {
         var z = [];
@@ -134,12 +134,12 @@ var D = /** @class */ (function (_super) {
     __extends(D, _super);
     function D() {
         var _this = _super.call(this, 1, 2) || this;
-        _this = _super.apply(this, __spreadArray([1, 2], a)) || this;
+        _this = _super.apply(this, __spreadArray([1, 2], a, false)) || this;
         return _this;
     }
     D.prototype.foo = function () {
         _super.prototype.foo.call(this, 1, 2);
-        _super.prototype.foo.apply(this, __spreadArray([1, 2], a));
+        _super.prototype.foo.apply(this, __spreadArray([1, 2], a, false));
     };
     return D;
 }(C));

--- a/tests/baselines/reference/callWithSpread.js
+++ b/tests/baselines/reference/callWithSpread.js
@@ -74,10 +74,14 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var _a, _b, _c, _d, _e, _f, _g;
 function foo(x, y) {

--- a/tests/baselines/reference/callWithSpread2.js
+++ b/tests/baselines/reference/callWithSpread2.js
@@ -39,7 +39,7 @@ prefix2("g", ...ns);
 
 //// [callWithSpread2.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -52,19 +52,19 @@ all.apply(void 0, ns);
 weird.apply(void 0, ns);
 weird.apply(void 0, mixed);
 weird.apply(void 0, tuple);
-prefix.apply(void 0, __spreadArray(["a"], ns));
-rest.apply(void 0, __spreadArray(["d"], ns));
+prefix.apply(void 0, __spreadArray(["a"], ns, false));
+rest.apply(void 0, __spreadArray(["d"], ns, false));
 // extra arguments
-normal.apply(void 0, __spreadArray(["g"], ns));
+normal.apply(void 0, __spreadArray(["g"], ns, false));
 thunk.apply(void 0, ns);
 // bad
 all.apply(void 0, mixed);
 all.apply(void 0, tuple);
-prefix.apply(void 0, __spreadArray(["b"], mixed));
-prefix.apply(void 0, __spreadArray(["c"], tuple));
-rest.apply(void 0, __spreadArray(["e"], mixed));
-rest.apply(void 0, __spreadArray(["f"], tuple));
+prefix.apply(void 0, __spreadArray(["b"], mixed, false));
+prefix.apply(void 0, __spreadArray(["c"], tuple, false));
+rest.apply(void 0, __spreadArray(["e"], mixed, false));
+rest.apply(void 0, __spreadArray(["f"], tuple, false));
 prefix.apply(void 0, ns); // required parameters are required
 prefix.apply(void 0, mixed);
 prefix.apply(void 0, tuple);
-prefix2.apply(void 0, __spreadArray(["g"], ns));
+prefix2.apply(void 0, __spreadArray(["g"], ns, false));

--- a/tests/baselines/reference/callWithSpread2.js
+++ b/tests/baselines/reference/callWithSpread2.js
@@ -38,10 +38,14 @@ prefix2("g", ...ns);
 
 
 //// [callWithSpread2.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // good
 all.apply(void 0, ns);

--- a/tests/baselines/reference/callWithSpread3.js
+++ b/tests/baselines/reference/callWithSpread3.js
@@ -38,7 +38,7 @@ fs5(...s2, "foo", ...s2);
 
 //// [callWithSpread3.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -47,24 +47,24 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 // error
-fs2.apply(void 0, __spreadArray(['a'], s2)); // error on ...s2
-fs2.apply(void 0, __spreadArray(['a', 'b', 'c'], s2)); // error on 'c' and ...s2
-fs2.apply(void 0, __spreadArray(__spreadArray(['a', 'b'], s2), ['c'])); // error on ...s2 and 'c'
-fs2.apply(void 0, __spreadArray(__spreadArray(['a', 'b', 'c'], s2), ['d'])); // error on 'c', ...s2 and 'd'
-fs2.apply(void 0, __spreadArray(__spreadArray([], s2), ['a'])); // error on 'a'
+fs2.apply(void 0, __spreadArray(['a'], s2, false)); // error on ...s2
+fs2.apply(void 0, __spreadArray(['a', 'b', 'c'], s2, false)); // error on 'c' and ...s2
+fs2.apply(void 0, __spreadArray(__spreadArray(['a', 'b'], s2, false), ['c'], false)); // error on ...s2 and 'c'
+fs2.apply(void 0, __spreadArray(__spreadArray(['a', 'b', 'c'], s2, false), ['d'], false)); // error on 'c', ...s2 and 'd'
+fs2.apply(void 0, __spreadArray(__spreadArray([], s2, false), ['a'], false)); // error on 'a'
 fs2.apply(void 0, s3); // error on ...s3
 fs2_.apply(void 0, s_); // error on ...s_
 fs2_.apply(void 0, s2n_); // error on ...s2n_
-fs2_.apply(void 0, __spreadArray(__spreadArray([], s_), s_)); // error on ...s_
-fs2_.apply(void 0, __spreadArray(__spreadArray(__spreadArray([], s_), s_), s_)); // error on ...s_
+fs2_.apply(void 0, __spreadArray(__spreadArray([], s_, false), s_, false)); // error on ...s_
+fs2_.apply(void 0, __spreadArray(__spreadArray(__spreadArray([], s_, false), s_, false), s_, false)); // error on ...s_
 // fs2n_(...s2, ...s_); //           FIXME: should be a type error
 fs2n_.apply(void 0, s2_); // error on ...s2_
 // ok
 fs2_.apply(void 0, s2_);
-fs2_.apply(void 0, __spreadArray(__spreadArray([], s2_), s_));
-fs2_.apply(void 0, __spreadArray(__spreadArray([], s2_), s2_));
-fs2_.apply(void 0, __spreadArray(__spreadArray([], s_), s2_));
+fs2_.apply(void 0, __spreadArray(__spreadArray([], s2_, false), s_, false));
+fs2_.apply(void 0, __spreadArray(__spreadArray([], s2_, false), s2_, false));
+fs2_.apply(void 0, __spreadArray(__spreadArray([], s_, false), s2_, false));
 fs2n_.apply(void 0, s2n_);
 fs2n_.apply(void 0, s2);
 // fs2n_(...s2, ...n_); // FIXME: should compile
-fs5.apply(void 0, __spreadArray(__spreadArray(__spreadArray([], s2), ["foo"]), s2));
+fs5.apply(void 0, __spreadArray(__spreadArray(__spreadArray([], s2, false), ["foo"], false), s2, false));

--- a/tests/baselines/reference/callWithSpread3.js
+++ b/tests/baselines/reference/callWithSpread3.js
@@ -37,10 +37,14 @@ fs5(...s2, "foo", ...s2);
 
 
 //// [callWithSpread3.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // error
 fs2.apply(void 0, __spreadArray(['a'], s2)); // error on ...s2

--- a/tests/baselines/reference/callWithSpread5.js
+++ b/tests/baselines/reference/callWithSpread5.js
@@ -10,7 +10,7 @@ fn(...nntnnnt, x)
 
 //// [callWithSpread5.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -18,5 +18,5 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     }
     return to.concat(ar || from);
 };
-fn.apply(void 0, __spreadArray(__spreadArray([], nnnu), [x]));
-fn.apply(void 0, __spreadArray(__spreadArray([], nntnnnt), [x]));
+fn.apply(void 0, __spreadArray(__spreadArray([], nnnu, false), [x], false));
+fn.apply(void 0, __spreadArray(__spreadArray([], nntnnnt, false), [x], false));

--- a/tests/baselines/reference/callWithSpread5.js
+++ b/tests/baselines/reference/callWithSpread5.js
@@ -9,10 +9,14 @@ fn(...nntnnnt, x)
 
 
 //// [callWithSpread5.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 fn.apply(void 0, __spreadArray(__spreadArray([], nnnu), [x]));
 fn.apply(void 0, __spreadArray(__spreadArray([], nntnnnt), [x]));

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.js
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.js
@@ -71,7 +71,7 @@ var [c14, c15, c16] = [1, 2, "string"];
  *      ...   LeftHandSideExpression
  */
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.js
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.js
@@ -70,10 +70,14 @@ var [c14, c15, c16] = [1, 2, "string"];
  * AssignmentRestElement:
  *      ...   LeftHandSideExpression
  */
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // In a destructuring assignment expression, the type of the expression on the right must be assignable to the assignment target on the left.
 // An expression of type S is considered assignable to an assignment target V if one of the following is true
@@ -93,7 +97,7 @@ var _e = foo(), b6 = _e[0], b7 = _e[1];
 var b8 = foo().slice(0);
 //      S is not a tuple- like type and the numeric index signature type of S is assignable to the target given in E.
 var temp = [1, 2, 3];
-var _f = __spreadArray([], temp), c0 = _f[0], c1 = _f[1];
+var _f = __spreadArray([], temp, true), c0 = _f[0], c1 = _f[1];
 var c2 = [][0];
 var _g = [[[]], [[[[]]]]], c3 = _g[0][0][0], c4 = _g[1][0][0][0][0];
 var _h = [[1], true], c5 = _h[0][0], c6 = _h[1];

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.js
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.js
@@ -87,7 +87,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -113,7 +113,7 @@ var _g = __read(foo(), 2), b6 = _g[0], b7 = _g[1];
 var _h = __read(foo()), b8 = _h.slice(0);
 //      S is not a tuple- like type and the numeric index signature type of S is assignable to the target given in E.
 var temp = [1, 2, 3];
-var _j = __read(__spreadArray([], __read(temp)), 2), c0 = _j[0], c1 = _j[1];
+var _j = __read(__spreadArray([], __read(temp), false), 2), c0 = _j[0], c1 = _j[1];
 var _k = __read([], 1), c2 = _k[0];
 var _l = __read([[[]], [[[[]]]]], 2), _m = __read(_l[0], 1), _o = __read(_m[0], 1), c3 = _o[0], _p = __read(_l[1], 1), _q = __read(_p[0], 1), _r = __read(_q[0], 1), _s = __read(_r[0], 1), c4 = _s[0];
 var _t = __read([[1], true], 2), _u = __read(_t[0], 1), c5 = _u[0], c6 = _t[1];

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.js
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.js
@@ -86,10 +86,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // In a destructuring assignment expression, the type of the expression on the right must be assignable to the assignment target on the left.
 // An expression of type S is considered assignable to an assignment target V if one of the following is true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.js
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.js
@@ -35,10 +35,14 @@ function foo(idx: number): F {
 var [c4, c5, c6] = foo(1);  // Error
 
 //// [destructuringArrayBindingPatternAndAssignment2.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // V is an array assignment pattern, S is the type Any or an array-like type (section 3.3.2), and, for each assignment element E in V,
 //      S is the type Any, or
@@ -55,8 +59,8 @@ var _c = bar(), _d = _c[0], b3 = _d === void 0 ? "string" : _d, b4 = _c[1], b5 =
 // V is an array assignment pattern, S is the type Any or an array-like type (section 3.3.2), and, for each assignment element E in V,
 //      S is not a tuple- like type and the numeric index signature type of S is assignable to the target given in E.
 var temp = [1, 2, 3];
-var _e = __spreadArray([], temp), c0 = _e[0], c1 = _e[1]; // Error
-var _f = __spreadArray([], temp), c2 = _f[0], c3 = _f[1]; // Error
+var _e = __spreadArray([], temp, true), c0 = _e[0], c1 = _e[1]; // Error
+var _f = __spreadArray([], temp, true), c2 = _f[0], c3 = _f[1]; // Error
 function foo(idx) {
     return {
         2: true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.js
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.js
@@ -36,7 +36,7 @@ var [c4, c5, c6] = foo(1);  // Error
 
 //// [destructuringArrayBindingPatternAndAssignment2.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/destructuringParameterDeclaration3ES5iterable.js
+++ b/tests/baselines/reference/destructuringParameterDeclaration3ES5iterable.js
@@ -64,10 +64,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 function a1() {
     var x = [];

--- a/tests/baselines/reference/destructuringParameterDeclaration3ES5iterable.js
+++ b/tests/baselines/reference/destructuringParameterDeclaration3ES5iterable.js
@@ -65,7 +65,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -114,8 +114,8 @@ function a11(_a) {
 }
 var array = [1, 2, 3];
 var array2 = [true, false, "hello"];
-a2(__spreadArray([], __read(array)));
-a1.apply(void 0, __spreadArray([], __read(array)));
+a2(__spreadArray([], __read(array), false));
+a1.apply(void 0, __spreadArray([], __read(array), false));
 a9([1, 2, [["string"]], false, true]); // Parameter type is [any, any, [[any]]]
 a10([1, 2, [["string"]], false, true]); // Parameter type is any[]
 a10([1, 2, 3, false, true]); // Parameter type is any[]

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5.js
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5.js
@@ -43,7 +43,7 @@ var {h: {h1 = [undefined, null]}}: { h: { h1: number[] } } = { h: { h1: [1, 2] }
 
 //// [destructuringVariableDeclaration1ES5.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5.js
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5.js
@@ -42,10 +42,14 @@ var {h: {h1 = [undefined, null]}}: { h: { h1: number[] } } = { h: { h1: [1, 2] }
 
 
 //// [destructuringVariableDeclaration1ES5.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // The type T associated with a destructuring variable declaration is determined as follows:
 //      If the declaration includes a type annotation, T is that type.
@@ -71,7 +75,7 @@ var _o = [1, "string"], d1 = _o[0], d2 = _o[1];
 //      Otherwise, if S is a tuple- like type (section 3.3.3):
 //              Otherwise, if S has a numeric index signature, T is the type of the numeric index signature.
 var temp1 = [true, false, true];
-var _p = __spreadArray([1, "string"], temp1), d3 = _p[0], d4 = _p[1];
+var _p = __spreadArray([1, "string"], temp1, true), d3 = _p[0], d4 = _p[1];
 //  Combining both forms of destructuring,
 var _q = { e: [1, 2, { b1: 4, b4: 0 }] }.e, e1 = _q[0], e2 = _q[1], _r = _q[2], e3 = _r === void 0 ? { b1: 1000, b4: 200 } : _r;
 var _s = { f: [1, 2, { f3: 4, f5: 0 }] }.f, f1 = _s[0], f2 = _s[1], _t = _s[2], f4 = _t.f3, f5 = _t.f5;

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.js
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.js
@@ -58,10 +58,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // The type T associated with a destructuring variable declaration is determined as follows:
 //      If the declaration includes a type annotation, T is that type.

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.js
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.js
@@ -59,7 +59,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -91,7 +91,7 @@ var _s = __read([1, "string"], 2), d1 = _s[0], d2 = _s[1];
 //      Otherwise, if S is a tuple- like type (section 3.3.3):
 //              Otherwise, if S has a numeric index signature, T is the type of the numeric index signature.
 var temp1 = [true, false, true];
-var _t = __read(__spreadArray([1, "string"], __read(temp1)), 2), d3 = _t[0], d4 = _t[1];
+var _t = __read(__spreadArray([1, "string"], __read(temp1), false), 2), d3 = _t[0], d4 = _t[1];
 //  Combining both forms of destructuring,
 var _u = __read({ e: [1, 2, { b1: 4, b4: 0 }] }.e, 3), e1 = _u[0], e2 = _u[1], _v = _u[2], e3 = _v === void 0 ? { b1: 1000, b4: 200 } : _v;
 var _w = __read({ f: [1, 2, { f3: 4, f5: 0 }] }.f, 4), f1 = _w[0], f2 = _w[1], _x = _w[2], f4 = _x.f3, f5 = _x.f5;

--- a/tests/baselines/reference/es5-asyncFunctionArrayLiterals.js
+++ b/tests/baselines/reference/es5-asyncFunctionArrayLiterals.js
@@ -70,7 +70,7 @@ function arrayLiteral2() {
                     _a = [[]];
                     return [4 /*yield*/, y];
                 case 1:
-                    x = __spreadArray.apply(void 0, [__spreadArray.apply(void 0, _a.concat([(_b.sent()), true])), [z]]);
+                    x = __spreadArray.apply(void 0, [__spreadArray.apply(void 0, _a.concat([(_b.sent()), true])), [z], false]);
                     return [2 /*return*/];
             }
         });
@@ -85,7 +85,7 @@ function arrayLiteral3() {
                     _a = [__spreadArray([], y, true)];
                     return [4 /*yield*/, z];
                 case 1:
-                    x = __spreadArray.apply(void 0, _a.concat([[_b.sent()]]));
+                    x = __spreadArray.apply(void 0, _a.concat([[_b.sent()], false]));
                     return [2 /*return*/];
             }
         });

--- a/tests/baselines/reference/es5-asyncFunctionArrayLiterals.js
+++ b/tests/baselines/reference/es5-asyncFunctionArrayLiterals.js
@@ -70,7 +70,7 @@ function arrayLiteral2() {
                     _a = [[]];
                     return [4 /*yield*/, y];
                 case 1:
-                    x = __spreadArray.apply(void 0, [__spreadArray.apply(void 0, _a.concat([(_b.sent())])), [z]]);
+                    x = __spreadArray.apply(void 0, [__spreadArray.apply(void 0, _a.concat([(_b.sent()), true])), [z]]);
                     return [2 /*return*/];
             }
         });
@@ -82,7 +82,7 @@ function arrayLiteral3() {
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
-                    _a = [__spreadArray([], y)];
+                    _a = [__spreadArray([], y, true)];
                     return [4 /*yield*/, z];
                 case 1:
                     x = __spreadArray.apply(void 0, _a.concat([[_b.sent()]]));
@@ -97,7 +97,7 @@ function arrayLiteral4() {
             switch (_a.label) {
                 case 0: return [4 /*yield*/, y];
                 case 1:
-                    x = __spreadArray.apply(void 0, [[_a.sent()], z]);
+                    x = __spreadArray.apply(void 0, [[_a.sent()], z, true]);
                     return [2 /*return*/];
             }
         });
@@ -112,7 +112,7 @@ function arrayLiteral5() {
                     _a = [[y]];
                     return [4 /*yield*/, z];
                 case 1:
-                    x = __spreadArray.apply(void 0, _a.concat([(_b.sent())]));
+                    x = __spreadArray.apply(void 0, _a.concat([(_b.sent()), true]));
                     return [2 /*return*/];
             }
         });

--- a/tests/baselines/reference/es5-asyncFunctionCallExpressions.js
+++ b/tests/baselines/reference/es5-asyncFunctionCallExpressions.js
@@ -146,7 +146,7 @@ function callExpression4() {
     return __awaiter(this, void 0, void 0, function () {
         return __generator(this, function (_a) {
             switch (_a.label) {
-                case 0: return [4 /*yield*/, x.apply(void 0, __spreadArray(__spreadArray([], y), [z]))];
+                case 0: return [4 /*yield*/, x.apply(void 0, __spreadArray(__spreadArray([], y, false), [z], false))];
                 case 1:
                     _a.sent();
                     return [2 /*return*/];
@@ -160,7 +160,7 @@ function callExpression5() {
             switch (_a.label) {
                 case 0: return [4 /*yield*/, x];
                 case 1:
-                    (_a.sent()).apply(void 0, __spreadArray(__spreadArray([], y), [z]));
+                    (_a.sent()).apply(void 0, __spreadArray(__spreadArray([], y, false), [z], false));
                     return [2 /*return*/];
             }
         });
@@ -177,7 +177,7 @@ function callExpression6() {
                     _d = [[]];
                     return [4 /*yield*/, y];
                 case 1:
-                    _b.apply(_a, _c.concat([__spreadArray.apply(void 0, [__spreadArray.apply(void 0, _d.concat([(_e.sent())])), [z]])]));
+                    _b.apply(_a, _c.concat([__spreadArray.apply(void 0, [__spreadArray.apply(void 0, _d.concat([(_e.sent()), false])), [z], false])]));
                     return [2 /*return*/];
             }
         });
@@ -191,10 +191,10 @@ function callExpression7() {
                 case 0:
                     _b = (_a = x).apply;
                     _c = [void 0];
-                    _d = [__spreadArray([], y)];
+                    _d = [__spreadArray([], y, false)];
                     return [4 /*yield*/, z];
                 case 1:
-                    _b.apply(_a, _c.concat([__spreadArray.apply(void 0, _d.concat([[_e.sent()]]))]));
+                    _b.apply(_a, _c.concat([__spreadArray.apply(void 0, _d.concat([[_e.sent()], false]))]));
                     return [2 /*return*/];
             }
         });
@@ -210,7 +210,7 @@ function callExpression8() {
                     _c = [void 0];
                     return [4 /*yield*/, y];
                 case 1:
-                    _b.apply(_a, _c.concat([__spreadArray.apply(void 0, [[_d.sent()], z])]));
+                    _b.apply(_a, _c.concat([__spreadArray.apply(void 0, [[_d.sent()], z, false])]));
                     return [2 /*return*/];
             }
         });
@@ -227,7 +227,7 @@ function callExpression9() {
                     _d = [[y]];
                     return [4 /*yield*/, z];
                 case 1:
-                    _b.apply(_a, _c.concat([__spreadArray.apply(void 0, _d.concat([(_e.sent())]))]));
+                    _b.apply(_a, _c.concat([__spreadArray.apply(void 0, _d.concat([(_e.sent()), false]))]));
                     return [2 /*return*/];
             }
         });

--- a/tests/baselines/reference/es5-asyncFunctionNewExpressions.js
+++ b/tests/baselines/reference/es5-asyncFunctionNewExpressions.js
@@ -145,7 +145,7 @@ function newExpression4() {
     return __awaiter(this, void 0, void 0, function () {
         return __generator(this, function (_a) {
             switch (_a.label) {
-                case 0: return [4 /*yield*/, new (x.bind.apply(x, __spreadArray(__spreadArray([void 0], y), [z])))()];
+                case 0: return [4 /*yield*/, new (x.bind.apply(x, __spreadArray(__spreadArray([void 0], y, false), [z], false)))()];
                 case 1:
                     _a.sent();
                     return [2 /*return*/];
@@ -160,7 +160,7 @@ function newExpression5() {
             switch (_b.label) {
                 case 0: return [4 /*yield*/, x];
                 case 1:
-                    new ((_a = (_b.sent())).bind.apply(_a, __spreadArray(__spreadArray([void 0], y), [z])))();
+                    new ((_a = (_b.sent())).bind.apply(_a, __spreadArray(__spreadArray([void 0], y, false), [z], false)))();
                     return [2 /*return*/];
             }
         });
@@ -177,7 +177,7 @@ function newExpression6() {
                     _d = [[void 0]];
                     return [4 /*yield*/, y];
                 case 1:
-                    new (_b.apply(_a, _c.concat([__spreadArray.apply(void 0, [__spreadArray.apply(void 0, _d.concat([(_e.sent())])), [z]])])))();
+                    new (_b.apply(_a, _c.concat([__spreadArray.apply(void 0, [__spreadArray.apply(void 0, _d.concat([(_e.sent()), false])), [z], false])])))();
                     return [2 /*return*/];
             }
         });
@@ -191,10 +191,10 @@ function newExpression7() {
                 case 0:
                     _b = (_a = x.bind).apply;
                     _c = [x];
-                    _d = [__spreadArray([void 0], y)];
+                    _d = [__spreadArray([void 0], y, false)];
                     return [4 /*yield*/, z];
                 case 1:
-                    new (_b.apply(_a, _c.concat([__spreadArray.apply(void 0, _d.concat([[_e.sent()]]))])))();
+                    new (_b.apply(_a, _c.concat([__spreadArray.apply(void 0, _d.concat([[_e.sent()], false]))])))();
                     return [2 /*return*/];
             }
         });
@@ -211,7 +211,7 @@ function newExpression8() {
                     _d = [void 0];
                     return [4 /*yield*/, y];
                 case 1:
-                    new (_b.apply(_a, _c.concat([__spreadArray.apply(void 0, [_d.concat([_e.sent()]), z])])))();
+                    new (_b.apply(_a, _c.concat([__spreadArray.apply(void 0, [_d.concat([_e.sent()]), z, false])])))();
                     return [2 /*return*/];
             }
         });
@@ -228,7 +228,7 @@ function newExpression9() {
                     _d = [[void 0, y]];
                     return [4 /*yield*/, z];
                 case 1:
-                    new (_b.apply(_a, _c.concat([__spreadArray.apply(void 0, _d.concat([(_e.sent())]))])))();
+                    new (_b.apply(_a, _c.concat([__spreadArray.apply(void 0, _d.concat([(_e.sent()), false]))])))();
                     return [2 /*return*/];
             }
         });

--- a/tests/baselines/reference/excessiveStackDepthFlatArray.js
+++ b/tests/baselines/reference/excessiveStackDepthFlatArray.js
@@ -42,7 +42,7 @@ const Component = () => {
 
 //// [index.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/excessiveStackDepthFlatArray.js
+++ b/tests/baselines/reference/excessiveStackDepthFlatArray.js
@@ -41,13 +41,17 @@ const Component = () => {
 
 
 //// [index.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 configureStore({
-    middleware: __spreadArray([], defaultMiddleware)
+    middleware: __spreadArray([], defaultMiddleware, true)
 });
 var Component = function () {
     var categories = ['Fruit', 'Vegetables'];

--- a/tests/baselines/reference/excessivelyLargeTupleSpread.js
+++ b/tests/baselines/reference/excessivelyLargeTupleSpread.js
@@ -42,7 +42,7 @@ const a14 = [...a13, ...a13] as const; // 2^14 > 10,000
 //// [excessivelyLargeTupleSpread.js]
 // #41771
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/excessivelyLargeTupleSpread.js
+++ b/tests/baselines/reference/excessivelyLargeTupleSpread.js
@@ -41,23 +41,27 @@ const a14 = [...a13, ...a13] as const; // 2^14 > 10,000
 
 //// [excessivelyLargeTupleSpread.js]
 // #41771
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var a0 = [0];
-var a1 = __spreadArray(__spreadArray([], a0), a0);
-var a2 = __spreadArray(__spreadArray([], a1), a1);
-var a3 = __spreadArray(__spreadArray([], a2), a2);
-var a4 = __spreadArray(__spreadArray([], a3), a3);
-var a5 = __spreadArray(__spreadArray([], a4), a4);
-var a6 = __spreadArray(__spreadArray([], a5), a5);
-var a7 = __spreadArray(__spreadArray([], a6), a6);
-var a8 = __spreadArray(__spreadArray([], a7), a7);
-var a9 = __spreadArray(__spreadArray([], a8), a8);
-var a10 = __spreadArray(__spreadArray([], a9), a9);
-var a11 = __spreadArray(__spreadArray([], a10), a10);
-var a12 = __spreadArray(__spreadArray([], a11), a11);
-var a13 = __spreadArray(__spreadArray([], a12), a12);
-var a14 = __spreadArray(__spreadArray([], a13), a13); // 2^14 > 10,000
+var a1 = __spreadArray(__spreadArray([], a0, true), a0, true);
+var a2 = __spreadArray(__spreadArray([], a1, true), a1, true);
+var a3 = __spreadArray(__spreadArray([], a2, true), a2, true);
+var a4 = __spreadArray(__spreadArray([], a3, true), a3, true);
+var a5 = __spreadArray(__spreadArray([], a4, true), a4, true);
+var a6 = __spreadArray(__spreadArray([], a5, true), a5, true);
+var a7 = __spreadArray(__spreadArray([], a6, true), a6, true);
+var a8 = __spreadArray(__spreadArray([], a7, true), a7, true);
+var a9 = __spreadArray(__spreadArray([], a8, true), a8, true);
+var a10 = __spreadArray(__spreadArray([], a9, true), a9, true);
+var a11 = __spreadArray(__spreadArray([], a10, true), a10, true);
+var a12 = __spreadArray(__spreadArray([], a11, true), a11, true);
+var a13 = __spreadArray(__spreadArray([], a12, true), a12, true);
+var a14 = __spreadArray(__spreadArray([], a13, true), a13, true); // 2^14 > 10,000

--- a/tests/baselines/reference/functionParameterArityMismatch.js
+++ b/tests/baselines/reference/functionParameterArityMismatch.js
@@ -18,7 +18,7 @@ f2(...[1], 2, 3, 4, 5, 6);
 
 //// [functionParameterArityMismatch.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -33,4 +33,4 @@ f2(1);
 f2(1, 2, 3);
 f2(1, 2, 3, 4, 5);
 f2(1, 2, 3, 4, 5, 6, 7);
-f2.apply(void 0, __spreadArray(__spreadArray([], [1]), [2, 3, 4, 5, 6]));
+f2.apply(void 0, __spreadArray(__spreadArray([], [1], false), [2, 3, 4, 5, 6], false));

--- a/tests/baselines/reference/functionParameterArityMismatch.js
+++ b/tests/baselines/reference/functionParameterArityMismatch.js
@@ -17,10 +17,14 @@ f2(...[1], 2, 3, 4, 5, 6);
 
 
 //// [functionParameterArityMismatch.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 f1();
 f1(1, 2);

--- a/tests/baselines/reference/genericRestParameters1.js
+++ b/tests/baselines/reference/genericRestParameters1.js
@@ -168,7 +168,7 @@ ff1 = ff4;  // Error
 //// [genericRestParameters1.js]
 "use strict";
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -181,48 +181,48 @@ f2 = f1;
 f1(42, "hello", true);
 f1(t3[0], t3[1], t3[2]);
 f1.apply(void 0, t3);
-f1.apply(void 0, __spreadArray([42], t2));
-f1.apply(void 0, __spreadArray([42, "hello"], t1));
-f1.apply(void 0, __spreadArray([42, "hello", true], t0));
+f1.apply(void 0, __spreadArray([42], t2, false));
+f1.apply(void 0, __spreadArray([42, "hello"], t1, false));
+f1.apply(void 0, __spreadArray([42, "hello", true], t0, false));
 f1(ns[0], ns[1], true);
-f1.apply(void 0, __spreadArray(__spreadArray([], ns), [true])); // FIXME: Error, since ...ns is considered as string|number here
+f1.apply(void 0, __spreadArray(__spreadArray([], ns, false), [true], false)); // FIXME: Error, since ...ns is considered as string|number here
 f2(42, "hello", true);
 f2(t3[0], t3[1], t3[2]);
 f2.apply(void 0, t3);
-f2.apply(void 0, __spreadArray([42], t2));
-f2.apply(void 0, __spreadArray([42, "hello"], t1));
-f2.apply(void 0, __spreadArray([42, "hello", true], t0));
+f2.apply(void 0, __spreadArray([42], t2, false));
+f2.apply(void 0, __spreadArray([42, "hello"], t1, false));
+f2.apply(void 0, __spreadArray([42, "hello", true], t0, false));
 f2(ns[0], ns[1], true);
-f2.apply(void 0, __spreadArray(__spreadArray([], ns), [true])); // FIXME: Error, since ...ns is considered as string|number here
+f2.apply(void 0, __spreadArray(__spreadArray([], ns, false), [true], false)); // FIXME: Error, since ...ns is considered as string|number here
 var x10 = f10(42, "hello", true); // [number, string, boolean]
 var x11 = f10(42, "hello"); // [number, string]
 var x12 = f10(42); // [number]
 var x13 = f10(); // []
 var x14 = f10.apply(void 0, t3); // [number, string, boolean]
-var x15 = f10.apply(void 0, __spreadArray([42], t2)); // [number, string, boolean]
-var x16 = f10.apply(void 0, __spreadArray([42, "hello"], t1)); // [number, string, boolean]
-var x17 = f10.apply(void 0, __spreadArray([42, "hello", true], t0)); // [number, string, boolean]
-var x18 = f10.apply(void 0, __spreadArray(__spreadArray([], ns), [true])); // (string | number | boolean)[]
+var x15 = f10.apply(void 0, __spreadArray([42], t2, false)); // [number, string, boolean]
+var x16 = f10.apply(void 0, __spreadArray([42, "hello"], t1, false)); // [number, string, boolean]
+var x17 = f10.apply(void 0, __spreadArray([42, "hello", true], t0, false)); // [number, string, boolean]
+var x18 = f10.apply(void 0, __spreadArray(__spreadArray([], ns, false), [true], false)); // (string | number | boolean)[]
 function g10(u, v) {
     var x1 = f10.apply(void 0, u); // U
     var x2 = f10.apply(void 0, v); // V
-    var x3 = f10.apply(void 0, __spreadArray([1], u)); // [number, ...string[]]
-    var x4 = f10.apply(void 0, __spreadArray(__spreadArray([], u), v)); // (string | number)[]
+    var x3 = f10.apply(void 0, __spreadArray([1], u, false)); // [number, ...string[]]
+    var x4 = f10.apply(void 0, __spreadArray(__spreadArray([], u, false), v, false)); // (string | number)[]
 }
 var z10 = f11(42, "hello", true); // [42, "hello", true]
 var z11 = f11(42, "hello"); // [42, "hello"]
 var z12 = f11(42); // [42]
 var z13 = f11(); // []
 var z14 = f11.apply(void 0, t3); // [number, string, boolean]
-var z15 = f11.apply(void 0, __spreadArray([42], t2)); // [42, string, boolean]
-var z16 = f11.apply(void 0, __spreadArray([42, "hello"], t1)); // [42, "hello", boolean]
-var z17 = f11.apply(void 0, __spreadArray([42, "hello", true], t0)); // [42, "hello", true]
-var z18 = f11.apply(void 0, __spreadArray(__spreadArray([], ns), [true])); // (string | number | true)[]
+var z15 = f11.apply(void 0, __spreadArray([42], t2, false)); // [42, string, boolean]
+var z16 = f11.apply(void 0, __spreadArray([42, "hello"], t1, false)); // [42, "hello", boolean]
+var z17 = f11.apply(void 0, __spreadArray([42, "hello", true], t0, false)); // [42, "hello", true]
+var z18 = f11.apply(void 0, __spreadArray(__spreadArray([], ns, false), [true], false)); // (string | number | true)[]
 function g11(u, v) {
     var x1 = f11.apply(void 0, u); // U
     var x2 = f11.apply(void 0, v); // V
-    var x3 = f11.apply(void 0, __spreadArray([1], u)); // [1, ...string[]]
-    var x4 = f11.apply(void 0, __spreadArray(__spreadArray([], u), v)); // (string | number)[]
+    var x3 = f11.apply(void 0, __spreadArray([1], u, false)); // [1, ...string[]]
+    var x4 = f11.apply(void 0, __spreadArray(__spreadArray([], u, false), v, false)); // (string | number)[]
 }
 function call(f) {
     var args = [];
@@ -248,7 +248,7 @@ function bind(f, x) {
         for (var _i = 0; _i < arguments.length; _i++) {
             rest[_i] = arguments[_i];
         }
-        return f.apply(void 0, __spreadArray([x], rest));
+        return f.apply(void 0, __spreadArray([x], rest, false));
     };
 }
 var f21 = bind(f20, 42); // (y: string, z: boolean) => string[]

--- a/tests/baselines/reference/genericRestParameters1.js
+++ b/tests/baselines/reference/genericRestParameters1.js
@@ -167,10 +167,14 @@ ff1 = ff4;  // Error
 
 //// [genericRestParameters1.js]
 "use strict";
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 f1 = f2;
 f2 = f1;

--- a/tests/baselines/reference/genericRestParameters2.js
+++ b/tests/baselines/reference/genericRestParameters2.js
@@ -82,7 +82,7 @@ type T12 = P1<(x: number, y: number) => void>;
 //// [genericRestParameters2.js]
 "use strict";
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -95,41 +95,41 @@ f10(42, "hello", true);
 f10(42, "hello", true, false);
 f10(t1[0], t1[1], t1[2], t1[3]);
 f10.apply(void 0, t1);
-f10.apply(void 0, __spreadArray([42], t2));
-f10.apply(void 0, __spreadArray([42, "hello"], t3));
-f10.apply(void 0, __spreadArray([42, "hello", true], t4));
-f10.apply(void 0, __spreadArray(__spreadArray(__spreadArray([42, "hello", true], t4), [false]), t3));
+f10.apply(void 0, __spreadArray([42], t2, false));
+f10.apply(void 0, __spreadArray([42, "hello"], t3, false));
+f10.apply(void 0, __spreadArray([42, "hello", true], t4, false));
+f10.apply(void 0, __spreadArray(__spreadArray(__spreadArray([42, "hello", true], t4, false), [false], false), t3, false));
 f11(42, "hello");
 f11(42, "hello", true);
 f11(42, "hello", true, false);
 f11(t1[0], t1[1], t1[2], t1[3]);
 f11.apply(void 0, t1);
-f11.apply(void 0, __spreadArray([42], t2));
-f11.apply(void 0, __spreadArray([42, "hello"], t3));
-f11.apply(void 0, __spreadArray([42, "hello", true], t4));
-f11.apply(void 0, __spreadArray(__spreadArray(__spreadArray([42, "hello", true], t4), [false]), t3));
+f11.apply(void 0, __spreadArray([42], t2, false));
+f11.apply(void 0, __spreadArray([42, "hello"], t3, false));
+f11.apply(void 0, __spreadArray([42, "hello", true], t4, false));
+f11.apply(void 0, __spreadArray(__spreadArray(__spreadArray([42, "hello", true], t4, false), [false], false), t3, false));
 f12(42, "hello");
 f12(42, "hello", true);
 f12(42, "hello", true, false);
 f12(t1[0], t1[1], t1[2], t1[3]);
 f12.apply(void 0, t1);
-f12.apply(void 0, __spreadArray([42], t2));
-f12.apply(void 0, __spreadArray([42, "hello"], t3));
-f12.apply(void 0, __spreadArray([42, "hello", true], t4));
-f12.apply(void 0, __spreadArray(__spreadArray(__spreadArray([42, "hello", true], t4), [false]), t3));
+f12.apply(void 0, __spreadArray([42], t2, false));
+f12.apply(void 0, __spreadArray([42, "hello"], t3, false));
+f12.apply(void 0, __spreadArray([42, "hello", true], t4, false));
+f12.apply(void 0, __spreadArray(__spreadArray(__spreadArray([42, "hello", true], t4, false), [false], false), t3, false));
 f13(42, "hello");
 f13(42, "hello", true);
 f13(42, "hello", true, false);
 f13(t1[0], t1[1], t1[2], t1[3]);
 f13.apply(void 0, t1);
-f13.apply(void 0, __spreadArray([42], t2));
-f13.apply(void 0, __spreadArray([42, "hello"], t3));
-f13.apply(void 0, __spreadArray([42, "hello", true], t4));
-f13.apply(void 0, __spreadArray(__spreadArray(__spreadArray([42, "hello", true], t4), [false]), t3));
+f13.apply(void 0, __spreadArray([42], t2, false));
+f13.apply(void 0, __spreadArray([42, "hello"], t3, false));
+f13.apply(void 0, __spreadArray([42, "hello", true], t4, false));
+f13.apply(void 0, __spreadArray(__spreadArray(__spreadArray([42, "hello", true], t4, false), [false], false), t3, false));
 f20.apply(void 0, t1);
-f20.apply(void 0, __spreadArray([42], t2));
-f20.apply(void 0, __spreadArray([42, "hello"], t3));
-f20.apply(void 0, __spreadArray(__spreadArray([42, "hello"], t2), [true]));
+f20.apply(void 0, __spreadArray([42], t2, false));
+f20.apply(void 0, __spreadArray([42, "hello"], t3, false));
+f20.apply(void 0, __spreadArray(__spreadArray([42, "hello"], t2, false), [true], false));
 
 
 //// [genericRestParameters2.d.ts]

--- a/tests/baselines/reference/genericRestParameters2.js
+++ b/tests/baselines/reference/genericRestParameters2.js
@@ -81,10 +81,14 @@ type T12 = P1<(x: number, y: number) => void>;
 
 //// [genericRestParameters2.js]
 "use strict";
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 f10(42, "hello");
 f10(42, "hello", true);

--- a/tests/baselines/reference/genericRestParameters3.js
+++ b/tests/baselines/reference/genericRestParameters3.js
@@ -69,7 +69,7 @@ foo2(...x2);
 //// [genericRestParameters3.js]
 "use strict";
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -79,10 +79,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
 };
 f1("foo", "abc");
 f1("foo", 10, true);
-f1.apply(void 0, __spreadArray(["foo"], t1));
-f1.apply(void 0, __spreadArray(["foo"], t2));
-f1.apply(void 0, __spreadArray(["foo"], t3));
-f1.apply(void 0, __spreadArray(["foo"], t4));
+f1.apply(void 0, __spreadArray(["foo"], t1, false));
+f1.apply(void 0, __spreadArray(["foo"], t2, false));
+f1.apply(void 0, __spreadArray(["foo"], t3, false));
+f1.apply(void 0, __spreadArray(["foo"], t4, false));
 f1("foo", 10); // Error
 f1("foo"); // Error
 f2 = f1;

--- a/tests/baselines/reference/genericRestParameters3.js
+++ b/tests/baselines/reference/genericRestParameters3.js
@@ -68,10 +68,14 @@ foo2(...x2);
 
 //// [genericRestParameters3.js]
 "use strict";
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 f1("foo", "abc");
 f1("foo", 10, true);

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -674,10 +674,14 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var Shape = /** @class */ (function () {
     function Shape() {

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -675,7 +675,7 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -962,7 +962,7 @@ function f1(thing) {
     var x1 = path(thing, 'a'); // { x: number, y: string }
     var x2 = path(thing, 'a', 'y'); // string
     var x3 = path(thing, 'b'); // boolean
-    var x4 = path.apply(void 0, __spreadArray([thing], ['a', 'x'])); // any
+    var x4 = path.apply(void 0, __spreadArray([thing], ['a', 'x'], false)); // any
 }
 // Repro from comment in #12114
 var assignTo2 = function (object, key1, key2) {

--- a/tests/baselines/reference/literalFreshnessPropagationOnNarrowing.js
+++ b/tests/baselines/reference/literalFreshnessPropagationOnNarrowing.js
@@ -63,7 +63,7 @@ function f5() {
 
 //// [literalFreshnessPropagationOnNarrowing.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/literalFreshnessPropagationOnNarrowing.js
+++ b/tests/baselines/reference/literalFreshnessPropagationOnNarrowing.js
@@ -62,10 +62,14 @@ function f5() {
 }
 
 //// [literalFreshnessPropagationOnNarrowing.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 function f1() {
     var b = true;
@@ -88,7 +92,7 @@ function f2() {
     // Desired: OK
     // 3.0: Error
     // 3.1: OK
-    var a5 = __spreadArray([], Array.isArray(elOrA) ? elOrA : [elOrA]);
+    var a5 = __spreadArray([], Array.isArray(elOrA) ? elOrA : [elOrA], true);
 }
 function f3() {
     var x = 'x';

--- a/tests/baselines/reference/newWithSpread.js
+++ b/tests/baselines/reference/newWithSpread.js
@@ -98,7 +98,7 @@ new i["a-b"][1](1, 2, ...a, "string");
 
 //// [newWithSpread.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -138,52 +138,52 @@ var h;
 var i;
 // Basic expression
 new f(1, 2, "string");
-new (f.bind.apply(f, __spreadArray([void 0, 1, 2], a)))();
-new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new (f.bind.apply(f, __spreadArray([void 0, 1, 2], a, false)))();
+new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Multiple spreads arguments
-new (f2.bind.apply(f2, __spreadArray(__spreadArray([void 0], a), a)))();
-new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a), a)))();
+new (f2.bind.apply(f2, __spreadArray(__spreadArray([void 0], a, false), a, false)))();
+new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a, false), a, false)))();
 // Call expression
 new f(1, 2, "string")();
-new (f.bind.apply(f, __spreadArray([void 0, 1, 2], a)))()();
-new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))()();
+new (f.bind.apply(f, __spreadArray([void 0, 1, 2], a, false)))()();
+new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))()();
 // Property access expression
 new b.f(1, 2, "string");
-new ((_a = b.f).bind.apply(_a, __spreadArray([void 0, 1, 2], a)))();
-new ((_b = b.f).bind.apply(_b, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_a = b.f).bind.apply(_a, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_b = b.f).bind.apply(_b, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Parenthesised expression
 new (b.f)(1, 2, "string");
-new ((_c = (b.f)).bind.apply(_c, __spreadArray([void 0, 1, 2], a)))();
-new ((_d = (b.f)).bind.apply(_d, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_c = (b.f)).bind.apply(_c, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_d = (b.f)).bind.apply(_d, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Element access expression
 new d[1].f(1, 2, "string");
-new ((_e = d[1].f).bind.apply(_e, __spreadArray([void 0, 1, 2], a)))();
-new ((_f = d[1].f).bind.apply(_f, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_e = d[1].f).bind.apply(_e, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_f = d[1].f).bind.apply(_f, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Element access expression with a punctuated key
 new e["a-b"].f(1, 2, "string");
-new ((_g = e["a-b"].f).bind.apply(_g, __spreadArray([void 0, 1, 2], a)))();
-new ((_h = e["a-b"].f).bind.apply(_h, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_g = e["a-b"].f).bind.apply(_g, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_h = e["a-b"].f).bind.apply(_h, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Basic expression
 new B(1, 2, "string");
-new (B.bind.apply(B, __spreadArray([void 0, 1, 2], a)))();
-new (B.bind.apply(B, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new (B.bind.apply(B, __spreadArray([void 0, 1, 2], a, false)))();
+new (B.bind.apply(B, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Property access expression
 new c["a-b"](1, 2, "string");
-new ((_j = c["a-b"]).bind.apply(_j, __spreadArray([void 0, 1, 2], a)))();
-new ((_k = c["a-b"]).bind.apply(_k, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_j = c["a-b"]).bind.apply(_j, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_k = c["a-b"]).bind.apply(_k, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Parenthesised expression
 new (c["a-b"])(1, 2, "string");
-new ((_l = (c["a-b"])).bind.apply(_l, __spreadArray([void 0, 1, 2], a)))();
-new ((_m = (c["a-b"])).bind.apply(_m, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_l = (c["a-b"])).bind.apply(_l, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_m = (c["a-b"])).bind.apply(_m, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Element access expression
 new g[1]["a-b"](1, 2, "string");
-new ((_o = g[1]["a-b"]).bind.apply(_o, __spreadArray([void 0, 1, 2], a)))();
-new ((_p = g[1]["a-b"]).bind.apply(_p, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_o = g[1]["a-b"]).bind.apply(_o, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_p = g[1]["a-b"]).bind.apply(_p, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Element access expression with a punctuated key
 new h["a-b"]["a-b"](1, 2, "string");
-new ((_q = h["a-b"]["a-b"]).bind.apply(_q, __spreadArray([void 0, 1, 2], a)))();
-new ((_r = h["a-b"]["a-b"]).bind.apply(_r, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_q = h["a-b"]["a-b"]).bind.apply(_q, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_r = h["a-b"]["a-b"]).bind.apply(_r, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Element access expression with a number
 new i["a-b"][1](1, 2, "string");
-new ((_s = i["a-b"][1]).bind.apply(_s, __spreadArray([void 0, 1, 2], a)))();
-new ((_t = i["a-b"][1]).bind.apply(_t, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_s = i["a-b"][1]).bind.apply(_s, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_t = i["a-b"][1]).bind.apply(_t, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();

--- a/tests/baselines/reference/newWithSpread.js
+++ b/tests/baselines/reference/newWithSpread.js
@@ -97,10 +97,14 @@ new i["a-b"][1](1, 2, ...a);
 new i["a-b"][1](1, 2, ...a, "string");
 
 //// [newWithSpread.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t;
 function f(x, y) {

--- a/tests/baselines/reference/newWithSpreadES5.js
+++ b/tests/baselines/reference/newWithSpreadES5.js
@@ -96,10 +96,14 @@ new i["a-b"][1](1, 2, ...a);
 new i["a-b"][1](1, 2, ...a, "string");
 
 //// [newWithSpreadES5.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t;
 function f(x, y) {

--- a/tests/baselines/reference/newWithSpreadES5.js
+++ b/tests/baselines/reference/newWithSpreadES5.js
@@ -97,7 +97,7 @@ new i["a-b"][1](1, 2, ...a, "string");
 
 //// [newWithSpreadES5.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -137,52 +137,52 @@ var h;
 var i;
 // Basic expression
 new f(1, 2, "string");
-new (f.bind.apply(f, __spreadArray([void 0, 1, 2], a)))();
-new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new (f.bind.apply(f, __spreadArray([void 0, 1, 2], a, false)))();
+new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Multiple spreads arguments
-new (f2.bind.apply(f2, __spreadArray(__spreadArray([void 0], a), a)))();
-new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a), a)))();
+new (f2.bind.apply(f2, __spreadArray(__spreadArray([void 0], a, false), a, false)))();
+new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a, false), a, false)))();
 // Call expression
 new f(1, 2, "string")();
-new (f.bind.apply(f, __spreadArray([void 0, 1, 2], a)))()();
-new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))()();
+new (f.bind.apply(f, __spreadArray([void 0, 1, 2], a, false)))()();
+new (f.bind.apply(f, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))()();
 // Property access expression
 new b.f(1, 2, "string");
-new ((_a = b.f).bind.apply(_a, __spreadArray([void 0, 1, 2], a)))();
-new ((_b = b.f).bind.apply(_b, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_a = b.f).bind.apply(_a, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_b = b.f).bind.apply(_b, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Parenthesised expression
 new (b.f)(1, 2, "string");
-new ((_c = (b.f)).bind.apply(_c, __spreadArray([void 0, 1, 2], a)))();
-new ((_d = (b.f)).bind.apply(_d, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_c = (b.f)).bind.apply(_c, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_d = (b.f)).bind.apply(_d, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Element access expression
 new d[1].f(1, 2, "string");
-new ((_e = d[1].f).bind.apply(_e, __spreadArray([void 0, 1, 2], a)))();
-new ((_f = d[1].f).bind.apply(_f, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_e = d[1].f).bind.apply(_e, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_f = d[1].f).bind.apply(_f, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Element access expression with a punctuated key
 new e["a-b"].f(1, 2, "string");
-new ((_g = e["a-b"].f).bind.apply(_g, __spreadArray([void 0, 1, 2], a)))();
-new ((_h = e["a-b"].f).bind.apply(_h, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_g = e["a-b"].f).bind.apply(_g, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_h = e["a-b"].f).bind.apply(_h, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Basic expression
 new B(1, 2, "string");
-new (B.bind.apply(B, __spreadArray([void 0, 1, 2], a)))();
-new (B.bind.apply(B, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new (B.bind.apply(B, __spreadArray([void 0, 1, 2], a, false)))();
+new (B.bind.apply(B, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Property access expression
 new c["a-b"](1, 2, "string");
-new ((_j = c["a-b"]).bind.apply(_j, __spreadArray([void 0, 1, 2], a)))();
-new ((_k = c["a-b"]).bind.apply(_k, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_j = c["a-b"]).bind.apply(_j, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_k = c["a-b"]).bind.apply(_k, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Parenthesised expression
 new (c["a-b"])(1, 2, "string");
-new ((_l = (c["a-b"])).bind.apply(_l, __spreadArray([void 0, 1, 2], a)))();
-new ((_m = (c["a-b"])).bind.apply(_m, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_l = (c["a-b"])).bind.apply(_l, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_m = (c["a-b"])).bind.apply(_m, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Element access expression
 new g[1]["a-b"](1, 2, "string");
-new ((_o = g[1]["a-b"]).bind.apply(_o, __spreadArray([void 0, 1, 2], a)))();
-new ((_p = g[1]["a-b"]).bind.apply(_p, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_o = g[1]["a-b"]).bind.apply(_o, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_p = g[1]["a-b"]).bind.apply(_p, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Element access expression with a punctuated key
 new h["a-b"]["a-b"](1, 2, "string");
-new ((_q = h["a-b"]["a-b"]).bind.apply(_q, __spreadArray([void 0, 1, 2], a)))();
-new ((_r = h["a-b"]["a-b"]).bind.apply(_r, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_q = h["a-b"]["a-b"]).bind.apply(_q, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_r = h["a-b"]["a-b"]).bind.apply(_r, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();
 // Element access expression with a number
 new i["a-b"][1](1, 2, "string");
-new ((_s = i["a-b"][1]).bind.apply(_s, __spreadArray([void 0, 1, 2], a)))();
-new ((_t = i["a-b"][1]).bind.apply(_t, __spreadArray(__spreadArray([void 0, 1, 2], a), ["string"])))();
+new ((_s = i["a-b"][1]).bind.apply(_s, __spreadArray([void 0, 1, 2], a, false)))();
+new ((_t = i["a-b"][1]).bind.apply(_t, __spreadArray(__spreadArray([void 0, 1, 2], a, false), ["string"], false)))();

--- a/tests/baselines/reference/noCrashOnNoLib.js
+++ b/tests/baselines/reference/noCrashOnNoLib.js
@@ -8,17 +8,21 @@ export function f() {
 
 //// [noCrashOnNoLib.js]
 "use strict";
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 exports.__esModule = true;
 exports.f = void 0;
 function f() {
     var e;
     while (true) {
-        e = __spreadArray([], (e || []));
+        e = __spreadArray([], (e || []), true);
     }
 }
 exports.f = f;

--- a/tests/baselines/reference/noCrashOnNoLib.js
+++ b/tests/baselines/reference/noCrashOnNoLib.js
@@ -9,7 +9,7 @@ export function f() {
 //// [noCrashOnNoLib.js]
 "use strict";
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.js
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.js
@@ -73,10 +73,14 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 function fn(a, b, c, d, e, f, g) {
     var c_1, c_1_1;
@@ -94,7 +98,7 @@ function fn(a, b, c, d, e, f, g) {
                     b++;
                     --b;
                     a === b;
-                    __spreadArray([], c);
+                    __spreadArray([], c, true);
                     for (_i = 0, c_2 = c; _i < c_2.length; _i++) {
                         s = c_2[_i];
                         fn(b, b, c, d, e, f, g);

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.js
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.js
@@ -74,7 +74,7 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/readonlyRestParameters.js
+++ b/tests/baselines/reference/readonlyRestParameters.js
@@ -30,7 +30,7 @@ function f4(...args: readonly string[]) {
 //// [readonlyRestParameters.js]
 "use strict";
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -50,7 +50,7 @@ function f1() {
     }
     f0.apply(void 0, args); // Error
     f1('abc', 'def');
-    f1.apply(void 0, __spreadArray(['abc'], args));
+    f1.apply(void 0, __spreadArray(['abc'], args, false));
     f1.apply(void 0, args);
 }
 function f2() {
@@ -60,10 +60,10 @@ function f2() {
     }
     f0.apply(void 0, args);
     f1('abc', 'def');
-    f1.apply(void 0, __spreadArray(['abc'], args));
+    f1.apply(void 0, __spreadArray(['abc'], args, false));
     f1.apply(void 0, args);
     f2('abc', 'def');
-    f2.apply(void 0, __spreadArray(['abc'], args)); // Error
+    f2.apply(void 0, __spreadArray(['abc'], args, false)); // Error
     f2.apply(void 0, args);
 }
 function f4() {

--- a/tests/baselines/reference/readonlyRestParameters.js
+++ b/tests/baselines/reference/readonlyRestParameters.js
@@ -29,10 +29,14 @@ function f4(...args: readonly string[]) {
 
 //// [readonlyRestParameters.js]
 "use strict";
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 function f0(a, b) {
     f0(a, b);

--- a/tests/baselines/reference/recursiveReverseMappedType.js
+++ b/tests/baselines/reference/recursiveReverseMappedType.js
@@ -18,7 +18,7 @@ function a<T>(l: Recur<T>[]): void {
 "use strict";
 // Repro from #38198
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/recursiveReverseMappedType.js
+++ b/tests/baselines/reference/recursiveReverseMappedType.js
@@ -17,13 +17,17 @@ function a<T>(l: Recur<T>[]): void {
 //// [recursiveReverseMappedType.js]
 "use strict";
 // Repro from #38198
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 function join(l) {
-    return __spreadArray(['marker'], l);
+    return __spreadArray(['marker'], l, true);
 }
 function a(l) {
     var x = join(l);

--- a/tests/baselines/reference/recursiveTypeReferences1.js
+++ b/tests/baselines/reference/recursiveTypeReferences1.js
@@ -132,10 +132,14 @@ function level(h: HTMLHeadingElement): number {
 
 //// [recursiveTypeReferences1.js]
 "use strict";
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var a0 = 1;
 var a1 = [1, [2, 3], [4, [5, [6, 7]]]];
@@ -185,7 +189,7 @@ function parse(node, index) {
     if (index === void 0) { index = []; }
     return html('ul', node.map(function (_a, i) {
         var el = _a[0], children = _a[1];
-        var idx = __spreadArray(__spreadArray([], index), [i + 1]);
+        var idx = __spreadArray(__spreadArray([], index, true), [i + 1]);
         return html('li', [
             html('a', { href: "#" + el.id, rel: 'noopener', 'data-index': idx.join('.') }, el.textContent),
             children.length > 0 ? parse(children, idx) : frag()

--- a/tests/baselines/reference/recursiveTypeReferences1.js
+++ b/tests/baselines/reference/recursiveTypeReferences1.js
@@ -133,7 +133,7 @@ function level(h: HTMLHeadingElement): number {
 //// [recursiveTypeReferences1.js]
 "use strict";
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -189,7 +189,7 @@ function parse(node, index) {
     if (index === void 0) { index = []; }
     return html('ul', node.map(function (_a, i) {
         var el = _a[0], children = _a[1];
-        var idx = __spreadArray(__spreadArray([], index, true), [i + 1]);
+        var idx = __spreadArray(__spreadArray([], index, true), [i + 1], false);
         return html('li', [
             html('a', { href: "#" + el.id, rel: 'noopener', 'data-index': idx.join('.') }, el.textContent),
             children.length > 0 ? parse(children, idx) : frag()

--- a/tests/baselines/reference/restTuplesFromContextualTypes.js
+++ b/tests/baselines/reference/restTuplesFromContextualTypes.js
@@ -101,10 +101,14 @@ const funcUnionTupleRest: TupleUnionFunc = (...params) => {
 
 //// [restTuplesFromContextualTypes.js]
 "use strict";
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 (function (a, b, c) { }).apply(void 0, t1);
 (function () {

--- a/tests/baselines/reference/restTuplesFromContextualTypes.js
+++ b/tests/baselines/reference/restTuplesFromContextualTypes.js
@@ -102,7 +102,7 @@ const funcUnionTupleRest: TupleUnionFunc = (...params) => {
 //// [restTuplesFromContextualTypes.js]
 "use strict";
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -210,31 +210,31 @@ f2(function (a, b, c) {
         x[_i - 3] = arguments[_i];
     }
 });
-(function (a, b, c) { }).apply(void 0, __spreadArray([1], t3));
+(function (a, b, c) { }).apply(void 0, __spreadArray([1], t3, false));
 (function () {
     var x = [];
     for (var _i = 0; _i < arguments.length; _i++) {
         x[_i] = arguments[_i];
     }
-}).apply(void 0, __spreadArray([1], t3));
+}).apply(void 0, __spreadArray([1], t3, false));
 (function (a) {
     var x = [];
     for (var _i = 1; _i < arguments.length; _i++) {
         x[_i - 1] = arguments[_i];
     }
-}).apply(void 0, __spreadArray([1], t3));
+}).apply(void 0, __spreadArray([1], t3, false));
 (function (a, b) {
     var x = [];
     for (var _i = 2; _i < arguments.length; _i++) {
         x[_i - 2] = arguments[_i];
     }
-}).apply(void 0, __spreadArray([1], t3));
+}).apply(void 0, __spreadArray([1], t3, false));
 (function (a, b, c) {
     var x = [];
     for (var _i = 3; _i < arguments.length; _i++) {
         x[_i - 3] = arguments[_i];
     }
-}).apply(void 0, __spreadArray([1], t3));
+}).apply(void 0, __spreadArray([1], t3, false));
 f3(function (a, b, c) { });
 f3(function () {
     var x = [];
@@ -272,13 +272,13 @@ function f4(t) {
         for (var _i = 1; _i < arguments.length; _i++) {
             x[_i - 1] = arguments[_i];
         }
-    }).apply(void 0, __spreadArray([1], t));
+    }).apply(void 0, __spreadArray([1], t, false));
     (function (a) {
         var x = [];
         for (var _i = 1; _i < arguments.length; _i++) {
             x[_i - 1] = arguments[_i];
         }
-    }).apply(void 0, __spreadArray([1, 2], t));
+    }).apply(void 0, __spreadArray([1, 2], t, false));
     function f(cb) { }
     f(function () {
         var x = [];

--- a/tests/baselines/reference/selfReferencingSpreadInLoop.js
+++ b/tests/baselines/reference/selfReferencingSpreadInLoop.js
@@ -7,7 +7,7 @@ for (const subcomponent of [1, 2, 3]) {
 
 //// [selfReferencingSpreadInLoop.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -18,5 +18,5 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
 var additional = [];
 for (var _i = 0, _a = [1, 2, 3]; _i < _a.length; _i++) {
     var subcomponent = _a[_i];
-    additional = __spreadArray(__spreadArray([], additional, true), [subcomponent]);
+    additional = __spreadArray(__spreadArray([], additional, true), [subcomponent], false);
 }

--- a/tests/baselines/reference/selfReferencingSpreadInLoop.js
+++ b/tests/baselines/reference/selfReferencingSpreadInLoop.js
@@ -6,13 +6,17 @@ for (const subcomponent of [1, 2, 3]) {
 
 
 //// [selfReferencingSpreadInLoop.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var additional = [];
 for (var _i = 0, _a = [1, 2, 3]; _i < _a.length; _i++) {
     var subcomponent = _a[_i];
-    additional = __spreadArray(__spreadArray([], additional), [subcomponent]);
+    additional = __spreadArray(__spreadArray([], additional, true), [subcomponent]);
 }

--- a/tests/baselines/reference/spliceTuples.js
+++ b/tests/baselines/reference/spliceTuples.js
@@ -26,7 +26,7 @@ k6 = [1, ...sbb_];
 
 //// [spliceTuples.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -37,7 +37,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
 var k1;
 k1 = __spreadArray([1], sb, true);
 var k2;
-k2 = __spreadArray(__spreadArray([1], sb, true), [1]);
+k2 = __spreadArray(__spreadArray([1], sb, true), [1], false);
 var k3;
 k3 = __spreadArray([1], sb_, true);
 var k4;

--- a/tests/baselines/reference/spliceTuples.js
+++ b/tests/baselines/reference/spliceTuples.js
@@ -25,20 +25,24 @@ k6 = [1, ...sbb_];
 
 
 //// [spliceTuples.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var k1;
-k1 = __spreadArray([1], sb);
+k1 = __spreadArray([1], sb, true);
 var k2;
-k2 = __spreadArray(__spreadArray([1], sb), [1]);
+k2 = __spreadArray(__spreadArray([1], sb, true), [1]);
 var k3;
-k3 = __spreadArray([1], sb_);
+k3 = __spreadArray([1], sb_, true);
 var k4;
-k4 = __spreadArray([1], sbb_);
+k4 = __spreadArray([1], sbb_, true);
 var k5;
-k5 = __spreadArray([1], sbb_);
+k5 = __spreadArray([1], sbb_, true);
 var k6;
-k6 = __spreadArray([1], sbb_);
+k6 = __spreadArray([1], sbb_, true);

--- a/tests/baselines/reference/spreadBooleanRespectsFreshness.js
+++ b/tests/baselines/reference/spreadBooleanRespectsFreshness.js
@@ -9,7 +9,7 @@ foo1 = [...Array.isArray(foo2) ? foo2 : [foo2]];
 
 //// [spreadBooleanRespectsFreshness.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/spreadBooleanRespectsFreshness.js
+++ b/tests/baselines/reference/spreadBooleanRespectsFreshness.js
@@ -8,9 +8,13 @@ declare let foo2: Foo;
 foo1 = [...Array.isArray(foo2) ? foo2 : [foo2]];
 
 //// [spreadBooleanRespectsFreshness.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
-foo1 = __spreadArray([], Array.isArray(foo2) ? foo2 : [foo2]);
+foo1 = __spreadArray([], Array.isArray(foo2) ? foo2 : [foo2], true);

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
@@ -43,7 +43,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -70,7 +70,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -105,11 +105,11 @@ function appfile4Spread() {
     }
 }
 var appfile4_ar = [20, 30];
-appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
+appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar), false));
 //# sourceMappingURL=module.js.map
 
 //// [/src/app/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;IAAA,OAAO,CAAC,GAAG,CAAC,SAAC,CAAC,CAAC;;;;;;ICFH,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,WAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;IAAA,OAAO,CAAC,GAAG,CAAC,SAAC,CAAC,CAAC;;;;;;ICFH,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,WAAE"}
 
 //// [/src/app/module.js.map.baseline.txt]
 ===================================================================
@@ -139,7 +139,7 @@ sourceFile:../lib/file0.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -249,7 +249,7 @@ sourceFile:../lib/file0.ts
 8 >                       ^^
 9 >                         ^
 10>                          ^
-11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -272,14 +272,14 @@ sourceFile:../lib/file0.ts
 9 >Emitted(44, 27) Source(3, 29) + SourceIndex(0)
 10>Emitted(44, 28) Source(3, 30) + SourceIndex(0)
 ---
->>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+>>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 1->
 2 >^^^^^^^^^^^^^^
 3 >              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                            ^^
 5 >                                              ^^^^^^^^^^
 6 >                                                        ^^^^^^^^^^^
-7 >                                                                   ^^^^
+7 >                                                                   ^^^^^^^^^^^
 1->
   >
 2 >libfile0Spread
@@ -294,7 +294,7 @@ sourceFile:../lib/file0.ts
 4 >Emitted(45, 47) Source(4, 18) + SourceIndex(0)
 5 >Emitted(45, 57) Source(4, 23) + SourceIndex(0)
 6 >Emitted(45, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(45, 72) Source(4, 36) + SourceIndex(0)
+7 >Emitted(45, 79) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -731,7 +731,7 @@ sourceFile:file4.ts
 8 >                       ^^
 9 >                         ^
 10>                          ^
-11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -754,14 +754,14 @@ sourceFile:file4.ts
 9 >Emitted(79, 27) Source(3, 29) + SourceIndex(5)
 10>Emitted(79, 28) Source(3, 30) + SourceIndex(5)
 ---
->>>appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
+>>>appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar), false));
 1->
 2 >^^^^^^^^^^^^^^
 3 >              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                            ^^
 5 >                                              ^^^^^^^^^^
 6 >                                                        ^^^^^^^^^^^
-7 >                                                                   ^^^^
+7 >                                                                   ^^^^^^^^^^^
 1->
   >
 2 >appfile4Spread
@@ -776,12 +776,12 @@ sourceFile:file4.ts
 4 >Emitted(80, 47) Source(4, 18) + SourceIndex(5)
 5 >Emitted(80, 57) Source(4, 23) + SourceIndex(5)
 6 >Emitted(80, 68) Source(4, 34) + SourceIndex(5)
-7 >Emitted(80, 72) Source(4, 36) + SourceIndex(5)
+7 >Emitted(80, 79) Source(4, 36) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/app/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":2196,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1344,"end":2196,"kind":"text"}]},{"pos":2196,"end":2786,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":2229,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1370,"end":2229,"kind":"text"}]},{"pos":2229,"end":2826,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/app/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -805,9 +805,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-840):: typescript:spreadArray
+emitHelpers: (506-866):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -816,7 +816,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (842-1342):: typescript:rest
+emitHelpers: (868-1368):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -829,9 +829,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1344-2196):: ../lib/module.js texts:: 1
+prepend: (1370-2229):: ../lib/module.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1344-2196)
+text: (1370-2229)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -840,7 +840,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -860,7 +860,7 @@ define("file2", ["require", "exports"], function (require, exports) {
 var globalConst = 10;
 
 ----------------------------------------------------------------------
-text: (2196-2786)
+text: (2229-2826)
 define("file3", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -878,7 +878,7 @@ function appfile4Spread() {
     }
 }
 var appfile4_ar = [20, 30];
-appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
+appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar), false));
 
 ======================================================================
 ======================================================================
@@ -927,32 +927,32 @@ declare const appfile4_ar: number[];
         },
         {
           "pos": 506,
-          "end": 840,
+          "end": 866,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 842,
-          "end": 1342,
+          "pos": 868,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1344,
-          "end": 2196,
+          "pos": 1370,
+          "end": 2229,
           "kind": "prepend",
           "data": "../lib/module.js",
           "texts": [
             {
-              "pos": 1344,
-              "end": 2196,
+              "pos": 1370,
+              "end": 2229,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2196,
-          "end": 2786,
+          "pos": 2229,
+          "end": 2826,
           "kind": "text"
         }
       ],
@@ -1012,7 +1012,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1039,7 +1039,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -1060,7 +1060,7 @@ var globalConst = 10;
 //# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;IAAA,OAAO,CAAC,GAAG,CAAC,SAAC,CAAC,CAAC;;;;;;ICFH,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,WAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;IAAA,OAAO,CAAC,GAAG,CAAC,SAAC,CAAC,CAAC;;;;;;ICFH,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
 
 //// [/src/lib/module.js.map.baseline.txt]
 ===================================================================
@@ -1090,7 +1090,7 @@ sourceFile:file0.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -1200,7 +1200,7 @@ sourceFile:file0.ts
 8 >                       ^^
 9 >                         ^
 10>                          ^
-11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1223,14 +1223,14 @@ sourceFile:file0.ts
 9 >Emitted(44, 27) Source(3, 29) + SourceIndex(0)
 10>Emitted(44, 28) Source(3, 30) + SourceIndex(0)
 ---
->>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+>>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 1->
 2 >^^^^^^^^^^^^^^
 3 >              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                            ^^
 5 >                                              ^^^^^^^^^^
 6 >                                                        ^^^^^^^^^^^
-7 >                                                                   ^^^^
+7 >                                                                   ^^^^^^^^^^^
 1->
   >
 2 >libfile0Spread
@@ -1245,7 +1245,7 @@ sourceFile:file0.ts
 4 >Emitted(45, 47) Source(4, 18) + SourceIndex(0)
 5 >Emitted(45, 57) Source(4, 23) + SourceIndex(0)
 6 >Emitted(45, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(45, 72) Source(4, 36) + SourceIndex(0)
+7 >Emitted(45, 79) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1460,7 +1460,7 @@ sourceFile:global.ts
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":2196,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":2229,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/lib/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1484,9 +1484,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-840):: typescript:spreadArray
+emitHelpers: (506-866):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1495,7 +1495,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (842-1342):: typescript:rest
+emitHelpers: (868-1368):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1508,7 +1508,7 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-text: (1344-2196)
+text: (1370-2229)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -1517,7 +1517,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -1574,19 +1574,19 @@ declare const globalConst = 10;
         },
         {
           "pos": 506,
-          "end": 840,
+          "end": 866,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 842,
-          "end": 1342,
+          "pos": 868,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1344,
-          "end": 2196,
+          "pos": 1370,
+          "end": 2229,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
@@ -42,10 +42,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -105,7 +109,7 @@ appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
 //# sourceMappingURL=module.js.map
 
 //// [/src/app/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;IAAA,OAAO,CAAC,GAAG,CAAC,SAAC,CAAC,CAAC;;;;;;ICFH,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;IAAA,OAAO,CAAC,GAAG,CAAC,SAAC,CAAC,CAAC;;;;;;ICFH,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE"}
 
 //// [/src/app/module.js.map.baseline.txt]
 ===================================================================
@@ -134,10 +138,14 @@ sourceFile:../lib/file0.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -164,12 +172,12 @@ sourceFile:../lib/file0.ts
 4 >           = 
 5 >             20
 6 >               ;
-1 >Emitted(33, 1) Source(1, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(1, 7) + SourceIndex(0)
-3 >Emitted(33, 11) Source(1, 13) + SourceIndex(0)
-4 >Emitted(33, 14) Source(1, 16) + SourceIndex(0)
-5 >Emitted(33, 16) Source(1, 18) + SourceIndex(0)
-6 >Emitted(33, 17) Source(1, 19) + SourceIndex(0)
+1 >Emitted(37, 1) Source(1, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(1, 7) + SourceIndex(0)
+3 >Emitted(37, 11) Source(1, 13) + SourceIndex(0)
+4 >Emitted(37, 14) Source(1, 16) + SourceIndex(0)
+5 >Emitted(37, 16) Source(1, 18) + SourceIndex(0)
+6 >Emitted(37, 17) Source(1, 19) + SourceIndex(0)
 ---
 >>>function libfile0Spread() {
 1->
@@ -179,9 +187,9 @@ sourceFile:../lib/file0.ts
   >
 2 >function 
 3 >         libfile0Spread
-1->Emitted(34, 1) Source(2, 1) + SourceIndex(0)
-2 >Emitted(34, 10) Source(2, 10) + SourceIndex(0)
-3 >Emitted(34, 24) Source(2, 24) + SourceIndex(0)
+1->Emitted(38, 1) Source(2, 1) + SourceIndex(0)
+2 >Emitted(38, 10) Source(2, 10) + SourceIndex(0)
+3 >Emitted(38, 24) Source(2, 24) + SourceIndex(0)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -189,8 +197,8 @@ sourceFile:../lib/file0.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(35, 5) Source(2, 25) + SourceIndex(0)
-2 >Emitted(35, 16) Source(2, 39) + SourceIndex(0)
+1 >Emitted(39, 5) Source(2, 25) + SourceIndex(0)
+2 >Emitted(39, 16) Source(2, 39) + SourceIndex(0)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -205,20 +213,20 @@ sourceFile:../lib/file0.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(36, 10) Source(2, 25) + SourceIndex(0)
-2 >Emitted(36, 20) Source(2, 39) + SourceIndex(0)
-3 >Emitted(36, 22) Source(2, 25) + SourceIndex(0)
-4 >Emitted(36, 43) Source(2, 39) + SourceIndex(0)
-5 >Emitted(36, 45) Source(2, 25) + SourceIndex(0)
-6 >Emitted(36, 49) Source(2, 39) + SourceIndex(0)
+1->Emitted(40, 10) Source(2, 25) + SourceIndex(0)
+2 >Emitted(40, 20) Source(2, 39) + SourceIndex(0)
+3 >Emitted(40, 22) Source(2, 25) + SourceIndex(0)
+4 >Emitted(40, 43) Source(2, 39) + SourceIndex(0)
+5 >Emitted(40, 45) Source(2, 25) + SourceIndex(0)
+6 >Emitted(40, 49) Source(2, 39) + SourceIndex(0)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(37, 9) Source(2, 25) + SourceIndex(0)
-2 >Emitted(37, 31) Source(2, 39) + SourceIndex(0)
+1 >Emitted(41, 9) Source(2, 25) + SourceIndex(0)
+2 >Emitted(41, 31) Source(2, 39) + SourceIndex(0)
 ---
 >>>    }
 >>>}
@@ -227,8 +235,8 @@ sourceFile:../lib/file0.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(39, 1) Source(2, 43) + SourceIndex(0)
-2 >Emitted(39, 2) Source(2, 44) + SourceIndex(0)
+1 >Emitted(43, 1) Source(2, 43) + SourceIndex(0)
+2 >Emitted(43, 2) Source(2, 44) + SourceIndex(0)
 ---
 >>>var libfile0_ar = [20, 30];
 1->
@@ -253,16 +261,16 @@ sourceFile:../lib/file0.ts
 8 >                       30
 9 >                         ]
 10>                          ;
-1->Emitted(40, 1) Source(3, 1) + SourceIndex(0)
-2 >Emitted(40, 5) Source(3, 7) + SourceIndex(0)
-3 >Emitted(40, 16) Source(3, 18) + SourceIndex(0)
-4 >Emitted(40, 19) Source(3, 21) + SourceIndex(0)
-5 >Emitted(40, 20) Source(3, 22) + SourceIndex(0)
-6 >Emitted(40, 22) Source(3, 24) + SourceIndex(0)
-7 >Emitted(40, 24) Source(3, 26) + SourceIndex(0)
-8 >Emitted(40, 26) Source(3, 28) + SourceIndex(0)
-9 >Emitted(40, 27) Source(3, 29) + SourceIndex(0)
-10>Emitted(40, 28) Source(3, 30) + SourceIndex(0)
+1->Emitted(44, 1) Source(3, 1) + SourceIndex(0)
+2 >Emitted(44, 5) Source(3, 7) + SourceIndex(0)
+3 >Emitted(44, 16) Source(3, 18) + SourceIndex(0)
+4 >Emitted(44, 19) Source(3, 21) + SourceIndex(0)
+5 >Emitted(44, 20) Source(3, 22) + SourceIndex(0)
+6 >Emitted(44, 22) Source(3, 24) + SourceIndex(0)
+7 >Emitted(44, 24) Source(3, 26) + SourceIndex(0)
+8 >Emitted(44, 26) Source(3, 28) + SourceIndex(0)
+9 >Emitted(44, 27) Source(3, 29) + SourceIndex(0)
+10>Emitted(44, 28) Source(3, 30) + SourceIndex(0)
 ---
 >>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
 1->
@@ -280,13 +288,13 @@ sourceFile:../lib/file0.ts
 5 >                                              , ...
 6 >                                                        libfile0_ar
 7 >                                                                   );
-1->Emitted(41, 1) Source(4, 1) + SourceIndex(0)
-2 >Emitted(41, 15) Source(4, 15) + SourceIndex(0)
-3 >Emitted(41, 45) Source(4, 16) + SourceIndex(0)
-4 >Emitted(41, 47) Source(4, 18) + SourceIndex(0)
-5 >Emitted(41, 57) Source(4, 23) + SourceIndex(0)
-6 >Emitted(41, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(41, 72) Source(4, 36) + SourceIndex(0)
+1->Emitted(45, 1) Source(4, 1) + SourceIndex(0)
+2 >Emitted(45, 15) Source(4, 15) + SourceIndex(0)
+3 >Emitted(45, 45) Source(4, 16) + SourceIndex(0)
+4 >Emitted(45, 47) Source(4, 18) + SourceIndex(0)
+5 >Emitted(45, 57) Source(4, 23) + SourceIndex(0)
+6 >Emitted(45, 68) Source(4, 34) + SourceIndex(0)
+7 >Emitted(45, 72) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -310,12 +318,12 @@ sourceFile:../lib/file1.ts
 4 >              = 
 5 >                10
 6 >                  ;
-1 >Emitted(46, 5) Source(1, 14) + SourceIndex(1)
-2 >Emitted(46, 13) Source(1, 14) + SourceIndex(1)
-3 >Emitted(46, 14) Source(1, 15) + SourceIndex(1)
-4 >Emitted(46, 17) Source(1, 18) + SourceIndex(1)
-5 >Emitted(46, 19) Source(1, 20) + SourceIndex(1)
-6 >Emitted(46, 20) Source(1, 21) + SourceIndex(1)
+1 >Emitted(50, 5) Source(1, 14) + SourceIndex(1)
+2 >Emitted(50, 13) Source(1, 14) + SourceIndex(1)
+3 >Emitted(50, 14) Source(1, 15) + SourceIndex(1)
+4 >Emitted(50, 17) Source(1, 18) + SourceIndex(1)
+5 >Emitted(50, 19) Source(1, 20) + SourceIndex(1)
+6 >Emitted(50, 20) Source(1, 21) + SourceIndex(1)
 ---
 >>>    function forlibfile1Rest() {
 1->^^^^
@@ -325,9 +333,9 @@ sourceFile:../lib/file1.ts
 1->
 2 >    function 
 3 >             forlibfile1Rest
-1->Emitted(47, 5) Source(1, 21) + SourceIndex(1)
-2 >Emitted(47, 14) Source(1, 30) + SourceIndex(1)
-3 >Emitted(47, 29) Source(1, 45) + SourceIndex(1)
+1->Emitted(51, 5) Source(1, 21) + SourceIndex(1)
+2 >Emitted(51, 14) Source(1, 30) + SourceIndex(1)
+3 >Emitted(51, 29) Source(1, 45) + SourceIndex(1)
 ---
 >>>        var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^^^^^
@@ -381,31 +389,31 @@ sourceFile:../lib/file1.ts
 23>                                                                       { b, ...rest }
 24>                                                                             = { a: 10, b: 30, yy: 30 }
 25>                                                                             ;
-1->Emitted(48, 9) Source(2, 1) + SourceIndex(1)
-2 >Emitted(48, 13) Source(2, 7) + SourceIndex(1)
-3 >Emitted(48, 18) Source(2, 24) + SourceIndex(1)
-4 >Emitted(48, 20) Source(2, 26) + SourceIndex(1)
-5 >Emitted(48, 21) Source(2, 27) + SourceIndex(1)
-6 >Emitted(48, 23) Source(2, 29) + SourceIndex(1)
-7 >Emitted(48, 25) Source(2, 31) + SourceIndex(1)
-8 >Emitted(48, 27) Source(2, 33) + SourceIndex(1)
-9 >Emitted(48, 28) Source(2, 34) + SourceIndex(1)
-10>Emitted(48, 30) Source(2, 36) + SourceIndex(1)
-11>Emitted(48, 32) Source(2, 38) + SourceIndex(1)
-12>Emitted(48, 34) Source(2, 40) + SourceIndex(1)
-13>Emitted(48, 36) Source(2, 42) + SourceIndex(1)
-14>Emitted(48, 38) Source(2, 44) + SourceIndex(1)
-15>Emitted(48, 40) Source(2, 46) + SourceIndex(1)
-16>Emitted(48, 42) Source(2, 48) + SourceIndex(1)
-17>Emitted(48, 44) Source(2, 9) + SourceIndex(1)
-18>Emitted(48, 45) Source(2, 10) + SourceIndex(1)
-19>Emitted(48, 52) Source(2, 10) + SourceIndex(1)
-20>Emitted(48, 54) Source(2, 15) + SourceIndex(1)
-21>Emitted(48, 58) Source(2, 19) + SourceIndex(1)
-22>Emitted(48, 72) Source(2, 7) + SourceIndex(1)
-23>Emitted(48, 77) Source(2, 21) + SourceIndex(1)
-24>Emitted(48, 78) Source(2, 48) + SourceIndex(1)
-25>Emitted(48, 79) Source(2, 49) + SourceIndex(1)
+1->Emitted(52, 9) Source(2, 1) + SourceIndex(1)
+2 >Emitted(52, 13) Source(2, 7) + SourceIndex(1)
+3 >Emitted(52, 18) Source(2, 24) + SourceIndex(1)
+4 >Emitted(52, 20) Source(2, 26) + SourceIndex(1)
+5 >Emitted(52, 21) Source(2, 27) + SourceIndex(1)
+6 >Emitted(52, 23) Source(2, 29) + SourceIndex(1)
+7 >Emitted(52, 25) Source(2, 31) + SourceIndex(1)
+8 >Emitted(52, 27) Source(2, 33) + SourceIndex(1)
+9 >Emitted(52, 28) Source(2, 34) + SourceIndex(1)
+10>Emitted(52, 30) Source(2, 36) + SourceIndex(1)
+11>Emitted(52, 32) Source(2, 38) + SourceIndex(1)
+12>Emitted(52, 34) Source(2, 40) + SourceIndex(1)
+13>Emitted(52, 36) Source(2, 42) + SourceIndex(1)
+14>Emitted(52, 38) Source(2, 44) + SourceIndex(1)
+15>Emitted(52, 40) Source(2, 46) + SourceIndex(1)
+16>Emitted(52, 42) Source(2, 48) + SourceIndex(1)
+17>Emitted(52, 44) Source(2, 9) + SourceIndex(1)
+18>Emitted(52, 45) Source(2, 10) + SourceIndex(1)
+19>Emitted(52, 52) Source(2, 10) + SourceIndex(1)
+20>Emitted(52, 54) Source(2, 15) + SourceIndex(1)
+21>Emitted(52, 58) Source(2, 19) + SourceIndex(1)
+22>Emitted(52, 72) Source(2, 7) + SourceIndex(1)
+23>Emitted(52, 77) Source(2, 21) + SourceIndex(1)
+24>Emitted(52, 78) Source(2, 48) + SourceIndex(1)
+25>Emitted(52, 79) Source(2, 49) + SourceIndex(1)
 ---
 >>>    }
 1 >^^^^
@@ -414,8 +422,8 @@ sourceFile:../lib/file1.ts
 1 >
   >
 2 >    }
-1 >Emitted(49, 5) Source(3, 1) + SourceIndex(1)
-2 >Emitted(49, 6) Source(3, 2) + SourceIndex(1)
+1 >Emitted(53, 5) Source(3, 1) + SourceIndex(1)
+2 >Emitted(53, 6) Source(3, 2) + SourceIndex(1)
 ---
 >>>    console.log(exports.x);
 1->^^^^
@@ -434,14 +442,14 @@ sourceFile:../lib/file1.ts
 6 >                x
 7 >                         )
 8 >                          ;
-1->Emitted(50, 5) Source(3, 2) + SourceIndex(1)
-2 >Emitted(50, 12) Source(3, 9) + SourceIndex(1)
-3 >Emitted(50, 13) Source(3, 10) + SourceIndex(1)
-4 >Emitted(50, 16) Source(3, 13) + SourceIndex(1)
-5 >Emitted(50, 17) Source(3, 14) + SourceIndex(1)
-6 >Emitted(50, 26) Source(3, 15) + SourceIndex(1)
-7 >Emitted(50, 27) Source(3, 16) + SourceIndex(1)
-8 >Emitted(50, 28) Source(3, 17) + SourceIndex(1)
+1->Emitted(54, 5) Source(3, 2) + SourceIndex(1)
+2 >Emitted(54, 12) Source(3, 9) + SourceIndex(1)
+3 >Emitted(54, 13) Source(3, 10) + SourceIndex(1)
+4 >Emitted(54, 16) Source(3, 13) + SourceIndex(1)
+5 >Emitted(54, 17) Source(3, 14) + SourceIndex(1)
+6 >Emitted(54, 26) Source(3, 15) + SourceIndex(1)
+7 >Emitted(54, 27) Source(3, 16) + SourceIndex(1)
+8 >Emitted(54, 28) Source(3, 17) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -465,12 +473,12 @@ sourceFile:../lib/file2.ts
 4 >              = 
 5 >                20
 6 >                  ;
-1 >Emitted(56, 5) Source(1, 14) + SourceIndex(2)
-2 >Emitted(56, 13) Source(1, 14) + SourceIndex(2)
-3 >Emitted(56, 14) Source(1, 15) + SourceIndex(2)
-4 >Emitted(56, 17) Source(1, 18) + SourceIndex(2)
-5 >Emitted(56, 19) Source(1, 20) + SourceIndex(2)
-6 >Emitted(56, 20) Source(1, 21) + SourceIndex(2)
+1 >Emitted(60, 5) Source(1, 14) + SourceIndex(2)
+2 >Emitted(60, 13) Source(1, 14) + SourceIndex(2)
+3 >Emitted(60, 14) Source(1, 15) + SourceIndex(2)
+4 >Emitted(60, 17) Source(1, 18) + SourceIndex(2)
+5 >Emitted(60, 19) Source(1, 20) + SourceIndex(2)
+6 >Emitted(60, 20) Source(1, 21) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -491,12 +499,12 @@ sourceFile:../lib/global.ts
 4 >                = 
 5 >                  10
 6 >                    ;
-1 >Emitted(58, 1) Source(1, 1) + SourceIndex(3)
-2 >Emitted(58, 5) Source(1, 7) + SourceIndex(3)
-3 >Emitted(58, 16) Source(1, 18) + SourceIndex(3)
-4 >Emitted(58, 19) Source(1, 21) + SourceIndex(3)
-5 >Emitted(58, 21) Source(1, 23) + SourceIndex(3)
-6 >Emitted(58, 22) Source(1, 24) + SourceIndex(3)
+1 >Emitted(62, 1) Source(1, 1) + SourceIndex(3)
+2 >Emitted(62, 5) Source(1, 7) + SourceIndex(3)
+3 >Emitted(62, 16) Source(1, 18) + SourceIndex(3)
+4 >Emitted(62, 19) Source(1, 21) + SourceIndex(3)
+5 >Emitted(62, 21) Source(1, 23) + SourceIndex(3)
+6 >Emitted(62, 22) Source(1, 24) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -520,12 +528,12 @@ sourceFile:file3.ts
 4 >              = 
 5 >                30
 6 >                  ;
-1->Emitted(63, 5) Source(1, 14) + SourceIndex(4)
-2 >Emitted(63, 13) Source(1, 14) + SourceIndex(4)
-3 >Emitted(63, 14) Source(1, 15) + SourceIndex(4)
-4 >Emitted(63, 17) Source(1, 18) + SourceIndex(4)
-5 >Emitted(63, 19) Source(1, 20) + SourceIndex(4)
-6 >Emitted(63, 20) Source(1, 21) + SourceIndex(4)
+1->Emitted(67, 5) Source(1, 14) + SourceIndex(4)
+2 >Emitted(67, 13) Source(1, 14) + SourceIndex(4)
+3 >Emitted(67, 14) Source(1, 15) + SourceIndex(4)
+4 >Emitted(67, 17) Source(1, 18) + SourceIndex(4)
+5 >Emitted(67, 19) Source(1, 20) + SourceIndex(4)
+6 >Emitted(67, 20) Source(1, 21) + SourceIndex(4)
 ---
 >>>    function forappfile3Rest() {
 1->^^^^
@@ -536,9 +544,9 @@ sourceFile:file3.ts
   >import { x } from "file1";
 2 >    function 
 3 >             forappfile3Rest
-1->Emitted(64, 5) Source(2, 27) + SourceIndex(4)
-2 >Emitted(64, 14) Source(2, 36) + SourceIndex(4)
-3 >Emitted(64, 29) Source(2, 51) + SourceIndex(4)
+1->Emitted(68, 5) Source(2, 27) + SourceIndex(4)
+2 >Emitted(68, 14) Source(2, 36) + SourceIndex(4)
+3 >Emitted(68, 29) Source(2, 51) + SourceIndex(4)
 ---
 >>>        var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^^^^^
@@ -592,31 +600,31 @@ sourceFile:file3.ts
 23>                                                                       { b, ...rest }
 24>                                                                             = { a: 10, b: 30, yy: 30 }
 25>                                                                             ;
-1->Emitted(65, 9) Source(3, 1) + SourceIndex(4)
-2 >Emitted(65, 13) Source(3, 7) + SourceIndex(4)
-3 >Emitted(65, 18) Source(3, 24) + SourceIndex(4)
-4 >Emitted(65, 20) Source(3, 26) + SourceIndex(4)
-5 >Emitted(65, 21) Source(3, 27) + SourceIndex(4)
-6 >Emitted(65, 23) Source(3, 29) + SourceIndex(4)
-7 >Emitted(65, 25) Source(3, 31) + SourceIndex(4)
-8 >Emitted(65, 27) Source(3, 33) + SourceIndex(4)
-9 >Emitted(65, 28) Source(3, 34) + SourceIndex(4)
-10>Emitted(65, 30) Source(3, 36) + SourceIndex(4)
-11>Emitted(65, 32) Source(3, 38) + SourceIndex(4)
-12>Emitted(65, 34) Source(3, 40) + SourceIndex(4)
-13>Emitted(65, 36) Source(3, 42) + SourceIndex(4)
-14>Emitted(65, 38) Source(3, 44) + SourceIndex(4)
-15>Emitted(65, 40) Source(3, 46) + SourceIndex(4)
-16>Emitted(65, 42) Source(3, 48) + SourceIndex(4)
-17>Emitted(65, 44) Source(3, 9) + SourceIndex(4)
-18>Emitted(65, 45) Source(3, 10) + SourceIndex(4)
-19>Emitted(65, 52) Source(3, 10) + SourceIndex(4)
-20>Emitted(65, 54) Source(3, 15) + SourceIndex(4)
-21>Emitted(65, 58) Source(3, 19) + SourceIndex(4)
-22>Emitted(65, 72) Source(3, 7) + SourceIndex(4)
-23>Emitted(65, 77) Source(3, 21) + SourceIndex(4)
-24>Emitted(65, 78) Source(3, 48) + SourceIndex(4)
-25>Emitted(65, 79) Source(3, 49) + SourceIndex(4)
+1->Emitted(69, 9) Source(3, 1) + SourceIndex(4)
+2 >Emitted(69, 13) Source(3, 7) + SourceIndex(4)
+3 >Emitted(69, 18) Source(3, 24) + SourceIndex(4)
+4 >Emitted(69, 20) Source(3, 26) + SourceIndex(4)
+5 >Emitted(69, 21) Source(3, 27) + SourceIndex(4)
+6 >Emitted(69, 23) Source(3, 29) + SourceIndex(4)
+7 >Emitted(69, 25) Source(3, 31) + SourceIndex(4)
+8 >Emitted(69, 27) Source(3, 33) + SourceIndex(4)
+9 >Emitted(69, 28) Source(3, 34) + SourceIndex(4)
+10>Emitted(69, 30) Source(3, 36) + SourceIndex(4)
+11>Emitted(69, 32) Source(3, 38) + SourceIndex(4)
+12>Emitted(69, 34) Source(3, 40) + SourceIndex(4)
+13>Emitted(69, 36) Source(3, 42) + SourceIndex(4)
+14>Emitted(69, 38) Source(3, 44) + SourceIndex(4)
+15>Emitted(69, 40) Source(3, 46) + SourceIndex(4)
+16>Emitted(69, 42) Source(3, 48) + SourceIndex(4)
+17>Emitted(69, 44) Source(3, 9) + SourceIndex(4)
+18>Emitted(69, 45) Source(3, 10) + SourceIndex(4)
+19>Emitted(69, 52) Source(3, 10) + SourceIndex(4)
+20>Emitted(69, 54) Source(3, 15) + SourceIndex(4)
+21>Emitted(69, 58) Source(3, 19) + SourceIndex(4)
+22>Emitted(69, 72) Source(3, 7) + SourceIndex(4)
+23>Emitted(69, 77) Source(3, 21) + SourceIndex(4)
+24>Emitted(69, 78) Source(3, 48) + SourceIndex(4)
+25>Emitted(69, 79) Source(3, 49) + SourceIndex(4)
 ---
 >>>    }
 1 >^^^^
@@ -624,8 +632,8 @@ sourceFile:file3.ts
 1 >
   >
 2 >    }
-1 >Emitted(66, 5) Source(4, 1) + SourceIndex(4)
-2 >Emitted(66, 6) Source(4, 2) + SourceIndex(4)
+1 >Emitted(70, 5) Source(4, 1) + SourceIndex(4)
+2 >Emitted(70, 6) Source(4, 2) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -646,12 +654,12 @@ sourceFile:file4.ts
 4 >          = 
 5 >            30
 6 >              ;
-1 >Emitted(68, 1) Source(1, 1) + SourceIndex(5)
-2 >Emitted(68, 5) Source(1, 7) + SourceIndex(5)
-3 >Emitted(68, 10) Source(1, 12) + SourceIndex(5)
-4 >Emitted(68, 13) Source(1, 15) + SourceIndex(5)
-5 >Emitted(68, 15) Source(1, 17) + SourceIndex(5)
-6 >Emitted(68, 16) Source(1, 18) + SourceIndex(5)
+1 >Emitted(72, 1) Source(1, 1) + SourceIndex(5)
+2 >Emitted(72, 5) Source(1, 7) + SourceIndex(5)
+3 >Emitted(72, 10) Source(1, 12) + SourceIndex(5)
+4 >Emitted(72, 13) Source(1, 15) + SourceIndex(5)
+5 >Emitted(72, 15) Source(1, 17) + SourceIndex(5)
+6 >Emitted(72, 16) Source(1, 18) + SourceIndex(5)
 ---
 >>>function appfile4Spread() {
 1->
@@ -661,9 +669,9 @@ sourceFile:file4.ts
   >
 2 >function 
 3 >         appfile4Spread
-1->Emitted(69, 1) Source(2, 1) + SourceIndex(5)
-2 >Emitted(69, 10) Source(2, 10) + SourceIndex(5)
-3 >Emitted(69, 24) Source(2, 24) + SourceIndex(5)
+1->Emitted(73, 1) Source(2, 1) + SourceIndex(5)
+2 >Emitted(73, 10) Source(2, 10) + SourceIndex(5)
+3 >Emitted(73, 24) Source(2, 24) + SourceIndex(5)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -671,8 +679,8 @@ sourceFile:file4.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(70, 5) Source(2, 25) + SourceIndex(5)
-2 >Emitted(70, 16) Source(2, 39) + SourceIndex(5)
+1 >Emitted(74, 5) Source(2, 25) + SourceIndex(5)
+2 >Emitted(74, 16) Source(2, 39) + SourceIndex(5)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -687,20 +695,20 @@ sourceFile:file4.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(71, 10) Source(2, 25) + SourceIndex(5)
-2 >Emitted(71, 20) Source(2, 39) + SourceIndex(5)
-3 >Emitted(71, 22) Source(2, 25) + SourceIndex(5)
-4 >Emitted(71, 43) Source(2, 39) + SourceIndex(5)
-5 >Emitted(71, 45) Source(2, 25) + SourceIndex(5)
-6 >Emitted(71, 49) Source(2, 39) + SourceIndex(5)
+1->Emitted(75, 10) Source(2, 25) + SourceIndex(5)
+2 >Emitted(75, 20) Source(2, 39) + SourceIndex(5)
+3 >Emitted(75, 22) Source(2, 25) + SourceIndex(5)
+4 >Emitted(75, 43) Source(2, 39) + SourceIndex(5)
+5 >Emitted(75, 45) Source(2, 25) + SourceIndex(5)
+6 >Emitted(75, 49) Source(2, 39) + SourceIndex(5)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(72, 9) Source(2, 25) + SourceIndex(5)
-2 >Emitted(72, 31) Source(2, 39) + SourceIndex(5)
+1 >Emitted(76, 9) Source(2, 25) + SourceIndex(5)
+2 >Emitted(76, 31) Source(2, 39) + SourceIndex(5)
 ---
 >>>    }
 >>>}
@@ -709,8 +717,8 @@ sourceFile:file4.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(74, 1) Source(2, 43) + SourceIndex(5)
-2 >Emitted(74, 2) Source(2, 44) + SourceIndex(5)
+1 >Emitted(78, 1) Source(2, 43) + SourceIndex(5)
+2 >Emitted(78, 2) Source(2, 44) + SourceIndex(5)
 ---
 >>>var appfile4_ar = [20, 30];
 1->
@@ -735,16 +743,16 @@ sourceFile:file4.ts
 8 >                       30
 9 >                         ]
 10>                          ;
-1->Emitted(75, 1) Source(3, 1) + SourceIndex(5)
-2 >Emitted(75, 5) Source(3, 7) + SourceIndex(5)
-3 >Emitted(75, 16) Source(3, 18) + SourceIndex(5)
-4 >Emitted(75, 19) Source(3, 21) + SourceIndex(5)
-5 >Emitted(75, 20) Source(3, 22) + SourceIndex(5)
-6 >Emitted(75, 22) Source(3, 24) + SourceIndex(5)
-7 >Emitted(75, 24) Source(3, 26) + SourceIndex(5)
-8 >Emitted(75, 26) Source(3, 28) + SourceIndex(5)
-9 >Emitted(75, 27) Source(3, 29) + SourceIndex(5)
-10>Emitted(75, 28) Source(3, 30) + SourceIndex(5)
+1->Emitted(79, 1) Source(3, 1) + SourceIndex(5)
+2 >Emitted(79, 5) Source(3, 7) + SourceIndex(5)
+3 >Emitted(79, 16) Source(3, 18) + SourceIndex(5)
+4 >Emitted(79, 19) Source(3, 21) + SourceIndex(5)
+5 >Emitted(79, 20) Source(3, 22) + SourceIndex(5)
+6 >Emitted(79, 22) Source(3, 24) + SourceIndex(5)
+7 >Emitted(79, 24) Source(3, 26) + SourceIndex(5)
+8 >Emitted(79, 26) Source(3, 28) + SourceIndex(5)
+9 >Emitted(79, 27) Source(3, 29) + SourceIndex(5)
+10>Emitted(79, 28) Source(3, 30) + SourceIndex(5)
 ---
 >>>appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
 1->
@@ -762,18 +770,18 @@ sourceFile:file4.ts
 5 >                                              , ...
 6 >                                                        appfile4_ar
 7 >                                                                   );
-1->Emitted(76, 1) Source(4, 1) + SourceIndex(5)
-2 >Emitted(76, 15) Source(4, 15) + SourceIndex(5)
-3 >Emitted(76, 45) Source(4, 16) + SourceIndex(5)
-4 >Emitted(76, 47) Source(4, 18) + SourceIndex(5)
-5 >Emitted(76, 57) Source(4, 23) + SourceIndex(5)
-6 >Emitted(76, 68) Source(4, 34) + SourceIndex(5)
-7 >Emitted(76, 72) Source(4, 36) + SourceIndex(5)
+1->Emitted(80, 1) Source(4, 1) + SourceIndex(5)
+2 >Emitted(80, 15) Source(4, 15) + SourceIndex(5)
+3 >Emitted(80, 45) Source(4, 16) + SourceIndex(5)
+4 >Emitted(80, 47) Source(4, 18) + SourceIndex(5)
+5 >Emitted(80, 57) Source(4, 23) + SourceIndex(5)
+6 >Emitted(80, 68) Source(4, 34) + SourceIndex(5)
+7 >Emitted(80, 72) Source(4, 36) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/app/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":697,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":699,"end":1199,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1201,"end":2053,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1201,"end":2053,"kind":"text"}]},{"pos":2053,"end":2643,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":2196,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1344,"end":2196,"kind":"text"}]},{"pos":2196,"end":2786,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/app/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -797,14 +805,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-697):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (506-840):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (699-1199):: typescript:rest
+emitHelpers: (842-1342):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -817,9 +829,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1201-2053):: ../lib/module.js texts:: 1
+prepend: (1344-2196):: ../lib/module.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1201-2053)
+text: (1344-2196)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -848,7 +860,7 @@ define("file2", ["require", "exports"], function (require, exports) {
 var globalConst = 10;
 
 ----------------------------------------------------------------------
-text: (2053-2643)
+text: (2196-2786)
 define("file3", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -915,32 +927,32 @@ declare const appfile4_ar: number[];
         },
         {
           "pos": 506,
-          "end": 697,
+          "end": 840,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 699,
-          "end": 1199,
+          "pos": 842,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1201,
-          "end": 2053,
+          "pos": 1344,
+          "end": 2196,
           "kind": "prepend",
           "data": "../lib/module.js",
           "texts": [
             {
-              "pos": 1201,
-              "end": 2053,
+              "pos": 1344,
+              "end": 2196,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2053,
-          "end": 2643,
+          "pos": 2196,
+          "end": 2786,
           "kind": "text"
         }
       ],
@@ -999,10 +1011,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -1044,7 +1060,7 @@ var globalConst = 10;
 //# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;IAAA,OAAO,CAAC,GAAG,CAAC,SAAC,CAAC,CAAC;;;;;;ICFH,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;IAAA,OAAO,CAAC,GAAG,CAAC,SAAC,CAAC,CAAC;;;;;;ICFH,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
 
 //// [/src/lib/module.js.map.baseline.txt]
 ===================================================================
@@ -1073,10 +1089,14 @@ sourceFile:file0.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -1103,12 +1123,12 @@ sourceFile:file0.ts
 4 >           = 
 5 >             20
 6 >               ;
-1 >Emitted(33, 1) Source(1, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(1, 7) + SourceIndex(0)
-3 >Emitted(33, 11) Source(1, 13) + SourceIndex(0)
-4 >Emitted(33, 14) Source(1, 16) + SourceIndex(0)
-5 >Emitted(33, 16) Source(1, 18) + SourceIndex(0)
-6 >Emitted(33, 17) Source(1, 19) + SourceIndex(0)
+1 >Emitted(37, 1) Source(1, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(1, 7) + SourceIndex(0)
+3 >Emitted(37, 11) Source(1, 13) + SourceIndex(0)
+4 >Emitted(37, 14) Source(1, 16) + SourceIndex(0)
+5 >Emitted(37, 16) Source(1, 18) + SourceIndex(0)
+6 >Emitted(37, 17) Source(1, 19) + SourceIndex(0)
 ---
 >>>function libfile0Spread() {
 1->
@@ -1118,9 +1138,9 @@ sourceFile:file0.ts
   >
 2 >function 
 3 >         libfile0Spread
-1->Emitted(34, 1) Source(2, 1) + SourceIndex(0)
-2 >Emitted(34, 10) Source(2, 10) + SourceIndex(0)
-3 >Emitted(34, 24) Source(2, 24) + SourceIndex(0)
+1->Emitted(38, 1) Source(2, 1) + SourceIndex(0)
+2 >Emitted(38, 10) Source(2, 10) + SourceIndex(0)
+3 >Emitted(38, 24) Source(2, 24) + SourceIndex(0)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -1128,8 +1148,8 @@ sourceFile:file0.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(35, 5) Source(2, 25) + SourceIndex(0)
-2 >Emitted(35, 16) Source(2, 39) + SourceIndex(0)
+1 >Emitted(39, 5) Source(2, 25) + SourceIndex(0)
+2 >Emitted(39, 16) Source(2, 39) + SourceIndex(0)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1144,20 +1164,20 @@ sourceFile:file0.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(36, 10) Source(2, 25) + SourceIndex(0)
-2 >Emitted(36, 20) Source(2, 39) + SourceIndex(0)
-3 >Emitted(36, 22) Source(2, 25) + SourceIndex(0)
-4 >Emitted(36, 43) Source(2, 39) + SourceIndex(0)
-5 >Emitted(36, 45) Source(2, 25) + SourceIndex(0)
-6 >Emitted(36, 49) Source(2, 39) + SourceIndex(0)
+1->Emitted(40, 10) Source(2, 25) + SourceIndex(0)
+2 >Emitted(40, 20) Source(2, 39) + SourceIndex(0)
+3 >Emitted(40, 22) Source(2, 25) + SourceIndex(0)
+4 >Emitted(40, 43) Source(2, 39) + SourceIndex(0)
+5 >Emitted(40, 45) Source(2, 25) + SourceIndex(0)
+6 >Emitted(40, 49) Source(2, 39) + SourceIndex(0)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(37, 9) Source(2, 25) + SourceIndex(0)
-2 >Emitted(37, 31) Source(2, 39) + SourceIndex(0)
+1 >Emitted(41, 9) Source(2, 25) + SourceIndex(0)
+2 >Emitted(41, 31) Source(2, 39) + SourceIndex(0)
 ---
 >>>    }
 >>>}
@@ -1166,8 +1186,8 @@ sourceFile:file0.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(39, 1) Source(2, 43) + SourceIndex(0)
-2 >Emitted(39, 2) Source(2, 44) + SourceIndex(0)
+1 >Emitted(43, 1) Source(2, 43) + SourceIndex(0)
+2 >Emitted(43, 2) Source(2, 44) + SourceIndex(0)
 ---
 >>>var libfile0_ar = [20, 30];
 1->
@@ -1192,16 +1212,16 @@ sourceFile:file0.ts
 8 >                       30
 9 >                         ]
 10>                          ;
-1->Emitted(40, 1) Source(3, 1) + SourceIndex(0)
-2 >Emitted(40, 5) Source(3, 7) + SourceIndex(0)
-3 >Emitted(40, 16) Source(3, 18) + SourceIndex(0)
-4 >Emitted(40, 19) Source(3, 21) + SourceIndex(0)
-5 >Emitted(40, 20) Source(3, 22) + SourceIndex(0)
-6 >Emitted(40, 22) Source(3, 24) + SourceIndex(0)
-7 >Emitted(40, 24) Source(3, 26) + SourceIndex(0)
-8 >Emitted(40, 26) Source(3, 28) + SourceIndex(0)
-9 >Emitted(40, 27) Source(3, 29) + SourceIndex(0)
-10>Emitted(40, 28) Source(3, 30) + SourceIndex(0)
+1->Emitted(44, 1) Source(3, 1) + SourceIndex(0)
+2 >Emitted(44, 5) Source(3, 7) + SourceIndex(0)
+3 >Emitted(44, 16) Source(3, 18) + SourceIndex(0)
+4 >Emitted(44, 19) Source(3, 21) + SourceIndex(0)
+5 >Emitted(44, 20) Source(3, 22) + SourceIndex(0)
+6 >Emitted(44, 22) Source(3, 24) + SourceIndex(0)
+7 >Emitted(44, 24) Source(3, 26) + SourceIndex(0)
+8 >Emitted(44, 26) Source(3, 28) + SourceIndex(0)
+9 >Emitted(44, 27) Source(3, 29) + SourceIndex(0)
+10>Emitted(44, 28) Source(3, 30) + SourceIndex(0)
 ---
 >>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
 1->
@@ -1219,13 +1239,13 @@ sourceFile:file0.ts
 5 >                                              , ...
 6 >                                                        libfile0_ar
 7 >                                                                   );
-1->Emitted(41, 1) Source(4, 1) + SourceIndex(0)
-2 >Emitted(41, 15) Source(4, 15) + SourceIndex(0)
-3 >Emitted(41, 45) Source(4, 16) + SourceIndex(0)
-4 >Emitted(41, 47) Source(4, 18) + SourceIndex(0)
-5 >Emitted(41, 57) Source(4, 23) + SourceIndex(0)
-6 >Emitted(41, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(41, 72) Source(4, 36) + SourceIndex(0)
+1->Emitted(45, 1) Source(4, 1) + SourceIndex(0)
+2 >Emitted(45, 15) Source(4, 15) + SourceIndex(0)
+3 >Emitted(45, 45) Source(4, 16) + SourceIndex(0)
+4 >Emitted(45, 47) Source(4, 18) + SourceIndex(0)
+5 >Emitted(45, 57) Source(4, 23) + SourceIndex(0)
+6 >Emitted(45, 68) Source(4, 34) + SourceIndex(0)
+7 >Emitted(45, 72) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1249,12 +1269,12 @@ sourceFile:file1.ts
 4 >              = 
 5 >                10
 6 >                  ;
-1 >Emitted(46, 5) Source(1, 14) + SourceIndex(1)
-2 >Emitted(46, 13) Source(1, 14) + SourceIndex(1)
-3 >Emitted(46, 14) Source(1, 15) + SourceIndex(1)
-4 >Emitted(46, 17) Source(1, 18) + SourceIndex(1)
-5 >Emitted(46, 19) Source(1, 20) + SourceIndex(1)
-6 >Emitted(46, 20) Source(1, 21) + SourceIndex(1)
+1 >Emitted(50, 5) Source(1, 14) + SourceIndex(1)
+2 >Emitted(50, 13) Source(1, 14) + SourceIndex(1)
+3 >Emitted(50, 14) Source(1, 15) + SourceIndex(1)
+4 >Emitted(50, 17) Source(1, 18) + SourceIndex(1)
+5 >Emitted(50, 19) Source(1, 20) + SourceIndex(1)
+6 >Emitted(50, 20) Source(1, 21) + SourceIndex(1)
 ---
 >>>    function forlibfile1Rest() {
 1->^^^^
@@ -1264,9 +1284,9 @@ sourceFile:file1.ts
 1->
 2 >    function 
 3 >             forlibfile1Rest
-1->Emitted(47, 5) Source(1, 21) + SourceIndex(1)
-2 >Emitted(47, 14) Source(1, 30) + SourceIndex(1)
-3 >Emitted(47, 29) Source(1, 45) + SourceIndex(1)
+1->Emitted(51, 5) Source(1, 21) + SourceIndex(1)
+2 >Emitted(51, 14) Source(1, 30) + SourceIndex(1)
+3 >Emitted(51, 29) Source(1, 45) + SourceIndex(1)
 ---
 >>>        var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^^^^^
@@ -1320,31 +1340,31 @@ sourceFile:file1.ts
 23>                                                                       { b, ...rest }
 24>                                                                             = { a: 10, b: 30, yy: 30 }
 25>                                                                             ;
-1->Emitted(48, 9) Source(2, 1) + SourceIndex(1)
-2 >Emitted(48, 13) Source(2, 7) + SourceIndex(1)
-3 >Emitted(48, 18) Source(2, 24) + SourceIndex(1)
-4 >Emitted(48, 20) Source(2, 26) + SourceIndex(1)
-5 >Emitted(48, 21) Source(2, 27) + SourceIndex(1)
-6 >Emitted(48, 23) Source(2, 29) + SourceIndex(1)
-7 >Emitted(48, 25) Source(2, 31) + SourceIndex(1)
-8 >Emitted(48, 27) Source(2, 33) + SourceIndex(1)
-9 >Emitted(48, 28) Source(2, 34) + SourceIndex(1)
-10>Emitted(48, 30) Source(2, 36) + SourceIndex(1)
-11>Emitted(48, 32) Source(2, 38) + SourceIndex(1)
-12>Emitted(48, 34) Source(2, 40) + SourceIndex(1)
-13>Emitted(48, 36) Source(2, 42) + SourceIndex(1)
-14>Emitted(48, 38) Source(2, 44) + SourceIndex(1)
-15>Emitted(48, 40) Source(2, 46) + SourceIndex(1)
-16>Emitted(48, 42) Source(2, 48) + SourceIndex(1)
-17>Emitted(48, 44) Source(2, 9) + SourceIndex(1)
-18>Emitted(48, 45) Source(2, 10) + SourceIndex(1)
-19>Emitted(48, 52) Source(2, 10) + SourceIndex(1)
-20>Emitted(48, 54) Source(2, 15) + SourceIndex(1)
-21>Emitted(48, 58) Source(2, 19) + SourceIndex(1)
-22>Emitted(48, 72) Source(2, 7) + SourceIndex(1)
-23>Emitted(48, 77) Source(2, 21) + SourceIndex(1)
-24>Emitted(48, 78) Source(2, 48) + SourceIndex(1)
-25>Emitted(48, 79) Source(2, 49) + SourceIndex(1)
+1->Emitted(52, 9) Source(2, 1) + SourceIndex(1)
+2 >Emitted(52, 13) Source(2, 7) + SourceIndex(1)
+3 >Emitted(52, 18) Source(2, 24) + SourceIndex(1)
+4 >Emitted(52, 20) Source(2, 26) + SourceIndex(1)
+5 >Emitted(52, 21) Source(2, 27) + SourceIndex(1)
+6 >Emitted(52, 23) Source(2, 29) + SourceIndex(1)
+7 >Emitted(52, 25) Source(2, 31) + SourceIndex(1)
+8 >Emitted(52, 27) Source(2, 33) + SourceIndex(1)
+9 >Emitted(52, 28) Source(2, 34) + SourceIndex(1)
+10>Emitted(52, 30) Source(2, 36) + SourceIndex(1)
+11>Emitted(52, 32) Source(2, 38) + SourceIndex(1)
+12>Emitted(52, 34) Source(2, 40) + SourceIndex(1)
+13>Emitted(52, 36) Source(2, 42) + SourceIndex(1)
+14>Emitted(52, 38) Source(2, 44) + SourceIndex(1)
+15>Emitted(52, 40) Source(2, 46) + SourceIndex(1)
+16>Emitted(52, 42) Source(2, 48) + SourceIndex(1)
+17>Emitted(52, 44) Source(2, 9) + SourceIndex(1)
+18>Emitted(52, 45) Source(2, 10) + SourceIndex(1)
+19>Emitted(52, 52) Source(2, 10) + SourceIndex(1)
+20>Emitted(52, 54) Source(2, 15) + SourceIndex(1)
+21>Emitted(52, 58) Source(2, 19) + SourceIndex(1)
+22>Emitted(52, 72) Source(2, 7) + SourceIndex(1)
+23>Emitted(52, 77) Source(2, 21) + SourceIndex(1)
+24>Emitted(52, 78) Source(2, 48) + SourceIndex(1)
+25>Emitted(52, 79) Source(2, 49) + SourceIndex(1)
 ---
 >>>    }
 1 >^^^^
@@ -1353,8 +1373,8 @@ sourceFile:file1.ts
 1 >
   >
 2 >    }
-1 >Emitted(49, 5) Source(3, 1) + SourceIndex(1)
-2 >Emitted(49, 6) Source(3, 2) + SourceIndex(1)
+1 >Emitted(53, 5) Source(3, 1) + SourceIndex(1)
+2 >Emitted(53, 6) Source(3, 2) + SourceIndex(1)
 ---
 >>>    console.log(exports.x);
 1->^^^^
@@ -1373,14 +1393,14 @@ sourceFile:file1.ts
 6 >                x
 7 >                         )
 8 >                          ;
-1->Emitted(50, 5) Source(3, 2) + SourceIndex(1)
-2 >Emitted(50, 12) Source(3, 9) + SourceIndex(1)
-3 >Emitted(50, 13) Source(3, 10) + SourceIndex(1)
-4 >Emitted(50, 16) Source(3, 13) + SourceIndex(1)
-5 >Emitted(50, 17) Source(3, 14) + SourceIndex(1)
-6 >Emitted(50, 26) Source(3, 15) + SourceIndex(1)
-7 >Emitted(50, 27) Source(3, 16) + SourceIndex(1)
-8 >Emitted(50, 28) Source(3, 17) + SourceIndex(1)
+1->Emitted(54, 5) Source(3, 2) + SourceIndex(1)
+2 >Emitted(54, 12) Source(3, 9) + SourceIndex(1)
+3 >Emitted(54, 13) Source(3, 10) + SourceIndex(1)
+4 >Emitted(54, 16) Source(3, 13) + SourceIndex(1)
+5 >Emitted(54, 17) Source(3, 14) + SourceIndex(1)
+6 >Emitted(54, 26) Source(3, 15) + SourceIndex(1)
+7 >Emitted(54, 27) Source(3, 16) + SourceIndex(1)
+8 >Emitted(54, 28) Source(3, 17) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1404,12 +1424,12 @@ sourceFile:file2.ts
 4 >              = 
 5 >                20
 6 >                  ;
-1 >Emitted(56, 5) Source(1, 14) + SourceIndex(2)
-2 >Emitted(56, 13) Source(1, 14) + SourceIndex(2)
-3 >Emitted(56, 14) Source(1, 15) + SourceIndex(2)
-4 >Emitted(56, 17) Source(1, 18) + SourceIndex(2)
-5 >Emitted(56, 19) Source(1, 20) + SourceIndex(2)
-6 >Emitted(56, 20) Source(1, 21) + SourceIndex(2)
+1 >Emitted(60, 5) Source(1, 14) + SourceIndex(2)
+2 >Emitted(60, 13) Source(1, 14) + SourceIndex(2)
+3 >Emitted(60, 14) Source(1, 15) + SourceIndex(2)
+4 >Emitted(60, 17) Source(1, 18) + SourceIndex(2)
+5 >Emitted(60, 19) Source(1, 20) + SourceIndex(2)
+6 >Emitted(60, 20) Source(1, 21) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1430,17 +1450,17 @@ sourceFile:global.ts
 4 >                = 
 5 >                  10
 6 >                    ;
-1 >Emitted(58, 1) Source(1, 1) + SourceIndex(3)
-2 >Emitted(58, 5) Source(1, 7) + SourceIndex(3)
-3 >Emitted(58, 16) Source(1, 18) + SourceIndex(3)
-4 >Emitted(58, 19) Source(1, 21) + SourceIndex(3)
-5 >Emitted(58, 21) Source(1, 23) + SourceIndex(3)
-6 >Emitted(58, 22) Source(1, 24) + SourceIndex(3)
+1 >Emitted(62, 1) Source(1, 1) + SourceIndex(3)
+2 >Emitted(62, 5) Source(1, 7) + SourceIndex(3)
+3 >Emitted(62, 16) Source(1, 18) + SourceIndex(3)
+4 >Emitted(62, 19) Source(1, 21) + SourceIndex(3)
+5 >Emitted(62, 21) Source(1, 23) + SourceIndex(3)
+6 >Emitted(62, 22) Source(1, 24) + SourceIndex(3)
 ---
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":697,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":699,"end":1199,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1201,"end":2053,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":2196,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/lib/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1464,14 +1484,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-697):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (506-840):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (699-1199):: typescript:rest
+emitHelpers: (842-1342):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1484,7 +1508,7 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-text: (1201-2053)
+text: (1344-2196)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -1550,19 +1574,19 @@ declare const globalConst = 10;
         },
         {
           "pos": 506,
-          "end": 697,
+          "end": 840,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 699,
-          "end": 1199,
+          "pos": 842,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1201,
-          "end": 2053,
+          "pos": 1344,
+          "end": 2196,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
@@ -40,10 +40,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -100,7 +104,7 @@ appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
 //# sourceMappingURL=module.js.map
 
 //// [/src/app/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe,KAAK,CAAC;;;;;;ICArC,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe,KAAK,CAAC;;;;;;ICArC,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE"}
 
 //// [/src/app/module.js.map.baseline.txt]
 ===================================================================
@@ -129,10 +133,14 @@ sourceFile:../lib/file0.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -159,12 +167,12 @@ sourceFile:../lib/file0.ts
 4 >           = 
 5 >             20
 6 >               ;
-1 >Emitted(33, 1) Source(1, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(1, 7) + SourceIndex(0)
-3 >Emitted(33, 11) Source(1, 13) + SourceIndex(0)
-4 >Emitted(33, 14) Source(1, 16) + SourceIndex(0)
-5 >Emitted(33, 16) Source(1, 18) + SourceIndex(0)
-6 >Emitted(33, 17) Source(1, 19) + SourceIndex(0)
+1 >Emitted(37, 1) Source(1, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(1, 7) + SourceIndex(0)
+3 >Emitted(37, 11) Source(1, 13) + SourceIndex(0)
+4 >Emitted(37, 14) Source(1, 16) + SourceIndex(0)
+5 >Emitted(37, 16) Source(1, 18) + SourceIndex(0)
+6 >Emitted(37, 17) Source(1, 19) + SourceIndex(0)
 ---
 >>>function libfile0Spread() {
 1->
@@ -174,9 +182,9 @@ sourceFile:../lib/file0.ts
   >
 2 >function 
 3 >         libfile0Spread
-1->Emitted(34, 1) Source(2, 1) + SourceIndex(0)
-2 >Emitted(34, 10) Source(2, 10) + SourceIndex(0)
-3 >Emitted(34, 24) Source(2, 24) + SourceIndex(0)
+1->Emitted(38, 1) Source(2, 1) + SourceIndex(0)
+2 >Emitted(38, 10) Source(2, 10) + SourceIndex(0)
+3 >Emitted(38, 24) Source(2, 24) + SourceIndex(0)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -184,8 +192,8 @@ sourceFile:../lib/file0.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(35, 5) Source(2, 25) + SourceIndex(0)
-2 >Emitted(35, 16) Source(2, 39) + SourceIndex(0)
+1 >Emitted(39, 5) Source(2, 25) + SourceIndex(0)
+2 >Emitted(39, 16) Source(2, 39) + SourceIndex(0)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -200,20 +208,20 @@ sourceFile:../lib/file0.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(36, 10) Source(2, 25) + SourceIndex(0)
-2 >Emitted(36, 20) Source(2, 39) + SourceIndex(0)
-3 >Emitted(36, 22) Source(2, 25) + SourceIndex(0)
-4 >Emitted(36, 43) Source(2, 39) + SourceIndex(0)
-5 >Emitted(36, 45) Source(2, 25) + SourceIndex(0)
-6 >Emitted(36, 49) Source(2, 39) + SourceIndex(0)
+1->Emitted(40, 10) Source(2, 25) + SourceIndex(0)
+2 >Emitted(40, 20) Source(2, 39) + SourceIndex(0)
+3 >Emitted(40, 22) Source(2, 25) + SourceIndex(0)
+4 >Emitted(40, 43) Source(2, 39) + SourceIndex(0)
+5 >Emitted(40, 45) Source(2, 25) + SourceIndex(0)
+6 >Emitted(40, 49) Source(2, 39) + SourceIndex(0)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(37, 9) Source(2, 25) + SourceIndex(0)
-2 >Emitted(37, 31) Source(2, 39) + SourceIndex(0)
+1 >Emitted(41, 9) Source(2, 25) + SourceIndex(0)
+2 >Emitted(41, 31) Source(2, 39) + SourceIndex(0)
 ---
 >>>    }
 >>>}
@@ -222,8 +230,8 @@ sourceFile:../lib/file0.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(39, 1) Source(2, 43) + SourceIndex(0)
-2 >Emitted(39, 2) Source(2, 44) + SourceIndex(0)
+1 >Emitted(43, 1) Source(2, 43) + SourceIndex(0)
+2 >Emitted(43, 2) Source(2, 44) + SourceIndex(0)
 ---
 >>>var libfile0_ar = [20, 30];
 1->
@@ -248,16 +256,16 @@ sourceFile:../lib/file0.ts
 8 >                       30
 9 >                         ]
 10>                          ;
-1->Emitted(40, 1) Source(3, 1) + SourceIndex(0)
-2 >Emitted(40, 5) Source(3, 7) + SourceIndex(0)
-3 >Emitted(40, 16) Source(3, 18) + SourceIndex(0)
-4 >Emitted(40, 19) Source(3, 21) + SourceIndex(0)
-5 >Emitted(40, 20) Source(3, 22) + SourceIndex(0)
-6 >Emitted(40, 22) Source(3, 24) + SourceIndex(0)
-7 >Emitted(40, 24) Source(3, 26) + SourceIndex(0)
-8 >Emitted(40, 26) Source(3, 28) + SourceIndex(0)
-9 >Emitted(40, 27) Source(3, 29) + SourceIndex(0)
-10>Emitted(40, 28) Source(3, 30) + SourceIndex(0)
+1->Emitted(44, 1) Source(3, 1) + SourceIndex(0)
+2 >Emitted(44, 5) Source(3, 7) + SourceIndex(0)
+3 >Emitted(44, 16) Source(3, 18) + SourceIndex(0)
+4 >Emitted(44, 19) Source(3, 21) + SourceIndex(0)
+5 >Emitted(44, 20) Source(3, 22) + SourceIndex(0)
+6 >Emitted(44, 22) Source(3, 24) + SourceIndex(0)
+7 >Emitted(44, 24) Source(3, 26) + SourceIndex(0)
+8 >Emitted(44, 26) Source(3, 28) + SourceIndex(0)
+9 >Emitted(44, 27) Source(3, 29) + SourceIndex(0)
+10>Emitted(44, 28) Source(3, 30) + SourceIndex(0)
 ---
 >>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
 1->
@@ -275,13 +283,13 @@ sourceFile:../lib/file0.ts
 5 >                                              , ...
 6 >                                                        libfile0_ar
 7 >                                                                   );
-1->Emitted(41, 1) Source(4, 1) + SourceIndex(0)
-2 >Emitted(41, 15) Source(4, 15) + SourceIndex(0)
-3 >Emitted(41, 45) Source(4, 16) + SourceIndex(0)
-4 >Emitted(41, 47) Source(4, 18) + SourceIndex(0)
-5 >Emitted(41, 57) Source(4, 23) + SourceIndex(0)
-6 >Emitted(41, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(41, 72) Source(4, 36) + SourceIndex(0)
+1->Emitted(45, 1) Source(4, 1) + SourceIndex(0)
+2 >Emitted(45, 15) Source(4, 15) + SourceIndex(0)
+3 >Emitted(45, 45) Source(4, 16) + SourceIndex(0)
+4 >Emitted(45, 47) Source(4, 18) + SourceIndex(0)
+5 >Emitted(45, 57) Source(4, 23) + SourceIndex(0)
+6 >Emitted(45, 68) Source(4, 34) + SourceIndex(0)
+7 >Emitted(45, 72) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -305,12 +313,12 @@ sourceFile:../lib/file1.ts
 4 >              = 
 5 >                10
 6 >                  ;
-1 >Emitted(46, 5) Source(1, 14) + SourceIndex(1)
-2 >Emitted(46, 13) Source(1, 14) + SourceIndex(1)
-3 >Emitted(46, 14) Source(1, 15) + SourceIndex(1)
-4 >Emitted(46, 17) Source(1, 18) + SourceIndex(1)
-5 >Emitted(46, 19) Source(1, 20) + SourceIndex(1)
-6 >Emitted(46, 20) Source(1, 21) + SourceIndex(1)
+1 >Emitted(50, 5) Source(1, 14) + SourceIndex(1)
+2 >Emitted(50, 13) Source(1, 14) + SourceIndex(1)
+3 >Emitted(50, 14) Source(1, 15) + SourceIndex(1)
+4 >Emitted(50, 17) Source(1, 18) + SourceIndex(1)
+5 >Emitted(50, 19) Source(1, 20) + SourceIndex(1)
+6 >Emitted(50, 20) Source(1, 21) + SourceIndex(1)
 ---
 >>>    function forlibfile1Rest() { }
 1->^^^^
@@ -323,11 +331,11 @@ sourceFile:../lib/file1.ts
 3 >             forlibfile1Rest
 4 >                            () { 
 5 >                                 }
-1->Emitted(47, 5) Source(1, 21) + SourceIndex(1)
-2 >Emitted(47, 14) Source(1, 30) + SourceIndex(1)
-3 >Emitted(47, 29) Source(1, 45) + SourceIndex(1)
-4 >Emitted(47, 34) Source(1, 50) + SourceIndex(1)
-5 >Emitted(47, 35) Source(1, 51) + SourceIndex(1)
+1->Emitted(51, 5) Source(1, 21) + SourceIndex(1)
+2 >Emitted(51, 14) Source(1, 30) + SourceIndex(1)
+3 >Emitted(51, 29) Source(1, 45) + SourceIndex(1)
+4 >Emitted(51, 34) Source(1, 50) + SourceIndex(1)
+5 >Emitted(51, 35) Source(1, 51) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -351,12 +359,12 @@ sourceFile:../lib/file2.ts
 4 >              = 
 5 >                20
 6 >                  ;
-1 >Emitted(53, 5) Source(1, 14) + SourceIndex(2)
-2 >Emitted(53, 13) Source(1, 14) + SourceIndex(2)
-3 >Emitted(53, 14) Source(1, 15) + SourceIndex(2)
-4 >Emitted(53, 17) Source(1, 18) + SourceIndex(2)
-5 >Emitted(53, 19) Source(1, 20) + SourceIndex(2)
-6 >Emitted(53, 20) Source(1, 21) + SourceIndex(2)
+1 >Emitted(57, 5) Source(1, 14) + SourceIndex(2)
+2 >Emitted(57, 13) Source(1, 14) + SourceIndex(2)
+3 >Emitted(57, 14) Source(1, 15) + SourceIndex(2)
+4 >Emitted(57, 17) Source(1, 18) + SourceIndex(2)
+5 >Emitted(57, 19) Source(1, 20) + SourceIndex(2)
+6 >Emitted(57, 20) Source(1, 21) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -377,12 +385,12 @@ sourceFile:../lib/global.ts
 4 >                = 
 5 >                  10
 6 >                    ;
-1 >Emitted(55, 1) Source(1, 1) + SourceIndex(3)
-2 >Emitted(55, 5) Source(1, 7) + SourceIndex(3)
-3 >Emitted(55, 16) Source(1, 18) + SourceIndex(3)
-4 >Emitted(55, 19) Source(1, 21) + SourceIndex(3)
-5 >Emitted(55, 21) Source(1, 23) + SourceIndex(3)
-6 >Emitted(55, 22) Source(1, 24) + SourceIndex(3)
+1 >Emitted(59, 1) Source(1, 1) + SourceIndex(3)
+2 >Emitted(59, 5) Source(1, 7) + SourceIndex(3)
+3 >Emitted(59, 16) Source(1, 18) + SourceIndex(3)
+4 >Emitted(59, 19) Source(1, 21) + SourceIndex(3)
+5 >Emitted(59, 21) Source(1, 23) + SourceIndex(3)
+6 >Emitted(59, 22) Source(1, 24) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -406,12 +414,12 @@ sourceFile:file3.ts
 4 >              = 
 5 >                30
 6 >                  ;
-1->Emitted(60, 5) Source(1, 14) + SourceIndex(4)
-2 >Emitted(60, 13) Source(1, 14) + SourceIndex(4)
-3 >Emitted(60, 14) Source(1, 15) + SourceIndex(4)
-4 >Emitted(60, 17) Source(1, 18) + SourceIndex(4)
-5 >Emitted(60, 19) Source(1, 20) + SourceIndex(4)
-6 >Emitted(60, 20) Source(1, 21) + SourceIndex(4)
+1->Emitted(64, 5) Source(1, 14) + SourceIndex(4)
+2 >Emitted(64, 13) Source(1, 14) + SourceIndex(4)
+3 >Emitted(64, 14) Source(1, 15) + SourceIndex(4)
+4 >Emitted(64, 17) Source(1, 18) + SourceIndex(4)
+5 >Emitted(64, 19) Source(1, 20) + SourceIndex(4)
+6 >Emitted(64, 20) Source(1, 21) + SourceIndex(4)
 ---
 >>>    function forappfile3Rest() {
 1->^^^^
@@ -422,9 +430,9 @@ sourceFile:file3.ts
   >import { x } from "file1";
 2 >    function 
 3 >             forappfile3Rest
-1->Emitted(61, 5) Source(2, 27) + SourceIndex(4)
-2 >Emitted(61, 14) Source(2, 36) + SourceIndex(4)
-3 >Emitted(61, 29) Source(2, 51) + SourceIndex(4)
+1->Emitted(65, 5) Source(2, 27) + SourceIndex(4)
+2 >Emitted(65, 14) Source(2, 36) + SourceIndex(4)
+3 >Emitted(65, 29) Source(2, 51) + SourceIndex(4)
 ---
 >>>        var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^^^^^
@@ -478,31 +486,31 @@ sourceFile:file3.ts
 23>                                                                       { b, ...rest }
 24>                                                                             = { a: 10, b: 30, yy: 30 }
 25>                                                                             ;
-1->Emitted(62, 9) Source(3, 1) + SourceIndex(4)
-2 >Emitted(62, 13) Source(3, 7) + SourceIndex(4)
-3 >Emitted(62, 18) Source(3, 24) + SourceIndex(4)
-4 >Emitted(62, 20) Source(3, 26) + SourceIndex(4)
-5 >Emitted(62, 21) Source(3, 27) + SourceIndex(4)
-6 >Emitted(62, 23) Source(3, 29) + SourceIndex(4)
-7 >Emitted(62, 25) Source(3, 31) + SourceIndex(4)
-8 >Emitted(62, 27) Source(3, 33) + SourceIndex(4)
-9 >Emitted(62, 28) Source(3, 34) + SourceIndex(4)
-10>Emitted(62, 30) Source(3, 36) + SourceIndex(4)
-11>Emitted(62, 32) Source(3, 38) + SourceIndex(4)
-12>Emitted(62, 34) Source(3, 40) + SourceIndex(4)
-13>Emitted(62, 36) Source(3, 42) + SourceIndex(4)
-14>Emitted(62, 38) Source(3, 44) + SourceIndex(4)
-15>Emitted(62, 40) Source(3, 46) + SourceIndex(4)
-16>Emitted(62, 42) Source(3, 48) + SourceIndex(4)
-17>Emitted(62, 44) Source(3, 9) + SourceIndex(4)
-18>Emitted(62, 45) Source(3, 10) + SourceIndex(4)
-19>Emitted(62, 52) Source(3, 10) + SourceIndex(4)
-20>Emitted(62, 54) Source(3, 15) + SourceIndex(4)
-21>Emitted(62, 58) Source(3, 19) + SourceIndex(4)
-22>Emitted(62, 72) Source(3, 7) + SourceIndex(4)
-23>Emitted(62, 77) Source(3, 21) + SourceIndex(4)
-24>Emitted(62, 78) Source(3, 48) + SourceIndex(4)
-25>Emitted(62, 79) Source(3, 49) + SourceIndex(4)
+1->Emitted(66, 9) Source(3, 1) + SourceIndex(4)
+2 >Emitted(66, 13) Source(3, 7) + SourceIndex(4)
+3 >Emitted(66, 18) Source(3, 24) + SourceIndex(4)
+4 >Emitted(66, 20) Source(3, 26) + SourceIndex(4)
+5 >Emitted(66, 21) Source(3, 27) + SourceIndex(4)
+6 >Emitted(66, 23) Source(3, 29) + SourceIndex(4)
+7 >Emitted(66, 25) Source(3, 31) + SourceIndex(4)
+8 >Emitted(66, 27) Source(3, 33) + SourceIndex(4)
+9 >Emitted(66, 28) Source(3, 34) + SourceIndex(4)
+10>Emitted(66, 30) Source(3, 36) + SourceIndex(4)
+11>Emitted(66, 32) Source(3, 38) + SourceIndex(4)
+12>Emitted(66, 34) Source(3, 40) + SourceIndex(4)
+13>Emitted(66, 36) Source(3, 42) + SourceIndex(4)
+14>Emitted(66, 38) Source(3, 44) + SourceIndex(4)
+15>Emitted(66, 40) Source(3, 46) + SourceIndex(4)
+16>Emitted(66, 42) Source(3, 48) + SourceIndex(4)
+17>Emitted(66, 44) Source(3, 9) + SourceIndex(4)
+18>Emitted(66, 45) Source(3, 10) + SourceIndex(4)
+19>Emitted(66, 52) Source(3, 10) + SourceIndex(4)
+20>Emitted(66, 54) Source(3, 15) + SourceIndex(4)
+21>Emitted(66, 58) Source(3, 19) + SourceIndex(4)
+22>Emitted(66, 72) Source(3, 7) + SourceIndex(4)
+23>Emitted(66, 77) Source(3, 21) + SourceIndex(4)
+24>Emitted(66, 78) Source(3, 48) + SourceIndex(4)
+25>Emitted(66, 79) Source(3, 49) + SourceIndex(4)
 ---
 >>>    }
 1 >^^^^
@@ -510,8 +518,8 @@ sourceFile:file3.ts
 1 >
   >
 2 >    }
-1 >Emitted(63, 5) Source(4, 1) + SourceIndex(4)
-2 >Emitted(63, 6) Source(4, 2) + SourceIndex(4)
+1 >Emitted(67, 5) Source(4, 1) + SourceIndex(4)
+2 >Emitted(67, 6) Source(4, 2) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -532,12 +540,12 @@ sourceFile:file4.ts
 4 >          = 
 5 >            30
 6 >              ;
-1 >Emitted(65, 1) Source(1, 1) + SourceIndex(5)
-2 >Emitted(65, 5) Source(1, 7) + SourceIndex(5)
-3 >Emitted(65, 10) Source(1, 12) + SourceIndex(5)
-4 >Emitted(65, 13) Source(1, 15) + SourceIndex(5)
-5 >Emitted(65, 15) Source(1, 17) + SourceIndex(5)
-6 >Emitted(65, 16) Source(1, 18) + SourceIndex(5)
+1 >Emitted(69, 1) Source(1, 1) + SourceIndex(5)
+2 >Emitted(69, 5) Source(1, 7) + SourceIndex(5)
+3 >Emitted(69, 10) Source(1, 12) + SourceIndex(5)
+4 >Emitted(69, 13) Source(1, 15) + SourceIndex(5)
+5 >Emitted(69, 15) Source(1, 17) + SourceIndex(5)
+6 >Emitted(69, 16) Source(1, 18) + SourceIndex(5)
 ---
 >>>function appfile4Spread() {
 1->
@@ -547,9 +555,9 @@ sourceFile:file4.ts
   >
 2 >function 
 3 >         appfile4Spread
-1->Emitted(66, 1) Source(2, 1) + SourceIndex(5)
-2 >Emitted(66, 10) Source(2, 10) + SourceIndex(5)
-3 >Emitted(66, 24) Source(2, 24) + SourceIndex(5)
+1->Emitted(70, 1) Source(2, 1) + SourceIndex(5)
+2 >Emitted(70, 10) Source(2, 10) + SourceIndex(5)
+3 >Emitted(70, 24) Source(2, 24) + SourceIndex(5)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -557,8 +565,8 @@ sourceFile:file4.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(67, 5) Source(2, 25) + SourceIndex(5)
-2 >Emitted(67, 16) Source(2, 39) + SourceIndex(5)
+1 >Emitted(71, 5) Source(2, 25) + SourceIndex(5)
+2 >Emitted(71, 16) Source(2, 39) + SourceIndex(5)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -573,20 +581,20 @@ sourceFile:file4.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(68, 10) Source(2, 25) + SourceIndex(5)
-2 >Emitted(68, 20) Source(2, 39) + SourceIndex(5)
-3 >Emitted(68, 22) Source(2, 25) + SourceIndex(5)
-4 >Emitted(68, 43) Source(2, 39) + SourceIndex(5)
-5 >Emitted(68, 45) Source(2, 25) + SourceIndex(5)
-6 >Emitted(68, 49) Source(2, 39) + SourceIndex(5)
+1->Emitted(72, 10) Source(2, 25) + SourceIndex(5)
+2 >Emitted(72, 20) Source(2, 39) + SourceIndex(5)
+3 >Emitted(72, 22) Source(2, 25) + SourceIndex(5)
+4 >Emitted(72, 43) Source(2, 39) + SourceIndex(5)
+5 >Emitted(72, 45) Source(2, 25) + SourceIndex(5)
+6 >Emitted(72, 49) Source(2, 39) + SourceIndex(5)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(69, 9) Source(2, 25) + SourceIndex(5)
-2 >Emitted(69, 31) Source(2, 39) + SourceIndex(5)
+1 >Emitted(73, 9) Source(2, 25) + SourceIndex(5)
+2 >Emitted(73, 31) Source(2, 39) + SourceIndex(5)
 ---
 >>>    }
 >>>}
@@ -595,8 +603,8 @@ sourceFile:file4.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(71, 1) Source(2, 43) + SourceIndex(5)
-2 >Emitted(71, 2) Source(2, 44) + SourceIndex(5)
+1 >Emitted(75, 1) Source(2, 43) + SourceIndex(5)
+2 >Emitted(75, 2) Source(2, 44) + SourceIndex(5)
 ---
 >>>var appfile4_ar = [20, 30];
 1->
@@ -621,16 +629,16 @@ sourceFile:file4.ts
 8 >                       30
 9 >                         ]
 10>                          ;
-1->Emitted(72, 1) Source(3, 1) + SourceIndex(5)
-2 >Emitted(72, 5) Source(3, 7) + SourceIndex(5)
-3 >Emitted(72, 16) Source(3, 18) + SourceIndex(5)
-4 >Emitted(72, 19) Source(3, 21) + SourceIndex(5)
-5 >Emitted(72, 20) Source(3, 22) + SourceIndex(5)
-6 >Emitted(72, 22) Source(3, 24) + SourceIndex(5)
-7 >Emitted(72, 24) Source(3, 26) + SourceIndex(5)
-8 >Emitted(72, 26) Source(3, 28) + SourceIndex(5)
-9 >Emitted(72, 27) Source(3, 29) + SourceIndex(5)
-10>Emitted(72, 28) Source(3, 30) + SourceIndex(5)
+1->Emitted(76, 1) Source(3, 1) + SourceIndex(5)
+2 >Emitted(76, 5) Source(3, 7) + SourceIndex(5)
+3 >Emitted(76, 16) Source(3, 18) + SourceIndex(5)
+4 >Emitted(76, 19) Source(3, 21) + SourceIndex(5)
+5 >Emitted(76, 20) Source(3, 22) + SourceIndex(5)
+6 >Emitted(76, 22) Source(3, 24) + SourceIndex(5)
+7 >Emitted(76, 24) Source(3, 26) + SourceIndex(5)
+8 >Emitted(76, 26) Source(3, 28) + SourceIndex(5)
+9 >Emitted(76, 27) Source(3, 29) + SourceIndex(5)
+10>Emitted(76, 28) Source(3, 30) + SourceIndex(5)
 ---
 >>>appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
 1->
@@ -648,18 +656,18 @@ sourceFile:file4.ts
 5 >                                              , ...
 6 >                                                        appfile4_ar
 7 >                                                                   );
-1->Emitted(73, 1) Source(4, 1) + SourceIndex(5)
-2 >Emitted(73, 15) Source(4, 15) + SourceIndex(5)
-3 >Emitted(73, 45) Source(4, 16) + SourceIndex(5)
-4 >Emitted(73, 47) Source(4, 18) + SourceIndex(5)
-5 >Emitted(73, 57) Source(4, 23) + SourceIndex(5)
-6 >Emitted(73, 68) Source(4, 34) + SourceIndex(5)
-7 >Emitted(73, 72) Source(4, 36) + SourceIndex(5)
+1->Emitted(77, 1) Source(4, 1) + SourceIndex(5)
+2 >Emitted(77, 15) Source(4, 15) + SourceIndex(5)
+3 >Emitted(77, 45) Source(4, 16) + SourceIndex(5)
+4 >Emitted(77, 47) Source(4, 18) + SourceIndex(5)
+5 >Emitted(77, 57) Source(4, 23) + SourceIndex(5)
+6 >Emitted(77, 68) Source(4, 34) + SourceIndex(5)
+7 >Emitted(77, 72) Source(4, 36) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/app/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":697,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":699,"end":1199,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1201,"end":1939,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1201,"end":1939,"kind":"text"}]},{"pos":1939,"end":2529,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":2082,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1344,"end":2082,"kind":"text"}]},{"pos":2082,"end":2672,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/app/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -683,14 +691,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-697):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (506-840):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (699-1199):: typescript:rest
+emitHelpers: (842-1342):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -703,9 +715,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1201-1939):: ../lib/module.js texts:: 1
+prepend: (1344-2082):: ../lib/module.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1201-1939)
+text: (1344-2082)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -731,7 +743,7 @@ define("file2", ["require", "exports"], function (require, exports) {
 var globalConst = 10;
 
 ----------------------------------------------------------------------
-text: (1939-2529)
+text: (2082-2672)
 define("file3", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -798,32 +810,32 @@ declare const appfile4_ar: number[];
         },
         {
           "pos": 506,
-          "end": 697,
+          "end": 840,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 699,
-          "end": 1199,
+          "pos": 842,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1201,
-          "end": 1939,
+          "pos": 1344,
+          "end": 2082,
           "kind": "prepend",
           "data": "../lib/module.js",
           "texts": [
             {
-              "pos": 1201,
-              "end": 1939,
+              "pos": 1344,
+              "end": 2082,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1939,
-          "end": 2529,
+          "pos": 2082,
+          "end": 2672,
           "kind": "text"
         }
       ],
@@ -882,10 +894,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var myGlob = 20;
 function libfile0Spread() {
@@ -913,7 +929,7 @@ var globalConst = 10;
 //# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe,KAAK,CAAC;;;;;;ICArC,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe,KAAK,CAAC;;;;;;ICArC,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
 
 //// [/src/lib/module.js.map.baseline.txt]
 ===================================================================
@@ -942,10 +958,14 @@ sourceFile:file0.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var myGlob = 20;
 1 >
@@ -961,12 +981,12 @@ sourceFile:file0.ts
 4 >           = 
 5 >             20
 6 >               ;
-1 >Emitted(22, 1) Source(1, 1) + SourceIndex(0)
-2 >Emitted(22, 5) Source(1, 7) + SourceIndex(0)
-3 >Emitted(22, 11) Source(1, 13) + SourceIndex(0)
-4 >Emitted(22, 14) Source(1, 16) + SourceIndex(0)
-5 >Emitted(22, 16) Source(1, 18) + SourceIndex(0)
-6 >Emitted(22, 17) Source(1, 19) + SourceIndex(0)
+1 >Emitted(26, 1) Source(1, 1) + SourceIndex(0)
+2 >Emitted(26, 5) Source(1, 7) + SourceIndex(0)
+3 >Emitted(26, 11) Source(1, 13) + SourceIndex(0)
+4 >Emitted(26, 14) Source(1, 16) + SourceIndex(0)
+5 >Emitted(26, 16) Source(1, 18) + SourceIndex(0)
+6 >Emitted(26, 17) Source(1, 19) + SourceIndex(0)
 ---
 >>>function libfile0Spread() {
 1->
@@ -976,9 +996,9 @@ sourceFile:file0.ts
   >
 2 >function 
 3 >         libfile0Spread
-1->Emitted(23, 1) Source(2, 1) + SourceIndex(0)
-2 >Emitted(23, 10) Source(2, 10) + SourceIndex(0)
-3 >Emitted(23, 24) Source(2, 24) + SourceIndex(0)
+1->Emitted(27, 1) Source(2, 1) + SourceIndex(0)
+2 >Emitted(27, 10) Source(2, 10) + SourceIndex(0)
+3 >Emitted(27, 24) Source(2, 24) + SourceIndex(0)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -986,8 +1006,8 @@ sourceFile:file0.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(24, 5) Source(2, 25) + SourceIndex(0)
-2 >Emitted(24, 16) Source(2, 39) + SourceIndex(0)
+1 >Emitted(28, 5) Source(2, 25) + SourceIndex(0)
+2 >Emitted(28, 16) Source(2, 39) + SourceIndex(0)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1002,20 +1022,20 @@ sourceFile:file0.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(25, 10) Source(2, 25) + SourceIndex(0)
-2 >Emitted(25, 20) Source(2, 39) + SourceIndex(0)
-3 >Emitted(25, 22) Source(2, 25) + SourceIndex(0)
-4 >Emitted(25, 43) Source(2, 39) + SourceIndex(0)
-5 >Emitted(25, 45) Source(2, 25) + SourceIndex(0)
-6 >Emitted(25, 49) Source(2, 39) + SourceIndex(0)
+1->Emitted(29, 10) Source(2, 25) + SourceIndex(0)
+2 >Emitted(29, 20) Source(2, 39) + SourceIndex(0)
+3 >Emitted(29, 22) Source(2, 25) + SourceIndex(0)
+4 >Emitted(29, 43) Source(2, 39) + SourceIndex(0)
+5 >Emitted(29, 45) Source(2, 25) + SourceIndex(0)
+6 >Emitted(29, 49) Source(2, 39) + SourceIndex(0)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(26, 9) Source(2, 25) + SourceIndex(0)
-2 >Emitted(26, 31) Source(2, 39) + SourceIndex(0)
+1 >Emitted(30, 9) Source(2, 25) + SourceIndex(0)
+2 >Emitted(30, 31) Source(2, 39) + SourceIndex(0)
 ---
 >>>    }
 >>>}
@@ -1024,8 +1044,8 @@ sourceFile:file0.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(28, 1) Source(2, 43) + SourceIndex(0)
-2 >Emitted(28, 2) Source(2, 44) + SourceIndex(0)
+1 >Emitted(32, 1) Source(2, 43) + SourceIndex(0)
+2 >Emitted(32, 2) Source(2, 44) + SourceIndex(0)
 ---
 >>>var libfile0_ar = [20, 30];
 1->
@@ -1050,16 +1070,16 @@ sourceFile:file0.ts
 8 >                       30
 9 >                         ]
 10>                          ;
-1->Emitted(29, 1) Source(3, 1) + SourceIndex(0)
-2 >Emitted(29, 5) Source(3, 7) + SourceIndex(0)
-3 >Emitted(29, 16) Source(3, 18) + SourceIndex(0)
-4 >Emitted(29, 19) Source(3, 21) + SourceIndex(0)
-5 >Emitted(29, 20) Source(3, 22) + SourceIndex(0)
-6 >Emitted(29, 22) Source(3, 24) + SourceIndex(0)
-7 >Emitted(29, 24) Source(3, 26) + SourceIndex(0)
-8 >Emitted(29, 26) Source(3, 28) + SourceIndex(0)
-9 >Emitted(29, 27) Source(3, 29) + SourceIndex(0)
-10>Emitted(29, 28) Source(3, 30) + SourceIndex(0)
+1->Emitted(33, 1) Source(3, 1) + SourceIndex(0)
+2 >Emitted(33, 5) Source(3, 7) + SourceIndex(0)
+3 >Emitted(33, 16) Source(3, 18) + SourceIndex(0)
+4 >Emitted(33, 19) Source(3, 21) + SourceIndex(0)
+5 >Emitted(33, 20) Source(3, 22) + SourceIndex(0)
+6 >Emitted(33, 22) Source(3, 24) + SourceIndex(0)
+7 >Emitted(33, 24) Source(3, 26) + SourceIndex(0)
+8 >Emitted(33, 26) Source(3, 28) + SourceIndex(0)
+9 >Emitted(33, 27) Source(3, 29) + SourceIndex(0)
+10>Emitted(33, 28) Source(3, 30) + SourceIndex(0)
 ---
 >>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
 1->
@@ -1077,13 +1097,13 @@ sourceFile:file0.ts
 5 >                                              , ...
 6 >                                                        libfile0_ar
 7 >                                                                   );
-1->Emitted(30, 1) Source(4, 1) + SourceIndex(0)
-2 >Emitted(30, 15) Source(4, 15) + SourceIndex(0)
-3 >Emitted(30, 45) Source(4, 16) + SourceIndex(0)
-4 >Emitted(30, 47) Source(4, 18) + SourceIndex(0)
-5 >Emitted(30, 57) Source(4, 23) + SourceIndex(0)
-6 >Emitted(30, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(30, 72) Source(4, 36) + SourceIndex(0)
+1->Emitted(34, 1) Source(4, 1) + SourceIndex(0)
+2 >Emitted(34, 15) Source(4, 15) + SourceIndex(0)
+3 >Emitted(34, 45) Source(4, 16) + SourceIndex(0)
+4 >Emitted(34, 47) Source(4, 18) + SourceIndex(0)
+5 >Emitted(34, 57) Source(4, 23) + SourceIndex(0)
+6 >Emitted(34, 68) Source(4, 34) + SourceIndex(0)
+7 >Emitted(34, 72) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1107,12 +1127,12 @@ sourceFile:file1.ts
 4 >              = 
 5 >                10
 6 >                  ;
-1 >Emitted(35, 5) Source(1, 14) + SourceIndex(1)
-2 >Emitted(35, 13) Source(1, 14) + SourceIndex(1)
-3 >Emitted(35, 14) Source(1, 15) + SourceIndex(1)
-4 >Emitted(35, 17) Source(1, 18) + SourceIndex(1)
-5 >Emitted(35, 19) Source(1, 20) + SourceIndex(1)
-6 >Emitted(35, 20) Source(1, 21) + SourceIndex(1)
+1 >Emitted(39, 5) Source(1, 14) + SourceIndex(1)
+2 >Emitted(39, 13) Source(1, 14) + SourceIndex(1)
+3 >Emitted(39, 14) Source(1, 15) + SourceIndex(1)
+4 >Emitted(39, 17) Source(1, 18) + SourceIndex(1)
+5 >Emitted(39, 19) Source(1, 20) + SourceIndex(1)
+6 >Emitted(39, 20) Source(1, 21) + SourceIndex(1)
 ---
 >>>    function forlibfile1Rest() { }
 1->^^^^
@@ -1125,11 +1145,11 @@ sourceFile:file1.ts
 3 >             forlibfile1Rest
 4 >                            () { 
 5 >                                 }
-1->Emitted(36, 5) Source(1, 21) + SourceIndex(1)
-2 >Emitted(36, 14) Source(1, 30) + SourceIndex(1)
-3 >Emitted(36, 29) Source(1, 45) + SourceIndex(1)
-4 >Emitted(36, 34) Source(1, 50) + SourceIndex(1)
-5 >Emitted(36, 35) Source(1, 51) + SourceIndex(1)
+1->Emitted(40, 5) Source(1, 21) + SourceIndex(1)
+2 >Emitted(40, 14) Source(1, 30) + SourceIndex(1)
+3 >Emitted(40, 29) Source(1, 45) + SourceIndex(1)
+4 >Emitted(40, 34) Source(1, 50) + SourceIndex(1)
+5 >Emitted(40, 35) Source(1, 51) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1153,12 +1173,12 @@ sourceFile:file2.ts
 4 >              = 
 5 >                20
 6 >                  ;
-1 >Emitted(42, 5) Source(1, 14) + SourceIndex(2)
-2 >Emitted(42, 13) Source(1, 14) + SourceIndex(2)
-3 >Emitted(42, 14) Source(1, 15) + SourceIndex(2)
-4 >Emitted(42, 17) Source(1, 18) + SourceIndex(2)
-5 >Emitted(42, 19) Source(1, 20) + SourceIndex(2)
-6 >Emitted(42, 20) Source(1, 21) + SourceIndex(2)
+1 >Emitted(46, 5) Source(1, 14) + SourceIndex(2)
+2 >Emitted(46, 13) Source(1, 14) + SourceIndex(2)
+3 >Emitted(46, 14) Source(1, 15) + SourceIndex(2)
+4 >Emitted(46, 17) Source(1, 18) + SourceIndex(2)
+5 >Emitted(46, 19) Source(1, 20) + SourceIndex(2)
+6 >Emitted(46, 20) Source(1, 21) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1179,17 +1199,17 @@ sourceFile:global.ts
 4 >                = 
 5 >                  10
 6 >                    ;
-1 >Emitted(44, 1) Source(1, 1) + SourceIndex(3)
-2 >Emitted(44, 5) Source(1, 7) + SourceIndex(3)
-3 >Emitted(44, 16) Source(1, 18) + SourceIndex(3)
-4 >Emitted(44, 19) Source(1, 21) + SourceIndex(3)
-5 >Emitted(44, 21) Source(1, 23) + SourceIndex(3)
-6 >Emitted(44, 22) Source(1, 24) + SourceIndex(3)
+1 >Emitted(48, 1) Source(1, 1) + SourceIndex(3)
+2 >Emitted(48, 5) Source(1, 7) + SourceIndex(3)
+3 >Emitted(48, 16) Source(1, 18) + SourceIndex(3)
+4 >Emitted(48, 19) Source(1, 21) + SourceIndex(3)
+5 >Emitted(48, 21) Source(1, 23) + SourceIndex(3)
+6 >Emitted(48, 22) Source(1, 24) + SourceIndex(3)
 ---
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":697,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":699,"end":1437,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1580,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/lib/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1213,14 +1233,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-697):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (506-840):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (699-1437)
+text: (842-1580)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -1283,13 +1307,13 @@ declare const globalConst = 10;
         },
         {
           "pos": 506,
-          "end": 697,
+          "end": 840,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 699,
-          "end": 1437,
+          "pos": 842,
+          "end": 1580,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
@@ -41,7 +41,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -68,7 +68,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -100,11 +100,11 @@ function appfile4Spread() {
     }
 }
 var appfile4_ar = [20, 30];
-appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
+appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar), false));
 //# sourceMappingURL=module.js.map
 
 //// [/src/app/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe,KAAK,CAAC;;;;;;ICArC,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,WAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe,KAAK,CAAC;;;;;;ICArC,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,WAAE"}
 
 //// [/src/app/module.js.map.baseline.txt]
 ===================================================================
@@ -134,7 +134,7 @@ sourceFile:../lib/file0.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -244,7 +244,7 @@ sourceFile:../lib/file0.ts
 8 >                       ^^
 9 >                         ^
 10>                          ^
-11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -267,14 +267,14 @@ sourceFile:../lib/file0.ts
 9 >Emitted(44, 27) Source(3, 29) + SourceIndex(0)
 10>Emitted(44, 28) Source(3, 30) + SourceIndex(0)
 ---
->>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+>>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 1->
 2 >^^^^^^^^^^^^^^
 3 >              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                            ^^
 5 >                                              ^^^^^^^^^^
 6 >                                                        ^^^^^^^^^^^
-7 >                                                                   ^^^^
+7 >                                                                   ^^^^^^^^^^^
 1->
   >
 2 >libfile0Spread
@@ -289,7 +289,7 @@ sourceFile:../lib/file0.ts
 4 >Emitted(45, 47) Source(4, 18) + SourceIndex(0)
 5 >Emitted(45, 57) Source(4, 23) + SourceIndex(0)
 6 >Emitted(45, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(45, 72) Source(4, 36) + SourceIndex(0)
+7 >Emitted(45, 79) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -617,7 +617,7 @@ sourceFile:file4.ts
 8 >                       ^^
 9 >                         ^
 10>                          ^
-11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -640,14 +640,14 @@ sourceFile:file4.ts
 9 >Emitted(76, 27) Source(3, 29) + SourceIndex(5)
 10>Emitted(76, 28) Source(3, 30) + SourceIndex(5)
 ---
->>>appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
+>>>appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar), false));
 1->
 2 >^^^^^^^^^^^^^^
 3 >              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                            ^^
 5 >                                              ^^^^^^^^^^
 6 >                                                        ^^^^^^^^^^^
-7 >                                                                   ^^^^
+7 >                                                                   ^^^^^^^^^^^
 1->
   >
 2 >appfile4Spread
@@ -662,12 +662,12 @@ sourceFile:file4.ts
 4 >Emitted(77, 47) Source(4, 18) + SourceIndex(5)
 5 >Emitted(77, 57) Source(4, 23) + SourceIndex(5)
 6 >Emitted(77, 68) Source(4, 34) + SourceIndex(5)
-7 >Emitted(77, 72) Source(4, 36) + SourceIndex(5)
+7 >Emitted(77, 79) Source(4, 36) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/app/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":2082,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1344,"end":2082,"kind":"text"}]},{"pos":2082,"end":2672,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":2115,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1370,"end":2115,"kind":"text"}]},{"pos":2115,"end":2712,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/app/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -691,9 +691,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-840):: typescript:spreadArray
+emitHelpers: (506-866):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -702,7 +702,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (842-1342):: typescript:rest
+emitHelpers: (868-1368):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -715,9 +715,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1344-2082):: ../lib/module.js texts:: 1
+prepend: (1370-2115):: ../lib/module.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1344-2082)
+text: (1370-2115)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -726,7 +726,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -743,7 +743,7 @@ define("file2", ["require", "exports"], function (require, exports) {
 var globalConst = 10;
 
 ----------------------------------------------------------------------
-text: (2082-2672)
+text: (2115-2712)
 define("file3", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -761,7 +761,7 @@ function appfile4Spread() {
     }
 }
 var appfile4_ar = [20, 30];
-appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
+appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar), false));
 
 ======================================================================
 ======================================================================
@@ -810,32 +810,32 @@ declare const appfile4_ar: number[];
         },
         {
           "pos": 506,
-          "end": 840,
+          "end": 866,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 842,
-          "end": 1342,
+          "pos": 868,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1344,
-          "end": 2082,
+          "pos": 1370,
+          "end": 2115,
           "kind": "prepend",
           "data": "../lib/module.js",
           "texts": [
             {
-              "pos": 1344,
-              "end": 2082,
+              "pos": 1370,
+              "end": 2115,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2082,
-          "end": 2672,
+          "pos": 2115,
+          "end": 2712,
           "kind": "text"
         }
       ],
@@ -895,7 +895,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -911,7 +911,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -929,7 +929,7 @@ var globalConst = 10;
 //# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe,KAAK,CAAC;;;;;;ICArC,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,WAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe,KAAK,CAAC;;;;;;ICArC,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
 
 //// [/src/lib/module.js.map.baseline.txt]
 ===================================================================
@@ -959,7 +959,7 @@ sourceFile:file0.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -1058,7 +1058,7 @@ sourceFile:file0.ts
 8 >                       ^^
 9 >                         ^
 10>                          ^
-11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1081,14 +1081,14 @@ sourceFile:file0.ts
 9 >Emitted(33, 27) Source(3, 29) + SourceIndex(0)
 10>Emitted(33, 28) Source(3, 30) + SourceIndex(0)
 ---
->>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+>>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 1->
 2 >^^^^^^^^^^^^^^
 3 >              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                            ^^
 5 >                                              ^^^^^^^^^^
 6 >                                                        ^^^^^^^^^^^
-7 >                                                                   ^^^^
+7 >                                                                   ^^^^^^^^^^^
 1->
   >
 2 >libfile0Spread
@@ -1103,7 +1103,7 @@ sourceFile:file0.ts
 4 >Emitted(34, 47) Source(4, 18) + SourceIndex(0)
 5 >Emitted(34, 57) Source(4, 23) + SourceIndex(0)
 6 >Emitted(34, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(34, 72) Source(4, 36) + SourceIndex(0)
+7 >Emitted(34, 79) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1209,7 +1209,7 @@ sourceFile:global.ts
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1580,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1613,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/lib/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1233,9 +1233,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-840):: typescript:spreadArray
+emitHelpers: (506-866):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1244,7 +1244,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (842-1580)
+text: (868-1613)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -1253,7 +1253,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -1307,13 +1307,13 @@ declare const globalConst = 10;
         },
         {
           "pos": 506,
-          "end": 840,
+          "end": 866,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 842,
-          "end": 1580,
+          "pos": 868,
+          "end": 1613,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/initial-build/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/initial-build/multiple-emitHelpers-in-all-projects.js
@@ -408,7 +408,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -435,7 +435,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -469,11 +469,11 @@ function appfile4Spread() {
     }
 }
 var appfile4_ar = [20, 30];
-appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
+appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar), false));
 //# sourceMappingURL=module.js.map
 
 //// [/src/app/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;;;;;ICFY,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,WAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;;;;;ICFY,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,WAAE"}
 
 //// [/src/app/module.js.map.baseline.txt]
 ===================================================================
@@ -503,7 +503,7 @@ sourceFile:../lib/file0.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -613,7 +613,7 @@ sourceFile:../lib/file0.ts
 8 >                       ^^
 9 >                         ^
 10>                          ^
-11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -636,14 +636,14 @@ sourceFile:../lib/file0.ts
 9 >Emitted(44, 27) Source(3, 29) + SourceIndex(0)
 10>Emitted(44, 28) Source(3, 30) + SourceIndex(0)
 ---
->>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+>>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 1->
 2 >^^^^^^^^^^^^^^
 3 >              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                            ^^
 5 >                                              ^^^^^^^^^^
 6 >                                                        ^^^^^^^^^^^
-7 >                                                                   ^^^^
+7 >                                                                   ^^^^^^^^^^^
 1->
   >
 2 >libfile0Spread
@@ -658,7 +658,7 @@ sourceFile:../lib/file0.ts
 4 >Emitted(45, 47) Source(4, 18) + SourceIndex(0)
 5 >Emitted(45, 57) Source(4, 23) + SourceIndex(0)
 6 >Emitted(45, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(45, 72) Source(4, 36) + SourceIndex(0)
+7 >Emitted(45, 79) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -1068,7 +1068,7 @@ sourceFile:file4.ts
 8 >                       ^^
 9 >                         ^
 10>                          ^
-11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1091,14 +1091,14 @@ sourceFile:file4.ts
 9 >Emitted(78, 27) Source(3, 29) + SourceIndex(5)
 10>Emitted(78, 28) Source(3, 30) + SourceIndex(5)
 ---
->>>appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
+>>>appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar), false));
 1->
 2 >^^^^^^^^^^^^^^
 3 >              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                            ^^
 5 >                                              ^^^^^^^^^^
 6 >                                                        ^^^^^^^^^^^
-7 >                                                                   ^^^^
+7 >                                                                   ^^^^^^^^^^^
 1->
   >
 2 >appfile4Spread
@@ -1113,12 +1113,12 @@ sourceFile:file4.ts
 4 >Emitted(79, 47) Source(4, 18) + SourceIndex(5)
 5 >Emitted(79, 57) Source(4, 23) + SourceIndex(5)
 6 >Emitted(79, 68) Source(4, 34) + SourceIndex(5)
-7 >Emitted(79, 72) Source(4, 36) + SourceIndex(5)
+7 >Emitted(79, 79) Source(4, 36) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/app/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":2167,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1344,"end":2167,"kind":"text"}]},{"pos":2167,"end":2757,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":2200,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1370,"end":2200,"kind":"text"}]},{"pos":2200,"end":2797,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/app/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1142,9 +1142,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-840):: typescript:spreadArray
+emitHelpers: (506-866):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1153,7 +1153,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (842-1342):: typescript:rest
+emitHelpers: (868-1368):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1166,9 +1166,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1344-2167):: ../lib/module.js texts:: 1
+prepend: (1370-2200):: ../lib/module.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1344-2167)
+text: (1370-2200)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -1177,7 +1177,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -1196,7 +1196,7 @@ define("file2", ["require", "exports"], function (require, exports) {
 var globalConst = 10;
 
 ----------------------------------------------------------------------
-text: (2167-2757)
+text: (2200-2797)
 define("file3", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -1214,7 +1214,7 @@ function appfile4Spread() {
     }
 }
 var appfile4_ar = [20, 30];
-appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
+appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar), false));
 
 ======================================================================
 ======================================================================
@@ -1263,32 +1263,32 @@ declare const appfile4_ar: number[];
         },
         {
           "pos": 506,
-          "end": 840,
+          "end": 866,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 842,
-          "end": 1342,
+          "pos": 868,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1344,
-          "end": 2167,
+          "pos": 1370,
+          "end": 2200,
           "kind": "prepend",
           "data": "../lib/module.js",
           "texts": [
             {
-              "pos": 1344,
-              "end": 2167,
+              "pos": 1370,
+              "end": 2200,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2167,
-          "end": 2757,
+          "pos": 2200,
+          "end": 2797,
           "kind": "text"
         }
       ],
@@ -1529,7 +1529,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1556,7 +1556,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -1576,7 +1576,7 @@ var globalConst = 10;
 //# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;;;;;ICFY,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,WAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;;;;;ICFY,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
 
 //// [/src/lib/module.js.map.baseline.txt]
 ===================================================================
@@ -1606,7 +1606,7 @@ sourceFile:file0.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -1716,7 +1716,7 @@ sourceFile:file0.ts
 8 >                       ^^
 9 >                         ^
 10>                          ^
-11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1739,14 +1739,14 @@ sourceFile:file0.ts
 9 >Emitted(44, 27) Source(3, 29) + SourceIndex(0)
 10>Emitted(44, 28) Source(3, 30) + SourceIndex(0)
 ---
->>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+>>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 1->
 2 >^^^^^^^^^^^^^^
 3 >              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                            ^^
 5 >                                              ^^^^^^^^^^
 6 >                                                        ^^^^^^^^^^^
-7 >                                                                   ^^^^
+7 >                                                                   ^^^^^^^^^^^
 1->
   >
 2 >libfile0Spread
@@ -1761,7 +1761,7 @@ sourceFile:file0.ts
 4 >Emitted(45, 47) Source(4, 18) + SourceIndex(0)
 5 >Emitted(45, 57) Source(4, 23) + SourceIndex(0)
 6 >Emitted(45, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(45, 72) Source(4, 36) + SourceIndex(0)
+7 >Emitted(45, 79) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1949,7 +1949,7 @@ sourceFile:global.ts
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":2167,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":2200,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/lib/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1973,9 +1973,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-840):: typescript:spreadArray
+emitHelpers: (506-866):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1984,7 +1984,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (842-1342):: typescript:rest
+emitHelpers: (868-1368):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1997,7 +1997,7 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-text: (1344-2167)
+text: (1370-2200)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -2006,7 +2006,7 @@ function libfile0Spread() {
     }
 }
 var libfile0_ar = [20, 30];
-libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
+libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar), false));
 define("file1", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -2062,19 +2062,19 @@ declare const globalConst = 10;
         },
         {
           "pos": 506,
-          "end": 840,
+          "end": 866,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 842,
-          "end": 1342,
+          "pos": 868,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1344,
-          "end": 2167,
+          "pos": 1370,
+          "end": 2200,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/initial-build/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/initial-build/multiple-emitHelpers-in-all-projects.js
@@ -407,10 +407,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -469,7 +473,7 @@ appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
 //# sourceMappingURL=module.js.map
 
 //// [/src/app/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;;;;;ICFY,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["../lib/file0.ts","../lib/file1.ts","../lib/file2.ts","../lib/global.ts","file3.ts","file4.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;;;;;ICFY,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC;;;;;ICAV,QAAA,CAAC,GAAG,EAAE,CAAC;IACM,SAAS,eAAe;QAClD,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;ACHD,IAAM,KAAK,GAAG,EAAE,CAAC;AACjB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE"}
 
 //// [/src/app/module.js.map.baseline.txt]
 ===================================================================
@@ -498,10 +502,14 @@ sourceFile:../lib/file0.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -528,12 +536,12 @@ sourceFile:../lib/file0.ts
 4 >           = 
 5 >             20
 6 >               ;
-1 >Emitted(33, 1) Source(1, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(1, 7) + SourceIndex(0)
-3 >Emitted(33, 11) Source(1, 13) + SourceIndex(0)
-4 >Emitted(33, 14) Source(1, 16) + SourceIndex(0)
-5 >Emitted(33, 16) Source(1, 18) + SourceIndex(0)
-6 >Emitted(33, 17) Source(1, 19) + SourceIndex(0)
+1 >Emitted(37, 1) Source(1, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(1, 7) + SourceIndex(0)
+3 >Emitted(37, 11) Source(1, 13) + SourceIndex(0)
+4 >Emitted(37, 14) Source(1, 16) + SourceIndex(0)
+5 >Emitted(37, 16) Source(1, 18) + SourceIndex(0)
+6 >Emitted(37, 17) Source(1, 19) + SourceIndex(0)
 ---
 >>>function libfile0Spread() {
 1->
@@ -543,9 +551,9 @@ sourceFile:../lib/file0.ts
   >
 2 >function 
 3 >         libfile0Spread
-1->Emitted(34, 1) Source(2, 1) + SourceIndex(0)
-2 >Emitted(34, 10) Source(2, 10) + SourceIndex(0)
-3 >Emitted(34, 24) Source(2, 24) + SourceIndex(0)
+1->Emitted(38, 1) Source(2, 1) + SourceIndex(0)
+2 >Emitted(38, 10) Source(2, 10) + SourceIndex(0)
+3 >Emitted(38, 24) Source(2, 24) + SourceIndex(0)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -553,8 +561,8 @@ sourceFile:../lib/file0.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(35, 5) Source(2, 25) + SourceIndex(0)
-2 >Emitted(35, 16) Source(2, 39) + SourceIndex(0)
+1 >Emitted(39, 5) Source(2, 25) + SourceIndex(0)
+2 >Emitted(39, 16) Source(2, 39) + SourceIndex(0)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -569,20 +577,20 @@ sourceFile:../lib/file0.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(36, 10) Source(2, 25) + SourceIndex(0)
-2 >Emitted(36, 20) Source(2, 39) + SourceIndex(0)
-3 >Emitted(36, 22) Source(2, 25) + SourceIndex(0)
-4 >Emitted(36, 43) Source(2, 39) + SourceIndex(0)
-5 >Emitted(36, 45) Source(2, 25) + SourceIndex(0)
-6 >Emitted(36, 49) Source(2, 39) + SourceIndex(0)
+1->Emitted(40, 10) Source(2, 25) + SourceIndex(0)
+2 >Emitted(40, 20) Source(2, 39) + SourceIndex(0)
+3 >Emitted(40, 22) Source(2, 25) + SourceIndex(0)
+4 >Emitted(40, 43) Source(2, 39) + SourceIndex(0)
+5 >Emitted(40, 45) Source(2, 25) + SourceIndex(0)
+6 >Emitted(40, 49) Source(2, 39) + SourceIndex(0)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(37, 9) Source(2, 25) + SourceIndex(0)
-2 >Emitted(37, 31) Source(2, 39) + SourceIndex(0)
+1 >Emitted(41, 9) Source(2, 25) + SourceIndex(0)
+2 >Emitted(41, 31) Source(2, 39) + SourceIndex(0)
 ---
 >>>    }
 >>>}
@@ -591,8 +599,8 @@ sourceFile:../lib/file0.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(39, 1) Source(2, 43) + SourceIndex(0)
-2 >Emitted(39, 2) Source(2, 44) + SourceIndex(0)
+1 >Emitted(43, 1) Source(2, 43) + SourceIndex(0)
+2 >Emitted(43, 2) Source(2, 44) + SourceIndex(0)
 ---
 >>>var libfile0_ar = [20, 30];
 1->
@@ -617,16 +625,16 @@ sourceFile:../lib/file0.ts
 8 >                       30
 9 >                         ]
 10>                          ;
-1->Emitted(40, 1) Source(3, 1) + SourceIndex(0)
-2 >Emitted(40, 5) Source(3, 7) + SourceIndex(0)
-3 >Emitted(40, 16) Source(3, 18) + SourceIndex(0)
-4 >Emitted(40, 19) Source(3, 21) + SourceIndex(0)
-5 >Emitted(40, 20) Source(3, 22) + SourceIndex(0)
-6 >Emitted(40, 22) Source(3, 24) + SourceIndex(0)
-7 >Emitted(40, 24) Source(3, 26) + SourceIndex(0)
-8 >Emitted(40, 26) Source(3, 28) + SourceIndex(0)
-9 >Emitted(40, 27) Source(3, 29) + SourceIndex(0)
-10>Emitted(40, 28) Source(3, 30) + SourceIndex(0)
+1->Emitted(44, 1) Source(3, 1) + SourceIndex(0)
+2 >Emitted(44, 5) Source(3, 7) + SourceIndex(0)
+3 >Emitted(44, 16) Source(3, 18) + SourceIndex(0)
+4 >Emitted(44, 19) Source(3, 21) + SourceIndex(0)
+5 >Emitted(44, 20) Source(3, 22) + SourceIndex(0)
+6 >Emitted(44, 22) Source(3, 24) + SourceIndex(0)
+7 >Emitted(44, 24) Source(3, 26) + SourceIndex(0)
+8 >Emitted(44, 26) Source(3, 28) + SourceIndex(0)
+9 >Emitted(44, 27) Source(3, 29) + SourceIndex(0)
+10>Emitted(44, 28) Source(3, 30) + SourceIndex(0)
 ---
 >>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
 1->
@@ -644,13 +652,13 @@ sourceFile:../lib/file0.ts
 5 >                                              , ...
 6 >                                                        libfile0_ar
 7 >                                                                   );
-1->Emitted(41, 1) Source(4, 1) + SourceIndex(0)
-2 >Emitted(41, 15) Source(4, 15) + SourceIndex(0)
-3 >Emitted(41, 45) Source(4, 16) + SourceIndex(0)
-4 >Emitted(41, 47) Source(4, 18) + SourceIndex(0)
-5 >Emitted(41, 57) Source(4, 23) + SourceIndex(0)
-6 >Emitted(41, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(41, 72) Source(4, 36) + SourceIndex(0)
+1->Emitted(45, 1) Source(4, 1) + SourceIndex(0)
+2 >Emitted(45, 15) Source(4, 15) + SourceIndex(0)
+3 >Emitted(45, 45) Source(4, 16) + SourceIndex(0)
+4 >Emitted(45, 47) Source(4, 18) + SourceIndex(0)
+5 >Emitted(45, 57) Source(4, 23) + SourceIndex(0)
+6 >Emitted(45, 68) Source(4, 34) + SourceIndex(0)
+7 >Emitted(45, 72) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -674,12 +682,12 @@ sourceFile:../lib/file1.ts
 4 >              = 
 5 >                10
 6 >                  ;
-1 >Emitted(46, 5) Source(1, 14) + SourceIndex(1)
-2 >Emitted(46, 13) Source(1, 14) + SourceIndex(1)
-3 >Emitted(46, 14) Source(1, 15) + SourceIndex(1)
-4 >Emitted(46, 17) Source(1, 18) + SourceIndex(1)
-5 >Emitted(46, 19) Source(1, 20) + SourceIndex(1)
-6 >Emitted(46, 20) Source(1, 21) + SourceIndex(1)
+1 >Emitted(50, 5) Source(1, 14) + SourceIndex(1)
+2 >Emitted(50, 13) Source(1, 14) + SourceIndex(1)
+3 >Emitted(50, 14) Source(1, 15) + SourceIndex(1)
+4 >Emitted(50, 17) Source(1, 18) + SourceIndex(1)
+5 >Emitted(50, 19) Source(1, 20) + SourceIndex(1)
+6 >Emitted(50, 20) Source(1, 21) + SourceIndex(1)
 ---
 >>>    function forlibfile1Rest() {
 1->^^^^
@@ -689,9 +697,9 @@ sourceFile:../lib/file1.ts
 1->
 2 >    function 
 3 >             forlibfile1Rest
-1->Emitted(47, 5) Source(1, 21) + SourceIndex(1)
-2 >Emitted(47, 14) Source(1, 30) + SourceIndex(1)
-3 >Emitted(47, 29) Source(1, 45) + SourceIndex(1)
+1->Emitted(51, 5) Source(1, 21) + SourceIndex(1)
+2 >Emitted(51, 14) Source(1, 30) + SourceIndex(1)
+3 >Emitted(51, 29) Source(1, 45) + SourceIndex(1)
 ---
 >>>        var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^^^^^
@@ -745,31 +753,31 @@ sourceFile:../lib/file1.ts
 23>                                                                       { b, ...rest }
 24>                                                                             = { a: 10, b: 30, yy: 30 }
 25>                                                                             ;
-1->Emitted(48, 9) Source(2, 1) + SourceIndex(1)
-2 >Emitted(48, 13) Source(2, 7) + SourceIndex(1)
-3 >Emitted(48, 18) Source(2, 24) + SourceIndex(1)
-4 >Emitted(48, 20) Source(2, 26) + SourceIndex(1)
-5 >Emitted(48, 21) Source(2, 27) + SourceIndex(1)
-6 >Emitted(48, 23) Source(2, 29) + SourceIndex(1)
-7 >Emitted(48, 25) Source(2, 31) + SourceIndex(1)
-8 >Emitted(48, 27) Source(2, 33) + SourceIndex(1)
-9 >Emitted(48, 28) Source(2, 34) + SourceIndex(1)
-10>Emitted(48, 30) Source(2, 36) + SourceIndex(1)
-11>Emitted(48, 32) Source(2, 38) + SourceIndex(1)
-12>Emitted(48, 34) Source(2, 40) + SourceIndex(1)
-13>Emitted(48, 36) Source(2, 42) + SourceIndex(1)
-14>Emitted(48, 38) Source(2, 44) + SourceIndex(1)
-15>Emitted(48, 40) Source(2, 46) + SourceIndex(1)
-16>Emitted(48, 42) Source(2, 48) + SourceIndex(1)
-17>Emitted(48, 44) Source(2, 9) + SourceIndex(1)
-18>Emitted(48, 45) Source(2, 10) + SourceIndex(1)
-19>Emitted(48, 52) Source(2, 10) + SourceIndex(1)
-20>Emitted(48, 54) Source(2, 15) + SourceIndex(1)
-21>Emitted(48, 58) Source(2, 19) + SourceIndex(1)
-22>Emitted(48, 72) Source(2, 7) + SourceIndex(1)
-23>Emitted(48, 77) Source(2, 21) + SourceIndex(1)
-24>Emitted(48, 78) Source(2, 48) + SourceIndex(1)
-25>Emitted(48, 79) Source(2, 49) + SourceIndex(1)
+1->Emitted(52, 9) Source(2, 1) + SourceIndex(1)
+2 >Emitted(52, 13) Source(2, 7) + SourceIndex(1)
+3 >Emitted(52, 18) Source(2, 24) + SourceIndex(1)
+4 >Emitted(52, 20) Source(2, 26) + SourceIndex(1)
+5 >Emitted(52, 21) Source(2, 27) + SourceIndex(1)
+6 >Emitted(52, 23) Source(2, 29) + SourceIndex(1)
+7 >Emitted(52, 25) Source(2, 31) + SourceIndex(1)
+8 >Emitted(52, 27) Source(2, 33) + SourceIndex(1)
+9 >Emitted(52, 28) Source(2, 34) + SourceIndex(1)
+10>Emitted(52, 30) Source(2, 36) + SourceIndex(1)
+11>Emitted(52, 32) Source(2, 38) + SourceIndex(1)
+12>Emitted(52, 34) Source(2, 40) + SourceIndex(1)
+13>Emitted(52, 36) Source(2, 42) + SourceIndex(1)
+14>Emitted(52, 38) Source(2, 44) + SourceIndex(1)
+15>Emitted(52, 40) Source(2, 46) + SourceIndex(1)
+16>Emitted(52, 42) Source(2, 48) + SourceIndex(1)
+17>Emitted(52, 44) Source(2, 9) + SourceIndex(1)
+18>Emitted(52, 45) Source(2, 10) + SourceIndex(1)
+19>Emitted(52, 52) Source(2, 10) + SourceIndex(1)
+20>Emitted(52, 54) Source(2, 15) + SourceIndex(1)
+21>Emitted(52, 58) Source(2, 19) + SourceIndex(1)
+22>Emitted(52, 72) Source(2, 7) + SourceIndex(1)
+23>Emitted(52, 77) Source(2, 21) + SourceIndex(1)
+24>Emitted(52, 78) Source(2, 48) + SourceIndex(1)
+25>Emitted(52, 79) Source(2, 49) + SourceIndex(1)
 ---
 >>>    }
 1 >^^^^
@@ -777,8 +785,8 @@ sourceFile:../lib/file1.ts
 1 >
   >
 2 >    }
-1 >Emitted(49, 5) Source(3, 1) + SourceIndex(1)
-2 >Emitted(49, 6) Source(3, 2) + SourceIndex(1)
+1 >Emitted(53, 5) Source(3, 1) + SourceIndex(1)
+2 >Emitted(53, 6) Source(3, 2) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -802,12 +810,12 @@ sourceFile:../lib/file2.ts
 4 >              = 
 5 >                20
 6 >                  ;
-1 >Emitted(55, 5) Source(1, 14) + SourceIndex(2)
-2 >Emitted(55, 13) Source(1, 14) + SourceIndex(2)
-3 >Emitted(55, 14) Source(1, 15) + SourceIndex(2)
-4 >Emitted(55, 17) Source(1, 18) + SourceIndex(2)
-5 >Emitted(55, 19) Source(1, 20) + SourceIndex(2)
-6 >Emitted(55, 20) Source(1, 21) + SourceIndex(2)
+1 >Emitted(59, 5) Source(1, 14) + SourceIndex(2)
+2 >Emitted(59, 13) Source(1, 14) + SourceIndex(2)
+3 >Emitted(59, 14) Source(1, 15) + SourceIndex(2)
+4 >Emitted(59, 17) Source(1, 18) + SourceIndex(2)
+5 >Emitted(59, 19) Source(1, 20) + SourceIndex(2)
+6 >Emitted(59, 20) Source(1, 21) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -828,12 +836,12 @@ sourceFile:../lib/global.ts
 4 >                = 
 5 >                  10
 6 >                    ;
-1 >Emitted(57, 1) Source(1, 1) + SourceIndex(3)
-2 >Emitted(57, 5) Source(1, 7) + SourceIndex(3)
-3 >Emitted(57, 16) Source(1, 18) + SourceIndex(3)
-4 >Emitted(57, 19) Source(1, 21) + SourceIndex(3)
-5 >Emitted(57, 21) Source(1, 23) + SourceIndex(3)
-6 >Emitted(57, 22) Source(1, 24) + SourceIndex(3)
+1 >Emitted(61, 1) Source(1, 1) + SourceIndex(3)
+2 >Emitted(61, 5) Source(1, 7) + SourceIndex(3)
+3 >Emitted(61, 16) Source(1, 18) + SourceIndex(3)
+4 >Emitted(61, 19) Source(1, 21) + SourceIndex(3)
+5 >Emitted(61, 21) Source(1, 23) + SourceIndex(3)
+6 >Emitted(61, 22) Source(1, 24) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -857,12 +865,12 @@ sourceFile:file3.ts
 4 >              = 
 5 >                30
 6 >                  ;
-1->Emitted(62, 5) Source(1, 14) + SourceIndex(4)
-2 >Emitted(62, 13) Source(1, 14) + SourceIndex(4)
-3 >Emitted(62, 14) Source(1, 15) + SourceIndex(4)
-4 >Emitted(62, 17) Source(1, 18) + SourceIndex(4)
-5 >Emitted(62, 19) Source(1, 20) + SourceIndex(4)
-6 >Emitted(62, 20) Source(1, 21) + SourceIndex(4)
+1->Emitted(66, 5) Source(1, 14) + SourceIndex(4)
+2 >Emitted(66, 13) Source(1, 14) + SourceIndex(4)
+3 >Emitted(66, 14) Source(1, 15) + SourceIndex(4)
+4 >Emitted(66, 17) Source(1, 18) + SourceIndex(4)
+5 >Emitted(66, 19) Source(1, 20) + SourceIndex(4)
+6 >Emitted(66, 20) Source(1, 21) + SourceIndex(4)
 ---
 >>>    function forappfile3Rest() {
 1->^^^^
@@ -873,9 +881,9 @@ sourceFile:file3.ts
   >import { x } from "file1";
 2 >    function 
 3 >             forappfile3Rest
-1->Emitted(63, 5) Source(2, 27) + SourceIndex(4)
-2 >Emitted(63, 14) Source(2, 36) + SourceIndex(4)
-3 >Emitted(63, 29) Source(2, 51) + SourceIndex(4)
+1->Emitted(67, 5) Source(2, 27) + SourceIndex(4)
+2 >Emitted(67, 14) Source(2, 36) + SourceIndex(4)
+3 >Emitted(67, 29) Source(2, 51) + SourceIndex(4)
 ---
 >>>        var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^^^^^
@@ -929,31 +937,31 @@ sourceFile:file3.ts
 23>                                                                       { b, ...rest }
 24>                                                                             = { a: 10, b: 30, yy: 30 }
 25>                                                                             ;
-1->Emitted(64, 9) Source(3, 1) + SourceIndex(4)
-2 >Emitted(64, 13) Source(3, 7) + SourceIndex(4)
-3 >Emitted(64, 18) Source(3, 24) + SourceIndex(4)
-4 >Emitted(64, 20) Source(3, 26) + SourceIndex(4)
-5 >Emitted(64, 21) Source(3, 27) + SourceIndex(4)
-6 >Emitted(64, 23) Source(3, 29) + SourceIndex(4)
-7 >Emitted(64, 25) Source(3, 31) + SourceIndex(4)
-8 >Emitted(64, 27) Source(3, 33) + SourceIndex(4)
-9 >Emitted(64, 28) Source(3, 34) + SourceIndex(4)
-10>Emitted(64, 30) Source(3, 36) + SourceIndex(4)
-11>Emitted(64, 32) Source(3, 38) + SourceIndex(4)
-12>Emitted(64, 34) Source(3, 40) + SourceIndex(4)
-13>Emitted(64, 36) Source(3, 42) + SourceIndex(4)
-14>Emitted(64, 38) Source(3, 44) + SourceIndex(4)
-15>Emitted(64, 40) Source(3, 46) + SourceIndex(4)
-16>Emitted(64, 42) Source(3, 48) + SourceIndex(4)
-17>Emitted(64, 44) Source(3, 9) + SourceIndex(4)
-18>Emitted(64, 45) Source(3, 10) + SourceIndex(4)
-19>Emitted(64, 52) Source(3, 10) + SourceIndex(4)
-20>Emitted(64, 54) Source(3, 15) + SourceIndex(4)
-21>Emitted(64, 58) Source(3, 19) + SourceIndex(4)
-22>Emitted(64, 72) Source(3, 7) + SourceIndex(4)
-23>Emitted(64, 77) Source(3, 21) + SourceIndex(4)
-24>Emitted(64, 78) Source(3, 48) + SourceIndex(4)
-25>Emitted(64, 79) Source(3, 49) + SourceIndex(4)
+1->Emitted(68, 9) Source(3, 1) + SourceIndex(4)
+2 >Emitted(68, 13) Source(3, 7) + SourceIndex(4)
+3 >Emitted(68, 18) Source(3, 24) + SourceIndex(4)
+4 >Emitted(68, 20) Source(3, 26) + SourceIndex(4)
+5 >Emitted(68, 21) Source(3, 27) + SourceIndex(4)
+6 >Emitted(68, 23) Source(3, 29) + SourceIndex(4)
+7 >Emitted(68, 25) Source(3, 31) + SourceIndex(4)
+8 >Emitted(68, 27) Source(3, 33) + SourceIndex(4)
+9 >Emitted(68, 28) Source(3, 34) + SourceIndex(4)
+10>Emitted(68, 30) Source(3, 36) + SourceIndex(4)
+11>Emitted(68, 32) Source(3, 38) + SourceIndex(4)
+12>Emitted(68, 34) Source(3, 40) + SourceIndex(4)
+13>Emitted(68, 36) Source(3, 42) + SourceIndex(4)
+14>Emitted(68, 38) Source(3, 44) + SourceIndex(4)
+15>Emitted(68, 40) Source(3, 46) + SourceIndex(4)
+16>Emitted(68, 42) Source(3, 48) + SourceIndex(4)
+17>Emitted(68, 44) Source(3, 9) + SourceIndex(4)
+18>Emitted(68, 45) Source(3, 10) + SourceIndex(4)
+19>Emitted(68, 52) Source(3, 10) + SourceIndex(4)
+20>Emitted(68, 54) Source(3, 15) + SourceIndex(4)
+21>Emitted(68, 58) Source(3, 19) + SourceIndex(4)
+22>Emitted(68, 72) Source(3, 7) + SourceIndex(4)
+23>Emitted(68, 77) Source(3, 21) + SourceIndex(4)
+24>Emitted(68, 78) Source(3, 48) + SourceIndex(4)
+25>Emitted(68, 79) Source(3, 49) + SourceIndex(4)
 ---
 >>>    }
 1 >^^^^
@@ -961,8 +969,8 @@ sourceFile:file3.ts
 1 >
   >
 2 >    }
-1 >Emitted(65, 5) Source(4, 1) + SourceIndex(4)
-2 >Emitted(65, 6) Source(4, 2) + SourceIndex(4)
+1 >Emitted(69, 5) Source(4, 1) + SourceIndex(4)
+2 >Emitted(69, 6) Source(4, 2) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/app/module.js
@@ -983,12 +991,12 @@ sourceFile:file4.ts
 4 >          = 
 5 >            30
 6 >              ;
-1 >Emitted(67, 1) Source(1, 1) + SourceIndex(5)
-2 >Emitted(67, 5) Source(1, 7) + SourceIndex(5)
-3 >Emitted(67, 10) Source(1, 12) + SourceIndex(5)
-4 >Emitted(67, 13) Source(1, 15) + SourceIndex(5)
-5 >Emitted(67, 15) Source(1, 17) + SourceIndex(5)
-6 >Emitted(67, 16) Source(1, 18) + SourceIndex(5)
+1 >Emitted(71, 1) Source(1, 1) + SourceIndex(5)
+2 >Emitted(71, 5) Source(1, 7) + SourceIndex(5)
+3 >Emitted(71, 10) Source(1, 12) + SourceIndex(5)
+4 >Emitted(71, 13) Source(1, 15) + SourceIndex(5)
+5 >Emitted(71, 15) Source(1, 17) + SourceIndex(5)
+6 >Emitted(71, 16) Source(1, 18) + SourceIndex(5)
 ---
 >>>function appfile4Spread() {
 1->
@@ -998,9 +1006,9 @@ sourceFile:file4.ts
   >
 2 >function 
 3 >         appfile4Spread
-1->Emitted(68, 1) Source(2, 1) + SourceIndex(5)
-2 >Emitted(68, 10) Source(2, 10) + SourceIndex(5)
-3 >Emitted(68, 24) Source(2, 24) + SourceIndex(5)
+1->Emitted(72, 1) Source(2, 1) + SourceIndex(5)
+2 >Emitted(72, 10) Source(2, 10) + SourceIndex(5)
+3 >Emitted(72, 24) Source(2, 24) + SourceIndex(5)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -1008,8 +1016,8 @@ sourceFile:file4.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(69, 5) Source(2, 25) + SourceIndex(5)
-2 >Emitted(69, 16) Source(2, 39) + SourceIndex(5)
+1 >Emitted(73, 5) Source(2, 25) + SourceIndex(5)
+2 >Emitted(73, 16) Source(2, 39) + SourceIndex(5)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1024,20 +1032,20 @@ sourceFile:file4.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(70, 10) Source(2, 25) + SourceIndex(5)
-2 >Emitted(70, 20) Source(2, 39) + SourceIndex(5)
-3 >Emitted(70, 22) Source(2, 25) + SourceIndex(5)
-4 >Emitted(70, 43) Source(2, 39) + SourceIndex(5)
-5 >Emitted(70, 45) Source(2, 25) + SourceIndex(5)
-6 >Emitted(70, 49) Source(2, 39) + SourceIndex(5)
+1->Emitted(74, 10) Source(2, 25) + SourceIndex(5)
+2 >Emitted(74, 20) Source(2, 39) + SourceIndex(5)
+3 >Emitted(74, 22) Source(2, 25) + SourceIndex(5)
+4 >Emitted(74, 43) Source(2, 39) + SourceIndex(5)
+5 >Emitted(74, 45) Source(2, 25) + SourceIndex(5)
+6 >Emitted(74, 49) Source(2, 39) + SourceIndex(5)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(71, 9) Source(2, 25) + SourceIndex(5)
-2 >Emitted(71, 31) Source(2, 39) + SourceIndex(5)
+1 >Emitted(75, 9) Source(2, 25) + SourceIndex(5)
+2 >Emitted(75, 31) Source(2, 39) + SourceIndex(5)
 ---
 >>>    }
 >>>}
@@ -1046,8 +1054,8 @@ sourceFile:file4.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(73, 1) Source(2, 43) + SourceIndex(5)
-2 >Emitted(73, 2) Source(2, 44) + SourceIndex(5)
+1 >Emitted(77, 1) Source(2, 43) + SourceIndex(5)
+2 >Emitted(77, 2) Source(2, 44) + SourceIndex(5)
 ---
 >>>var appfile4_ar = [20, 30];
 1->
@@ -1072,16 +1080,16 @@ sourceFile:file4.ts
 8 >                       30
 9 >                         ]
 10>                          ;
-1->Emitted(74, 1) Source(3, 1) + SourceIndex(5)
-2 >Emitted(74, 5) Source(3, 7) + SourceIndex(5)
-3 >Emitted(74, 16) Source(3, 18) + SourceIndex(5)
-4 >Emitted(74, 19) Source(3, 21) + SourceIndex(5)
-5 >Emitted(74, 20) Source(3, 22) + SourceIndex(5)
-6 >Emitted(74, 22) Source(3, 24) + SourceIndex(5)
-7 >Emitted(74, 24) Source(3, 26) + SourceIndex(5)
-8 >Emitted(74, 26) Source(3, 28) + SourceIndex(5)
-9 >Emitted(74, 27) Source(3, 29) + SourceIndex(5)
-10>Emitted(74, 28) Source(3, 30) + SourceIndex(5)
+1->Emitted(78, 1) Source(3, 1) + SourceIndex(5)
+2 >Emitted(78, 5) Source(3, 7) + SourceIndex(5)
+3 >Emitted(78, 16) Source(3, 18) + SourceIndex(5)
+4 >Emitted(78, 19) Source(3, 21) + SourceIndex(5)
+5 >Emitted(78, 20) Source(3, 22) + SourceIndex(5)
+6 >Emitted(78, 22) Source(3, 24) + SourceIndex(5)
+7 >Emitted(78, 24) Source(3, 26) + SourceIndex(5)
+8 >Emitted(78, 26) Source(3, 28) + SourceIndex(5)
+9 >Emitted(78, 27) Source(3, 29) + SourceIndex(5)
+10>Emitted(78, 28) Source(3, 30) + SourceIndex(5)
 ---
 >>>appfile4Spread.apply(void 0, __spreadArray([10], __read(appfile4_ar)));
 1->
@@ -1099,18 +1107,18 @@ sourceFile:file4.ts
 5 >                                              , ...
 6 >                                                        appfile4_ar
 7 >                                                                   );
-1->Emitted(75, 1) Source(4, 1) + SourceIndex(5)
-2 >Emitted(75, 15) Source(4, 15) + SourceIndex(5)
-3 >Emitted(75, 45) Source(4, 16) + SourceIndex(5)
-4 >Emitted(75, 47) Source(4, 18) + SourceIndex(5)
-5 >Emitted(75, 57) Source(4, 23) + SourceIndex(5)
-6 >Emitted(75, 68) Source(4, 34) + SourceIndex(5)
-7 >Emitted(75, 72) Source(4, 36) + SourceIndex(5)
+1->Emitted(79, 1) Source(4, 1) + SourceIndex(5)
+2 >Emitted(79, 15) Source(4, 15) + SourceIndex(5)
+3 >Emitted(79, 45) Source(4, 16) + SourceIndex(5)
+4 >Emitted(79, 47) Source(4, 18) + SourceIndex(5)
+5 >Emitted(79, 57) Source(4, 23) + SourceIndex(5)
+6 >Emitted(79, 68) Source(4, 34) + SourceIndex(5)
+7 >Emitted(79, 72) Source(4, 36) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/app/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":697,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":699,"end":1199,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1201,"end":2024,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1201,"end":2024,"kind":"text"}]},{"pos":2024,"end":2614,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":2167,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1344,"end":2167,"kind":"text"}]},{"pos":2167,"end":2757,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/app/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1134,14 +1142,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-697):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (506-840):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (699-1199):: typescript:rest
+emitHelpers: (842-1342):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1154,9 +1166,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1201-2024):: ../lib/module.js texts:: 1
+prepend: (1344-2167):: ../lib/module.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1201-2024)
+text: (1344-2167)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -1184,7 +1196,7 @@ define("file2", ["require", "exports"], function (require, exports) {
 var globalConst = 10;
 
 ----------------------------------------------------------------------
-text: (2024-2614)
+text: (2167-2757)
 define("file3", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -1251,32 +1263,32 @@ declare const appfile4_ar: number[];
         },
         {
           "pos": 506,
-          "end": 697,
+          "end": 840,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 699,
-          "end": 1199,
+          "pos": 842,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1201,
-          "end": 2024,
+          "pos": 1344,
+          "end": 2167,
           "kind": "prepend",
           "data": "../lib/module.js",
           "texts": [
             {
-              "pos": 1201,
-              "end": 2024,
+              "pos": 1344,
+              "end": 2167,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2024,
-          "end": 2614,
+          "pos": 2167,
+          "end": 2757,
           "kind": "text"
         }
       ],
@@ -1516,10 +1528,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -1560,7 +1576,7 @@ var globalConst = 10;
 //# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.js.map]
-{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;;;;;ICFY,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
+{"version":3,"file":"module.js","sourceRoot":"","sources":["file0.ts","file1.ts","file2.ts","global.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,IAAM,MAAM,GAAG,EAAE,CAAC;AAClB,SAAS,cAAc;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AAC3C,IAAM,WAAW,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC7B,cAAc,8BAAC,EAAE,UAAK,WAAW,IAAE;;;;;ICHtB,QAAA,CAAC,GAAG,EAAE,CAAC;IAAA,SAAS,eAAe;QAC5C,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;IAChD,CAAC;;;;;;ICFY,QAAA,CAAC,GAAG,EAAE,CAAC;;ACApB,IAAM,WAAW,GAAG,EAAE,CAAC"}
 
 //// [/src/lib/module.js.map.baseline.txt]
 ===================================================================
@@ -1589,10 +1605,14 @@ sourceFile:file0.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -1619,12 +1639,12 @@ sourceFile:file0.ts
 4 >           = 
 5 >             20
 6 >               ;
-1 >Emitted(33, 1) Source(1, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(1, 7) + SourceIndex(0)
-3 >Emitted(33, 11) Source(1, 13) + SourceIndex(0)
-4 >Emitted(33, 14) Source(1, 16) + SourceIndex(0)
-5 >Emitted(33, 16) Source(1, 18) + SourceIndex(0)
-6 >Emitted(33, 17) Source(1, 19) + SourceIndex(0)
+1 >Emitted(37, 1) Source(1, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(1, 7) + SourceIndex(0)
+3 >Emitted(37, 11) Source(1, 13) + SourceIndex(0)
+4 >Emitted(37, 14) Source(1, 16) + SourceIndex(0)
+5 >Emitted(37, 16) Source(1, 18) + SourceIndex(0)
+6 >Emitted(37, 17) Source(1, 19) + SourceIndex(0)
 ---
 >>>function libfile0Spread() {
 1->
@@ -1634,9 +1654,9 @@ sourceFile:file0.ts
   >
 2 >function 
 3 >         libfile0Spread
-1->Emitted(34, 1) Source(2, 1) + SourceIndex(0)
-2 >Emitted(34, 10) Source(2, 10) + SourceIndex(0)
-3 >Emitted(34, 24) Source(2, 24) + SourceIndex(0)
+1->Emitted(38, 1) Source(2, 1) + SourceIndex(0)
+2 >Emitted(38, 10) Source(2, 10) + SourceIndex(0)
+3 >Emitted(38, 24) Source(2, 24) + SourceIndex(0)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -1644,8 +1664,8 @@ sourceFile:file0.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(35, 5) Source(2, 25) + SourceIndex(0)
-2 >Emitted(35, 16) Source(2, 39) + SourceIndex(0)
+1 >Emitted(39, 5) Source(2, 25) + SourceIndex(0)
+2 >Emitted(39, 16) Source(2, 39) + SourceIndex(0)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1660,20 +1680,20 @@ sourceFile:file0.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(36, 10) Source(2, 25) + SourceIndex(0)
-2 >Emitted(36, 20) Source(2, 39) + SourceIndex(0)
-3 >Emitted(36, 22) Source(2, 25) + SourceIndex(0)
-4 >Emitted(36, 43) Source(2, 39) + SourceIndex(0)
-5 >Emitted(36, 45) Source(2, 25) + SourceIndex(0)
-6 >Emitted(36, 49) Source(2, 39) + SourceIndex(0)
+1->Emitted(40, 10) Source(2, 25) + SourceIndex(0)
+2 >Emitted(40, 20) Source(2, 39) + SourceIndex(0)
+3 >Emitted(40, 22) Source(2, 25) + SourceIndex(0)
+4 >Emitted(40, 43) Source(2, 39) + SourceIndex(0)
+5 >Emitted(40, 45) Source(2, 25) + SourceIndex(0)
+6 >Emitted(40, 49) Source(2, 39) + SourceIndex(0)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(37, 9) Source(2, 25) + SourceIndex(0)
-2 >Emitted(37, 31) Source(2, 39) + SourceIndex(0)
+1 >Emitted(41, 9) Source(2, 25) + SourceIndex(0)
+2 >Emitted(41, 31) Source(2, 39) + SourceIndex(0)
 ---
 >>>    }
 >>>}
@@ -1682,8 +1702,8 @@ sourceFile:file0.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(39, 1) Source(2, 43) + SourceIndex(0)
-2 >Emitted(39, 2) Source(2, 44) + SourceIndex(0)
+1 >Emitted(43, 1) Source(2, 43) + SourceIndex(0)
+2 >Emitted(43, 2) Source(2, 44) + SourceIndex(0)
 ---
 >>>var libfile0_ar = [20, 30];
 1->
@@ -1708,16 +1728,16 @@ sourceFile:file0.ts
 8 >                       30
 9 >                         ]
 10>                          ;
-1->Emitted(40, 1) Source(3, 1) + SourceIndex(0)
-2 >Emitted(40, 5) Source(3, 7) + SourceIndex(0)
-3 >Emitted(40, 16) Source(3, 18) + SourceIndex(0)
-4 >Emitted(40, 19) Source(3, 21) + SourceIndex(0)
-5 >Emitted(40, 20) Source(3, 22) + SourceIndex(0)
-6 >Emitted(40, 22) Source(3, 24) + SourceIndex(0)
-7 >Emitted(40, 24) Source(3, 26) + SourceIndex(0)
-8 >Emitted(40, 26) Source(3, 28) + SourceIndex(0)
-9 >Emitted(40, 27) Source(3, 29) + SourceIndex(0)
-10>Emitted(40, 28) Source(3, 30) + SourceIndex(0)
+1->Emitted(44, 1) Source(3, 1) + SourceIndex(0)
+2 >Emitted(44, 5) Source(3, 7) + SourceIndex(0)
+3 >Emitted(44, 16) Source(3, 18) + SourceIndex(0)
+4 >Emitted(44, 19) Source(3, 21) + SourceIndex(0)
+5 >Emitted(44, 20) Source(3, 22) + SourceIndex(0)
+6 >Emitted(44, 22) Source(3, 24) + SourceIndex(0)
+7 >Emitted(44, 24) Source(3, 26) + SourceIndex(0)
+8 >Emitted(44, 26) Source(3, 28) + SourceIndex(0)
+9 >Emitted(44, 27) Source(3, 29) + SourceIndex(0)
+10>Emitted(44, 28) Source(3, 30) + SourceIndex(0)
 ---
 >>>libfile0Spread.apply(void 0, __spreadArray([10], __read(libfile0_ar)));
 1->
@@ -1735,13 +1755,13 @@ sourceFile:file0.ts
 5 >                                              , ...
 6 >                                                        libfile0_ar
 7 >                                                                   );
-1->Emitted(41, 1) Source(4, 1) + SourceIndex(0)
-2 >Emitted(41, 15) Source(4, 15) + SourceIndex(0)
-3 >Emitted(41, 45) Source(4, 16) + SourceIndex(0)
-4 >Emitted(41, 47) Source(4, 18) + SourceIndex(0)
-5 >Emitted(41, 57) Source(4, 23) + SourceIndex(0)
-6 >Emitted(41, 68) Source(4, 34) + SourceIndex(0)
-7 >Emitted(41, 72) Source(4, 36) + SourceIndex(0)
+1->Emitted(45, 1) Source(4, 1) + SourceIndex(0)
+2 >Emitted(45, 15) Source(4, 15) + SourceIndex(0)
+3 >Emitted(45, 45) Source(4, 16) + SourceIndex(0)
+4 >Emitted(45, 47) Source(4, 18) + SourceIndex(0)
+5 >Emitted(45, 57) Source(4, 23) + SourceIndex(0)
+6 >Emitted(45, 68) Source(4, 34) + SourceIndex(0)
+7 >Emitted(45, 72) Source(4, 36) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1765,12 +1785,12 @@ sourceFile:file1.ts
 4 >              = 
 5 >                10
 6 >                  ;
-1 >Emitted(46, 5) Source(1, 14) + SourceIndex(1)
-2 >Emitted(46, 13) Source(1, 14) + SourceIndex(1)
-3 >Emitted(46, 14) Source(1, 15) + SourceIndex(1)
-4 >Emitted(46, 17) Source(1, 18) + SourceIndex(1)
-5 >Emitted(46, 19) Source(1, 20) + SourceIndex(1)
-6 >Emitted(46, 20) Source(1, 21) + SourceIndex(1)
+1 >Emitted(50, 5) Source(1, 14) + SourceIndex(1)
+2 >Emitted(50, 13) Source(1, 14) + SourceIndex(1)
+3 >Emitted(50, 14) Source(1, 15) + SourceIndex(1)
+4 >Emitted(50, 17) Source(1, 18) + SourceIndex(1)
+5 >Emitted(50, 19) Source(1, 20) + SourceIndex(1)
+6 >Emitted(50, 20) Source(1, 21) + SourceIndex(1)
 ---
 >>>    function forlibfile1Rest() {
 1->^^^^
@@ -1780,9 +1800,9 @@ sourceFile:file1.ts
 1->
 2 >    function 
 3 >             forlibfile1Rest
-1->Emitted(47, 5) Source(1, 21) + SourceIndex(1)
-2 >Emitted(47, 14) Source(1, 30) + SourceIndex(1)
-3 >Emitted(47, 29) Source(1, 45) + SourceIndex(1)
+1->Emitted(51, 5) Source(1, 21) + SourceIndex(1)
+2 >Emitted(51, 14) Source(1, 30) + SourceIndex(1)
+3 >Emitted(51, 29) Source(1, 45) + SourceIndex(1)
 ---
 >>>        var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^^^^^
@@ -1836,31 +1856,31 @@ sourceFile:file1.ts
 23>                                                                       { b, ...rest }
 24>                                                                             = { a: 10, b: 30, yy: 30 }
 25>                                                                             ;
-1->Emitted(48, 9) Source(2, 1) + SourceIndex(1)
-2 >Emitted(48, 13) Source(2, 7) + SourceIndex(1)
-3 >Emitted(48, 18) Source(2, 24) + SourceIndex(1)
-4 >Emitted(48, 20) Source(2, 26) + SourceIndex(1)
-5 >Emitted(48, 21) Source(2, 27) + SourceIndex(1)
-6 >Emitted(48, 23) Source(2, 29) + SourceIndex(1)
-7 >Emitted(48, 25) Source(2, 31) + SourceIndex(1)
-8 >Emitted(48, 27) Source(2, 33) + SourceIndex(1)
-9 >Emitted(48, 28) Source(2, 34) + SourceIndex(1)
-10>Emitted(48, 30) Source(2, 36) + SourceIndex(1)
-11>Emitted(48, 32) Source(2, 38) + SourceIndex(1)
-12>Emitted(48, 34) Source(2, 40) + SourceIndex(1)
-13>Emitted(48, 36) Source(2, 42) + SourceIndex(1)
-14>Emitted(48, 38) Source(2, 44) + SourceIndex(1)
-15>Emitted(48, 40) Source(2, 46) + SourceIndex(1)
-16>Emitted(48, 42) Source(2, 48) + SourceIndex(1)
-17>Emitted(48, 44) Source(2, 9) + SourceIndex(1)
-18>Emitted(48, 45) Source(2, 10) + SourceIndex(1)
-19>Emitted(48, 52) Source(2, 10) + SourceIndex(1)
-20>Emitted(48, 54) Source(2, 15) + SourceIndex(1)
-21>Emitted(48, 58) Source(2, 19) + SourceIndex(1)
-22>Emitted(48, 72) Source(2, 7) + SourceIndex(1)
-23>Emitted(48, 77) Source(2, 21) + SourceIndex(1)
-24>Emitted(48, 78) Source(2, 48) + SourceIndex(1)
-25>Emitted(48, 79) Source(2, 49) + SourceIndex(1)
+1->Emitted(52, 9) Source(2, 1) + SourceIndex(1)
+2 >Emitted(52, 13) Source(2, 7) + SourceIndex(1)
+3 >Emitted(52, 18) Source(2, 24) + SourceIndex(1)
+4 >Emitted(52, 20) Source(2, 26) + SourceIndex(1)
+5 >Emitted(52, 21) Source(2, 27) + SourceIndex(1)
+6 >Emitted(52, 23) Source(2, 29) + SourceIndex(1)
+7 >Emitted(52, 25) Source(2, 31) + SourceIndex(1)
+8 >Emitted(52, 27) Source(2, 33) + SourceIndex(1)
+9 >Emitted(52, 28) Source(2, 34) + SourceIndex(1)
+10>Emitted(52, 30) Source(2, 36) + SourceIndex(1)
+11>Emitted(52, 32) Source(2, 38) + SourceIndex(1)
+12>Emitted(52, 34) Source(2, 40) + SourceIndex(1)
+13>Emitted(52, 36) Source(2, 42) + SourceIndex(1)
+14>Emitted(52, 38) Source(2, 44) + SourceIndex(1)
+15>Emitted(52, 40) Source(2, 46) + SourceIndex(1)
+16>Emitted(52, 42) Source(2, 48) + SourceIndex(1)
+17>Emitted(52, 44) Source(2, 9) + SourceIndex(1)
+18>Emitted(52, 45) Source(2, 10) + SourceIndex(1)
+19>Emitted(52, 52) Source(2, 10) + SourceIndex(1)
+20>Emitted(52, 54) Source(2, 15) + SourceIndex(1)
+21>Emitted(52, 58) Source(2, 19) + SourceIndex(1)
+22>Emitted(52, 72) Source(2, 7) + SourceIndex(1)
+23>Emitted(52, 77) Source(2, 21) + SourceIndex(1)
+24>Emitted(52, 78) Source(2, 48) + SourceIndex(1)
+25>Emitted(52, 79) Source(2, 49) + SourceIndex(1)
 ---
 >>>    }
 1 >^^^^
@@ -1868,8 +1888,8 @@ sourceFile:file1.ts
 1 >
   >
 2 >    }
-1 >Emitted(49, 5) Source(3, 1) + SourceIndex(1)
-2 >Emitted(49, 6) Source(3, 2) + SourceIndex(1)
+1 >Emitted(53, 5) Source(3, 1) + SourceIndex(1)
+2 >Emitted(53, 6) Source(3, 2) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1893,12 +1913,12 @@ sourceFile:file2.ts
 4 >              = 
 5 >                20
 6 >                  ;
-1 >Emitted(55, 5) Source(1, 14) + SourceIndex(2)
-2 >Emitted(55, 13) Source(1, 14) + SourceIndex(2)
-3 >Emitted(55, 14) Source(1, 15) + SourceIndex(2)
-4 >Emitted(55, 17) Source(1, 18) + SourceIndex(2)
-5 >Emitted(55, 19) Source(1, 20) + SourceIndex(2)
-6 >Emitted(55, 20) Source(1, 21) + SourceIndex(2)
+1 >Emitted(59, 5) Source(1, 14) + SourceIndex(2)
+2 >Emitted(59, 13) Source(1, 14) + SourceIndex(2)
+3 >Emitted(59, 14) Source(1, 15) + SourceIndex(2)
+4 >Emitted(59, 17) Source(1, 18) + SourceIndex(2)
+5 >Emitted(59, 19) Source(1, 20) + SourceIndex(2)
+6 >Emitted(59, 20) Source(1, 21) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/lib/module.js
@@ -1919,17 +1939,17 @@ sourceFile:global.ts
 4 >                = 
 5 >                  10
 6 >                    ;
-1 >Emitted(57, 1) Source(1, 1) + SourceIndex(3)
-2 >Emitted(57, 5) Source(1, 7) + SourceIndex(3)
-3 >Emitted(57, 16) Source(1, 18) + SourceIndex(3)
-4 >Emitted(57, 19) Source(1, 21) + SourceIndex(3)
-5 >Emitted(57, 21) Source(1, 23) + SourceIndex(3)
-6 >Emitted(57, 22) Source(1, 24) + SourceIndex(3)
+1 >Emitted(61, 1) Source(1, 1) + SourceIndex(3)
+2 >Emitted(61, 5) Source(1, 7) + SourceIndex(3)
+3 >Emitted(61, 16) Source(1, 18) + SourceIndex(3)
+4 >Emitted(61, 19) Source(1, 21) + SourceIndex(3)
+5 >Emitted(61, 21) Source(1, 23) + SourceIndex(3)
+6 >Emitted(61, 22) Source(1, 24) + SourceIndex(3)
 ---
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":697,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":699,"end":1199,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1201,"end":2024,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":2167,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/lib/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1953,14 +1973,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-697):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (506-840):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (699-1199):: typescript:rest
+emitHelpers: (842-1342):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1973,7 +1997,7 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-text: (1201-2024)
+text: (1344-2167)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -2038,19 +2062,19 @@ declare const globalConst = 10;
         },
         {
           "pos": 506,
-          "end": 697,
+          "end": 840,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 699,
-          "end": 1199,
+          "pos": 842,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1201,
-          "end": 2024,
+          "pos": 1344,
+          "end": 2167,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
@@ -70,10 +70,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var s = "Hello, world";
 console.log(s);
@@ -96,7 +100,7 @@ firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3
 //# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.js.map]
-{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
 
 //// [/src/first/bin/first-output.js.map.baseline.txt]
 ===================================================================
@@ -136,10 +140,14 @@ sourceFile:../first_PART1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -158,12 +166,12 @@ sourceFile:../first_PART1.ts
 4 >      = 
 5 >        "Hello, world"
 6 >                      ;
-1 >Emitted(33, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(5, 7) + SourceIndex(0)
-3 >Emitted(33, 6) Source(5, 8) + SourceIndex(0)
-4 >Emitted(33, 9) Source(5, 11) + SourceIndex(0)
-5 >Emitted(33, 23) Source(5, 25) + SourceIndex(0)
-6 >Emitted(33, 24) Source(5, 26) + SourceIndex(0)
+1 >Emitted(37, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(5, 7) + SourceIndex(0)
+3 >Emitted(37, 6) Source(5, 8) + SourceIndex(0)
+4 >Emitted(37, 9) Source(5, 11) + SourceIndex(0)
+5 >Emitted(37, 23) Source(5, 25) + SourceIndex(0)
+6 >Emitted(37, 24) Source(5, 26) + SourceIndex(0)
 ---
 >>>console.log(s);
 1 >
@@ -189,14 +197,14 @@ sourceFile:../first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1 >Emitted(34, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(34, 8) Source(11, 8) + SourceIndex(0)
-3 >Emitted(34, 9) Source(11, 9) + SourceIndex(0)
-4 >Emitted(34, 12) Source(11, 12) + SourceIndex(0)
-5 >Emitted(34, 13) Source(11, 13) + SourceIndex(0)
-6 >Emitted(34, 14) Source(11, 14) + SourceIndex(0)
-7 >Emitted(34, 15) Source(11, 15) + SourceIndex(0)
-8 >Emitted(34, 16) Source(11, 16) + SourceIndex(0)
+1 >Emitted(38, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(38, 8) Source(11, 8) + SourceIndex(0)
+3 >Emitted(38, 9) Source(11, 9) + SourceIndex(0)
+4 >Emitted(38, 12) Source(11, 12) + SourceIndex(0)
+5 >Emitted(38, 13) Source(11, 13) + SourceIndex(0)
+6 >Emitted(38, 14) Source(11, 14) + SourceIndex(0)
+7 >Emitted(38, 15) Source(11, 15) + SourceIndex(0)
+8 >Emitted(38, 16) Source(11, 16) + SourceIndex(0)
 ---
 >>>function forfirstfirst_PART1Rest() {
 1->
@@ -207,9 +215,9 @@ sourceFile:../first_PART1.ts
   >
 2 >function 
 3 >         forfirstfirst_PART1Rest
-1->Emitted(35, 1) Source(12, 1) + SourceIndex(0)
-2 >Emitted(35, 10) Source(12, 10) + SourceIndex(0)
-3 >Emitted(35, 33) Source(12, 33) + SourceIndex(0)
+1->Emitted(39, 1) Source(12, 1) + SourceIndex(0)
+2 >Emitted(39, 10) Source(12, 10) + SourceIndex(0)
+3 >Emitted(39, 33) Source(12, 33) + SourceIndex(0)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -263,31 +271,31 @@ sourceFile:../first_PART1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(36, 5) Source(13, 1) + SourceIndex(0)
-2 >Emitted(36, 9) Source(13, 7) + SourceIndex(0)
-3 >Emitted(36, 14) Source(13, 24) + SourceIndex(0)
-4 >Emitted(36, 16) Source(13, 26) + SourceIndex(0)
-5 >Emitted(36, 17) Source(13, 27) + SourceIndex(0)
-6 >Emitted(36, 19) Source(13, 29) + SourceIndex(0)
-7 >Emitted(36, 21) Source(13, 31) + SourceIndex(0)
-8 >Emitted(36, 23) Source(13, 33) + SourceIndex(0)
-9 >Emitted(36, 24) Source(13, 34) + SourceIndex(0)
-10>Emitted(36, 26) Source(13, 36) + SourceIndex(0)
-11>Emitted(36, 28) Source(13, 38) + SourceIndex(0)
-12>Emitted(36, 30) Source(13, 40) + SourceIndex(0)
-13>Emitted(36, 32) Source(13, 42) + SourceIndex(0)
-14>Emitted(36, 34) Source(13, 44) + SourceIndex(0)
-15>Emitted(36, 36) Source(13, 46) + SourceIndex(0)
-16>Emitted(36, 38) Source(13, 48) + SourceIndex(0)
-17>Emitted(36, 40) Source(13, 9) + SourceIndex(0)
-18>Emitted(36, 41) Source(13, 10) + SourceIndex(0)
-19>Emitted(36, 48) Source(13, 10) + SourceIndex(0)
-20>Emitted(36, 50) Source(13, 15) + SourceIndex(0)
-21>Emitted(36, 54) Source(13, 19) + SourceIndex(0)
-22>Emitted(36, 68) Source(13, 7) + SourceIndex(0)
-23>Emitted(36, 73) Source(13, 21) + SourceIndex(0)
-24>Emitted(36, 74) Source(13, 48) + SourceIndex(0)
-25>Emitted(36, 75) Source(13, 49) + SourceIndex(0)
+1->Emitted(40, 5) Source(13, 1) + SourceIndex(0)
+2 >Emitted(40, 9) Source(13, 7) + SourceIndex(0)
+3 >Emitted(40, 14) Source(13, 24) + SourceIndex(0)
+4 >Emitted(40, 16) Source(13, 26) + SourceIndex(0)
+5 >Emitted(40, 17) Source(13, 27) + SourceIndex(0)
+6 >Emitted(40, 19) Source(13, 29) + SourceIndex(0)
+7 >Emitted(40, 21) Source(13, 31) + SourceIndex(0)
+8 >Emitted(40, 23) Source(13, 33) + SourceIndex(0)
+9 >Emitted(40, 24) Source(13, 34) + SourceIndex(0)
+10>Emitted(40, 26) Source(13, 36) + SourceIndex(0)
+11>Emitted(40, 28) Source(13, 38) + SourceIndex(0)
+12>Emitted(40, 30) Source(13, 40) + SourceIndex(0)
+13>Emitted(40, 32) Source(13, 42) + SourceIndex(0)
+14>Emitted(40, 34) Source(13, 44) + SourceIndex(0)
+15>Emitted(40, 36) Source(13, 46) + SourceIndex(0)
+16>Emitted(40, 38) Source(13, 48) + SourceIndex(0)
+17>Emitted(40, 40) Source(13, 9) + SourceIndex(0)
+18>Emitted(40, 41) Source(13, 10) + SourceIndex(0)
+19>Emitted(40, 48) Source(13, 10) + SourceIndex(0)
+20>Emitted(40, 50) Source(13, 15) + SourceIndex(0)
+21>Emitted(40, 54) Source(13, 19) + SourceIndex(0)
+22>Emitted(40, 68) Source(13, 7) + SourceIndex(0)
+23>Emitted(40, 73) Source(13, 21) + SourceIndex(0)
+24>Emitted(40, 74) Source(13, 48) + SourceIndex(0)
+25>Emitted(40, 75) Source(13, 49) + SourceIndex(0)
 ---
 >>>}
 1 >
@@ -296,8 +304,8 @@ sourceFile:../first_PART1.ts
 1 >
   >
 2 >}
-1 >Emitted(37, 1) Source(14, 1) + SourceIndex(0)
-2 >Emitted(37, 2) Source(14, 2) + SourceIndex(0)
+1 >Emitted(41, 1) Source(14, 1) + SourceIndex(0)
+2 >Emitted(41, 2) Source(14, 2) + SourceIndex(0)
 ---
 >>>console.log(s);
 1->
@@ -317,14 +325,14 @@ sourceFile:../first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1->Emitted(38, 1) Source(14, 2) + SourceIndex(0)
-2 >Emitted(38, 8) Source(14, 9) + SourceIndex(0)
-3 >Emitted(38, 9) Source(14, 10) + SourceIndex(0)
-4 >Emitted(38, 12) Source(14, 13) + SourceIndex(0)
-5 >Emitted(38, 13) Source(14, 14) + SourceIndex(0)
-6 >Emitted(38, 14) Source(14, 15) + SourceIndex(0)
-7 >Emitted(38, 15) Source(14, 16) + SourceIndex(0)
-8 >Emitted(38, 16) Source(14, 17) + SourceIndex(0)
+1->Emitted(42, 1) Source(14, 2) + SourceIndex(0)
+2 >Emitted(42, 8) Source(14, 9) + SourceIndex(0)
+3 >Emitted(42, 9) Source(14, 10) + SourceIndex(0)
+4 >Emitted(42, 12) Source(14, 13) + SourceIndex(0)
+5 >Emitted(42, 13) Source(14, 14) + SourceIndex(0)
+6 >Emitted(42, 14) Source(14, 15) + SourceIndex(0)
+7 >Emitted(42, 15) Source(14, 16) + SourceIndex(0)
+8 >Emitted(42, 16) Source(14, 17) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/first/bin/first-output.js
@@ -349,15 +357,15 @@ sourceFile:../first_part2.ts
 7 >             ()
 8 >               )
 9 >                ;
-1->Emitted(39, 1) Source(1, 1) + SourceIndex(1)
-2 >Emitted(39, 8) Source(1, 8) + SourceIndex(1)
-3 >Emitted(39, 9) Source(1, 9) + SourceIndex(1)
-4 >Emitted(39, 12) Source(1, 12) + SourceIndex(1)
-5 >Emitted(39, 13) Source(1, 13) + SourceIndex(1)
-6 >Emitted(39, 14) Source(1, 14) + SourceIndex(1)
-7 >Emitted(39, 16) Source(1, 16) + SourceIndex(1)
-8 >Emitted(39, 17) Source(1, 17) + SourceIndex(1)
-9 >Emitted(39, 18) Source(1, 18) + SourceIndex(1)
+1->Emitted(43, 1) Source(1, 1) + SourceIndex(1)
+2 >Emitted(43, 8) Source(1, 8) + SourceIndex(1)
+3 >Emitted(43, 9) Source(1, 9) + SourceIndex(1)
+4 >Emitted(43, 12) Source(1, 12) + SourceIndex(1)
+5 >Emitted(43, 13) Source(1, 13) + SourceIndex(1)
+6 >Emitted(43, 14) Source(1, 14) + SourceIndex(1)
+7 >Emitted(43, 16) Source(1, 16) + SourceIndex(1)
+8 >Emitted(43, 17) Source(1, 17) + SourceIndex(1)
+9 >Emitted(43, 18) Source(1, 18) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/first/bin/first-output.js
@@ -371,9 +379,9 @@ sourceFile:../first_part3.ts
 1 >
 2 >function 
 3 >         f
-1 >Emitted(40, 1) Source(1, 1) + SourceIndex(2)
-2 >Emitted(40, 10) Source(1, 10) + SourceIndex(2)
-3 >Emitted(40, 11) Source(1, 11) + SourceIndex(2)
+1 >Emitted(44, 1) Source(1, 1) + SourceIndex(2)
+2 >Emitted(44, 10) Source(1, 10) + SourceIndex(2)
+3 >Emitted(44, 11) Source(1, 11) + SourceIndex(2)
 ---
 >>>    return "JS does hoists";
 1->^^^^
@@ -385,10 +393,10 @@ sourceFile:../first_part3.ts
 2 >    return 
 3 >           "JS does hoists"
 4 >                           ;
-1->Emitted(41, 5) Source(2, 5) + SourceIndex(2)
-2 >Emitted(41, 12) Source(2, 12) + SourceIndex(2)
-3 >Emitted(41, 28) Source(2, 28) + SourceIndex(2)
-4 >Emitted(41, 29) Source(2, 29) + SourceIndex(2)
+1->Emitted(45, 5) Source(2, 5) + SourceIndex(2)
+2 >Emitted(45, 12) Source(2, 12) + SourceIndex(2)
+3 >Emitted(45, 28) Source(2, 28) + SourceIndex(2)
+4 >Emitted(45, 29) Source(2, 29) + SourceIndex(2)
 ---
 >>>}
 1 >
@@ -397,8 +405,8 @@ sourceFile:../first_part3.ts
 1 >
   >
 2 >}
-1 >Emitted(42, 1) Source(3, 1) + SourceIndex(2)
-2 >Emitted(42, 2) Source(3, 2) + SourceIndex(2)
+1 >Emitted(46, 1) Source(3, 1) + SourceIndex(2)
+2 >Emitted(46, 2) Source(3, 2) + SourceIndex(2)
 ---
 >>>function firstfirst_part3Spread() {
 1->
@@ -408,9 +416,9 @@ sourceFile:../first_part3.ts
   >
 2 >function 
 3 >         firstfirst_part3Spread
-1->Emitted(43, 1) Source(4, 1) + SourceIndex(2)
-2 >Emitted(43, 10) Source(4, 10) + SourceIndex(2)
-3 >Emitted(43, 32) Source(4, 32) + SourceIndex(2)
+1->Emitted(47, 1) Source(4, 1) + SourceIndex(2)
+2 >Emitted(47, 10) Source(4, 10) + SourceIndex(2)
+3 >Emitted(47, 32) Source(4, 32) + SourceIndex(2)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -418,8 +426,8 @@ sourceFile:../first_part3.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(44, 5) Source(4, 33) + SourceIndex(2)
-2 >Emitted(44, 16) Source(4, 47) + SourceIndex(2)
+1 >Emitted(48, 5) Source(4, 33) + SourceIndex(2)
+2 >Emitted(48, 16) Source(4, 47) + SourceIndex(2)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -434,20 +442,20 @@ sourceFile:../first_part3.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(45, 10) Source(4, 33) + SourceIndex(2)
-2 >Emitted(45, 20) Source(4, 47) + SourceIndex(2)
-3 >Emitted(45, 22) Source(4, 33) + SourceIndex(2)
-4 >Emitted(45, 43) Source(4, 47) + SourceIndex(2)
-5 >Emitted(45, 45) Source(4, 33) + SourceIndex(2)
-6 >Emitted(45, 49) Source(4, 47) + SourceIndex(2)
+1->Emitted(49, 10) Source(4, 33) + SourceIndex(2)
+2 >Emitted(49, 20) Source(4, 47) + SourceIndex(2)
+3 >Emitted(49, 22) Source(4, 33) + SourceIndex(2)
+4 >Emitted(49, 43) Source(4, 47) + SourceIndex(2)
+5 >Emitted(49, 45) Source(4, 33) + SourceIndex(2)
+6 >Emitted(49, 49) Source(4, 47) + SourceIndex(2)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(46, 9) Source(4, 33) + SourceIndex(2)
-2 >Emitted(46, 31) Source(4, 47) + SourceIndex(2)
+1 >Emitted(50, 9) Source(4, 33) + SourceIndex(2)
+2 >Emitted(50, 31) Source(4, 47) + SourceIndex(2)
 ---
 >>>    }
 >>>}
@@ -456,8 +464,8 @@ sourceFile:../first_part3.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(48, 1) Source(4, 51) + SourceIndex(2)
-2 >Emitted(48, 2) Source(4, 52) + SourceIndex(2)
+1 >Emitted(52, 1) Source(4, 51) + SourceIndex(2)
+2 >Emitted(52, 2) Source(4, 52) + SourceIndex(2)
 ---
 >>>var firstfirst_part3_ar = [20, 30];
 1->
@@ -482,16 +490,16 @@ sourceFile:../first_part3.ts
 8 >                               30
 9 >                                 ]
 10>                                  ;
-1->Emitted(49, 1) Source(5, 1) + SourceIndex(2)
-2 >Emitted(49, 5) Source(5, 7) + SourceIndex(2)
-3 >Emitted(49, 24) Source(5, 26) + SourceIndex(2)
-4 >Emitted(49, 27) Source(5, 29) + SourceIndex(2)
-5 >Emitted(49, 28) Source(5, 30) + SourceIndex(2)
-6 >Emitted(49, 30) Source(5, 32) + SourceIndex(2)
-7 >Emitted(49, 32) Source(5, 34) + SourceIndex(2)
-8 >Emitted(49, 34) Source(5, 36) + SourceIndex(2)
-9 >Emitted(49, 35) Source(5, 37) + SourceIndex(2)
-10>Emitted(49, 36) Source(5, 38) + SourceIndex(2)
+1->Emitted(53, 1) Source(5, 1) + SourceIndex(2)
+2 >Emitted(53, 5) Source(5, 7) + SourceIndex(2)
+3 >Emitted(53, 24) Source(5, 26) + SourceIndex(2)
+4 >Emitted(53, 27) Source(5, 29) + SourceIndex(2)
+5 >Emitted(53, 28) Source(5, 30) + SourceIndex(2)
+6 >Emitted(53, 30) Source(5, 32) + SourceIndex(2)
+7 >Emitted(53, 32) Source(5, 34) + SourceIndex(2)
+8 >Emitted(53, 34) Source(5, 36) + SourceIndex(2)
+9 >Emitted(53, 35) Source(5, 37) + SourceIndex(2)
+10>Emitted(53, 36) Source(5, 38) + SourceIndex(2)
 ---
 >>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
 1->
@@ -509,18 +517,18 @@ sourceFile:../first_part3.ts
 5 >                                                      , ...
 6 >                                                                firstfirst_part3_ar
 7 >                                                                                   );
-1->Emitted(50, 1) Source(6, 1) + SourceIndex(2)
-2 >Emitted(50, 23) Source(6, 23) + SourceIndex(2)
-3 >Emitted(50, 53) Source(6, 24) + SourceIndex(2)
-4 >Emitted(50, 55) Source(6, 26) + SourceIndex(2)
-5 >Emitted(50, 65) Source(6, 31) + SourceIndex(2)
-6 >Emitted(50, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(50, 88) Source(6, 52) + SourceIndex(2)
+1->Emitted(54, 1) Source(6, 1) + SourceIndex(2)
+2 >Emitted(54, 23) Source(6, 23) + SourceIndex(2)
+3 >Emitted(54, 53) Source(6, 24) + SourceIndex(2)
+4 >Emitted(54, 55) Source(6, 26) + SourceIndex(2)
+5 >Emitted(54, 65) Source(6, 31) + SourceIndex(2)
+6 >Emitted(54, 84) Source(6, 50) + SourceIndex(2)
+7 >Emitted(54, 88) Source(6, 52) + SourceIndex(2)
 ---
 >>>//# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1199,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1201,"end":1720,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1863,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/first/bin/first-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -557,14 +565,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1199):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (1008-1342):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (1201-1720)
+text: (1344-1863)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -628,13 +640,13 @@ declare const firstfirst_part3_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1199,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1201,
-          "end": 1720,
+          "pos": 1344,
+          "end": 1863,
           "kind": "text"
         }
       ],
@@ -688,10 +700,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var s = "Hello, world";
 console.log(s);
@@ -753,7 +769,7 @@ thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -793,10 +809,14 @@ sourceFile:../../../first/first_PART1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -815,12 +835,12 @@ sourceFile:../../../first/first_PART1.ts
 4 >      = 
 5 >        "Hello, world"
 6 >                      ;
-1 >Emitted(33, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(5, 7) + SourceIndex(0)
-3 >Emitted(33, 6) Source(5, 8) + SourceIndex(0)
-4 >Emitted(33, 9) Source(5, 11) + SourceIndex(0)
-5 >Emitted(33, 23) Source(5, 25) + SourceIndex(0)
-6 >Emitted(33, 24) Source(5, 26) + SourceIndex(0)
+1 >Emitted(37, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(5, 7) + SourceIndex(0)
+3 >Emitted(37, 6) Source(5, 8) + SourceIndex(0)
+4 >Emitted(37, 9) Source(5, 11) + SourceIndex(0)
+5 >Emitted(37, 23) Source(5, 25) + SourceIndex(0)
+6 >Emitted(37, 24) Source(5, 26) + SourceIndex(0)
 ---
 >>>console.log(s);
 1 >
@@ -846,14 +866,14 @@ sourceFile:../../../first/first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1 >Emitted(34, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(34, 8) Source(11, 8) + SourceIndex(0)
-3 >Emitted(34, 9) Source(11, 9) + SourceIndex(0)
-4 >Emitted(34, 12) Source(11, 12) + SourceIndex(0)
-5 >Emitted(34, 13) Source(11, 13) + SourceIndex(0)
-6 >Emitted(34, 14) Source(11, 14) + SourceIndex(0)
-7 >Emitted(34, 15) Source(11, 15) + SourceIndex(0)
-8 >Emitted(34, 16) Source(11, 16) + SourceIndex(0)
+1 >Emitted(38, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(38, 8) Source(11, 8) + SourceIndex(0)
+3 >Emitted(38, 9) Source(11, 9) + SourceIndex(0)
+4 >Emitted(38, 12) Source(11, 12) + SourceIndex(0)
+5 >Emitted(38, 13) Source(11, 13) + SourceIndex(0)
+6 >Emitted(38, 14) Source(11, 14) + SourceIndex(0)
+7 >Emitted(38, 15) Source(11, 15) + SourceIndex(0)
+8 >Emitted(38, 16) Source(11, 16) + SourceIndex(0)
 ---
 >>>function forfirstfirst_PART1Rest() {
 1->
@@ -864,9 +884,9 @@ sourceFile:../../../first/first_PART1.ts
   >
 2 >function 
 3 >         forfirstfirst_PART1Rest
-1->Emitted(35, 1) Source(12, 1) + SourceIndex(0)
-2 >Emitted(35, 10) Source(12, 10) + SourceIndex(0)
-3 >Emitted(35, 33) Source(12, 33) + SourceIndex(0)
+1->Emitted(39, 1) Source(12, 1) + SourceIndex(0)
+2 >Emitted(39, 10) Source(12, 10) + SourceIndex(0)
+3 >Emitted(39, 33) Source(12, 33) + SourceIndex(0)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -920,31 +940,31 @@ sourceFile:../../../first/first_PART1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(36, 5) Source(13, 1) + SourceIndex(0)
-2 >Emitted(36, 9) Source(13, 7) + SourceIndex(0)
-3 >Emitted(36, 14) Source(13, 24) + SourceIndex(0)
-4 >Emitted(36, 16) Source(13, 26) + SourceIndex(0)
-5 >Emitted(36, 17) Source(13, 27) + SourceIndex(0)
-6 >Emitted(36, 19) Source(13, 29) + SourceIndex(0)
-7 >Emitted(36, 21) Source(13, 31) + SourceIndex(0)
-8 >Emitted(36, 23) Source(13, 33) + SourceIndex(0)
-9 >Emitted(36, 24) Source(13, 34) + SourceIndex(0)
-10>Emitted(36, 26) Source(13, 36) + SourceIndex(0)
-11>Emitted(36, 28) Source(13, 38) + SourceIndex(0)
-12>Emitted(36, 30) Source(13, 40) + SourceIndex(0)
-13>Emitted(36, 32) Source(13, 42) + SourceIndex(0)
-14>Emitted(36, 34) Source(13, 44) + SourceIndex(0)
-15>Emitted(36, 36) Source(13, 46) + SourceIndex(0)
-16>Emitted(36, 38) Source(13, 48) + SourceIndex(0)
-17>Emitted(36, 40) Source(13, 9) + SourceIndex(0)
-18>Emitted(36, 41) Source(13, 10) + SourceIndex(0)
-19>Emitted(36, 48) Source(13, 10) + SourceIndex(0)
-20>Emitted(36, 50) Source(13, 15) + SourceIndex(0)
-21>Emitted(36, 54) Source(13, 19) + SourceIndex(0)
-22>Emitted(36, 68) Source(13, 7) + SourceIndex(0)
-23>Emitted(36, 73) Source(13, 21) + SourceIndex(0)
-24>Emitted(36, 74) Source(13, 48) + SourceIndex(0)
-25>Emitted(36, 75) Source(13, 49) + SourceIndex(0)
+1->Emitted(40, 5) Source(13, 1) + SourceIndex(0)
+2 >Emitted(40, 9) Source(13, 7) + SourceIndex(0)
+3 >Emitted(40, 14) Source(13, 24) + SourceIndex(0)
+4 >Emitted(40, 16) Source(13, 26) + SourceIndex(0)
+5 >Emitted(40, 17) Source(13, 27) + SourceIndex(0)
+6 >Emitted(40, 19) Source(13, 29) + SourceIndex(0)
+7 >Emitted(40, 21) Source(13, 31) + SourceIndex(0)
+8 >Emitted(40, 23) Source(13, 33) + SourceIndex(0)
+9 >Emitted(40, 24) Source(13, 34) + SourceIndex(0)
+10>Emitted(40, 26) Source(13, 36) + SourceIndex(0)
+11>Emitted(40, 28) Source(13, 38) + SourceIndex(0)
+12>Emitted(40, 30) Source(13, 40) + SourceIndex(0)
+13>Emitted(40, 32) Source(13, 42) + SourceIndex(0)
+14>Emitted(40, 34) Source(13, 44) + SourceIndex(0)
+15>Emitted(40, 36) Source(13, 46) + SourceIndex(0)
+16>Emitted(40, 38) Source(13, 48) + SourceIndex(0)
+17>Emitted(40, 40) Source(13, 9) + SourceIndex(0)
+18>Emitted(40, 41) Source(13, 10) + SourceIndex(0)
+19>Emitted(40, 48) Source(13, 10) + SourceIndex(0)
+20>Emitted(40, 50) Source(13, 15) + SourceIndex(0)
+21>Emitted(40, 54) Source(13, 19) + SourceIndex(0)
+22>Emitted(40, 68) Source(13, 7) + SourceIndex(0)
+23>Emitted(40, 73) Source(13, 21) + SourceIndex(0)
+24>Emitted(40, 74) Source(13, 48) + SourceIndex(0)
+25>Emitted(40, 75) Source(13, 49) + SourceIndex(0)
 ---
 >>>}
 1 >
@@ -953,8 +973,8 @@ sourceFile:../../../first/first_PART1.ts
 1 >
   >
 2 >}
-1 >Emitted(37, 1) Source(14, 1) + SourceIndex(0)
-2 >Emitted(37, 2) Source(14, 2) + SourceIndex(0)
+1 >Emitted(41, 1) Source(14, 1) + SourceIndex(0)
+2 >Emitted(41, 2) Source(14, 2) + SourceIndex(0)
 ---
 >>>console.log(s);
 1->
@@ -974,14 +994,14 @@ sourceFile:../../../first/first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1->Emitted(38, 1) Source(14, 2) + SourceIndex(0)
-2 >Emitted(38, 8) Source(14, 9) + SourceIndex(0)
-3 >Emitted(38, 9) Source(14, 10) + SourceIndex(0)
-4 >Emitted(38, 12) Source(14, 13) + SourceIndex(0)
-5 >Emitted(38, 13) Source(14, 14) + SourceIndex(0)
-6 >Emitted(38, 14) Source(14, 15) + SourceIndex(0)
-7 >Emitted(38, 15) Source(14, 16) + SourceIndex(0)
-8 >Emitted(38, 16) Source(14, 17) + SourceIndex(0)
+1->Emitted(42, 1) Source(14, 2) + SourceIndex(0)
+2 >Emitted(42, 8) Source(14, 9) + SourceIndex(0)
+3 >Emitted(42, 9) Source(14, 10) + SourceIndex(0)
+4 >Emitted(42, 12) Source(14, 13) + SourceIndex(0)
+5 >Emitted(42, 13) Source(14, 14) + SourceIndex(0)
+6 >Emitted(42, 14) Source(14, 15) + SourceIndex(0)
+7 >Emitted(42, 15) Source(14, 16) + SourceIndex(0)
+8 >Emitted(42, 16) Source(14, 17) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1006,15 +1026,15 @@ sourceFile:../../../first/first_part2.ts
 7 >             ()
 8 >               )
 9 >                ;
-1->Emitted(39, 1) Source(1, 1) + SourceIndex(1)
-2 >Emitted(39, 8) Source(1, 8) + SourceIndex(1)
-3 >Emitted(39, 9) Source(1, 9) + SourceIndex(1)
-4 >Emitted(39, 12) Source(1, 12) + SourceIndex(1)
-5 >Emitted(39, 13) Source(1, 13) + SourceIndex(1)
-6 >Emitted(39, 14) Source(1, 14) + SourceIndex(1)
-7 >Emitted(39, 16) Source(1, 16) + SourceIndex(1)
-8 >Emitted(39, 17) Source(1, 17) + SourceIndex(1)
-9 >Emitted(39, 18) Source(1, 18) + SourceIndex(1)
+1->Emitted(43, 1) Source(1, 1) + SourceIndex(1)
+2 >Emitted(43, 8) Source(1, 8) + SourceIndex(1)
+3 >Emitted(43, 9) Source(1, 9) + SourceIndex(1)
+4 >Emitted(43, 12) Source(1, 12) + SourceIndex(1)
+5 >Emitted(43, 13) Source(1, 13) + SourceIndex(1)
+6 >Emitted(43, 14) Source(1, 14) + SourceIndex(1)
+7 >Emitted(43, 16) Source(1, 16) + SourceIndex(1)
+8 >Emitted(43, 17) Source(1, 17) + SourceIndex(1)
+9 >Emitted(43, 18) Source(1, 18) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1028,9 +1048,9 @@ sourceFile:../../../first/first_part3.ts
 1 >
 2 >function 
 3 >         f
-1 >Emitted(40, 1) Source(1, 1) + SourceIndex(2)
-2 >Emitted(40, 10) Source(1, 10) + SourceIndex(2)
-3 >Emitted(40, 11) Source(1, 11) + SourceIndex(2)
+1 >Emitted(44, 1) Source(1, 1) + SourceIndex(2)
+2 >Emitted(44, 10) Source(1, 10) + SourceIndex(2)
+3 >Emitted(44, 11) Source(1, 11) + SourceIndex(2)
 ---
 >>>    return "JS does hoists";
 1->^^^^
@@ -1042,10 +1062,10 @@ sourceFile:../../../first/first_part3.ts
 2 >    return 
 3 >           "JS does hoists"
 4 >                           ;
-1->Emitted(41, 5) Source(2, 5) + SourceIndex(2)
-2 >Emitted(41, 12) Source(2, 12) + SourceIndex(2)
-3 >Emitted(41, 28) Source(2, 28) + SourceIndex(2)
-4 >Emitted(41, 29) Source(2, 29) + SourceIndex(2)
+1->Emitted(45, 5) Source(2, 5) + SourceIndex(2)
+2 >Emitted(45, 12) Source(2, 12) + SourceIndex(2)
+3 >Emitted(45, 28) Source(2, 28) + SourceIndex(2)
+4 >Emitted(45, 29) Source(2, 29) + SourceIndex(2)
 ---
 >>>}
 1 >
@@ -1054,8 +1074,8 @@ sourceFile:../../../first/first_part3.ts
 1 >
   >
 2 >}
-1 >Emitted(42, 1) Source(3, 1) + SourceIndex(2)
-2 >Emitted(42, 2) Source(3, 2) + SourceIndex(2)
+1 >Emitted(46, 1) Source(3, 1) + SourceIndex(2)
+2 >Emitted(46, 2) Source(3, 2) + SourceIndex(2)
 ---
 >>>function firstfirst_part3Spread() {
 1->
@@ -1065,9 +1085,9 @@ sourceFile:../../../first/first_part3.ts
   >
 2 >function 
 3 >         firstfirst_part3Spread
-1->Emitted(43, 1) Source(4, 1) + SourceIndex(2)
-2 >Emitted(43, 10) Source(4, 10) + SourceIndex(2)
-3 >Emitted(43, 32) Source(4, 32) + SourceIndex(2)
+1->Emitted(47, 1) Source(4, 1) + SourceIndex(2)
+2 >Emitted(47, 10) Source(4, 10) + SourceIndex(2)
+3 >Emitted(47, 32) Source(4, 32) + SourceIndex(2)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -1075,8 +1095,8 @@ sourceFile:../../../first/first_part3.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(44, 5) Source(4, 33) + SourceIndex(2)
-2 >Emitted(44, 16) Source(4, 47) + SourceIndex(2)
+1 >Emitted(48, 5) Source(4, 33) + SourceIndex(2)
+2 >Emitted(48, 16) Source(4, 47) + SourceIndex(2)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1091,20 +1111,20 @@ sourceFile:../../../first/first_part3.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(45, 10) Source(4, 33) + SourceIndex(2)
-2 >Emitted(45, 20) Source(4, 47) + SourceIndex(2)
-3 >Emitted(45, 22) Source(4, 33) + SourceIndex(2)
-4 >Emitted(45, 43) Source(4, 47) + SourceIndex(2)
-5 >Emitted(45, 45) Source(4, 33) + SourceIndex(2)
-6 >Emitted(45, 49) Source(4, 47) + SourceIndex(2)
+1->Emitted(49, 10) Source(4, 33) + SourceIndex(2)
+2 >Emitted(49, 20) Source(4, 47) + SourceIndex(2)
+3 >Emitted(49, 22) Source(4, 33) + SourceIndex(2)
+4 >Emitted(49, 43) Source(4, 47) + SourceIndex(2)
+5 >Emitted(49, 45) Source(4, 33) + SourceIndex(2)
+6 >Emitted(49, 49) Source(4, 47) + SourceIndex(2)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(46, 9) Source(4, 33) + SourceIndex(2)
-2 >Emitted(46, 31) Source(4, 47) + SourceIndex(2)
+1 >Emitted(50, 9) Source(4, 33) + SourceIndex(2)
+2 >Emitted(50, 31) Source(4, 47) + SourceIndex(2)
 ---
 >>>    }
 >>>}
@@ -1113,8 +1133,8 @@ sourceFile:../../../first/first_part3.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(48, 1) Source(4, 51) + SourceIndex(2)
-2 >Emitted(48, 2) Source(4, 52) + SourceIndex(2)
+1 >Emitted(52, 1) Source(4, 51) + SourceIndex(2)
+2 >Emitted(52, 2) Source(4, 52) + SourceIndex(2)
 ---
 >>>var firstfirst_part3_ar = [20, 30];
 1->
@@ -1139,16 +1159,16 @@ sourceFile:../../../first/first_part3.ts
 8 >                               30
 9 >                                 ]
 10>                                  ;
-1->Emitted(49, 1) Source(5, 1) + SourceIndex(2)
-2 >Emitted(49, 5) Source(5, 7) + SourceIndex(2)
-3 >Emitted(49, 24) Source(5, 26) + SourceIndex(2)
-4 >Emitted(49, 27) Source(5, 29) + SourceIndex(2)
-5 >Emitted(49, 28) Source(5, 30) + SourceIndex(2)
-6 >Emitted(49, 30) Source(5, 32) + SourceIndex(2)
-7 >Emitted(49, 32) Source(5, 34) + SourceIndex(2)
-8 >Emitted(49, 34) Source(5, 36) + SourceIndex(2)
-9 >Emitted(49, 35) Source(5, 37) + SourceIndex(2)
-10>Emitted(49, 36) Source(5, 38) + SourceIndex(2)
+1->Emitted(53, 1) Source(5, 1) + SourceIndex(2)
+2 >Emitted(53, 5) Source(5, 7) + SourceIndex(2)
+3 >Emitted(53, 24) Source(5, 26) + SourceIndex(2)
+4 >Emitted(53, 27) Source(5, 29) + SourceIndex(2)
+5 >Emitted(53, 28) Source(5, 30) + SourceIndex(2)
+6 >Emitted(53, 30) Source(5, 32) + SourceIndex(2)
+7 >Emitted(53, 32) Source(5, 34) + SourceIndex(2)
+8 >Emitted(53, 34) Source(5, 36) + SourceIndex(2)
+9 >Emitted(53, 35) Source(5, 37) + SourceIndex(2)
+10>Emitted(53, 36) Source(5, 38) + SourceIndex(2)
 ---
 >>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
 1->
@@ -1166,13 +1186,13 @@ sourceFile:../../../first/first_part3.ts
 5 >                                                      , ...
 6 >                                                                firstfirst_part3_ar
 7 >                                                                                   );
-1->Emitted(50, 1) Source(6, 1) + SourceIndex(2)
-2 >Emitted(50, 23) Source(6, 23) + SourceIndex(2)
-3 >Emitted(50, 53) Source(6, 24) + SourceIndex(2)
-4 >Emitted(50, 55) Source(6, 26) + SourceIndex(2)
-5 >Emitted(50, 65) Source(6, 31) + SourceIndex(2)
-6 >Emitted(50, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(50, 88) Source(6, 52) + SourceIndex(2)
+1->Emitted(54, 1) Source(6, 1) + SourceIndex(2)
+2 >Emitted(54, 23) Source(6, 23) + SourceIndex(2)
+3 >Emitted(54, 53) Source(6, 24) + SourceIndex(2)
+4 >Emitted(54, 55) Source(6, 26) + SourceIndex(2)
+5 >Emitted(54, 65) Source(6, 31) + SourceIndex(2)
+6 >Emitted(54, 84) Source(6, 50) + SourceIndex(2)
+7 >Emitted(54, 88) Source(6, 52) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1198,10 +1218,10 @@ sourceFile:../../../second/second_part1.ts
   >     
   >         f();
   >     }
-1 >Emitted(51, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(51, 5) Source(5, 11) + SourceIndex(3)
-3 >Emitted(51, 6) Source(5, 12) + SourceIndex(3)
-4 >Emitted(51, 7) Source(11, 2) + SourceIndex(3)
+1 >Emitted(55, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(55, 5) Source(5, 11) + SourceIndex(3)
+3 >Emitted(55, 6) Source(5, 12) + SourceIndex(3)
+4 >Emitted(55, 7) Source(11, 2) + SourceIndex(3)
 ---
 >>>(function (N) {
 1->
@@ -1211,9 +1231,9 @@ sourceFile:../../../second/second_part1.ts
 1->
 2 >namespace 
 3 >           N
-1->Emitted(52, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(52, 12) Source(5, 11) + SourceIndex(3)
-3 >Emitted(52, 13) Source(5, 12) + SourceIndex(3)
+1->Emitted(56, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(56, 12) Source(5, 11) + SourceIndex(3)
+3 >Emitted(56, 13) Source(5, 12) + SourceIndex(3)
 ---
 >>>    function f() {
 1->^^^^
@@ -1224,9 +1244,9 @@ sourceFile:../../../second/second_part1.ts
   >    
 2 >    function 
 3 >             f
-1->Emitted(53, 5) Source(6, 5) + SourceIndex(3)
-2 >Emitted(53, 14) Source(6, 14) + SourceIndex(3)
-3 >Emitted(53, 15) Source(6, 15) + SourceIndex(3)
+1->Emitted(57, 5) Source(6, 5) + SourceIndex(3)
+2 >Emitted(57, 14) Source(6, 14) + SourceIndex(3)
+3 >Emitted(57, 15) Source(6, 15) + SourceIndex(3)
 ---
 >>>        console.log('testing');
 1->^^^^^^^^
@@ -1246,14 +1266,14 @@ sourceFile:../../../second/second_part1.ts
 6 >                    'testing'
 7 >                             )
 8 >                              ;
-1->Emitted(54, 9) Source(7, 9) + SourceIndex(3)
-2 >Emitted(54, 16) Source(7, 16) + SourceIndex(3)
-3 >Emitted(54, 17) Source(7, 17) + SourceIndex(3)
-4 >Emitted(54, 20) Source(7, 20) + SourceIndex(3)
-5 >Emitted(54, 21) Source(7, 21) + SourceIndex(3)
-6 >Emitted(54, 30) Source(7, 30) + SourceIndex(3)
-7 >Emitted(54, 31) Source(7, 31) + SourceIndex(3)
-8 >Emitted(54, 32) Source(7, 32) + SourceIndex(3)
+1->Emitted(58, 9) Source(7, 9) + SourceIndex(3)
+2 >Emitted(58, 16) Source(7, 16) + SourceIndex(3)
+3 >Emitted(58, 17) Source(7, 17) + SourceIndex(3)
+4 >Emitted(58, 20) Source(7, 20) + SourceIndex(3)
+5 >Emitted(58, 21) Source(7, 21) + SourceIndex(3)
+6 >Emitted(58, 30) Source(7, 30) + SourceIndex(3)
+7 >Emitted(58, 31) Source(7, 31) + SourceIndex(3)
+8 >Emitted(58, 32) Source(7, 32) + SourceIndex(3)
 ---
 >>>    }
 1 >^^^^
@@ -1262,8 +1282,8 @@ sourceFile:../../../second/second_part1.ts
 1 >
   >    
 2 >    }
-1 >Emitted(55, 5) Source(8, 5) + SourceIndex(3)
-2 >Emitted(55, 6) Source(8, 6) + SourceIndex(3)
+1 >Emitted(59, 5) Source(8, 5) + SourceIndex(3)
+2 >Emitted(59, 6) Source(8, 6) + SourceIndex(3)
 ---
 >>>    f();
 1->^^^^
@@ -1277,10 +1297,10 @@ sourceFile:../../../second/second_part1.ts
 2 >    f
 3 >     ()
 4 >       ;
-1->Emitted(56, 5) Source(10, 5) + SourceIndex(3)
-2 >Emitted(56, 6) Source(10, 6) + SourceIndex(3)
-3 >Emitted(56, 8) Source(10, 8) + SourceIndex(3)
-4 >Emitted(56, 9) Source(10, 9) + SourceIndex(3)
+1->Emitted(60, 5) Source(10, 5) + SourceIndex(3)
+2 >Emitted(60, 6) Source(10, 6) + SourceIndex(3)
+3 >Emitted(60, 8) Source(10, 8) + SourceIndex(3)
+4 >Emitted(60, 9) Source(10, 9) + SourceIndex(3)
 ---
 >>>})(N || (N = {}));
 1->
@@ -1305,13 +1325,13 @@ sourceFile:../../../second/second_part1.ts
   >          
   >              f();
   >          }
-1->Emitted(57, 1) Source(11, 1) + SourceIndex(3)
-2 >Emitted(57, 2) Source(11, 2) + SourceIndex(3)
-3 >Emitted(57, 4) Source(5, 11) + SourceIndex(3)
-4 >Emitted(57, 5) Source(5, 12) + SourceIndex(3)
-5 >Emitted(57, 10) Source(5, 11) + SourceIndex(3)
-6 >Emitted(57, 11) Source(5, 12) + SourceIndex(3)
-7 >Emitted(57, 19) Source(11, 2) + SourceIndex(3)
+1->Emitted(61, 1) Source(11, 1) + SourceIndex(3)
+2 >Emitted(61, 2) Source(11, 2) + SourceIndex(3)
+3 >Emitted(61, 4) Source(5, 11) + SourceIndex(3)
+4 >Emitted(61, 5) Source(5, 12) + SourceIndex(3)
+5 >Emitted(61, 10) Source(5, 11) + SourceIndex(3)
+6 >Emitted(61, 11) Source(5, 12) + SourceIndex(3)
+7 >Emitted(61, 19) Source(11, 2) + SourceIndex(3)
 ---
 >>>function forsecondsecond_part1Rest() {
 1->
@@ -1322,9 +1342,9 @@ sourceFile:../../../second/second_part1.ts
   >
 2 >function 
 3 >         forsecondsecond_part1Rest
-1->Emitted(58, 1) Source(12, 1) + SourceIndex(3)
-2 >Emitted(58, 10) Source(12, 10) + SourceIndex(3)
-3 >Emitted(58, 35) Source(12, 35) + SourceIndex(3)
+1->Emitted(62, 1) Source(12, 1) + SourceIndex(3)
+2 >Emitted(62, 10) Source(12, 10) + SourceIndex(3)
+3 >Emitted(62, 35) Source(12, 35) + SourceIndex(3)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -1378,31 +1398,31 @@ sourceFile:../../../second/second_part1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(59, 5) Source(13, 1) + SourceIndex(3)
-2 >Emitted(59, 9) Source(13, 7) + SourceIndex(3)
-3 >Emitted(59, 14) Source(13, 24) + SourceIndex(3)
-4 >Emitted(59, 16) Source(13, 26) + SourceIndex(3)
-5 >Emitted(59, 17) Source(13, 27) + SourceIndex(3)
-6 >Emitted(59, 19) Source(13, 29) + SourceIndex(3)
-7 >Emitted(59, 21) Source(13, 31) + SourceIndex(3)
-8 >Emitted(59, 23) Source(13, 33) + SourceIndex(3)
-9 >Emitted(59, 24) Source(13, 34) + SourceIndex(3)
-10>Emitted(59, 26) Source(13, 36) + SourceIndex(3)
-11>Emitted(59, 28) Source(13, 38) + SourceIndex(3)
-12>Emitted(59, 30) Source(13, 40) + SourceIndex(3)
-13>Emitted(59, 32) Source(13, 42) + SourceIndex(3)
-14>Emitted(59, 34) Source(13, 44) + SourceIndex(3)
-15>Emitted(59, 36) Source(13, 46) + SourceIndex(3)
-16>Emitted(59, 38) Source(13, 48) + SourceIndex(3)
-17>Emitted(59, 40) Source(13, 9) + SourceIndex(3)
-18>Emitted(59, 41) Source(13, 10) + SourceIndex(3)
-19>Emitted(59, 48) Source(13, 10) + SourceIndex(3)
-20>Emitted(59, 50) Source(13, 15) + SourceIndex(3)
-21>Emitted(59, 54) Source(13, 19) + SourceIndex(3)
-22>Emitted(59, 68) Source(13, 7) + SourceIndex(3)
-23>Emitted(59, 73) Source(13, 21) + SourceIndex(3)
-24>Emitted(59, 74) Source(13, 48) + SourceIndex(3)
-25>Emitted(59, 75) Source(13, 49) + SourceIndex(3)
+1->Emitted(63, 5) Source(13, 1) + SourceIndex(3)
+2 >Emitted(63, 9) Source(13, 7) + SourceIndex(3)
+3 >Emitted(63, 14) Source(13, 24) + SourceIndex(3)
+4 >Emitted(63, 16) Source(13, 26) + SourceIndex(3)
+5 >Emitted(63, 17) Source(13, 27) + SourceIndex(3)
+6 >Emitted(63, 19) Source(13, 29) + SourceIndex(3)
+7 >Emitted(63, 21) Source(13, 31) + SourceIndex(3)
+8 >Emitted(63, 23) Source(13, 33) + SourceIndex(3)
+9 >Emitted(63, 24) Source(13, 34) + SourceIndex(3)
+10>Emitted(63, 26) Source(13, 36) + SourceIndex(3)
+11>Emitted(63, 28) Source(13, 38) + SourceIndex(3)
+12>Emitted(63, 30) Source(13, 40) + SourceIndex(3)
+13>Emitted(63, 32) Source(13, 42) + SourceIndex(3)
+14>Emitted(63, 34) Source(13, 44) + SourceIndex(3)
+15>Emitted(63, 36) Source(13, 46) + SourceIndex(3)
+16>Emitted(63, 38) Source(13, 48) + SourceIndex(3)
+17>Emitted(63, 40) Source(13, 9) + SourceIndex(3)
+18>Emitted(63, 41) Source(13, 10) + SourceIndex(3)
+19>Emitted(63, 48) Source(13, 10) + SourceIndex(3)
+20>Emitted(63, 50) Source(13, 15) + SourceIndex(3)
+21>Emitted(63, 54) Source(13, 19) + SourceIndex(3)
+22>Emitted(63, 68) Source(13, 7) + SourceIndex(3)
+23>Emitted(63, 73) Source(13, 21) + SourceIndex(3)
+24>Emitted(63, 74) Source(13, 48) + SourceIndex(3)
+25>Emitted(63, 75) Source(13, 49) + SourceIndex(3)
 ---
 >>>}
 1 >
@@ -1411,8 +1431,8 @@ sourceFile:../../../second/second_part1.ts
 1 >
   >
 2 >}
-1 >Emitted(60, 1) Source(14, 1) + SourceIndex(3)
-2 >Emitted(60, 2) Source(14, 2) + SourceIndex(3)
+1 >Emitted(64, 1) Source(14, 1) + SourceIndex(3)
+2 >Emitted(64, 2) Source(14, 2) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1422,13 +1442,13 @@ sourceFile:../../../second/second_part2.ts
 1->
 2 >^^^^^^^^^^^^^^^^^^^->
 1->
-1->Emitted(61, 1) Source(1, 1) + SourceIndex(4)
+1->Emitted(65, 1) Source(1, 1) + SourceIndex(4)
 ---
 >>>    function C() {
 1->^^^^
 2 >    ^^->
 1->
-1->Emitted(62, 5) Source(1, 1) + SourceIndex(4)
+1->Emitted(66, 5) Source(1, 1) + SourceIndex(4)
 ---
 >>>    }
 1->^^^^
@@ -1440,8 +1460,8 @@ sourceFile:../../../second/second_part2.ts
   >    }
   >
 2 >    }
-1->Emitted(63, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(63, 6) Source(5, 2) + SourceIndex(4)
+1->Emitted(67, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(67, 6) Source(5, 2) + SourceIndex(4)
 ---
 >>>    C.prototype.doSomething = function () {
 1->^^^^
@@ -1451,9 +1471,9 @@ sourceFile:../../../second/second_part2.ts
 1->
 2 >    doSomething
 3 >                           
-1->Emitted(64, 5) Source(2, 5) + SourceIndex(4)
-2 >Emitted(64, 28) Source(2, 16) + SourceIndex(4)
-3 >Emitted(64, 31) Source(2, 5) + SourceIndex(4)
+1->Emitted(68, 5) Source(2, 5) + SourceIndex(4)
+2 >Emitted(68, 28) Source(2, 16) + SourceIndex(4)
+3 >Emitted(68, 31) Source(2, 5) + SourceIndex(4)
 ---
 >>>        console.log("something got done");
 1->^^^^^^^^
@@ -1473,14 +1493,14 @@ sourceFile:../../../second/second_part2.ts
 6 >                    "something got done"
 7 >                                        )
 8 >                                         ;
-1->Emitted(65, 9) Source(3, 9) + SourceIndex(4)
-2 >Emitted(65, 16) Source(3, 16) + SourceIndex(4)
-3 >Emitted(65, 17) Source(3, 17) + SourceIndex(4)
-4 >Emitted(65, 20) Source(3, 20) + SourceIndex(4)
-5 >Emitted(65, 21) Source(3, 21) + SourceIndex(4)
-6 >Emitted(65, 41) Source(3, 41) + SourceIndex(4)
-7 >Emitted(65, 42) Source(3, 42) + SourceIndex(4)
-8 >Emitted(65, 43) Source(3, 43) + SourceIndex(4)
+1->Emitted(69, 9) Source(3, 9) + SourceIndex(4)
+2 >Emitted(69, 16) Source(3, 16) + SourceIndex(4)
+3 >Emitted(69, 17) Source(3, 17) + SourceIndex(4)
+4 >Emitted(69, 20) Source(3, 20) + SourceIndex(4)
+5 >Emitted(69, 21) Source(3, 21) + SourceIndex(4)
+6 >Emitted(69, 41) Source(3, 41) + SourceIndex(4)
+7 >Emitted(69, 42) Source(3, 42) + SourceIndex(4)
+8 >Emitted(69, 43) Source(3, 43) + SourceIndex(4)
 ---
 >>>    };
 1 >^^^^
@@ -1489,8 +1509,8 @@ sourceFile:../../../second/second_part2.ts
 1 >
   >    
 2 >    }
-1 >Emitted(66, 5) Source(4, 5) + SourceIndex(4)
-2 >Emitted(66, 6) Source(4, 6) + SourceIndex(4)
+1 >Emitted(70, 5) Source(4, 5) + SourceIndex(4)
+2 >Emitted(70, 6) Source(4, 6) + SourceIndex(4)
 ---
 >>>    return C;
 1->^^^^
@@ -1498,8 +1518,8 @@ sourceFile:../../../second/second_part2.ts
 1->
   >
 2 >    }
-1->Emitted(67, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(67, 13) Source(5, 2) + SourceIndex(4)
+1->Emitted(71, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(71, 13) Source(5, 2) + SourceIndex(4)
 ---
 >>>}());
 1 >
@@ -1515,10 +1535,10 @@ sourceFile:../../../second/second_part2.ts
   >         console.log("something got done");
   >     }
   > }
-1 >Emitted(68, 1) Source(5, 1) + SourceIndex(4)
-2 >Emitted(68, 2) Source(5, 2) + SourceIndex(4)
-3 >Emitted(68, 2) Source(1, 1) + SourceIndex(4)
-4 >Emitted(68, 6) Source(5, 2) + SourceIndex(4)
+1 >Emitted(72, 1) Source(5, 1) + SourceIndex(4)
+2 >Emitted(72, 2) Source(5, 2) + SourceIndex(4)
+3 >Emitted(72, 2) Source(1, 1) + SourceIndex(4)
+4 >Emitted(72, 6) Source(5, 2) + SourceIndex(4)
 ---
 >>>function secondsecond_part2Spread() {
 1->
@@ -1529,9 +1549,9 @@ sourceFile:../../../second/second_part2.ts
   >
 2 >function 
 3 >         secondsecond_part2Spread
-1->Emitted(69, 1) Source(7, 1) + SourceIndex(4)
-2 >Emitted(69, 10) Source(7, 10) + SourceIndex(4)
-3 >Emitted(69, 34) Source(7, 34) + SourceIndex(4)
+1->Emitted(73, 1) Source(7, 1) + SourceIndex(4)
+2 >Emitted(73, 10) Source(7, 10) + SourceIndex(4)
+3 >Emitted(73, 34) Source(7, 34) + SourceIndex(4)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -1539,8 +1559,8 @@ sourceFile:../../../second/second_part2.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(70, 5) Source(7, 35) + SourceIndex(4)
-2 >Emitted(70, 16) Source(7, 49) + SourceIndex(4)
+1 >Emitted(74, 5) Source(7, 35) + SourceIndex(4)
+2 >Emitted(74, 16) Source(7, 49) + SourceIndex(4)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1555,20 +1575,20 @@ sourceFile:../../../second/second_part2.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(71, 10) Source(7, 35) + SourceIndex(4)
-2 >Emitted(71, 20) Source(7, 49) + SourceIndex(4)
-3 >Emitted(71, 22) Source(7, 35) + SourceIndex(4)
-4 >Emitted(71, 43) Source(7, 49) + SourceIndex(4)
-5 >Emitted(71, 45) Source(7, 35) + SourceIndex(4)
-6 >Emitted(71, 49) Source(7, 49) + SourceIndex(4)
+1->Emitted(75, 10) Source(7, 35) + SourceIndex(4)
+2 >Emitted(75, 20) Source(7, 49) + SourceIndex(4)
+3 >Emitted(75, 22) Source(7, 35) + SourceIndex(4)
+4 >Emitted(75, 43) Source(7, 49) + SourceIndex(4)
+5 >Emitted(75, 45) Source(7, 35) + SourceIndex(4)
+6 >Emitted(75, 49) Source(7, 49) + SourceIndex(4)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(72, 9) Source(7, 35) + SourceIndex(4)
-2 >Emitted(72, 31) Source(7, 49) + SourceIndex(4)
+1 >Emitted(76, 9) Source(7, 35) + SourceIndex(4)
+2 >Emitted(76, 31) Source(7, 49) + SourceIndex(4)
 ---
 >>>    }
 >>>}
@@ -1577,8 +1597,8 @@ sourceFile:../../../second/second_part2.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(74, 1) Source(7, 53) + SourceIndex(4)
-2 >Emitted(74, 2) Source(7, 54) + SourceIndex(4)
+1 >Emitted(78, 1) Source(7, 53) + SourceIndex(4)
+2 >Emitted(78, 2) Source(7, 54) + SourceIndex(4)
 ---
 >>>var secondsecond_part2_ar = [20, 30];
 1->
@@ -1603,16 +1623,16 @@ sourceFile:../../../second/second_part2.ts
 8 >                                 30
 9 >                                   ]
 10>                                    ;
-1->Emitted(75, 1) Source(8, 1) + SourceIndex(4)
-2 >Emitted(75, 5) Source(8, 7) + SourceIndex(4)
-3 >Emitted(75, 26) Source(8, 28) + SourceIndex(4)
-4 >Emitted(75, 29) Source(8, 31) + SourceIndex(4)
-5 >Emitted(75, 30) Source(8, 32) + SourceIndex(4)
-6 >Emitted(75, 32) Source(8, 34) + SourceIndex(4)
-7 >Emitted(75, 34) Source(8, 36) + SourceIndex(4)
-8 >Emitted(75, 36) Source(8, 38) + SourceIndex(4)
-9 >Emitted(75, 37) Source(8, 39) + SourceIndex(4)
-10>Emitted(75, 38) Source(8, 40) + SourceIndex(4)
+1->Emitted(79, 1) Source(8, 1) + SourceIndex(4)
+2 >Emitted(79, 5) Source(8, 7) + SourceIndex(4)
+3 >Emitted(79, 26) Source(8, 28) + SourceIndex(4)
+4 >Emitted(79, 29) Source(8, 31) + SourceIndex(4)
+5 >Emitted(79, 30) Source(8, 32) + SourceIndex(4)
+6 >Emitted(79, 32) Source(8, 34) + SourceIndex(4)
+7 >Emitted(79, 34) Source(8, 36) + SourceIndex(4)
+8 >Emitted(79, 36) Source(8, 38) + SourceIndex(4)
+9 >Emitted(79, 37) Source(8, 39) + SourceIndex(4)
+10>Emitted(79, 38) Source(8, 40) + SourceIndex(4)
 ---
 >>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
 1->
@@ -1630,13 +1650,13 @@ sourceFile:../../../second/second_part2.ts
 5 >                                                        , ...
 6 >                                                                  secondsecond_part2_ar
 7 >                                                                                       );
-1->Emitted(76, 1) Source(9, 1) + SourceIndex(4)
-2 >Emitted(76, 25) Source(9, 25) + SourceIndex(4)
-3 >Emitted(76, 55) Source(9, 26) + SourceIndex(4)
-4 >Emitted(76, 57) Source(9, 28) + SourceIndex(4)
-5 >Emitted(76, 67) Source(9, 33) + SourceIndex(4)
-6 >Emitted(76, 88) Source(9, 54) + SourceIndex(4)
-7 >Emitted(76, 92) Source(9, 56) + SourceIndex(4)
+1->Emitted(80, 1) Source(9, 1) + SourceIndex(4)
+2 >Emitted(80, 25) Source(9, 25) + SourceIndex(4)
+3 >Emitted(80, 55) Source(9, 26) + SourceIndex(4)
+4 >Emitted(80, 57) Source(9, 28) + SourceIndex(4)
+5 >Emitted(80, 67) Source(9, 33) + SourceIndex(4)
+6 >Emitted(80, 88) Source(9, 54) + SourceIndex(4)
+7 >Emitted(80, 92) Source(9, 56) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1660,14 +1680,14 @@ sourceFile:../../third_part1.ts
 6 >            C
 7 >             ()
 8 >               ;
-1 >Emitted(77, 1) Source(1, 1) + SourceIndex(5)
-2 >Emitted(77, 5) Source(1, 5) + SourceIndex(5)
-3 >Emitted(77, 6) Source(1, 6) + SourceIndex(5)
-4 >Emitted(77, 9) Source(1, 9) + SourceIndex(5)
-5 >Emitted(77, 13) Source(1, 13) + SourceIndex(5)
-6 >Emitted(77, 14) Source(1, 14) + SourceIndex(5)
-7 >Emitted(77, 16) Source(1, 16) + SourceIndex(5)
-8 >Emitted(77, 17) Source(1, 17) + SourceIndex(5)
+1 >Emitted(81, 1) Source(1, 1) + SourceIndex(5)
+2 >Emitted(81, 5) Source(1, 5) + SourceIndex(5)
+3 >Emitted(81, 6) Source(1, 6) + SourceIndex(5)
+4 >Emitted(81, 9) Source(1, 9) + SourceIndex(5)
+5 >Emitted(81, 13) Source(1, 13) + SourceIndex(5)
+6 >Emitted(81, 14) Source(1, 14) + SourceIndex(5)
+7 >Emitted(81, 16) Source(1, 16) + SourceIndex(5)
+8 >Emitted(81, 17) Source(1, 17) + SourceIndex(5)
 ---
 >>>c.doSomething();
 1->
@@ -1684,12 +1704,12 @@ sourceFile:../../third_part1.ts
 4 >  doSomething
 5 >             ()
 6 >               ;
-1->Emitted(78, 1) Source(2, 1) + SourceIndex(5)
-2 >Emitted(78, 2) Source(2, 2) + SourceIndex(5)
-3 >Emitted(78, 3) Source(2, 3) + SourceIndex(5)
-4 >Emitted(78, 14) Source(2, 14) + SourceIndex(5)
-5 >Emitted(78, 16) Source(2, 16) + SourceIndex(5)
-6 >Emitted(78, 17) Source(2, 17) + SourceIndex(5)
+1->Emitted(82, 1) Source(2, 1) + SourceIndex(5)
+2 >Emitted(82, 2) Source(2, 2) + SourceIndex(5)
+3 >Emitted(82, 3) Source(2, 3) + SourceIndex(5)
+4 >Emitted(82, 14) Source(2, 14) + SourceIndex(5)
+5 >Emitted(82, 16) Source(2, 16) + SourceIndex(5)
+6 >Emitted(82, 17) Source(2, 17) + SourceIndex(5)
 ---
 >>>function forthirdthird_part1Rest() {
 1->
@@ -1700,9 +1720,9 @@ sourceFile:../../third_part1.ts
   >
 2 >function 
 3 >         forthirdthird_part1Rest
-1->Emitted(79, 1) Source(3, 1) + SourceIndex(5)
-2 >Emitted(79, 10) Source(3, 10) + SourceIndex(5)
-3 >Emitted(79, 33) Source(3, 33) + SourceIndex(5)
+1->Emitted(83, 1) Source(3, 1) + SourceIndex(5)
+2 >Emitted(83, 10) Source(3, 10) + SourceIndex(5)
+3 >Emitted(83, 33) Source(3, 33) + SourceIndex(5)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -1756,31 +1776,31 @@ sourceFile:../../third_part1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(80, 5) Source(4, 1) + SourceIndex(5)
-2 >Emitted(80, 9) Source(4, 7) + SourceIndex(5)
-3 >Emitted(80, 14) Source(4, 24) + SourceIndex(5)
-4 >Emitted(80, 16) Source(4, 26) + SourceIndex(5)
-5 >Emitted(80, 17) Source(4, 27) + SourceIndex(5)
-6 >Emitted(80, 19) Source(4, 29) + SourceIndex(5)
-7 >Emitted(80, 21) Source(4, 31) + SourceIndex(5)
-8 >Emitted(80, 23) Source(4, 33) + SourceIndex(5)
-9 >Emitted(80, 24) Source(4, 34) + SourceIndex(5)
-10>Emitted(80, 26) Source(4, 36) + SourceIndex(5)
-11>Emitted(80, 28) Source(4, 38) + SourceIndex(5)
-12>Emitted(80, 30) Source(4, 40) + SourceIndex(5)
-13>Emitted(80, 32) Source(4, 42) + SourceIndex(5)
-14>Emitted(80, 34) Source(4, 44) + SourceIndex(5)
-15>Emitted(80, 36) Source(4, 46) + SourceIndex(5)
-16>Emitted(80, 38) Source(4, 48) + SourceIndex(5)
-17>Emitted(80, 40) Source(4, 9) + SourceIndex(5)
-18>Emitted(80, 41) Source(4, 10) + SourceIndex(5)
-19>Emitted(80, 48) Source(4, 10) + SourceIndex(5)
-20>Emitted(80, 50) Source(4, 15) + SourceIndex(5)
-21>Emitted(80, 54) Source(4, 19) + SourceIndex(5)
-22>Emitted(80, 68) Source(4, 7) + SourceIndex(5)
-23>Emitted(80, 73) Source(4, 21) + SourceIndex(5)
-24>Emitted(80, 74) Source(4, 48) + SourceIndex(5)
-25>Emitted(80, 75) Source(4, 49) + SourceIndex(5)
+1->Emitted(84, 5) Source(4, 1) + SourceIndex(5)
+2 >Emitted(84, 9) Source(4, 7) + SourceIndex(5)
+3 >Emitted(84, 14) Source(4, 24) + SourceIndex(5)
+4 >Emitted(84, 16) Source(4, 26) + SourceIndex(5)
+5 >Emitted(84, 17) Source(4, 27) + SourceIndex(5)
+6 >Emitted(84, 19) Source(4, 29) + SourceIndex(5)
+7 >Emitted(84, 21) Source(4, 31) + SourceIndex(5)
+8 >Emitted(84, 23) Source(4, 33) + SourceIndex(5)
+9 >Emitted(84, 24) Source(4, 34) + SourceIndex(5)
+10>Emitted(84, 26) Source(4, 36) + SourceIndex(5)
+11>Emitted(84, 28) Source(4, 38) + SourceIndex(5)
+12>Emitted(84, 30) Source(4, 40) + SourceIndex(5)
+13>Emitted(84, 32) Source(4, 42) + SourceIndex(5)
+14>Emitted(84, 34) Source(4, 44) + SourceIndex(5)
+15>Emitted(84, 36) Source(4, 46) + SourceIndex(5)
+16>Emitted(84, 38) Source(4, 48) + SourceIndex(5)
+17>Emitted(84, 40) Source(4, 9) + SourceIndex(5)
+18>Emitted(84, 41) Source(4, 10) + SourceIndex(5)
+19>Emitted(84, 48) Source(4, 10) + SourceIndex(5)
+20>Emitted(84, 50) Source(4, 15) + SourceIndex(5)
+21>Emitted(84, 54) Source(4, 19) + SourceIndex(5)
+22>Emitted(84, 68) Source(4, 7) + SourceIndex(5)
+23>Emitted(84, 73) Source(4, 21) + SourceIndex(5)
+24>Emitted(84, 74) Source(4, 48) + SourceIndex(5)
+25>Emitted(84, 75) Source(4, 49) + SourceIndex(5)
 ---
 >>>}
 1 >
@@ -1789,8 +1809,8 @@ sourceFile:../../third_part1.ts
 1 >
   >
 2 >}
-1 >Emitted(81, 1) Source(5, 1) + SourceIndex(5)
-2 >Emitted(81, 2) Source(5, 2) + SourceIndex(5)
+1 >Emitted(85, 1) Source(5, 1) + SourceIndex(5)
+2 >Emitted(85, 2) Source(5, 2) + SourceIndex(5)
 ---
 >>>function thirdthird_part1Spread() {
 1->
@@ -1800,9 +1820,9 @@ sourceFile:../../third_part1.ts
   >
 2 >function 
 3 >         thirdthird_part1Spread
-1->Emitted(82, 1) Source(6, 1) + SourceIndex(5)
-2 >Emitted(82, 10) Source(6, 10) + SourceIndex(5)
-3 >Emitted(82, 32) Source(6, 32) + SourceIndex(5)
+1->Emitted(86, 1) Source(6, 1) + SourceIndex(5)
+2 >Emitted(86, 10) Source(6, 10) + SourceIndex(5)
+3 >Emitted(86, 32) Source(6, 32) + SourceIndex(5)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -1810,8 +1830,8 @@ sourceFile:../../third_part1.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(83, 5) Source(6, 33) + SourceIndex(5)
-2 >Emitted(83, 16) Source(6, 47) + SourceIndex(5)
+1 >Emitted(87, 5) Source(6, 33) + SourceIndex(5)
+2 >Emitted(87, 16) Source(6, 47) + SourceIndex(5)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1826,20 +1846,20 @@ sourceFile:../../third_part1.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(84, 10) Source(6, 33) + SourceIndex(5)
-2 >Emitted(84, 20) Source(6, 47) + SourceIndex(5)
-3 >Emitted(84, 22) Source(6, 33) + SourceIndex(5)
-4 >Emitted(84, 43) Source(6, 47) + SourceIndex(5)
-5 >Emitted(84, 45) Source(6, 33) + SourceIndex(5)
-6 >Emitted(84, 49) Source(6, 47) + SourceIndex(5)
+1->Emitted(88, 10) Source(6, 33) + SourceIndex(5)
+2 >Emitted(88, 20) Source(6, 47) + SourceIndex(5)
+3 >Emitted(88, 22) Source(6, 33) + SourceIndex(5)
+4 >Emitted(88, 43) Source(6, 47) + SourceIndex(5)
+5 >Emitted(88, 45) Source(6, 33) + SourceIndex(5)
+6 >Emitted(88, 49) Source(6, 47) + SourceIndex(5)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(85, 9) Source(6, 33) + SourceIndex(5)
-2 >Emitted(85, 31) Source(6, 47) + SourceIndex(5)
+1 >Emitted(89, 9) Source(6, 33) + SourceIndex(5)
+2 >Emitted(89, 31) Source(6, 47) + SourceIndex(5)
 ---
 >>>    }
 >>>}
@@ -1848,8 +1868,8 @@ sourceFile:../../third_part1.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(87, 1) Source(6, 51) + SourceIndex(5)
-2 >Emitted(87, 2) Source(6, 52) + SourceIndex(5)
+1 >Emitted(91, 1) Source(6, 51) + SourceIndex(5)
+2 >Emitted(91, 2) Source(6, 52) + SourceIndex(5)
 ---
 >>>var thirdthird_part1_ar = [20, 30];
 1->
@@ -1874,16 +1894,16 @@ sourceFile:../../third_part1.ts
 8 >                               30
 9 >                                 ]
 10>                                  ;
-1->Emitted(88, 1) Source(7, 1) + SourceIndex(5)
-2 >Emitted(88, 5) Source(7, 7) + SourceIndex(5)
-3 >Emitted(88, 24) Source(7, 26) + SourceIndex(5)
-4 >Emitted(88, 27) Source(7, 29) + SourceIndex(5)
-5 >Emitted(88, 28) Source(7, 30) + SourceIndex(5)
-6 >Emitted(88, 30) Source(7, 32) + SourceIndex(5)
-7 >Emitted(88, 32) Source(7, 34) + SourceIndex(5)
-8 >Emitted(88, 34) Source(7, 36) + SourceIndex(5)
-9 >Emitted(88, 35) Source(7, 37) + SourceIndex(5)
-10>Emitted(88, 36) Source(7, 38) + SourceIndex(5)
+1->Emitted(92, 1) Source(7, 1) + SourceIndex(5)
+2 >Emitted(92, 5) Source(7, 7) + SourceIndex(5)
+3 >Emitted(92, 24) Source(7, 26) + SourceIndex(5)
+4 >Emitted(92, 27) Source(7, 29) + SourceIndex(5)
+5 >Emitted(92, 28) Source(7, 30) + SourceIndex(5)
+6 >Emitted(92, 30) Source(7, 32) + SourceIndex(5)
+7 >Emitted(92, 32) Source(7, 34) + SourceIndex(5)
+8 >Emitted(92, 34) Source(7, 36) + SourceIndex(5)
+9 >Emitted(92, 35) Source(7, 37) + SourceIndex(5)
+10>Emitted(92, 36) Source(7, 38) + SourceIndex(5)
 ---
 >>>thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
 1->
@@ -1901,18 +1921,18 @@ sourceFile:../../third_part1.ts
 5 >                                                      , ...
 6 >                                                                thirdthird_part1_ar
 7 >                                                                                   );
-1->Emitted(89, 1) Source(8, 1) + SourceIndex(5)
-2 >Emitted(89, 23) Source(8, 23) + SourceIndex(5)
-3 >Emitted(89, 53) Source(8, 24) + SourceIndex(5)
-4 >Emitted(89, 55) Source(8, 26) + SourceIndex(5)
-5 >Emitted(89, 65) Source(8, 31) + SourceIndex(5)
-6 >Emitted(89, 84) Source(8, 50) + SourceIndex(5)
-7 >Emitted(89, 88) Source(8, 52) + SourceIndex(5)
+1->Emitted(93, 1) Source(8, 1) + SourceIndex(5)
+2 >Emitted(93, 23) Source(8, 23) + SourceIndex(5)
+3 >Emitted(93, 53) Source(8, 24) + SourceIndex(5)
+4 >Emitted(93, 55) Source(8, 26) + SourceIndex(5)
+5 >Emitted(93, 65) Source(8, 31) + SourceIndex(5)
+6 >Emitted(93, 84) Source(8, 50) + SourceIndex(5)
+7 >Emitted(93, 88) Source(8, 52) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1199,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1201,"end":1720,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1201,"end":1720,"kind":"text"}]},{"pos":1720,"end":2407,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1720,"end":2407,"kind":"text"}]},{"pos":2407,"end":2835,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1863,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1863,"kind":"text"}]},{"pos":1863,"end":2550,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1863,"end":2550,"kind":"text"}]},{"pos":2550,"end":2978,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1949,16 +1969,20 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1199):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (1008-1342):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-prepend: (1201-1720):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1344-1863):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1201-1720)
+text: (1344-1863)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -1979,9 +2003,9 @@ var firstfirst_part3_ar = [20, 30];
 firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
 
 ----------------------------------------------------------------------
-prepend: (1720-2407):: ../../../2/second-output.js texts:: 1
+prepend: (1863-2550):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1720-2407)
+text: (1863-2550)
 var N;
 (function (N) {
     function f() {
@@ -2010,7 +2034,7 @@ var secondsecond_part2_ar = [20, 30];
 secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
 
 ----------------------------------------------------------------------
-text: (2407-2835)
+text: (2550-2978)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -2091,39 +2115,39 @@ declare const thirdthird_part1_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1199,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1201,
-          "end": 1720,
+          "pos": 1344,
+          "end": 1863,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1201,
-              "end": 1720,
+              "pos": 1344,
+              "end": 1863,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1720,
-          "end": 2407,
+          "pos": 1863,
+          "end": 2550,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1720,
-              "end": 2407,
+              "pos": 1863,
+              "end": 2550,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2407,
-          "end": 2835,
+          "pos": 2550,
+          "end": 2978,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
@@ -71,7 +71,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -96,11 +96,11 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 //# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.js.map]
-{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,WAAE"}
 
 //// [/src/first/bin/first-output.js.map.baseline.txt]
 ===================================================================
@@ -141,7 +141,7 @@ sourceFile:../first_PART1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -478,7 +478,7 @@ sourceFile:../first_part3.ts
 8 >                               ^^
 9 >                                 ^
 10>                                  ^
-11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -501,14 +501,14 @@ sourceFile:../first_part3.ts
 9 >Emitted(53, 35) Source(5, 37) + SourceIndex(2)
 10>Emitted(53, 36) Source(5, 38) + SourceIndex(2)
 ---
->>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+>>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^
 3 >                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                    ^^
 5 >                                                      ^^^^^^^^^^
 6 >                                                                ^^^^^^^^^^^^^^^^^^^
-7 >                                                                                   ^^^^
+7 >                                                                                   ^^^^^^^^^^^
 1->
   >
 2 >firstfirst_part3Spread
@@ -523,12 +523,12 @@ sourceFile:../first_part3.ts
 4 >Emitted(54, 55) Source(6, 26) + SourceIndex(2)
 5 >Emitted(54, 65) Source(6, 31) + SourceIndex(2)
 6 >Emitted(54, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(54, 88) Source(6, 52) + SourceIndex(2)
+7 >Emitted(54, 95) Source(6, 52) + SourceIndex(2)
 ---
 >>>//# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1863,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1896,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/first/bin/first-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -565,9 +565,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1342):: typescript:spreadArray
+emitHelpers: (1008-1368):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -576,7 +576,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (1344-1863)
+text: (1370-1896)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -594,7 +594,7 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 
 ======================================================================
 ======================================================================
@@ -640,13 +640,13 @@ declare const firstfirst_part3_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1342,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1344,
-          "end": 1863,
+          "pos": 1370,
+          "end": 1896,
           "kind": "text"
         }
       ],
@@ -701,7 +701,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -726,7 +726,7 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 var N;
 (function (N) {
     function f() {
@@ -752,7 +752,7 @@ function secondsecond_part2Spread() {
     }
 }
 var secondsecond_part2_ar = [20, 30];
-secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -765,11 +765,11 @@ function thirdthird_part1Spread() {
     }
 }
 var thirdthird_part1_ar = [20, 30];
-thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
+thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar), false));
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,WAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,WAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,WAAE"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -810,7 +810,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -1147,7 +1147,7 @@ sourceFile:../../../first/first_part3.ts
 8 >                               ^^
 9 >                                 ^
 10>                                  ^
-11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1170,14 +1170,14 @@ sourceFile:../../../first/first_part3.ts
 9 >Emitted(53, 35) Source(5, 37) + SourceIndex(2)
 10>Emitted(53, 36) Source(5, 38) + SourceIndex(2)
 ---
->>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+>>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^
 3 >                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                    ^^
 5 >                                                      ^^^^^^^^^^
 6 >                                                                ^^^^^^^^^^^^^^^^^^^
-7 >                                                                                   ^^^^
+7 >                                                                                   ^^^^^^^^^^^
 1->
   >
 2 >firstfirst_part3Spread
@@ -1192,7 +1192,7 @@ sourceFile:../../../first/first_part3.ts
 4 >Emitted(54, 55) Source(6, 26) + SourceIndex(2)
 5 >Emitted(54, 65) Source(6, 31) + SourceIndex(2)
 6 >Emitted(54, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(54, 88) Source(6, 52) + SourceIndex(2)
+7 >Emitted(54, 95) Source(6, 52) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1611,7 +1611,7 @@ sourceFile:../../../second/second_part2.ts
 8 >                                 ^^
 9 >                                   ^
 10>                                    ^
-11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1634,14 +1634,14 @@ sourceFile:../../../second/second_part2.ts
 9 >Emitted(79, 37) Source(8, 39) + SourceIndex(4)
 10>Emitted(79, 38) Source(8, 40) + SourceIndex(4)
 ---
->>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+>>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^^^
 3 >                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                      ^^
 5 >                                                        ^^^^^^^^^^
 6 >                                                                  ^^^^^^^^^^^^^^^^^^^^^
-7 >                                                                                       ^^^^
+7 >                                                                                       ^^^^^^^^^^^
 1->
   >
 2 >secondsecond_part2Spread
@@ -1656,7 +1656,7 @@ sourceFile:../../../second/second_part2.ts
 4 >Emitted(80, 57) Source(9, 28) + SourceIndex(4)
 5 >Emitted(80, 67) Source(9, 33) + SourceIndex(4)
 6 >Emitted(80, 88) Source(9, 54) + SourceIndex(4)
-7 >Emitted(80, 92) Source(9, 56) + SourceIndex(4)
+7 >Emitted(80, 99) Source(9, 56) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1882,7 +1882,7 @@ sourceFile:../../third_part1.ts
 8 >                               ^^
 9 >                                 ^
 10>                                  ^
-11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1905,14 +1905,14 @@ sourceFile:../../third_part1.ts
 9 >Emitted(92, 35) Source(7, 37) + SourceIndex(5)
 10>Emitted(92, 36) Source(7, 38) + SourceIndex(5)
 ---
->>>thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
+>>>thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^
 3 >                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                    ^^
 5 >                                                      ^^^^^^^^^^
 6 >                                                                ^^^^^^^^^^^^^^^^^^^
-7 >                                                                                   ^^^^
+7 >                                                                                   ^^^^^^^^^^^
 1->
   >
 2 >thirdthird_part1Spread
@@ -1927,12 +1927,12 @@ sourceFile:../../third_part1.ts
 4 >Emitted(93, 55) Source(8, 26) + SourceIndex(5)
 5 >Emitted(93, 65) Source(8, 31) + SourceIndex(5)
 6 >Emitted(93, 84) Source(8, 50) + SourceIndex(5)
-7 >Emitted(93, 88) Source(8, 52) + SourceIndex(5)
+7 >Emitted(93, 95) Source(8, 52) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1863,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1863,"kind":"text"}]},{"pos":1863,"end":2550,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1863,"end":2550,"kind":"text"}]},{"pos":2550,"end":2978,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1896,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1896,"kind":"text"}]},{"pos":1896,"end":2590,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1896,"end":2590,"kind":"text"}]},{"pos":2590,"end":3025,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1969,9 +1969,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1342):: typescript:spreadArray
+emitHelpers: (1008-1368):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1980,9 +1980,9 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-prepend: (1344-1863):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1370-1896):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1344-1863)
+text: (1370-1896)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -2000,12 +2000,12 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 
 ----------------------------------------------------------------------
-prepend: (1863-2550):: ../../../2/second-output.js texts:: 1
+prepend: (1896-2590):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1863-2550)
+text: (1896-2590)
 var N;
 (function (N) {
     function f() {
@@ -2031,10 +2031,10 @@ function secondsecond_part2Spread() {
     }
 }
 var secondsecond_part2_ar = [20, 30];
-secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 
 ----------------------------------------------------------------------
-text: (2550-2978)
+text: (2590-3025)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -2047,7 +2047,7 @@ function thirdthird_part1Spread() {
     }
 }
 var thirdthird_part1_ar = [20, 30];
-thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
+thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar), false));
 
 ======================================================================
 ======================================================================
@@ -2115,39 +2115,39 @@ declare const thirdthird_part1_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1342,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1344,
-          "end": 1863,
+          "pos": 1370,
+          "end": 1896,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1344,
-              "end": 1863,
+              "pos": 1370,
+              "end": 1896,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1863,
-          "end": 2550,
+          "pos": 1896,
+          "end": 2590,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1863,
-              "end": 2550,
+              "pos": 1896,
+              "end": 2590,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2550,
-          "end": 2978,
+          "pos": 2590,
+          "end": 3025,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-different-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-different-projects.js
@@ -472,10 +472,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var s = "Hello, world";
 console.log(s);
@@ -518,7 +522,7 @@ function forthirdthird_part1Rest() {
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -558,10 +562,14 @@ sourceFile:../../../first/first_PART1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -580,12 +588,12 @@ sourceFile:../../../first/first_PART1.ts
 4 >      = 
 5 >        "Hello, world"
 6 >                      ;
-1 >Emitted(33, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(5, 7) + SourceIndex(0)
-3 >Emitted(33, 6) Source(5, 8) + SourceIndex(0)
-4 >Emitted(33, 9) Source(5, 11) + SourceIndex(0)
-5 >Emitted(33, 23) Source(5, 25) + SourceIndex(0)
-6 >Emitted(33, 24) Source(5, 26) + SourceIndex(0)
+1 >Emitted(37, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(5, 7) + SourceIndex(0)
+3 >Emitted(37, 6) Source(5, 8) + SourceIndex(0)
+4 >Emitted(37, 9) Source(5, 11) + SourceIndex(0)
+5 >Emitted(37, 23) Source(5, 25) + SourceIndex(0)
+6 >Emitted(37, 24) Source(5, 26) + SourceIndex(0)
 ---
 >>>console.log(s);
 1 >
@@ -611,14 +619,14 @@ sourceFile:../../../first/first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1 >Emitted(34, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(34, 8) Source(11, 8) + SourceIndex(0)
-3 >Emitted(34, 9) Source(11, 9) + SourceIndex(0)
-4 >Emitted(34, 12) Source(11, 12) + SourceIndex(0)
-5 >Emitted(34, 13) Source(11, 13) + SourceIndex(0)
-6 >Emitted(34, 14) Source(11, 14) + SourceIndex(0)
-7 >Emitted(34, 15) Source(11, 15) + SourceIndex(0)
-8 >Emitted(34, 16) Source(11, 16) + SourceIndex(0)
+1 >Emitted(38, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(38, 8) Source(11, 8) + SourceIndex(0)
+3 >Emitted(38, 9) Source(11, 9) + SourceIndex(0)
+4 >Emitted(38, 12) Source(11, 12) + SourceIndex(0)
+5 >Emitted(38, 13) Source(11, 13) + SourceIndex(0)
+6 >Emitted(38, 14) Source(11, 14) + SourceIndex(0)
+7 >Emitted(38, 15) Source(11, 15) + SourceIndex(0)
+8 >Emitted(38, 16) Source(11, 16) + SourceIndex(0)
 ---
 >>>function forfirstfirst_PART1Rest() {
 1->
@@ -629,9 +637,9 @@ sourceFile:../../../first/first_PART1.ts
   >
 2 >function 
 3 >         forfirstfirst_PART1Rest
-1->Emitted(35, 1) Source(12, 1) + SourceIndex(0)
-2 >Emitted(35, 10) Source(12, 10) + SourceIndex(0)
-3 >Emitted(35, 33) Source(12, 33) + SourceIndex(0)
+1->Emitted(39, 1) Source(12, 1) + SourceIndex(0)
+2 >Emitted(39, 10) Source(12, 10) + SourceIndex(0)
+3 >Emitted(39, 33) Source(12, 33) + SourceIndex(0)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -685,31 +693,31 @@ sourceFile:../../../first/first_PART1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(36, 5) Source(13, 1) + SourceIndex(0)
-2 >Emitted(36, 9) Source(13, 7) + SourceIndex(0)
-3 >Emitted(36, 14) Source(13, 24) + SourceIndex(0)
-4 >Emitted(36, 16) Source(13, 26) + SourceIndex(0)
-5 >Emitted(36, 17) Source(13, 27) + SourceIndex(0)
-6 >Emitted(36, 19) Source(13, 29) + SourceIndex(0)
-7 >Emitted(36, 21) Source(13, 31) + SourceIndex(0)
-8 >Emitted(36, 23) Source(13, 33) + SourceIndex(0)
-9 >Emitted(36, 24) Source(13, 34) + SourceIndex(0)
-10>Emitted(36, 26) Source(13, 36) + SourceIndex(0)
-11>Emitted(36, 28) Source(13, 38) + SourceIndex(0)
-12>Emitted(36, 30) Source(13, 40) + SourceIndex(0)
-13>Emitted(36, 32) Source(13, 42) + SourceIndex(0)
-14>Emitted(36, 34) Source(13, 44) + SourceIndex(0)
-15>Emitted(36, 36) Source(13, 46) + SourceIndex(0)
-16>Emitted(36, 38) Source(13, 48) + SourceIndex(0)
-17>Emitted(36, 40) Source(13, 9) + SourceIndex(0)
-18>Emitted(36, 41) Source(13, 10) + SourceIndex(0)
-19>Emitted(36, 48) Source(13, 10) + SourceIndex(0)
-20>Emitted(36, 50) Source(13, 15) + SourceIndex(0)
-21>Emitted(36, 54) Source(13, 19) + SourceIndex(0)
-22>Emitted(36, 68) Source(13, 7) + SourceIndex(0)
-23>Emitted(36, 73) Source(13, 21) + SourceIndex(0)
-24>Emitted(36, 74) Source(13, 48) + SourceIndex(0)
-25>Emitted(36, 75) Source(13, 49) + SourceIndex(0)
+1->Emitted(40, 5) Source(13, 1) + SourceIndex(0)
+2 >Emitted(40, 9) Source(13, 7) + SourceIndex(0)
+3 >Emitted(40, 14) Source(13, 24) + SourceIndex(0)
+4 >Emitted(40, 16) Source(13, 26) + SourceIndex(0)
+5 >Emitted(40, 17) Source(13, 27) + SourceIndex(0)
+6 >Emitted(40, 19) Source(13, 29) + SourceIndex(0)
+7 >Emitted(40, 21) Source(13, 31) + SourceIndex(0)
+8 >Emitted(40, 23) Source(13, 33) + SourceIndex(0)
+9 >Emitted(40, 24) Source(13, 34) + SourceIndex(0)
+10>Emitted(40, 26) Source(13, 36) + SourceIndex(0)
+11>Emitted(40, 28) Source(13, 38) + SourceIndex(0)
+12>Emitted(40, 30) Source(13, 40) + SourceIndex(0)
+13>Emitted(40, 32) Source(13, 42) + SourceIndex(0)
+14>Emitted(40, 34) Source(13, 44) + SourceIndex(0)
+15>Emitted(40, 36) Source(13, 46) + SourceIndex(0)
+16>Emitted(40, 38) Source(13, 48) + SourceIndex(0)
+17>Emitted(40, 40) Source(13, 9) + SourceIndex(0)
+18>Emitted(40, 41) Source(13, 10) + SourceIndex(0)
+19>Emitted(40, 48) Source(13, 10) + SourceIndex(0)
+20>Emitted(40, 50) Source(13, 15) + SourceIndex(0)
+21>Emitted(40, 54) Source(13, 19) + SourceIndex(0)
+22>Emitted(40, 68) Source(13, 7) + SourceIndex(0)
+23>Emitted(40, 73) Source(13, 21) + SourceIndex(0)
+24>Emitted(40, 74) Source(13, 48) + SourceIndex(0)
+25>Emitted(40, 75) Source(13, 49) + SourceIndex(0)
 ---
 >>>}
 1 >
@@ -718,8 +726,8 @@ sourceFile:../../../first/first_PART1.ts
 1 >
   >
 2 >}
-1 >Emitted(37, 1) Source(14, 1) + SourceIndex(0)
-2 >Emitted(37, 2) Source(14, 2) + SourceIndex(0)
+1 >Emitted(41, 1) Source(14, 1) + SourceIndex(0)
+2 >Emitted(41, 2) Source(14, 2) + SourceIndex(0)
 ---
 >>>console.log(s);
 1->
@@ -739,14 +747,14 @@ sourceFile:../../../first/first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1->Emitted(38, 1) Source(14, 2) + SourceIndex(0)
-2 >Emitted(38, 8) Source(14, 9) + SourceIndex(0)
-3 >Emitted(38, 9) Source(14, 10) + SourceIndex(0)
-4 >Emitted(38, 12) Source(14, 13) + SourceIndex(0)
-5 >Emitted(38, 13) Source(14, 14) + SourceIndex(0)
-6 >Emitted(38, 14) Source(14, 15) + SourceIndex(0)
-7 >Emitted(38, 15) Source(14, 16) + SourceIndex(0)
-8 >Emitted(38, 16) Source(14, 17) + SourceIndex(0)
+1->Emitted(42, 1) Source(14, 2) + SourceIndex(0)
+2 >Emitted(42, 8) Source(14, 9) + SourceIndex(0)
+3 >Emitted(42, 9) Source(14, 10) + SourceIndex(0)
+4 >Emitted(42, 12) Source(14, 13) + SourceIndex(0)
+5 >Emitted(42, 13) Source(14, 14) + SourceIndex(0)
+6 >Emitted(42, 14) Source(14, 15) + SourceIndex(0)
+7 >Emitted(42, 15) Source(14, 16) + SourceIndex(0)
+8 >Emitted(42, 16) Source(14, 17) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -771,15 +779,15 @@ sourceFile:../../../first/first_part2.ts
 7 >             ()
 8 >               )
 9 >                ;
-1->Emitted(39, 1) Source(1, 1) + SourceIndex(1)
-2 >Emitted(39, 8) Source(1, 8) + SourceIndex(1)
-3 >Emitted(39, 9) Source(1, 9) + SourceIndex(1)
-4 >Emitted(39, 12) Source(1, 12) + SourceIndex(1)
-5 >Emitted(39, 13) Source(1, 13) + SourceIndex(1)
-6 >Emitted(39, 14) Source(1, 14) + SourceIndex(1)
-7 >Emitted(39, 16) Source(1, 16) + SourceIndex(1)
-8 >Emitted(39, 17) Source(1, 17) + SourceIndex(1)
-9 >Emitted(39, 18) Source(1, 18) + SourceIndex(1)
+1->Emitted(43, 1) Source(1, 1) + SourceIndex(1)
+2 >Emitted(43, 8) Source(1, 8) + SourceIndex(1)
+3 >Emitted(43, 9) Source(1, 9) + SourceIndex(1)
+4 >Emitted(43, 12) Source(1, 12) + SourceIndex(1)
+5 >Emitted(43, 13) Source(1, 13) + SourceIndex(1)
+6 >Emitted(43, 14) Source(1, 14) + SourceIndex(1)
+7 >Emitted(43, 16) Source(1, 16) + SourceIndex(1)
+8 >Emitted(43, 17) Source(1, 17) + SourceIndex(1)
+9 >Emitted(43, 18) Source(1, 18) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -793,9 +801,9 @@ sourceFile:../../../first/first_part3.ts
 1 >
 2 >function 
 3 >         f
-1 >Emitted(40, 1) Source(1, 1) + SourceIndex(2)
-2 >Emitted(40, 10) Source(1, 10) + SourceIndex(2)
-3 >Emitted(40, 11) Source(1, 11) + SourceIndex(2)
+1 >Emitted(44, 1) Source(1, 1) + SourceIndex(2)
+2 >Emitted(44, 10) Source(1, 10) + SourceIndex(2)
+3 >Emitted(44, 11) Source(1, 11) + SourceIndex(2)
 ---
 >>>    return "JS does hoists";
 1->^^^^
@@ -807,10 +815,10 @@ sourceFile:../../../first/first_part3.ts
 2 >    return 
 3 >           "JS does hoists"
 4 >                           ;
-1->Emitted(41, 5) Source(2, 5) + SourceIndex(2)
-2 >Emitted(41, 12) Source(2, 12) + SourceIndex(2)
-3 >Emitted(41, 28) Source(2, 28) + SourceIndex(2)
-4 >Emitted(41, 29) Source(2, 29) + SourceIndex(2)
+1->Emitted(45, 5) Source(2, 5) + SourceIndex(2)
+2 >Emitted(45, 12) Source(2, 12) + SourceIndex(2)
+3 >Emitted(45, 28) Source(2, 28) + SourceIndex(2)
+4 >Emitted(45, 29) Source(2, 29) + SourceIndex(2)
 ---
 >>>}
 1 >
@@ -819,8 +827,8 @@ sourceFile:../../../first/first_part3.ts
 1 >
   >
 2 >}
-1 >Emitted(42, 1) Source(3, 1) + SourceIndex(2)
-2 >Emitted(42, 2) Source(3, 2) + SourceIndex(2)
+1 >Emitted(46, 1) Source(3, 1) + SourceIndex(2)
+2 >Emitted(46, 2) Source(3, 2) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -846,10 +854,10 @@ sourceFile:../../../second/second_part1.ts
   >     
   >         f();
   >     }
-1->Emitted(43, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(43, 5) Source(5, 11) + SourceIndex(3)
-3 >Emitted(43, 6) Source(5, 12) + SourceIndex(3)
-4 >Emitted(43, 7) Source(11, 2) + SourceIndex(3)
+1->Emitted(47, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(47, 5) Source(5, 11) + SourceIndex(3)
+3 >Emitted(47, 6) Source(5, 12) + SourceIndex(3)
+4 >Emitted(47, 7) Source(11, 2) + SourceIndex(3)
 ---
 >>>(function (N) {
 1->
@@ -859,9 +867,9 @@ sourceFile:../../../second/second_part1.ts
 1->
 2 >namespace 
 3 >           N
-1->Emitted(44, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(44, 12) Source(5, 11) + SourceIndex(3)
-3 >Emitted(44, 13) Source(5, 12) + SourceIndex(3)
+1->Emitted(48, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(48, 12) Source(5, 11) + SourceIndex(3)
+3 >Emitted(48, 13) Source(5, 12) + SourceIndex(3)
 ---
 >>>    function f() {
 1->^^^^
@@ -872,9 +880,9 @@ sourceFile:../../../second/second_part1.ts
   >    
 2 >    function 
 3 >             f
-1->Emitted(45, 5) Source(6, 5) + SourceIndex(3)
-2 >Emitted(45, 14) Source(6, 14) + SourceIndex(3)
-3 >Emitted(45, 15) Source(6, 15) + SourceIndex(3)
+1->Emitted(49, 5) Source(6, 5) + SourceIndex(3)
+2 >Emitted(49, 14) Source(6, 14) + SourceIndex(3)
+3 >Emitted(49, 15) Source(6, 15) + SourceIndex(3)
 ---
 >>>        console.log('testing');
 1->^^^^^^^^
@@ -894,14 +902,14 @@ sourceFile:../../../second/second_part1.ts
 6 >                    'testing'
 7 >                             )
 8 >                              ;
-1->Emitted(46, 9) Source(7, 9) + SourceIndex(3)
-2 >Emitted(46, 16) Source(7, 16) + SourceIndex(3)
-3 >Emitted(46, 17) Source(7, 17) + SourceIndex(3)
-4 >Emitted(46, 20) Source(7, 20) + SourceIndex(3)
-5 >Emitted(46, 21) Source(7, 21) + SourceIndex(3)
-6 >Emitted(46, 30) Source(7, 30) + SourceIndex(3)
-7 >Emitted(46, 31) Source(7, 31) + SourceIndex(3)
-8 >Emitted(46, 32) Source(7, 32) + SourceIndex(3)
+1->Emitted(50, 9) Source(7, 9) + SourceIndex(3)
+2 >Emitted(50, 16) Source(7, 16) + SourceIndex(3)
+3 >Emitted(50, 17) Source(7, 17) + SourceIndex(3)
+4 >Emitted(50, 20) Source(7, 20) + SourceIndex(3)
+5 >Emitted(50, 21) Source(7, 21) + SourceIndex(3)
+6 >Emitted(50, 30) Source(7, 30) + SourceIndex(3)
+7 >Emitted(50, 31) Source(7, 31) + SourceIndex(3)
+8 >Emitted(50, 32) Source(7, 32) + SourceIndex(3)
 ---
 >>>    }
 1 >^^^^
@@ -910,8 +918,8 @@ sourceFile:../../../second/second_part1.ts
 1 >
   >    
 2 >    }
-1 >Emitted(47, 5) Source(8, 5) + SourceIndex(3)
-2 >Emitted(47, 6) Source(8, 6) + SourceIndex(3)
+1 >Emitted(51, 5) Source(8, 5) + SourceIndex(3)
+2 >Emitted(51, 6) Source(8, 6) + SourceIndex(3)
 ---
 >>>    f();
 1->^^^^
@@ -925,10 +933,10 @@ sourceFile:../../../second/second_part1.ts
 2 >    f
 3 >     ()
 4 >       ;
-1->Emitted(48, 5) Source(10, 5) + SourceIndex(3)
-2 >Emitted(48, 6) Source(10, 6) + SourceIndex(3)
-3 >Emitted(48, 8) Source(10, 8) + SourceIndex(3)
-4 >Emitted(48, 9) Source(10, 9) + SourceIndex(3)
+1->Emitted(52, 5) Source(10, 5) + SourceIndex(3)
+2 >Emitted(52, 6) Source(10, 6) + SourceIndex(3)
+3 >Emitted(52, 8) Source(10, 8) + SourceIndex(3)
+4 >Emitted(52, 9) Source(10, 9) + SourceIndex(3)
 ---
 >>>})(N || (N = {}));
 1->
@@ -953,13 +961,13 @@ sourceFile:../../../second/second_part1.ts
   >          
   >              f();
   >          }
-1->Emitted(49, 1) Source(11, 1) + SourceIndex(3)
-2 >Emitted(49, 2) Source(11, 2) + SourceIndex(3)
-3 >Emitted(49, 4) Source(5, 11) + SourceIndex(3)
-4 >Emitted(49, 5) Source(5, 12) + SourceIndex(3)
-5 >Emitted(49, 10) Source(5, 11) + SourceIndex(3)
-6 >Emitted(49, 11) Source(5, 12) + SourceIndex(3)
-7 >Emitted(49, 19) Source(11, 2) + SourceIndex(3)
+1->Emitted(53, 1) Source(11, 1) + SourceIndex(3)
+2 >Emitted(53, 2) Source(11, 2) + SourceIndex(3)
+3 >Emitted(53, 4) Source(5, 11) + SourceIndex(3)
+4 >Emitted(53, 5) Source(5, 12) + SourceIndex(3)
+5 >Emitted(53, 10) Source(5, 11) + SourceIndex(3)
+6 >Emitted(53, 11) Source(5, 12) + SourceIndex(3)
+7 >Emitted(53, 19) Source(11, 2) + SourceIndex(3)
 ---
 >>>function secondsecond_part1Spread() {
 1->
@@ -970,9 +978,9 @@ sourceFile:../../../second/second_part1.ts
   >
 2 >function 
 3 >         secondsecond_part1Spread
-1->Emitted(50, 1) Source(13, 1) + SourceIndex(3)
-2 >Emitted(50, 10) Source(13, 10) + SourceIndex(3)
-3 >Emitted(50, 34) Source(13, 34) + SourceIndex(3)
+1->Emitted(54, 1) Source(13, 1) + SourceIndex(3)
+2 >Emitted(54, 10) Source(13, 10) + SourceIndex(3)
+3 >Emitted(54, 34) Source(13, 34) + SourceIndex(3)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -980,8 +988,8 @@ sourceFile:../../../second/second_part1.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(51, 5) Source(13, 35) + SourceIndex(3)
-2 >Emitted(51, 16) Source(13, 49) + SourceIndex(3)
+1 >Emitted(55, 5) Source(13, 35) + SourceIndex(3)
+2 >Emitted(55, 16) Source(13, 49) + SourceIndex(3)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -996,20 +1004,20 @@ sourceFile:../../../second/second_part1.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(52, 10) Source(13, 35) + SourceIndex(3)
-2 >Emitted(52, 20) Source(13, 49) + SourceIndex(3)
-3 >Emitted(52, 22) Source(13, 35) + SourceIndex(3)
-4 >Emitted(52, 43) Source(13, 49) + SourceIndex(3)
-5 >Emitted(52, 45) Source(13, 35) + SourceIndex(3)
-6 >Emitted(52, 49) Source(13, 49) + SourceIndex(3)
+1->Emitted(56, 10) Source(13, 35) + SourceIndex(3)
+2 >Emitted(56, 20) Source(13, 49) + SourceIndex(3)
+3 >Emitted(56, 22) Source(13, 35) + SourceIndex(3)
+4 >Emitted(56, 43) Source(13, 49) + SourceIndex(3)
+5 >Emitted(56, 45) Source(13, 35) + SourceIndex(3)
+6 >Emitted(56, 49) Source(13, 49) + SourceIndex(3)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(53, 9) Source(13, 35) + SourceIndex(3)
-2 >Emitted(53, 31) Source(13, 49) + SourceIndex(3)
+1 >Emitted(57, 9) Source(13, 35) + SourceIndex(3)
+2 >Emitted(57, 31) Source(13, 49) + SourceIndex(3)
 ---
 >>>    }
 >>>}
@@ -1018,8 +1026,8 @@ sourceFile:../../../second/second_part1.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(55, 1) Source(13, 53) + SourceIndex(3)
-2 >Emitted(55, 2) Source(13, 54) + SourceIndex(3)
+1 >Emitted(59, 1) Source(13, 53) + SourceIndex(3)
+2 >Emitted(59, 2) Source(13, 54) + SourceIndex(3)
 ---
 >>>var secondsecond_part1_ar = [20, 30];
 1->
@@ -1044,16 +1052,16 @@ sourceFile:../../../second/second_part1.ts
 8 >                                 30
 9 >                                   ]
 10>                                    ;
-1->Emitted(56, 1) Source(14, 1) + SourceIndex(3)
-2 >Emitted(56, 5) Source(14, 7) + SourceIndex(3)
-3 >Emitted(56, 26) Source(14, 28) + SourceIndex(3)
-4 >Emitted(56, 29) Source(14, 31) + SourceIndex(3)
-5 >Emitted(56, 30) Source(14, 32) + SourceIndex(3)
-6 >Emitted(56, 32) Source(14, 34) + SourceIndex(3)
-7 >Emitted(56, 34) Source(14, 36) + SourceIndex(3)
-8 >Emitted(56, 36) Source(14, 38) + SourceIndex(3)
-9 >Emitted(56, 37) Source(14, 39) + SourceIndex(3)
-10>Emitted(56, 38) Source(14, 40) + SourceIndex(3)
+1->Emitted(60, 1) Source(14, 1) + SourceIndex(3)
+2 >Emitted(60, 5) Source(14, 7) + SourceIndex(3)
+3 >Emitted(60, 26) Source(14, 28) + SourceIndex(3)
+4 >Emitted(60, 29) Source(14, 31) + SourceIndex(3)
+5 >Emitted(60, 30) Source(14, 32) + SourceIndex(3)
+6 >Emitted(60, 32) Source(14, 34) + SourceIndex(3)
+7 >Emitted(60, 34) Source(14, 36) + SourceIndex(3)
+8 >Emitted(60, 36) Source(14, 38) + SourceIndex(3)
+9 >Emitted(60, 37) Source(14, 39) + SourceIndex(3)
+10>Emitted(60, 38) Source(14, 40) + SourceIndex(3)
 ---
 >>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
 1->
@@ -1071,13 +1079,13 @@ sourceFile:../../../second/second_part1.ts
 5 >                                                        , ...
 6 >                                                                  secondsecond_part1_ar
 7 >                                                                                       );
-1->Emitted(57, 1) Source(15, 1) + SourceIndex(3)
-2 >Emitted(57, 25) Source(15, 25) + SourceIndex(3)
-3 >Emitted(57, 55) Source(15, 26) + SourceIndex(3)
-4 >Emitted(57, 57) Source(15, 28) + SourceIndex(3)
-5 >Emitted(57, 67) Source(15, 33) + SourceIndex(3)
-6 >Emitted(57, 88) Source(15, 54) + SourceIndex(3)
-7 >Emitted(57, 92) Source(15, 56) + SourceIndex(3)
+1->Emitted(61, 1) Source(15, 1) + SourceIndex(3)
+2 >Emitted(61, 25) Source(15, 25) + SourceIndex(3)
+3 >Emitted(61, 55) Source(15, 26) + SourceIndex(3)
+4 >Emitted(61, 57) Source(15, 28) + SourceIndex(3)
+5 >Emitted(61, 67) Source(15, 33) + SourceIndex(3)
+6 >Emitted(61, 88) Source(15, 54) + SourceIndex(3)
+7 >Emitted(61, 92) Source(15, 56) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1087,13 +1095,13 @@ sourceFile:../../../second/second_part2.ts
 1 >
 2 >^^^^^^^^^^^^^^^^^^^->
 1 >
-1 >Emitted(58, 1) Source(1, 1) + SourceIndex(4)
+1 >Emitted(62, 1) Source(1, 1) + SourceIndex(4)
 ---
 >>>    function C() {
 1->^^^^
 2 >    ^^->
 1->
-1->Emitted(59, 5) Source(1, 1) + SourceIndex(4)
+1->Emitted(63, 5) Source(1, 1) + SourceIndex(4)
 ---
 >>>    }
 1->^^^^
@@ -1105,8 +1113,8 @@ sourceFile:../../../second/second_part2.ts
   >    }
   >
 2 >    }
-1->Emitted(60, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(60, 6) Source(5, 2) + SourceIndex(4)
+1->Emitted(64, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(64, 6) Source(5, 2) + SourceIndex(4)
 ---
 >>>    C.prototype.doSomething = function () {
 1->^^^^
@@ -1116,9 +1124,9 @@ sourceFile:../../../second/second_part2.ts
 1->
 2 >    doSomething
 3 >                           
-1->Emitted(61, 5) Source(2, 5) + SourceIndex(4)
-2 >Emitted(61, 28) Source(2, 16) + SourceIndex(4)
-3 >Emitted(61, 31) Source(2, 5) + SourceIndex(4)
+1->Emitted(65, 5) Source(2, 5) + SourceIndex(4)
+2 >Emitted(65, 28) Source(2, 16) + SourceIndex(4)
+3 >Emitted(65, 31) Source(2, 5) + SourceIndex(4)
 ---
 >>>        console.log("something got done");
 1->^^^^^^^^
@@ -1138,14 +1146,14 @@ sourceFile:../../../second/second_part2.ts
 6 >                    "something got done"
 7 >                                        )
 8 >                                         ;
-1->Emitted(62, 9) Source(3, 9) + SourceIndex(4)
-2 >Emitted(62, 16) Source(3, 16) + SourceIndex(4)
-3 >Emitted(62, 17) Source(3, 17) + SourceIndex(4)
-4 >Emitted(62, 20) Source(3, 20) + SourceIndex(4)
-5 >Emitted(62, 21) Source(3, 21) + SourceIndex(4)
-6 >Emitted(62, 41) Source(3, 41) + SourceIndex(4)
-7 >Emitted(62, 42) Source(3, 42) + SourceIndex(4)
-8 >Emitted(62, 43) Source(3, 43) + SourceIndex(4)
+1->Emitted(66, 9) Source(3, 9) + SourceIndex(4)
+2 >Emitted(66, 16) Source(3, 16) + SourceIndex(4)
+3 >Emitted(66, 17) Source(3, 17) + SourceIndex(4)
+4 >Emitted(66, 20) Source(3, 20) + SourceIndex(4)
+5 >Emitted(66, 21) Source(3, 21) + SourceIndex(4)
+6 >Emitted(66, 41) Source(3, 41) + SourceIndex(4)
+7 >Emitted(66, 42) Source(3, 42) + SourceIndex(4)
+8 >Emitted(66, 43) Source(3, 43) + SourceIndex(4)
 ---
 >>>    };
 1 >^^^^
@@ -1154,8 +1162,8 @@ sourceFile:../../../second/second_part2.ts
 1 >
   >    
 2 >    }
-1 >Emitted(63, 5) Source(4, 5) + SourceIndex(4)
-2 >Emitted(63, 6) Source(4, 6) + SourceIndex(4)
+1 >Emitted(67, 5) Source(4, 5) + SourceIndex(4)
+2 >Emitted(67, 6) Source(4, 6) + SourceIndex(4)
 ---
 >>>    return C;
 1->^^^^
@@ -1163,8 +1171,8 @@ sourceFile:../../../second/second_part2.ts
 1->
   >
 2 >    }
-1->Emitted(64, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(64, 13) Source(5, 2) + SourceIndex(4)
+1->Emitted(68, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(68, 13) Source(5, 2) + SourceIndex(4)
 ---
 >>>}());
 1 >
@@ -1180,10 +1188,10 @@ sourceFile:../../../second/second_part2.ts
   >         console.log("something got done");
   >     }
   > }
-1 >Emitted(65, 1) Source(5, 1) + SourceIndex(4)
-2 >Emitted(65, 2) Source(5, 2) + SourceIndex(4)
-3 >Emitted(65, 2) Source(1, 1) + SourceIndex(4)
-4 >Emitted(65, 6) Source(5, 2) + SourceIndex(4)
+1 >Emitted(69, 1) Source(5, 1) + SourceIndex(4)
+2 >Emitted(69, 2) Source(5, 2) + SourceIndex(4)
+3 >Emitted(69, 2) Source(1, 1) + SourceIndex(4)
+4 >Emitted(69, 6) Source(5, 2) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1207,14 +1215,14 @@ sourceFile:../../third_part1.ts
 6 >            C
 7 >             ()
 8 >               ;
-1->Emitted(66, 1) Source(1, 1) + SourceIndex(5)
-2 >Emitted(66, 5) Source(1, 5) + SourceIndex(5)
-3 >Emitted(66, 6) Source(1, 6) + SourceIndex(5)
-4 >Emitted(66, 9) Source(1, 9) + SourceIndex(5)
-5 >Emitted(66, 13) Source(1, 13) + SourceIndex(5)
-6 >Emitted(66, 14) Source(1, 14) + SourceIndex(5)
-7 >Emitted(66, 16) Source(1, 16) + SourceIndex(5)
-8 >Emitted(66, 17) Source(1, 17) + SourceIndex(5)
+1->Emitted(70, 1) Source(1, 1) + SourceIndex(5)
+2 >Emitted(70, 5) Source(1, 5) + SourceIndex(5)
+3 >Emitted(70, 6) Source(1, 6) + SourceIndex(5)
+4 >Emitted(70, 9) Source(1, 9) + SourceIndex(5)
+5 >Emitted(70, 13) Source(1, 13) + SourceIndex(5)
+6 >Emitted(70, 14) Source(1, 14) + SourceIndex(5)
+7 >Emitted(70, 16) Source(1, 16) + SourceIndex(5)
+8 >Emitted(70, 17) Source(1, 17) + SourceIndex(5)
 ---
 >>>c.doSomething();
 1->
@@ -1231,12 +1239,12 @@ sourceFile:../../third_part1.ts
 4 >  doSomething
 5 >             ()
 6 >               ;
-1->Emitted(67, 1) Source(2, 1) + SourceIndex(5)
-2 >Emitted(67, 2) Source(2, 2) + SourceIndex(5)
-3 >Emitted(67, 3) Source(2, 3) + SourceIndex(5)
-4 >Emitted(67, 14) Source(2, 14) + SourceIndex(5)
-5 >Emitted(67, 16) Source(2, 16) + SourceIndex(5)
-6 >Emitted(67, 17) Source(2, 17) + SourceIndex(5)
+1->Emitted(71, 1) Source(2, 1) + SourceIndex(5)
+2 >Emitted(71, 2) Source(2, 2) + SourceIndex(5)
+3 >Emitted(71, 3) Source(2, 3) + SourceIndex(5)
+4 >Emitted(71, 14) Source(2, 14) + SourceIndex(5)
+5 >Emitted(71, 16) Source(2, 16) + SourceIndex(5)
+6 >Emitted(71, 17) Source(2, 17) + SourceIndex(5)
 ---
 >>>function forthirdthird_part1Rest() {
 1->
@@ -1247,9 +1255,9 @@ sourceFile:../../third_part1.ts
   >
 2 >function 
 3 >         forthirdthird_part1Rest
-1->Emitted(68, 1) Source(3, 1) + SourceIndex(5)
-2 >Emitted(68, 10) Source(3, 10) + SourceIndex(5)
-3 >Emitted(68, 33) Source(3, 33) + SourceIndex(5)
+1->Emitted(72, 1) Source(3, 1) + SourceIndex(5)
+2 >Emitted(72, 10) Source(3, 10) + SourceIndex(5)
+3 >Emitted(72, 33) Source(3, 33) + SourceIndex(5)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -1303,31 +1311,31 @@ sourceFile:../../third_part1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(69, 5) Source(4, 1) + SourceIndex(5)
-2 >Emitted(69, 9) Source(4, 7) + SourceIndex(5)
-3 >Emitted(69, 14) Source(4, 24) + SourceIndex(5)
-4 >Emitted(69, 16) Source(4, 26) + SourceIndex(5)
-5 >Emitted(69, 17) Source(4, 27) + SourceIndex(5)
-6 >Emitted(69, 19) Source(4, 29) + SourceIndex(5)
-7 >Emitted(69, 21) Source(4, 31) + SourceIndex(5)
-8 >Emitted(69, 23) Source(4, 33) + SourceIndex(5)
-9 >Emitted(69, 24) Source(4, 34) + SourceIndex(5)
-10>Emitted(69, 26) Source(4, 36) + SourceIndex(5)
-11>Emitted(69, 28) Source(4, 38) + SourceIndex(5)
-12>Emitted(69, 30) Source(4, 40) + SourceIndex(5)
-13>Emitted(69, 32) Source(4, 42) + SourceIndex(5)
-14>Emitted(69, 34) Source(4, 44) + SourceIndex(5)
-15>Emitted(69, 36) Source(4, 46) + SourceIndex(5)
-16>Emitted(69, 38) Source(4, 48) + SourceIndex(5)
-17>Emitted(69, 40) Source(4, 9) + SourceIndex(5)
-18>Emitted(69, 41) Source(4, 10) + SourceIndex(5)
-19>Emitted(69, 48) Source(4, 10) + SourceIndex(5)
-20>Emitted(69, 50) Source(4, 15) + SourceIndex(5)
-21>Emitted(69, 54) Source(4, 19) + SourceIndex(5)
-22>Emitted(69, 68) Source(4, 7) + SourceIndex(5)
-23>Emitted(69, 73) Source(4, 21) + SourceIndex(5)
-24>Emitted(69, 74) Source(4, 48) + SourceIndex(5)
-25>Emitted(69, 75) Source(4, 49) + SourceIndex(5)
+1->Emitted(73, 5) Source(4, 1) + SourceIndex(5)
+2 >Emitted(73, 9) Source(4, 7) + SourceIndex(5)
+3 >Emitted(73, 14) Source(4, 24) + SourceIndex(5)
+4 >Emitted(73, 16) Source(4, 26) + SourceIndex(5)
+5 >Emitted(73, 17) Source(4, 27) + SourceIndex(5)
+6 >Emitted(73, 19) Source(4, 29) + SourceIndex(5)
+7 >Emitted(73, 21) Source(4, 31) + SourceIndex(5)
+8 >Emitted(73, 23) Source(4, 33) + SourceIndex(5)
+9 >Emitted(73, 24) Source(4, 34) + SourceIndex(5)
+10>Emitted(73, 26) Source(4, 36) + SourceIndex(5)
+11>Emitted(73, 28) Source(4, 38) + SourceIndex(5)
+12>Emitted(73, 30) Source(4, 40) + SourceIndex(5)
+13>Emitted(73, 32) Source(4, 42) + SourceIndex(5)
+14>Emitted(73, 34) Source(4, 44) + SourceIndex(5)
+15>Emitted(73, 36) Source(4, 46) + SourceIndex(5)
+16>Emitted(73, 38) Source(4, 48) + SourceIndex(5)
+17>Emitted(73, 40) Source(4, 9) + SourceIndex(5)
+18>Emitted(73, 41) Source(4, 10) + SourceIndex(5)
+19>Emitted(73, 48) Source(4, 10) + SourceIndex(5)
+20>Emitted(73, 50) Source(4, 15) + SourceIndex(5)
+21>Emitted(73, 54) Source(4, 19) + SourceIndex(5)
+22>Emitted(73, 68) Source(4, 7) + SourceIndex(5)
+23>Emitted(73, 73) Source(4, 21) + SourceIndex(5)
+24>Emitted(73, 74) Source(4, 48) + SourceIndex(5)
+25>Emitted(73, 75) Source(4, 49) + SourceIndex(5)
 ---
 >>>}
 1 >
@@ -1336,13 +1344,13 @@ sourceFile:../../third_part1.ts
 1 >
   >
 2 >}
-1 >Emitted(70, 1) Source(5, 1) + SourceIndex(5)
-2 >Emitted(70, 2) Source(5, 2) + SourceIndex(5)
+1 >Emitted(74, 1) Source(5, 1) + SourceIndex(5)
+2 >Emitted(74, 2) Source(5, 2) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1199,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1201,"end":1445,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1201,"end":1445,"kind":"text"}]},{"pos":1445,"end":2013,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1445,"end":2013,"kind":"text"}]},{"pos":2013,"end":2166,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1588,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1588,"kind":"text"}]},{"pos":1588,"end":2156,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1588,"end":2156,"kind":"text"}]},{"pos":2156,"end":2309,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1379,16 +1387,20 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1199):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (1008-1342):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-prepend: (1201-1445):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1344-1588):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1201-1445)
+text: (1344-1588)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -1401,9 +1413,9 @@ function f() {
 }
 
 ----------------------------------------------------------------------
-prepend: (1445-2013):: ../../../2/second-output.js texts:: 1
+prepend: (1588-2156):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1445-2013)
+text: (1588-2156)
 var N;
 (function (N) {
     function f() {
@@ -1429,7 +1441,7 @@ var C = (function () {
 }());
 
 ----------------------------------------------------------------------
-text: (2013-2166)
+text: (2156-2309)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -1497,39 +1509,39 @@ declare function forthirdthird_part1Rest(): void;
         },
         {
           "pos": 1008,
-          "end": 1199,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1201,
-          "end": 1445,
+          "pos": 1344,
+          "end": 1588,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1201,
-              "end": 1445,
+              "pos": 1344,
+              "end": 1588,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1445,
-          "end": 2013,
+          "pos": 1588,
+          "end": 2156,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1445,
-              "end": 2013,
+              "pos": 1588,
+              "end": 2156,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2013,
-          "end": 2166,
+          "pos": 2156,
+          "end": 2309,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-different-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-different-projects.js
@@ -473,7 +473,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -505,7 +505,7 @@ function secondsecond_part1Spread() {
     }
 }
 var secondsecond_part1_ar = [20, 30];
-secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 var C = (function () {
     function C() {
     }
@@ -522,7 +522,7 @@ function forthirdthird_part1Rest() {
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AAAA,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;ACbhB,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,WAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -563,7 +563,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -1040,7 +1040,7 @@ sourceFile:../../../second/second_part1.ts
 8 >                                 ^^
 9 >                                   ^
 10>                                    ^
-11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1063,14 +1063,14 @@ sourceFile:../../../second/second_part1.ts
 9 >Emitted(60, 37) Source(14, 39) + SourceIndex(3)
 10>Emitted(60, 38) Source(14, 40) + SourceIndex(3)
 ---
->>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+>>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^^^
 3 >                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                      ^^
 5 >                                                        ^^^^^^^^^^
 6 >                                                                  ^^^^^^^^^^^^^^^^^^^^^
-7 >                                                                                       ^^^^
+7 >                                                                                       ^^^^^^^^^^^
 1->
   >
 2 >secondsecond_part1Spread
@@ -1085,7 +1085,7 @@ sourceFile:../../../second/second_part1.ts
 4 >Emitted(61, 57) Source(15, 28) + SourceIndex(3)
 5 >Emitted(61, 67) Source(15, 33) + SourceIndex(3)
 6 >Emitted(61, 88) Source(15, 54) + SourceIndex(3)
-7 >Emitted(61, 92) Source(15, 56) + SourceIndex(3)
+7 >Emitted(61, 99) Source(15, 56) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1350,7 +1350,7 @@ sourceFile:../../third_part1.ts
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1588,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1588,"kind":"text"}]},{"pos":1588,"end":2156,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1588,"end":2156,"kind":"text"}]},{"pos":2156,"end":2309,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1614,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1614,"kind":"text"}]},{"pos":1614,"end":2189,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1614,"end":2189,"kind":"text"}]},{"pos":2189,"end":2342,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1387,9 +1387,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1342):: typescript:spreadArray
+emitHelpers: (1008-1368):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1398,9 +1398,9 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-prepend: (1344-1588):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1370-1614):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1344-1588)
+text: (1370-1614)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -1413,9 +1413,9 @@ function f() {
 }
 
 ----------------------------------------------------------------------
-prepend: (1588-2156):: ../../../2/second-output.js texts:: 1
+prepend: (1614-2189):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1588-2156)
+text: (1614-2189)
 var N;
 (function (N) {
     function f() {
@@ -1430,7 +1430,7 @@ function secondsecond_part1Spread() {
     }
 }
 var secondsecond_part1_ar = [20, 30];
-secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 var C = (function () {
     function C() {
     }
@@ -1441,7 +1441,7 @@ var C = (function () {
 }());
 
 ----------------------------------------------------------------------
-text: (2156-2309)
+text: (2189-2342)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -1509,39 +1509,39 @@ declare function forthirdthird_part1Rest(): void;
         },
         {
           "pos": 1008,
-          "end": 1342,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1344,
-          "end": 1588,
+          "pos": 1370,
+          "end": 1614,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1344,
-              "end": 1588,
+              "pos": 1370,
+              "end": 1614,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1588,
-          "end": 2156,
+          "pos": 1614,
+          "end": 2189,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1588,
-              "end": 2156,
+              "pos": 1614,
+              "end": 2189,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2156,
-          "end": 2309,
+          "pos": 2189,
+          "end": 2342,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
@@ -257,7 +257,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -279,11 +279,11 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 //# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.js.map]
-{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,WAAE"}
 
 //// [/src/first/bin/first-output.js.map.baseline.txt]
 ===================================================================
@@ -313,7 +313,7 @@ sourceFile:../first_PART1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -540,7 +540,7 @@ sourceFile:../first_part3.ts
 8 >                               ^^
 9 >                                 ^
 10>                                  ^
-11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -563,14 +563,14 @@ sourceFile:../first_part3.ts
 9 >Emitted(39, 35) Source(5, 37) + SourceIndex(2)
 10>Emitted(39, 36) Source(5, 38) + SourceIndex(2)
 ---
->>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+>>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^
 3 >                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                    ^^
 5 >                                                      ^^^^^^^^^^
 6 >                                                                ^^^^^^^^^^^^^^^^^^^
-7 >                                                                                   ^^^^
+7 >                                                                                   ^^^^^^^^^^^
 1->
   >
 2 >firstfirst_part3Spread
@@ -585,12 +585,12 @@ sourceFile:../first_part3.ts
 4 >Emitted(40, 55) Source(6, 26) + SourceIndex(2)
 5 >Emitted(40, 65) Source(6, 31) + SourceIndex(2)
 6 >Emitted(40, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(40, 88) Source(6, 52) + SourceIndex(2)
+7 >Emitted(40, 95) Source(6, 52) + SourceIndex(2)
 ---
 >>>//# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1267,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1300,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/first/bin/first-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -614,9 +614,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-840):: typescript:spreadArray
+emitHelpers: (506-866):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -625,7 +625,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (842-1267)
+text: (868-1300)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() { }
@@ -640,7 +640,7 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 
 ======================================================================
 ======================================================================
@@ -680,13 +680,13 @@ declare const firstfirst_part3_ar: number[];
         },
         {
           "pos": 506,
-          "end": 840,
+          "end": 866,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 842,
-          "end": 1267,
+          "pos": 868,
+          "end": 1300,
           "kind": "text"
         }
       ],
@@ -1182,7 +1182,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1215,7 +1215,7 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 var N;
 (function (N) {
     function f() {
@@ -1241,7 +1241,7 @@ function secondsecond_part2Spread() {
     }
 }
 var secondsecond_part2_ar = [20, 30];
-secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -1254,11 +1254,11 @@ function thirdthird_part1Spread() {
     }
 }
 var thirdthird_part1_ar = [20, 30];
-thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
+thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar), false));
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,WAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,WAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,WAAE"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -1288,7 +1288,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -1526,7 +1526,7 @@ sourceFile:../../../first/first_part3.ts
 8 >                               ^^
 9 >                                 ^
 10>                                  ^
-11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1549,14 +1549,14 @@ sourceFile:../../../first/first_part3.ts
 9 >Emitted(50, 35) Source(5, 37) + SourceIndex(2)
 10>Emitted(50, 36) Source(5, 38) + SourceIndex(2)
 ---
->>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+>>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^
 3 >                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                    ^^
 5 >                                                      ^^^^^^^^^^
 6 >                                                                ^^^^^^^^^^^^^^^^^^^
-7 >                                                                                   ^^^^
+7 >                                                                                   ^^^^^^^^^^^
 1->
   >
 2 >firstfirst_part3Spread
@@ -1571,7 +1571,7 @@ sourceFile:../../../first/first_part3.ts
 4 >Emitted(51, 55) Source(6, 26) + SourceIndex(2)
 5 >Emitted(51, 65) Source(6, 31) + SourceIndex(2)
 6 >Emitted(51, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(51, 88) Source(6, 52) + SourceIndex(2)
+7 >Emitted(51, 95) Source(6, 52) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1990,7 +1990,7 @@ sourceFile:../../../second/second_part2.ts
 8 >                                 ^^
 9 >                                   ^
 10>                                    ^
-11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -2013,14 +2013,14 @@ sourceFile:../../../second/second_part2.ts
 9 >Emitted(76, 37) Source(8, 39) + SourceIndex(4)
 10>Emitted(76, 38) Source(8, 40) + SourceIndex(4)
 ---
->>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+>>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^^^
 3 >                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                      ^^
 5 >                                                        ^^^^^^^^^^
 6 >                                                                  ^^^^^^^^^^^^^^^^^^^^^
-7 >                                                                                       ^^^^
+7 >                                                                                       ^^^^^^^^^^^
 1->
   >
 2 >secondsecond_part2Spread
@@ -2035,7 +2035,7 @@ sourceFile:../../../second/second_part2.ts
 4 >Emitted(77, 57) Source(9, 28) + SourceIndex(4)
 5 >Emitted(77, 67) Source(9, 33) + SourceIndex(4)
 6 >Emitted(77, 88) Source(9, 54) + SourceIndex(4)
-7 >Emitted(77, 92) Source(9, 56) + SourceIndex(4)
+7 >Emitted(77, 99) Source(9, 56) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2261,7 +2261,7 @@ sourceFile:../../third_part1.ts
 8 >                               ^^
 9 >                                 ^
 10>                                  ^
-11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -2284,14 +2284,14 @@ sourceFile:../../third_part1.ts
 9 >Emitted(89, 35) Source(7, 37) + SourceIndex(5)
 10>Emitted(89, 36) Source(7, 38) + SourceIndex(5)
 ---
->>>thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
+>>>thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^
 3 >                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                    ^^
 5 >                                                      ^^^^^^^^^^
 6 >                                                                ^^^^^^^^^^^^^^^^^^^
-7 >                                                                                   ^^^^
+7 >                                                                                   ^^^^^^^^^^^
 1->
   >
 2 >thirdthird_part1Spread
@@ -2306,12 +2306,12 @@ sourceFile:../../third_part1.ts
 4 >Emitted(90, 55) Source(8, 26) + SourceIndex(5)
 5 >Emitted(90, 65) Source(8, 31) + SourceIndex(5)
 6 >Emitted(90, 84) Source(8, 50) + SourceIndex(5)
-7 >Emitted(90, 88) Source(8, 52) + SourceIndex(5)
+7 >Emitted(90, 95) Source(8, 52) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":1769,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1769,"kind":"text"}]},{"pos":1769,"end":2456,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1769,"end":2456,"kind":"text"}]},{"pos":2456,"end":2884,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":1802,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1802,"kind":"text"}]},{"pos":1802,"end":2496,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1802,"end":2496,"kind":"text"}]},{"pos":2496,"end":2931,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -2335,9 +2335,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-840):: typescript:spreadArray
+emitHelpers: (506-866):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -2346,7 +2346,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (842-1342):: typescript:rest
+emitHelpers: (868-1368):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -2359,9 +2359,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1344-1769):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1370-1802):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1344-1769)
+text: (1370-1802)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() { }
@@ -2376,12 +2376,12 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 
 ----------------------------------------------------------------------
-prepend: (1769-2456):: ../../../2/second-output.js texts:: 1
+prepend: (1802-2496):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1769-2456)
+text: (1802-2496)
 var N;
 (function (N) {
     function f() {
@@ -2407,10 +2407,10 @@ function secondsecond_part2Spread() {
     }
 }
 var secondsecond_part2_ar = [20, 30];
-secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 
 ----------------------------------------------------------------------
-text: (2456-2884)
+text: (2496-2931)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -2423,7 +2423,7 @@ function thirdthird_part1Spread() {
     }
 }
 var thirdthird_part1_ar = [20, 30];
-thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
+thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar), false));
 
 ======================================================================
 ======================================================================
@@ -2485,45 +2485,45 @@ declare const thirdthird_part1_ar: number[];
         },
         {
           "pos": 506,
-          "end": 840,
+          "end": 866,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 842,
-          "end": 1342,
+          "pos": 868,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1344,
-          "end": 1769,
+          "pos": 1370,
+          "end": 1802,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1344,
-              "end": 1769,
+              "pos": 1370,
+              "end": 1802,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1769,
-          "end": 2456,
+          "pos": 1802,
+          "end": 2496,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1769,
-              "end": 2456,
+              "pos": 1802,
+              "end": 2496,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2456,
-          "end": 2884,
+          "pos": 2496,
+          "end": 2931,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
@@ -256,10 +256,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var s = "Hello, world";
 console.log(s);
@@ -279,7 +283,7 @@ firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3
 //# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.js.map]
-{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
 
 //// [/src/first/bin/first-output.js.map.baseline.txt]
 ===================================================================
@@ -308,10 +312,14 @@ sourceFile:../first_PART1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -330,12 +338,12 @@ sourceFile:../first_PART1.ts
 4 >      = 
 5 >        "Hello, world"
 6 >                      ;
-1 >Emitted(22, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(22, 5) Source(5, 7) + SourceIndex(0)
-3 >Emitted(22, 6) Source(5, 8) + SourceIndex(0)
-4 >Emitted(22, 9) Source(5, 11) + SourceIndex(0)
-5 >Emitted(22, 23) Source(5, 25) + SourceIndex(0)
-6 >Emitted(22, 24) Source(5, 26) + SourceIndex(0)
+1 >Emitted(26, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(26, 5) Source(5, 7) + SourceIndex(0)
+3 >Emitted(26, 6) Source(5, 8) + SourceIndex(0)
+4 >Emitted(26, 9) Source(5, 11) + SourceIndex(0)
+5 >Emitted(26, 23) Source(5, 25) + SourceIndex(0)
+6 >Emitted(26, 24) Source(5, 26) + SourceIndex(0)
 ---
 >>>console.log(s);
 1 >
@@ -361,14 +369,14 @@ sourceFile:../first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1 >Emitted(23, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(23, 8) Source(11, 8) + SourceIndex(0)
-3 >Emitted(23, 9) Source(11, 9) + SourceIndex(0)
-4 >Emitted(23, 12) Source(11, 12) + SourceIndex(0)
-5 >Emitted(23, 13) Source(11, 13) + SourceIndex(0)
-6 >Emitted(23, 14) Source(11, 14) + SourceIndex(0)
-7 >Emitted(23, 15) Source(11, 15) + SourceIndex(0)
-8 >Emitted(23, 16) Source(11, 16) + SourceIndex(0)
+1 >Emitted(27, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(27, 8) Source(11, 8) + SourceIndex(0)
+3 >Emitted(27, 9) Source(11, 9) + SourceIndex(0)
+4 >Emitted(27, 12) Source(11, 12) + SourceIndex(0)
+5 >Emitted(27, 13) Source(11, 13) + SourceIndex(0)
+6 >Emitted(27, 14) Source(11, 14) + SourceIndex(0)
+7 >Emitted(27, 15) Source(11, 15) + SourceIndex(0)
+8 >Emitted(27, 16) Source(11, 16) + SourceIndex(0)
 ---
 >>>function forfirstfirst_PART1Rest() { }
 1->
@@ -382,11 +390,11 @@ sourceFile:../first_PART1.ts
 3 >         forfirstfirst_PART1Rest
 4 >                                () { 
 5 >                                     }
-1->Emitted(24, 1) Source(12, 1) + SourceIndex(0)
-2 >Emitted(24, 10) Source(12, 10) + SourceIndex(0)
-3 >Emitted(24, 33) Source(12, 33) + SourceIndex(0)
-4 >Emitted(24, 38) Source(12, 38) + SourceIndex(0)
-5 >Emitted(24, 39) Source(12, 39) + SourceIndex(0)
+1->Emitted(28, 1) Source(12, 1) + SourceIndex(0)
+2 >Emitted(28, 10) Source(12, 10) + SourceIndex(0)
+3 >Emitted(28, 33) Source(12, 33) + SourceIndex(0)
+4 >Emitted(28, 38) Source(12, 38) + SourceIndex(0)
+5 >Emitted(28, 39) Source(12, 39) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/first/bin/first-output.js
@@ -411,15 +419,15 @@ sourceFile:../first_part2.ts
 7 >             ()
 8 >               )
 9 >                ;
-1 >Emitted(25, 1) Source(1, 1) + SourceIndex(1)
-2 >Emitted(25, 8) Source(1, 8) + SourceIndex(1)
-3 >Emitted(25, 9) Source(1, 9) + SourceIndex(1)
-4 >Emitted(25, 12) Source(1, 12) + SourceIndex(1)
-5 >Emitted(25, 13) Source(1, 13) + SourceIndex(1)
-6 >Emitted(25, 14) Source(1, 14) + SourceIndex(1)
-7 >Emitted(25, 16) Source(1, 16) + SourceIndex(1)
-8 >Emitted(25, 17) Source(1, 17) + SourceIndex(1)
-9 >Emitted(25, 18) Source(1, 18) + SourceIndex(1)
+1 >Emitted(29, 1) Source(1, 1) + SourceIndex(1)
+2 >Emitted(29, 8) Source(1, 8) + SourceIndex(1)
+3 >Emitted(29, 9) Source(1, 9) + SourceIndex(1)
+4 >Emitted(29, 12) Source(1, 12) + SourceIndex(1)
+5 >Emitted(29, 13) Source(1, 13) + SourceIndex(1)
+6 >Emitted(29, 14) Source(1, 14) + SourceIndex(1)
+7 >Emitted(29, 16) Source(1, 16) + SourceIndex(1)
+8 >Emitted(29, 17) Source(1, 17) + SourceIndex(1)
+9 >Emitted(29, 18) Source(1, 18) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/first/bin/first-output.js
@@ -433,9 +441,9 @@ sourceFile:../first_part3.ts
 1 >
 2 >function 
 3 >         f
-1 >Emitted(26, 1) Source(1, 1) + SourceIndex(2)
-2 >Emitted(26, 10) Source(1, 10) + SourceIndex(2)
-3 >Emitted(26, 11) Source(1, 11) + SourceIndex(2)
+1 >Emitted(30, 1) Source(1, 1) + SourceIndex(2)
+2 >Emitted(30, 10) Source(1, 10) + SourceIndex(2)
+3 >Emitted(30, 11) Source(1, 11) + SourceIndex(2)
 ---
 >>>    return "JS does hoists";
 1->^^^^
@@ -447,10 +455,10 @@ sourceFile:../first_part3.ts
 2 >    return 
 3 >           "JS does hoists"
 4 >                           ;
-1->Emitted(27, 5) Source(2, 5) + SourceIndex(2)
-2 >Emitted(27, 12) Source(2, 12) + SourceIndex(2)
-3 >Emitted(27, 28) Source(2, 28) + SourceIndex(2)
-4 >Emitted(27, 29) Source(2, 29) + SourceIndex(2)
+1->Emitted(31, 5) Source(2, 5) + SourceIndex(2)
+2 >Emitted(31, 12) Source(2, 12) + SourceIndex(2)
+3 >Emitted(31, 28) Source(2, 28) + SourceIndex(2)
+4 >Emitted(31, 29) Source(2, 29) + SourceIndex(2)
 ---
 >>>}
 1 >
@@ -459,8 +467,8 @@ sourceFile:../first_part3.ts
 1 >
   >
 2 >}
-1 >Emitted(28, 1) Source(3, 1) + SourceIndex(2)
-2 >Emitted(28, 2) Source(3, 2) + SourceIndex(2)
+1 >Emitted(32, 1) Source(3, 1) + SourceIndex(2)
+2 >Emitted(32, 2) Source(3, 2) + SourceIndex(2)
 ---
 >>>function firstfirst_part3Spread() {
 1->
@@ -470,9 +478,9 @@ sourceFile:../first_part3.ts
   >
 2 >function 
 3 >         firstfirst_part3Spread
-1->Emitted(29, 1) Source(4, 1) + SourceIndex(2)
-2 >Emitted(29, 10) Source(4, 10) + SourceIndex(2)
-3 >Emitted(29, 32) Source(4, 32) + SourceIndex(2)
+1->Emitted(33, 1) Source(4, 1) + SourceIndex(2)
+2 >Emitted(33, 10) Source(4, 10) + SourceIndex(2)
+3 >Emitted(33, 32) Source(4, 32) + SourceIndex(2)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -480,8 +488,8 @@ sourceFile:../first_part3.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(30, 5) Source(4, 33) + SourceIndex(2)
-2 >Emitted(30, 16) Source(4, 47) + SourceIndex(2)
+1 >Emitted(34, 5) Source(4, 33) + SourceIndex(2)
+2 >Emitted(34, 16) Source(4, 47) + SourceIndex(2)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -496,20 +504,20 @@ sourceFile:../first_part3.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(31, 10) Source(4, 33) + SourceIndex(2)
-2 >Emitted(31, 20) Source(4, 47) + SourceIndex(2)
-3 >Emitted(31, 22) Source(4, 33) + SourceIndex(2)
-4 >Emitted(31, 43) Source(4, 47) + SourceIndex(2)
-5 >Emitted(31, 45) Source(4, 33) + SourceIndex(2)
-6 >Emitted(31, 49) Source(4, 47) + SourceIndex(2)
+1->Emitted(35, 10) Source(4, 33) + SourceIndex(2)
+2 >Emitted(35, 20) Source(4, 47) + SourceIndex(2)
+3 >Emitted(35, 22) Source(4, 33) + SourceIndex(2)
+4 >Emitted(35, 43) Source(4, 47) + SourceIndex(2)
+5 >Emitted(35, 45) Source(4, 33) + SourceIndex(2)
+6 >Emitted(35, 49) Source(4, 47) + SourceIndex(2)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(32, 9) Source(4, 33) + SourceIndex(2)
-2 >Emitted(32, 31) Source(4, 47) + SourceIndex(2)
+1 >Emitted(36, 9) Source(4, 33) + SourceIndex(2)
+2 >Emitted(36, 31) Source(4, 47) + SourceIndex(2)
 ---
 >>>    }
 >>>}
@@ -518,8 +526,8 @@ sourceFile:../first_part3.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(34, 1) Source(4, 51) + SourceIndex(2)
-2 >Emitted(34, 2) Source(4, 52) + SourceIndex(2)
+1 >Emitted(38, 1) Source(4, 51) + SourceIndex(2)
+2 >Emitted(38, 2) Source(4, 52) + SourceIndex(2)
 ---
 >>>var firstfirst_part3_ar = [20, 30];
 1->
@@ -544,16 +552,16 @@ sourceFile:../first_part3.ts
 8 >                               30
 9 >                                 ]
 10>                                  ;
-1->Emitted(35, 1) Source(5, 1) + SourceIndex(2)
-2 >Emitted(35, 5) Source(5, 7) + SourceIndex(2)
-3 >Emitted(35, 24) Source(5, 26) + SourceIndex(2)
-4 >Emitted(35, 27) Source(5, 29) + SourceIndex(2)
-5 >Emitted(35, 28) Source(5, 30) + SourceIndex(2)
-6 >Emitted(35, 30) Source(5, 32) + SourceIndex(2)
-7 >Emitted(35, 32) Source(5, 34) + SourceIndex(2)
-8 >Emitted(35, 34) Source(5, 36) + SourceIndex(2)
-9 >Emitted(35, 35) Source(5, 37) + SourceIndex(2)
-10>Emitted(35, 36) Source(5, 38) + SourceIndex(2)
+1->Emitted(39, 1) Source(5, 1) + SourceIndex(2)
+2 >Emitted(39, 5) Source(5, 7) + SourceIndex(2)
+3 >Emitted(39, 24) Source(5, 26) + SourceIndex(2)
+4 >Emitted(39, 27) Source(5, 29) + SourceIndex(2)
+5 >Emitted(39, 28) Source(5, 30) + SourceIndex(2)
+6 >Emitted(39, 30) Source(5, 32) + SourceIndex(2)
+7 >Emitted(39, 32) Source(5, 34) + SourceIndex(2)
+8 >Emitted(39, 34) Source(5, 36) + SourceIndex(2)
+9 >Emitted(39, 35) Source(5, 37) + SourceIndex(2)
+10>Emitted(39, 36) Source(5, 38) + SourceIndex(2)
 ---
 >>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
 1->
@@ -571,18 +579,18 @@ sourceFile:../first_part3.ts
 5 >                                                      , ...
 6 >                                                                firstfirst_part3_ar
 7 >                                                                                   );
-1->Emitted(36, 1) Source(6, 1) + SourceIndex(2)
-2 >Emitted(36, 23) Source(6, 23) + SourceIndex(2)
-3 >Emitted(36, 53) Source(6, 24) + SourceIndex(2)
-4 >Emitted(36, 55) Source(6, 26) + SourceIndex(2)
-5 >Emitted(36, 65) Source(6, 31) + SourceIndex(2)
-6 >Emitted(36, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(36, 88) Source(6, 52) + SourceIndex(2)
+1->Emitted(40, 1) Source(6, 1) + SourceIndex(2)
+2 >Emitted(40, 23) Source(6, 23) + SourceIndex(2)
+3 >Emitted(40, 53) Source(6, 24) + SourceIndex(2)
+4 >Emitted(40, 55) Source(6, 26) + SourceIndex(2)
+5 >Emitted(40, 65) Source(6, 31) + SourceIndex(2)
+6 >Emitted(40, 84) Source(6, 50) + SourceIndex(2)
+7 >Emitted(40, 88) Source(6, 52) + SourceIndex(2)
 ---
 >>>//# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":697,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":699,"end":1124,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1267,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/first/bin/first-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -606,14 +614,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-697):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (506-840):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (699-1124)
+text: (842-1267)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() { }
@@ -668,13 +680,13 @@ declare const firstfirst_part3_ar: number[];
         },
         {
           "pos": 506,
-          "end": 697,
+          "end": 840,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 699,
-          "end": 1124,
+          "pos": 842,
+          "end": 1267,
           "kind": "text"
         }
       ],
@@ -1169,10 +1181,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -1242,7 +1258,7 @@ thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -1271,10 +1287,14 @@ sourceFile:../../../first/first_PART1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -1304,12 +1324,12 @@ sourceFile:../../../first/first_PART1.ts
 4 >      = 
 5 >        "Hello, world"
 6 >                      ;
-1 >Emitted(33, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(5, 7) + SourceIndex(0)
-3 >Emitted(33, 6) Source(5, 8) + SourceIndex(0)
-4 >Emitted(33, 9) Source(5, 11) + SourceIndex(0)
-5 >Emitted(33, 23) Source(5, 25) + SourceIndex(0)
-6 >Emitted(33, 24) Source(5, 26) + SourceIndex(0)
+1 >Emitted(37, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(5, 7) + SourceIndex(0)
+3 >Emitted(37, 6) Source(5, 8) + SourceIndex(0)
+4 >Emitted(37, 9) Source(5, 11) + SourceIndex(0)
+5 >Emitted(37, 23) Source(5, 25) + SourceIndex(0)
+6 >Emitted(37, 24) Source(5, 26) + SourceIndex(0)
 ---
 >>>console.log(s);
 1 >
@@ -1335,14 +1355,14 @@ sourceFile:../../../first/first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1 >Emitted(34, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(34, 8) Source(11, 8) + SourceIndex(0)
-3 >Emitted(34, 9) Source(11, 9) + SourceIndex(0)
-4 >Emitted(34, 12) Source(11, 12) + SourceIndex(0)
-5 >Emitted(34, 13) Source(11, 13) + SourceIndex(0)
-6 >Emitted(34, 14) Source(11, 14) + SourceIndex(0)
-7 >Emitted(34, 15) Source(11, 15) + SourceIndex(0)
-8 >Emitted(34, 16) Source(11, 16) + SourceIndex(0)
+1 >Emitted(38, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(38, 8) Source(11, 8) + SourceIndex(0)
+3 >Emitted(38, 9) Source(11, 9) + SourceIndex(0)
+4 >Emitted(38, 12) Source(11, 12) + SourceIndex(0)
+5 >Emitted(38, 13) Source(11, 13) + SourceIndex(0)
+6 >Emitted(38, 14) Source(11, 14) + SourceIndex(0)
+7 >Emitted(38, 15) Source(11, 15) + SourceIndex(0)
+8 >Emitted(38, 16) Source(11, 16) + SourceIndex(0)
 ---
 >>>function forfirstfirst_PART1Rest() { }
 1->
@@ -1356,11 +1376,11 @@ sourceFile:../../../first/first_PART1.ts
 3 >         forfirstfirst_PART1Rest
 4 >                                () { 
 5 >                                     }
-1->Emitted(35, 1) Source(12, 1) + SourceIndex(0)
-2 >Emitted(35, 10) Source(12, 10) + SourceIndex(0)
-3 >Emitted(35, 33) Source(12, 33) + SourceIndex(0)
-4 >Emitted(35, 38) Source(12, 38) + SourceIndex(0)
-5 >Emitted(35, 39) Source(12, 39) + SourceIndex(0)
+1->Emitted(39, 1) Source(12, 1) + SourceIndex(0)
+2 >Emitted(39, 10) Source(12, 10) + SourceIndex(0)
+3 >Emitted(39, 33) Source(12, 33) + SourceIndex(0)
+4 >Emitted(39, 38) Source(12, 38) + SourceIndex(0)
+5 >Emitted(39, 39) Source(12, 39) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1385,15 +1405,15 @@ sourceFile:../../../first/first_part2.ts
 7 >             ()
 8 >               )
 9 >                ;
-1 >Emitted(36, 1) Source(1, 1) + SourceIndex(1)
-2 >Emitted(36, 8) Source(1, 8) + SourceIndex(1)
-3 >Emitted(36, 9) Source(1, 9) + SourceIndex(1)
-4 >Emitted(36, 12) Source(1, 12) + SourceIndex(1)
-5 >Emitted(36, 13) Source(1, 13) + SourceIndex(1)
-6 >Emitted(36, 14) Source(1, 14) + SourceIndex(1)
-7 >Emitted(36, 16) Source(1, 16) + SourceIndex(1)
-8 >Emitted(36, 17) Source(1, 17) + SourceIndex(1)
-9 >Emitted(36, 18) Source(1, 18) + SourceIndex(1)
+1 >Emitted(40, 1) Source(1, 1) + SourceIndex(1)
+2 >Emitted(40, 8) Source(1, 8) + SourceIndex(1)
+3 >Emitted(40, 9) Source(1, 9) + SourceIndex(1)
+4 >Emitted(40, 12) Source(1, 12) + SourceIndex(1)
+5 >Emitted(40, 13) Source(1, 13) + SourceIndex(1)
+6 >Emitted(40, 14) Source(1, 14) + SourceIndex(1)
+7 >Emitted(40, 16) Source(1, 16) + SourceIndex(1)
+8 >Emitted(40, 17) Source(1, 17) + SourceIndex(1)
+9 >Emitted(40, 18) Source(1, 18) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1407,9 +1427,9 @@ sourceFile:../../../first/first_part3.ts
 1 >
 2 >function 
 3 >         f
-1 >Emitted(37, 1) Source(1, 1) + SourceIndex(2)
-2 >Emitted(37, 10) Source(1, 10) + SourceIndex(2)
-3 >Emitted(37, 11) Source(1, 11) + SourceIndex(2)
+1 >Emitted(41, 1) Source(1, 1) + SourceIndex(2)
+2 >Emitted(41, 10) Source(1, 10) + SourceIndex(2)
+3 >Emitted(41, 11) Source(1, 11) + SourceIndex(2)
 ---
 >>>    return "JS does hoists";
 1->^^^^
@@ -1421,10 +1441,10 @@ sourceFile:../../../first/first_part3.ts
 2 >    return 
 3 >           "JS does hoists"
 4 >                           ;
-1->Emitted(38, 5) Source(2, 5) + SourceIndex(2)
-2 >Emitted(38, 12) Source(2, 12) + SourceIndex(2)
-3 >Emitted(38, 28) Source(2, 28) + SourceIndex(2)
-4 >Emitted(38, 29) Source(2, 29) + SourceIndex(2)
+1->Emitted(42, 5) Source(2, 5) + SourceIndex(2)
+2 >Emitted(42, 12) Source(2, 12) + SourceIndex(2)
+3 >Emitted(42, 28) Source(2, 28) + SourceIndex(2)
+4 >Emitted(42, 29) Source(2, 29) + SourceIndex(2)
 ---
 >>>}
 1 >
@@ -1433,8 +1453,8 @@ sourceFile:../../../first/first_part3.ts
 1 >
   >
 2 >}
-1 >Emitted(39, 1) Source(3, 1) + SourceIndex(2)
-2 >Emitted(39, 2) Source(3, 2) + SourceIndex(2)
+1 >Emitted(43, 1) Source(3, 1) + SourceIndex(2)
+2 >Emitted(43, 2) Source(3, 2) + SourceIndex(2)
 ---
 >>>function firstfirst_part3Spread() {
 1->
@@ -1444,9 +1464,9 @@ sourceFile:../../../first/first_part3.ts
   >
 2 >function 
 3 >         firstfirst_part3Spread
-1->Emitted(40, 1) Source(4, 1) + SourceIndex(2)
-2 >Emitted(40, 10) Source(4, 10) + SourceIndex(2)
-3 >Emitted(40, 32) Source(4, 32) + SourceIndex(2)
+1->Emitted(44, 1) Source(4, 1) + SourceIndex(2)
+2 >Emitted(44, 10) Source(4, 10) + SourceIndex(2)
+3 >Emitted(44, 32) Source(4, 32) + SourceIndex(2)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -1454,8 +1474,8 @@ sourceFile:../../../first/first_part3.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(41, 5) Source(4, 33) + SourceIndex(2)
-2 >Emitted(41, 16) Source(4, 47) + SourceIndex(2)
+1 >Emitted(45, 5) Source(4, 33) + SourceIndex(2)
+2 >Emitted(45, 16) Source(4, 47) + SourceIndex(2)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1470,20 +1490,20 @@ sourceFile:../../../first/first_part3.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(42, 10) Source(4, 33) + SourceIndex(2)
-2 >Emitted(42, 20) Source(4, 47) + SourceIndex(2)
-3 >Emitted(42, 22) Source(4, 33) + SourceIndex(2)
-4 >Emitted(42, 43) Source(4, 47) + SourceIndex(2)
-5 >Emitted(42, 45) Source(4, 33) + SourceIndex(2)
-6 >Emitted(42, 49) Source(4, 47) + SourceIndex(2)
+1->Emitted(46, 10) Source(4, 33) + SourceIndex(2)
+2 >Emitted(46, 20) Source(4, 47) + SourceIndex(2)
+3 >Emitted(46, 22) Source(4, 33) + SourceIndex(2)
+4 >Emitted(46, 43) Source(4, 47) + SourceIndex(2)
+5 >Emitted(46, 45) Source(4, 33) + SourceIndex(2)
+6 >Emitted(46, 49) Source(4, 47) + SourceIndex(2)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(43, 9) Source(4, 33) + SourceIndex(2)
-2 >Emitted(43, 31) Source(4, 47) + SourceIndex(2)
+1 >Emitted(47, 9) Source(4, 33) + SourceIndex(2)
+2 >Emitted(47, 31) Source(4, 47) + SourceIndex(2)
 ---
 >>>    }
 >>>}
@@ -1492,8 +1512,8 @@ sourceFile:../../../first/first_part3.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(45, 1) Source(4, 51) + SourceIndex(2)
-2 >Emitted(45, 2) Source(4, 52) + SourceIndex(2)
+1 >Emitted(49, 1) Source(4, 51) + SourceIndex(2)
+2 >Emitted(49, 2) Source(4, 52) + SourceIndex(2)
 ---
 >>>var firstfirst_part3_ar = [20, 30];
 1->
@@ -1518,16 +1538,16 @@ sourceFile:../../../first/first_part3.ts
 8 >                               30
 9 >                                 ]
 10>                                  ;
-1->Emitted(46, 1) Source(5, 1) + SourceIndex(2)
-2 >Emitted(46, 5) Source(5, 7) + SourceIndex(2)
-3 >Emitted(46, 24) Source(5, 26) + SourceIndex(2)
-4 >Emitted(46, 27) Source(5, 29) + SourceIndex(2)
-5 >Emitted(46, 28) Source(5, 30) + SourceIndex(2)
-6 >Emitted(46, 30) Source(5, 32) + SourceIndex(2)
-7 >Emitted(46, 32) Source(5, 34) + SourceIndex(2)
-8 >Emitted(46, 34) Source(5, 36) + SourceIndex(2)
-9 >Emitted(46, 35) Source(5, 37) + SourceIndex(2)
-10>Emitted(46, 36) Source(5, 38) + SourceIndex(2)
+1->Emitted(50, 1) Source(5, 1) + SourceIndex(2)
+2 >Emitted(50, 5) Source(5, 7) + SourceIndex(2)
+3 >Emitted(50, 24) Source(5, 26) + SourceIndex(2)
+4 >Emitted(50, 27) Source(5, 29) + SourceIndex(2)
+5 >Emitted(50, 28) Source(5, 30) + SourceIndex(2)
+6 >Emitted(50, 30) Source(5, 32) + SourceIndex(2)
+7 >Emitted(50, 32) Source(5, 34) + SourceIndex(2)
+8 >Emitted(50, 34) Source(5, 36) + SourceIndex(2)
+9 >Emitted(50, 35) Source(5, 37) + SourceIndex(2)
+10>Emitted(50, 36) Source(5, 38) + SourceIndex(2)
 ---
 >>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
 1->
@@ -1545,13 +1565,13 @@ sourceFile:../../../first/first_part3.ts
 5 >                                                      , ...
 6 >                                                                firstfirst_part3_ar
 7 >                                                                                   );
-1->Emitted(47, 1) Source(6, 1) + SourceIndex(2)
-2 >Emitted(47, 23) Source(6, 23) + SourceIndex(2)
-3 >Emitted(47, 53) Source(6, 24) + SourceIndex(2)
-4 >Emitted(47, 55) Source(6, 26) + SourceIndex(2)
-5 >Emitted(47, 65) Source(6, 31) + SourceIndex(2)
-6 >Emitted(47, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(47, 88) Source(6, 52) + SourceIndex(2)
+1->Emitted(51, 1) Source(6, 1) + SourceIndex(2)
+2 >Emitted(51, 23) Source(6, 23) + SourceIndex(2)
+3 >Emitted(51, 53) Source(6, 24) + SourceIndex(2)
+4 >Emitted(51, 55) Source(6, 26) + SourceIndex(2)
+5 >Emitted(51, 65) Source(6, 31) + SourceIndex(2)
+6 >Emitted(51, 84) Source(6, 50) + SourceIndex(2)
+7 >Emitted(51, 88) Source(6, 52) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1577,10 +1597,10 @@ sourceFile:../../../second/second_part1.ts
   >     
   >         f();
   >     }
-1 >Emitted(48, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(48, 5) Source(5, 11) + SourceIndex(3)
-3 >Emitted(48, 6) Source(5, 12) + SourceIndex(3)
-4 >Emitted(48, 7) Source(11, 2) + SourceIndex(3)
+1 >Emitted(52, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(52, 5) Source(5, 11) + SourceIndex(3)
+3 >Emitted(52, 6) Source(5, 12) + SourceIndex(3)
+4 >Emitted(52, 7) Source(11, 2) + SourceIndex(3)
 ---
 >>>(function (N) {
 1->
@@ -1590,9 +1610,9 @@ sourceFile:../../../second/second_part1.ts
 1->
 2 >namespace 
 3 >           N
-1->Emitted(49, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(49, 12) Source(5, 11) + SourceIndex(3)
-3 >Emitted(49, 13) Source(5, 12) + SourceIndex(3)
+1->Emitted(53, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(53, 12) Source(5, 11) + SourceIndex(3)
+3 >Emitted(53, 13) Source(5, 12) + SourceIndex(3)
 ---
 >>>    function f() {
 1->^^^^
@@ -1603,9 +1623,9 @@ sourceFile:../../../second/second_part1.ts
   >    
 2 >    function 
 3 >             f
-1->Emitted(50, 5) Source(6, 5) + SourceIndex(3)
-2 >Emitted(50, 14) Source(6, 14) + SourceIndex(3)
-3 >Emitted(50, 15) Source(6, 15) + SourceIndex(3)
+1->Emitted(54, 5) Source(6, 5) + SourceIndex(3)
+2 >Emitted(54, 14) Source(6, 14) + SourceIndex(3)
+3 >Emitted(54, 15) Source(6, 15) + SourceIndex(3)
 ---
 >>>        console.log('testing');
 1->^^^^^^^^
@@ -1625,14 +1645,14 @@ sourceFile:../../../second/second_part1.ts
 6 >                    'testing'
 7 >                             )
 8 >                              ;
-1->Emitted(51, 9) Source(7, 9) + SourceIndex(3)
-2 >Emitted(51, 16) Source(7, 16) + SourceIndex(3)
-3 >Emitted(51, 17) Source(7, 17) + SourceIndex(3)
-4 >Emitted(51, 20) Source(7, 20) + SourceIndex(3)
-5 >Emitted(51, 21) Source(7, 21) + SourceIndex(3)
-6 >Emitted(51, 30) Source(7, 30) + SourceIndex(3)
-7 >Emitted(51, 31) Source(7, 31) + SourceIndex(3)
-8 >Emitted(51, 32) Source(7, 32) + SourceIndex(3)
+1->Emitted(55, 9) Source(7, 9) + SourceIndex(3)
+2 >Emitted(55, 16) Source(7, 16) + SourceIndex(3)
+3 >Emitted(55, 17) Source(7, 17) + SourceIndex(3)
+4 >Emitted(55, 20) Source(7, 20) + SourceIndex(3)
+5 >Emitted(55, 21) Source(7, 21) + SourceIndex(3)
+6 >Emitted(55, 30) Source(7, 30) + SourceIndex(3)
+7 >Emitted(55, 31) Source(7, 31) + SourceIndex(3)
+8 >Emitted(55, 32) Source(7, 32) + SourceIndex(3)
 ---
 >>>    }
 1 >^^^^
@@ -1641,8 +1661,8 @@ sourceFile:../../../second/second_part1.ts
 1 >
   >    
 2 >    }
-1 >Emitted(52, 5) Source(8, 5) + SourceIndex(3)
-2 >Emitted(52, 6) Source(8, 6) + SourceIndex(3)
+1 >Emitted(56, 5) Source(8, 5) + SourceIndex(3)
+2 >Emitted(56, 6) Source(8, 6) + SourceIndex(3)
 ---
 >>>    f();
 1->^^^^
@@ -1656,10 +1676,10 @@ sourceFile:../../../second/second_part1.ts
 2 >    f
 3 >     ()
 4 >       ;
-1->Emitted(53, 5) Source(10, 5) + SourceIndex(3)
-2 >Emitted(53, 6) Source(10, 6) + SourceIndex(3)
-3 >Emitted(53, 8) Source(10, 8) + SourceIndex(3)
-4 >Emitted(53, 9) Source(10, 9) + SourceIndex(3)
+1->Emitted(57, 5) Source(10, 5) + SourceIndex(3)
+2 >Emitted(57, 6) Source(10, 6) + SourceIndex(3)
+3 >Emitted(57, 8) Source(10, 8) + SourceIndex(3)
+4 >Emitted(57, 9) Source(10, 9) + SourceIndex(3)
 ---
 >>>})(N || (N = {}));
 1->
@@ -1684,13 +1704,13 @@ sourceFile:../../../second/second_part1.ts
   >          
   >              f();
   >          }
-1->Emitted(54, 1) Source(11, 1) + SourceIndex(3)
-2 >Emitted(54, 2) Source(11, 2) + SourceIndex(3)
-3 >Emitted(54, 4) Source(5, 11) + SourceIndex(3)
-4 >Emitted(54, 5) Source(5, 12) + SourceIndex(3)
-5 >Emitted(54, 10) Source(5, 11) + SourceIndex(3)
-6 >Emitted(54, 11) Source(5, 12) + SourceIndex(3)
-7 >Emitted(54, 19) Source(11, 2) + SourceIndex(3)
+1->Emitted(58, 1) Source(11, 1) + SourceIndex(3)
+2 >Emitted(58, 2) Source(11, 2) + SourceIndex(3)
+3 >Emitted(58, 4) Source(5, 11) + SourceIndex(3)
+4 >Emitted(58, 5) Source(5, 12) + SourceIndex(3)
+5 >Emitted(58, 10) Source(5, 11) + SourceIndex(3)
+6 >Emitted(58, 11) Source(5, 12) + SourceIndex(3)
+7 >Emitted(58, 19) Source(11, 2) + SourceIndex(3)
 ---
 >>>function forsecondsecond_part1Rest() {
 1->
@@ -1701,9 +1721,9 @@ sourceFile:../../../second/second_part1.ts
   >
 2 >function 
 3 >         forsecondsecond_part1Rest
-1->Emitted(55, 1) Source(12, 1) + SourceIndex(3)
-2 >Emitted(55, 10) Source(12, 10) + SourceIndex(3)
-3 >Emitted(55, 35) Source(12, 35) + SourceIndex(3)
+1->Emitted(59, 1) Source(12, 1) + SourceIndex(3)
+2 >Emitted(59, 10) Source(12, 10) + SourceIndex(3)
+3 >Emitted(59, 35) Source(12, 35) + SourceIndex(3)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -1757,31 +1777,31 @@ sourceFile:../../../second/second_part1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(56, 5) Source(13, 1) + SourceIndex(3)
-2 >Emitted(56, 9) Source(13, 7) + SourceIndex(3)
-3 >Emitted(56, 14) Source(13, 24) + SourceIndex(3)
-4 >Emitted(56, 16) Source(13, 26) + SourceIndex(3)
-5 >Emitted(56, 17) Source(13, 27) + SourceIndex(3)
-6 >Emitted(56, 19) Source(13, 29) + SourceIndex(3)
-7 >Emitted(56, 21) Source(13, 31) + SourceIndex(3)
-8 >Emitted(56, 23) Source(13, 33) + SourceIndex(3)
-9 >Emitted(56, 24) Source(13, 34) + SourceIndex(3)
-10>Emitted(56, 26) Source(13, 36) + SourceIndex(3)
-11>Emitted(56, 28) Source(13, 38) + SourceIndex(3)
-12>Emitted(56, 30) Source(13, 40) + SourceIndex(3)
-13>Emitted(56, 32) Source(13, 42) + SourceIndex(3)
-14>Emitted(56, 34) Source(13, 44) + SourceIndex(3)
-15>Emitted(56, 36) Source(13, 46) + SourceIndex(3)
-16>Emitted(56, 38) Source(13, 48) + SourceIndex(3)
-17>Emitted(56, 40) Source(13, 9) + SourceIndex(3)
-18>Emitted(56, 41) Source(13, 10) + SourceIndex(3)
-19>Emitted(56, 48) Source(13, 10) + SourceIndex(3)
-20>Emitted(56, 50) Source(13, 15) + SourceIndex(3)
-21>Emitted(56, 54) Source(13, 19) + SourceIndex(3)
-22>Emitted(56, 68) Source(13, 7) + SourceIndex(3)
-23>Emitted(56, 73) Source(13, 21) + SourceIndex(3)
-24>Emitted(56, 74) Source(13, 48) + SourceIndex(3)
-25>Emitted(56, 75) Source(13, 49) + SourceIndex(3)
+1->Emitted(60, 5) Source(13, 1) + SourceIndex(3)
+2 >Emitted(60, 9) Source(13, 7) + SourceIndex(3)
+3 >Emitted(60, 14) Source(13, 24) + SourceIndex(3)
+4 >Emitted(60, 16) Source(13, 26) + SourceIndex(3)
+5 >Emitted(60, 17) Source(13, 27) + SourceIndex(3)
+6 >Emitted(60, 19) Source(13, 29) + SourceIndex(3)
+7 >Emitted(60, 21) Source(13, 31) + SourceIndex(3)
+8 >Emitted(60, 23) Source(13, 33) + SourceIndex(3)
+9 >Emitted(60, 24) Source(13, 34) + SourceIndex(3)
+10>Emitted(60, 26) Source(13, 36) + SourceIndex(3)
+11>Emitted(60, 28) Source(13, 38) + SourceIndex(3)
+12>Emitted(60, 30) Source(13, 40) + SourceIndex(3)
+13>Emitted(60, 32) Source(13, 42) + SourceIndex(3)
+14>Emitted(60, 34) Source(13, 44) + SourceIndex(3)
+15>Emitted(60, 36) Source(13, 46) + SourceIndex(3)
+16>Emitted(60, 38) Source(13, 48) + SourceIndex(3)
+17>Emitted(60, 40) Source(13, 9) + SourceIndex(3)
+18>Emitted(60, 41) Source(13, 10) + SourceIndex(3)
+19>Emitted(60, 48) Source(13, 10) + SourceIndex(3)
+20>Emitted(60, 50) Source(13, 15) + SourceIndex(3)
+21>Emitted(60, 54) Source(13, 19) + SourceIndex(3)
+22>Emitted(60, 68) Source(13, 7) + SourceIndex(3)
+23>Emitted(60, 73) Source(13, 21) + SourceIndex(3)
+24>Emitted(60, 74) Source(13, 48) + SourceIndex(3)
+25>Emitted(60, 75) Source(13, 49) + SourceIndex(3)
 ---
 >>>}
 1 >
@@ -1790,8 +1810,8 @@ sourceFile:../../../second/second_part1.ts
 1 >
   >
 2 >}
-1 >Emitted(57, 1) Source(14, 1) + SourceIndex(3)
-2 >Emitted(57, 2) Source(14, 2) + SourceIndex(3)
+1 >Emitted(61, 1) Source(14, 1) + SourceIndex(3)
+2 >Emitted(61, 2) Source(14, 2) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1801,13 +1821,13 @@ sourceFile:../../../second/second_part2.ts
 1->
 2 >^^^^^^^^^^^^^^^^^^^->
 1->
-1->Emitted(58, 1) Source(1, 1) + SourceIndex(4)
+1->Emitted(62, 1) Source(1, 1) + SourceIndex(4)
 ---
 >>>    function C() {
 1->^^^^
 2 >    ^^->
 1->
-1->Emitted(59, 5) Source(1, 1) + SourceIndex(4)
+1->Emitted(63, 5) Source(1, 1) + SourceIndex(4)
 ---
 >>>    }
 1->^^^^
@@ -1819,8 +1839,8 @@ sourceFile:../../../second/second_part2.ts
   >    }
   >
 2 >    }
-1->Emitted(60, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(60, 6) Source(5, 2) + SourceIndex(4)
+1->Emitted(64, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(64, 6) Source(5, 2) + SourceIndex(4)
 ---
 >>>    C.prototype.doSomething = function () {
 1->^^^^
@@ -1830,9 +1850,9 @@ sourceFile:../../../second/second_part2.ts
 1->
 2 >    doSomething
 3 >                           
-1->Emitted(61, 5) Source(2, 5) + SourceIndex(4)
-2 >Emitted(61, 28) Source(2, 16) + SourceIndex(4)
-3 >Emitted(61, 31) Source(2, 5) + SourceIndex(4)
+1->Emitted(65, 5) Source(2, 5) + SourceIndex(4)
+2 >Emitted(65, 28) Source(2, 16) + SourceIndex(4)
+3 >Emitted(65, 31) Source(2, 5) + SourceIndex(4)
 ---
 >>>        console.log("something got done");
 1->^^^^^^^^
@@ -1852,14 +1872,14 @@ sourceFile:../../../second/second_part2.ts
 6 >                    "something got done"
 7 >                                        )
 8 >                                         ;
-1->Emitted(62, 9) Source(3, 9) + SourceIndex(4)
-2 >Emitted(62, 16) Source(3, 16) + SourceIndex(4)
-3 >Emitted(62, 17) Source(3, 17) + SourceIndex(4)
-4 >Emitted(62, 20) Source(3, 20) + SourceIndex(4)
-5 >Emitted(62, 21) Source(3, 21) + SourceIndex(4)
-6 >Emitted(62, 41) Source(3, 41) + SourceIndex(4)
-7 >Emitted(62, 42) Source(3, 42) + SourceIndex(4)
-8 >Emitted(62, 43) Source(3, 43) + SourceIndex(4)
+1->Emitted(66, 9) Source(3, 9) + SourceIndex(4)
+2 >Emitted(66, 16) Source(3, 16) + SourceIndex(4)
+3 >Emitted(66, 17) Source(3, 17) + SourceIndex(4)
+4 >Emitted(66, 20) Source(3, 20) + SourceIndex(4)
+5 >Emitted(66, 21) Source(3, 21) + SourceIndex(4)
+6 >Emitted(66, 41) Source(3, 41) + SourceIndex(4)
+7 >Emitted(66, 42) Source(3, 42) + SourceIndex(4)
+8 >Emitted(66, 43) Source(3, 43) + SourceIndex(4)
 ---
 >>>    };
 1 >^^^^
@@ -1868,8 +1888,8 @@ sourceFile:../../../second/second_part2.ts
 1 >
   >    
 2 >    }
-1 >Emitted(63, 5) Source(4, 5) + SourceIndex(4)
-2 >Emitted(63, 6) Source(4, 6) + SourceIndex(4)
+1 >Emitted(67, 5) Source(4, 5) + SourceIndex(4)
+2 >Emitted(67, 6) Source(4, 6) + SourceIndex(4)
 ---
 >>>    return C;
 1->^^^^
@@ -1877,8 +1897,8 @@ sourceFile:../../../second/second_part2.ts
 1->
   >
 2 >    }
-1->Emitted(64, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(64, 13) Source(5, 2) + SourceIndex(4)
+1->Emitted(68, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(68, 13) Source(5, 2) + SourceIndex(4)
 ---
 >>>}());
 1 >
@@ -1894,10 +1914,10 @@ sourceFile:../../../second/second_part2.ts
   >         console.log("something got done");
   >     }
   > }
-1 >Emitted(65, 1) Source(5, 1) + SourceIndex(4)
-2 >Emitted(65, 2) Source(5, 2) + SourceIndex(4)
-3 >Emitted(65, 2) Source(1, 1) + SourceIndex(4)
-4 >Emitted(65, 6) Source(5, 2) + SourceIndex(4)
+1 >Emitted(69, 1) Source(5, 1) + SourceIndex(4)
+2 >Emitted(69, 2) Source(5, 2) + SourceIndex(4)
+3 >Emitted(69, 2) Source(1, 1) + SourceIndex(4)
+4 >Emitted(69, 6) Source(5, 2) + SourceIndex(4)
 ---
 >>>function secondsecond_part2Spread() {
 1->
@@ -1908,9 +1928,9 @@ sourceFile:../../../second/second_part2.ts
   >
 2 >function 
 3 >         secondsecond_part2Spread
-1->Emitted(66, 1) Source(7, 1) + SourceIndex(4)
-2 >Emitted(66, 10) Source(7, 10) + SourceIndex(4)
-3 >Emitted(66, 34) Source(7, 34) + SourceIndex(4)
+1->Emitted(70, 1) Source(7, 1) + SourceIndex(4)
+2 >Emitted(70, 10) Source(7, 10) + SourceIndex(4)
+3 >Emitted(70, 34) Source(7, 34) + SourceIndex(4)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -1918,8 +1938,8 @@ sourceFile:../../../second/second_part2.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(67, 5) Source(7, 35) + SourceIndex(4)
-2 >Emitted(67, 16) Source(7, 49) + SourceIndex(4)
+1 >Emitted(71, 5) Source(7, 35) + SourceIndex(4)
+2 >Emitted(71, 16) Source(7, 49) + SourceIndex(4)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1934,20 +1954,20 @@ sourceFile:../../../second/second_part2.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(68, 10) Source(7, 35) + SourceIndex(4)
-2 >Emitted(68, 20) Source(7, 49) + SourceIndex(4)
-3 >Emitted(68, 22) Source(7, 35) + SourceIndex(4)
-4 >Emitted(68, 43) Source(7, 49) + SourceIndex(4)
-5 >Emitted(68, 45) Source(7, 35) + SourceIndex(4)
-6 >Emitted(68, 49) Source(7, 49) + SourceIndex(4)
+1->Emitted(72, 10) Source(7, 35) + SourceIndex(4)
+2 >Emitted(72, 20) Source(7, 49) + SourceIndex(4)
+3 >Emitted(72, 22) Source(7, 35) + SourceIndex(4)
+4 >Emitted(72, 43) Source(7, 49) + SourceIndex(4)
+5 >Emitted(72, 45) Source(7, 35) + SourceIndex(4)
+6 >Emitted(72, 49) Source(7, 49) + SourceIndex(4)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(69, 9) Source(7, 35) + SourceIndex(4)
-2 >Emitted(69, 31) Source(7, 49) + SourceIndex(4)
+1 >Emitted(73, 9) Source(7, 35) + SourceIndex(4)
+2 >Emitted(73, 31) Source(7, 49) + SourceIndex(4)
 ---
 >>>    }
 >>>}
@@ -1956,8 +1976,8 @@ sourceFile:../../../second/second_part2.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(71, 1) Source(7, 53) + SourceIndex(4)
-2 >Emitted(71, 2) Source(7, 54) + SourceIndex(4)
+1 >Emitted(75, 1) Source(7, 53) + SourceIndex(4)
+2 >Emitted(75, 2) Source(7, 54) + SourceIndex(4)
 ---
 >>>var secondsecond_part2_ar = [20, 30];
 1->
@@ -1982,16 +2002,16 @@ sourceFile:../../../second/second_part2.ts
 8 >                                 30
 9 >                                   ]
 10>                                    ;
-1->Emitted(72, 1) Source(8, 1) + SourceIndex(4)
-2 >Emitted(72, 5) Source(8, 7) + SourceIndex(4)
-3 >Emitted(72, 26) Source(8, 28) + SourceIndex(4)
-4 >Emitted(72, 29) Source(8, 31) + SourceIndex(4)
-5 >Emitted(72, 30) Source(8, 32) + SourceIndex(4)
-6 >Emitted(72, 32) Source(8, 34) + SourceIndex(4)
-7 >Emitted(72, 34) Source(8, 36) + SourceIndex(4)
-8 >Emitted(72, 36) Source(8, 38) + SourceIndex(4)
-9 >Emitted(72, 37) Source(8, 39) + SourceIndex(4)
-10>Emitted(72, 38) Source(8, 40) + SourceIndex(4)
+1->Emitted(76, 1) Source(8, 1) + SourceIndex(4)
+2 >Emitted(76, 5) Source(8, 7) + SourceIndex(4)
+3 >Emitted(76, 26) Source(8, 28) + SourceIndex(4)
+4 >Emitted(76, 29) Source(8, 31) + SourceIndex(4)
+5 >Emitted(76, 30) Source(8, 32) + SourceIndex(4)
+6 >Emitted(76, 32) Source(8, 34) + SourceIndex(4)
+7 >Emitted(76, 34) Source(8, 36) + SourceIndex(4)
+8 >Emitted(76, 36) Source(8, 38) + SourceIndex(4)
+9 >Emitted(76, 37) Source(8, 39) + SourceIndex(4)
+10>Emitted(76, 38) Source(8, 40) + SourceIndex(4)
 ---
 >>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
 1->
@@ -2009,13 +2029,13 @@ sourceFile:../../../second/second_part2.ts
 5 >                                                        , ...
 6 >                                                                  secondsecond_part2_ar
 7 >                                                                                       );
-1->Emitted(73, 1) Source(9, 1) + SourceIndex(4)
-2 >Emitted(73, 25) Source(9, 25) + SourceIndex(4)
-3 >Emitted(73, 55) Source(9, 26) + SourceIndex(4)
-4 >Emitted(73, 57) Source(9, 28) + SourceIndex(4)
-5 >Emitted(73, 67) Source(9, 33) + SourceIndex(4)
-6 >Emitted(73, 88) Source(9, 54) + SourceIndex(4)
-7 >Emitted(73, 92) Source(9, 56) + SourceIndex(4)
+1->Emitted(77, 1) Source(9, 1) + SourceIndex(4)
+2 >Emitted(77, 25) Source(9, 25) + SourceIndex(4)
+3 >Emitted(77, 55) Source(9, 26) + SourceIndex(4)
+4 >Emitted(77, 57) Source(9, 28) + SourceIndex(4)
+5 >Emitted(77, 67) Source(9, 33) + SourceIndex(4)
+6 >Emitted(77, 88) Source(9, 54) + SourceIndex(4)
+7 >Emitted(77, 92) Source(9, 56) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2039,14 +2059,14 @@ sourceFile:../../third_part1.ts
 6 >            C
 7 >             ()
 8 >               ;
-1 >Emitted(74, 1) Source(1, 1) + SourceIndex(5)
-2 >Emitted(74, 5) Source(1, 5) + SourceIndex(5)
-3 >Emitted(74, 6) Source(1, 6) + SourceIndex(5)
-4 >Emitted(74, 9) Source(1, 9) + SourceIndex(5)
-5 >Emitted(74, 13) Source(1, 13) + SourceIndex(5)
-6 >Emitted(74, 14) Source(1, 14) + SourceIndex(5)
-7 >Emitted(74, 16) Source(1, 16) + SourceIndex(5)
-8 >Emitted(74, 17) Source(1, 17) + SourceIndex(5)
+1 >Emitted(78, 1) Source(1, 1) + SourceIndex(5)
+2 >Emitted(78, 5) Source(1, 5) + SourceIndex(5)
+3 >Emitted(78, 6) Source(1, 6) + SourceIndex(5)
+4 >Emitted(78, 9) Source(1, 9) + SourceIndex(5)
+5 >Emitted(78, 13) Source(1, 13) + SourceIndex(5)
+6 >Emitted(78, 14) Source(1, 14) + SourceIndex(5)
+7 >Emitted(78, 16) Source(1, 16) + SourceIndex(5)
+8 >Emitted(78, 17) Source(1, 17) + SourceIndex(5)
 ---
 >>>c.doSomething();
 1->
@@ -2063,12 +2083,12 @@ sourceFile:../../third_part1.ts
 4 >  doSomething
 5 >             ()
 6 >               ;
-1->Emitted(75, 1) Source(2, 1) + SourceIndex(5)
-2 >Emitted(75, 2) Source(2, 2) + SourceIndex(5)
-3 >Emitted(75, 3) Source(2, 3) + SourceIndex(5)
-4 >Emitted(75, 14) Source(2, 14) + SourceIndex(5)
-5 >Emitted(75, 16) Source(2, 16) + SourceIndex(5)
-6 >Emitted(75, 17) Source(2, 17) + SourceIndex(5)
+1->Emitted(79, 1) Source(2, 1) + SourceIndex(5)
+2 >Emitted(79, 2) Source(2, 2) + SourceIndex(5)
+3 >Emitted(79, 3) Source(2, 3) + SourceIndex(5)
+4 >Emitted(79, 14) Source(2, 14) + SourceIndex(5)
+5 >Emitted(79, 16) Source(2, 16) + SourceIndex(5)
+6 >Emitted(79, 17) Source(2, 17) + SourceIndex(5)
 ---
 >>>function forthirdthird_part1Rest() {
 1->
@@ -2079,9 +2099,9 @@ sourceFile:../../third_part1.ts
   >
 2 >function 
 3 >         forthirdthird_part1Rest
-1->Emitted(76, 1) Source(3, 1) + SourceIndex(5)
-2 >Emitted(76, 10) Source(3, 10) + SourceIndex(5)
-3 >Emitted(76, 33) Source(3, 33) + SourceIndex(5)
+1->Emitted(80, 1) Source(3, 1) + SourceIndex(5)
+2 >Emitted(80, 10) Source(3, 10) + SourceIndex(5)
+3 >Emitted(80, 33) Source(3, 33) + SourceIndex(5)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -2135,31 +2155,31 @@ sourceFile:../../third_part1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(77, 5) Source(4, 1) + SourceIndex(5)
-2 >Emitted(77, 9) Source(4, 7) + SourceIndex(5)
-3 >Emitted(77, 14) Source(4, 24) + SourceIndex(5)
-4 >Emitted(77, 16) Source(4, 26) + SourceIndex(5)
-5 >Emitted(77, 17) Source(4, 27) + SourceIndex(5)
-6 >Emitted(77, 19) Source(4, 29) + SourceIndex(5)
-7 >Emitted(77, 21) Source(4, 31) + SourceIndex(5)
-8 >Emitted(77, 23) Source(4, 33) + SourceIndex(5)
-9 >Emitted(77, 24) Source(4, 34) + SourceIndex(5)
-10>Emitted(77, 26) Source(4, 36) + SourceIndex(5)
-11>Emitted(77, 28) Source(4, 38) + SourceIndex(5)
-12>Emitted(77, 30) Source(4, 40) + SourceIndex(5)
-13>Emitted(77, 32) Source(4, 42) + SourceIndex(5)
-14>Emitted(77, 34) Source(4, 44) + SourceIndex(5)
-15>Emitted(77, 36) Source(4, 46) + SourceIndex(5)
-16>Emitted(77, 38) Source(4, 48) + SourceIndex(5)
-17>Emitted(77, 40) Source(4, 9) + SourceIndex(5)
-18>Emitted(77, 41) Source(4, 10) + SourceIndex(5)
-19>Emitted(77, 48) Source(4, 10) + SourceIndex(5)
-20>Emitted(77, 50) Source(4, 15) + SourceIndex(5)
-21>Emitted(77, 54) Source(4, 19) + SourceIndex(5)
-22>Emitted(77, 68) Source(4, 7) + SourceIndex(5)
-23>Emitted(77, 73) Source(4, 21) + SourceIndex(5)
-24>Emitted(77, 74) Source(4, 48) + SourceIndex(5)
-25>Emitted(77, 75) Source(4, 49) + SourceIndex(5)
+1->Emitted(81, 5) Source(4, 1) + SourceIndex(5)
+2 >Emitted(81, 9) Source(4, 7) + SourceIndex(5)
+3 >Emitted(81, 14) Source(4, 24) + SourceIndex(5)
+4 >Emitted(81, 16) Source(4, 26) + SourceIndex(5)
+5 >Emitted(81, 17) Source(4, 27) + SourceIndex(5)
+6 >Emitted(81, 19) Source(4, 29) + SourceIndex(5)
+7 >Emitted(81, 21) Source(4, 31) + SourceIndex(5)
+8 >Emitted(81, 23) Source(4, 33) + SourceIndex(5)
+9 >Emitted(81, 24) Source(4, 34) + SourceIndex(5)
+10>Emitted(81, 26) Source(4, 36) + SourceIndex(5)
+11>Emitted(81, 28) Source(4, 38) + SourceIndex(5)
+12>Emitted(81, 30) Source(4, 40) + SourceIndex(5)
+13>Emitted(81, 32) Source(4, 42) + SourceIndex(5)
+14>Emitted(81, 34) Source(4, 44) + SourceIndex(5)
+15>Emitted(81, 36) Source(4, 46) + SourceIndex(5)
+16>Emitted(81, 38) Source(4, 48) + SourceIndex(5)
+17>Emitted(81, 40) Source(4, 9) + SourceIndex(5)
+18>Emitted(81, 41) Source(4, 10) + SourceIndex(5)
+19>Emitted(81, 48) Source(4, 10) + SourceIndex(5)
+20>Emitted(81, 50) Source(4, 15) + SourceIndex(5)
+21>Emitted(81, 54) Source(4, 19) + SourceIndex(5)
+22>Emitted(81, 68) Source(4, 7) + SourceIndex(5)
+23>Emitted(81, 73) Source(4, 21) + SourceIndex(5)
+24>Emitted(81, 74) Source(4, 48) + SourceIndex(5)
+25>Emitted(81, 75) Source(4, 49) + SourceIndex(5)
 ---
 >>>}
 1 >
@@ -2168,8 +2188,8 @@ sourceFile:../../third_part1.ts
 1 >
   >
 2 >}
-1 >Emitted(78, 1) Source(5, 1) + SourceIndex(5)
-2 >Emitted(78, 2) Source(5, 2) + SourceIndex(5)
+1 >Emitted(82, 1) Source(5, 1) + SourceIndex(5)
+2 >Emitted(82, 2) Source(5, 2) + SourceIndex(5)
 ---
 >>>function thirdthird_part1Spread() {
 1->
@@ -2179,9 +2199,9 @@ sourceFile:../../third_part1.ts
   >
 2 >function 
 3 >         thirdthird_part1Spread
-1->Emitted(79, 1) Source(6, 1) + SourceIndex(5)
-2 >Emitted(79, 10) Source(6, 10) + SourceIndex(5)
-3 >Emitted(79, 32) Source(6, 32) + SourceIndex(5)
+1->Emitted(83, 1) Source(6, 1) + SourceIndex(5)
+2 >Emitted(83, 10) Source(6, 10) + SourceIndex(5)
+3 >Emitted(83, 32) Source(6, 32) + SourceIndex(5)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -2189,8 +2209,8 @@ sourceFile:../../third_part1.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(80, 5) Source(6, 33) + SourceIndex(5)
-2 >Emitted(80, 16) Source(6, 47) + SourceIndex(5)
+1 >Emitted(84, 5) Source(6, 33) + SourceIndex(5)
+2 >Emitted(84, 16) Source(6, 47) + SourceIndex(5)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -2205,20 +2225,20 @@ sourceFile:../../third_part1.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(81, 10) Source(6, 33) + SourceIndex(5)
-2 >Emitted(81, 20) Source(6, 47) + SourceIndex(5)
-3 >Emitted(81, 22) Source(6, 33) + SourceIndex(5)
-4 >Emitted(81, 43) Source(6, 47) + SourceIndex(5)
-5 >Emitted(81, 45) Source(6, 33) + SourceIndex(5)
-6 >Emitted(81, 49) Source(6, 47) + SourceIndex(5)
+1->Emitted(85, 10) Source(6, 33) + SourceIndex(5)
+2 >Emitted(85, 20) Source(6, 47) + SourceIndex(5)
+3 >Emitted(85, 22) Source(6, 33) + SourceIndex(5)
+4 >Emitted(85, 43) Source(6, 47) + SourceIndex(5)
+5 >Emitted(85, 45) Source(6, 33) + SourceIndex(5)
+6 >Emitted(85, 49) Source(6, 47) + SourceIndex(5)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(82, 9) Source(6, 33) + SourceIndex(5)
-2 >Emitted(82, 31) Source(6, 47) + SourceIndex(5)
+1 >Emitted(86, 9) Source(6, 33) + SourceIndex(5)
+2 >Emitted(86, 31) Source(6, 47) + SourceIndex(5)
 ---
 >>>    }
 >>>}
@@ -2227,8 +2247,8 @@ sourceFile:../../third_part1.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(84, 1) Source(6, 51) + SourceIndex(5)
-2 >Emitted(84, 2) Source(6, 52) + SourceIndex(5)
+1 >Emitted(88, 1) Source(6, 51) + SourceIndex(5)
+2 >Emitted(88, 2) Source(6, 52) + SourceIndex(5)
 ---
 >>>var thirdthird_part1_ar = [20, 30];
 1->
@@ -2253,16 +2273,16 @@ sourceFile:../../third_part1.ts
 8 >                               30
 9 >                                 ]
 10>                                  ;
-1->Emitted(85, 1) Source(7, 1) + SourceIndex(5)
-2 >Emitted(85, 5) Source(7, 7) + SourceIndex(5)
-3 >Emitted(85, 24) Source(7, 26) + SourceIndex(5)
-4 >Emitted(85, 27) Source(7, 29) + SourceIndex(5)
-5 >Emitted(85, 28) Source(7, 30) + SourceIndex(5)
-6 >Emitted(85, 30) Source(7, 32) + SourceIndex(5)
-7 >Emitted(85, 32) Source(7, 34) + SourceIndex(5)
-8 >Emitted(85, 34) Source(7, 36) + SourceIndex(5)
-9 >Emitted(85, 35) Source(7, 37) + SourceIndex(5)
-10>Emitted(85, 36) Source(7, 38) + SourceIndex(5)
+1->Emitted(89, 1) Source(7, 1) + SourceIndex(5)
+2 >Emitted(89, 5) Source(7, 7) + SourceIndex(5)
+3 >Emitted(89, 24) Source(7, 26) + SourceIndex(5)
+4 >Emitted(89, 27) Source(7, 29) + SourceIndex(5)
+5 >Emitted(89, 28) Source(7, 30) + SourceIndex(5)
+6 >Emitted(89, 30) Source(7, 32) + SourceIndex(5)
+7 >Emitted(89, 32) Source(7, 34) + SourceIndex(5)
+8 >Emitted(89, 34) Source(7, 36) + SourceIndex(5)
+9 >Emitted(89, 35) Source(7, 37) + SourceIndex(5)
+10>Emitted(89, 36) Source(7, 38) + SourceIndex(5)
 ---
 >>>thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
 1->
@@ -2280,18 +2300,18 @@ sourceFile:../../third_part1.ts
 5 >                                                      , ...
 6 >                                                                thirdthird_part1_ar
 7 >                                                                                   );
-1->Emitted(86, 1) Source(8, 1) + SourceIndex(5)
-2 >Emitted(86, 23) Source(8, 23) + SourceIndex(5)
-3 >Emitted(86, 53) Source(8, 24) + SourceIndex(5)
-4 >Emitted(86, 55) Source(8, 26) + SourceIndex(5)
-5 >Emitted(86, 65) Source(8, 31) + SourceIndex(5)
-6 >Emitted(86, 84) Source(8, 50) + SourceIndex(5)
-7 >Emitted(86, 88) Source(8, 52) + SourceIndex(5)
+1->Emitted(90, 1) Source(8, 1) + SourceIndex(5)
+2 >Emitted(90, 23) Source(8, 23) + SourceIndex(5)
+3 >Emitted(90, 53) Source(8, 24) + SourceIndex(5)
+4 >Emitted(90, 55) Source(8, 26) + SourceIndex(5)
+5 >Emitted(90, 65) Source(8, 31) + SourceIndex(5)
+6 >Emitted(90, 84) Source(8, 50) + SourceIndex(5)
+7 >Emitted(90, 88) Source(8, 52) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":697,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":699,"end":1199,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1201,"end":1626,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1201,"end":1626,"kind":"text"}]},{"pos":1626,"end":2313,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1626,"end":2313,"kind":"text"}]},{"pos":2313,"end":2741,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":1769,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1769,"kind":"text"}]},{"pos":1769,"end":2456,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1769,"end":2456,"kind":"text"}]},{"pos":2456,"end":2884,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -2315,14 +2335,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-697):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (506-840):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (699-1199):: typescript:rest
+emitHelpers: (842-1342):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -2335,9 +2359,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1201-1626):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1344-1769):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1201-1626)
+text: (1344-1769)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() { }
@@ -2355,9 +2379,9 @@ var firstfirst_part3_ar = [20, 30];
 firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
 
 ----------------------------------------------------------------------
-prepend: (1626-2313):: ../../../2/second-output.js texts:: 1
+prepend: (1769-2456):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1626-2313)
+text: (1769-2456)
 var N;
 (function (N) {
     function f() {
@@ -2386,7 +2410,7 @@ var secondsecond_part2_ar = [20, 30];
 secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
 
 ----------------------------------------------------------------------
-text: (2313-2741)
+text: (2456-2884)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -2461,45 +2485,45 @@ declare const thirdthird_part1_ar: number[];
         },
         {
           "pos": 506,
-          "end": 697,
+          "end": 840,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 699,
-          "end": 1199,
+          "pos": 842,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1201,
-          "end": 1626,
+          "pos": 1344,
+          "end": 1769,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1201,
-              "end": 1626,
+              "pos": 1344,
+              "end": 1769,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1626,
-          "end": 2313,
+          "pos": 1769,
+          "end": 2456,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1626,
-              "end": 2313,
+              "pos": 1769,
+              "end": 2456,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2313,
-          "end": 2741,
+          "pos": 2456,
+          "end": 2884,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-different-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-different-projects.js
@@ -778,7 +778,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -818,7 +818,7 @@ function secondsecond_part1Spread() {
     }
 }
 var secondsecond_part1_ar = [20, 30];
-secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 var C = (function () {
     function C() {
     }
@@ -835,7 +835,7 @@ function forthirdthird_part1Rest() {
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,WAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -865,7 +865,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -1243,7 +1243,7 @@ sourceFile:../../../second/second_part1.ts
 8 >                                 ^^
 9 >                                   ^
 10>                                    ^
-11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1266,14 +1266,14 @@ sourceFile:../../../second/second_part1.ts
 9 >Emitted(57, 37) Source(14, 39) + SourceIndex(3)
 10>Emitted(57, 38) Source(14, 40) + SourceIndex(3)
 ---
->>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+>>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^^^
 3 >                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                      ^^
 5 >                                                        ^^^^^^^^^^
 6 >                                                                  ^^^^^^^^^^^^^^^^^^^^^
-7 >                                                                                       ^^^^
+7 >                                                                                       ^^^^^^^^^^^
 1->
   >
 2 >secondsecond_part1Spread
@@ -1288,7 +1288,7 @@ sourceFile:../../../second/second_part1.ts
 4 >Emitted(58, 57) Source(15, 28) + SourceIndex(3)
 5 >Emitted(58, 67) Source(15, 33) + SourceIndex(3)
 6 >Emitted(58, 88) Source(15, 54) + SourceIndex(3)
-7 >Emitted(58, 92) Source(15, 56) + SourceIndex(3)
+7 >Emitted(58, 99) Source(15, 56) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1553,7 +1553,7 @@ sourceFile:../../third_part1.ts
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":1494,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1494,"kind":"text"}]},{"pos":1494,"end":2062,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1494,"end":2062,"kind":"text"}]},{"pos":2062,"end":2215,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":1520,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1520,"kind":"text"}]},{"pos":1520,"end":2095,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1520,"end":2095,"kind":"text"}]},{"pos":2095,"end":2248,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1577,9 +1577,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-840):: typescript:spreadArray
+emitHelpers: (506-866):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1588,7 +1588,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (842-1342):: typescript:rest
+emitHelpers: (868-1368):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1601,9 +1601,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1344-1494):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1370-1520):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1344-1494)
+text: (1370-1520)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() { }
@@ -1613,9 +1613,9 @@ function f() {
 }
 
 ----------------------------------------------------------------------
-prepend: (1494-2062):: ../../../2/second-output.js texts:: 1
+prepend: (1520-2095):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1494-2062)
+text: (1520-2095)
 var N;
 (function (N) {
     function f() {
@@ -1630,7 +1630,7 @@ function secondsecond_part1Spread() {
     }
 }
 var secondsecond_part1_ar = [20, 30];
-secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 var C = (function () {
     function C() {
     }
@@ -1641,7 +1641,7 @@ var C = (function () {
 }());
 
 ----------------------------------------------------------------------
-text: (2062-2215)
+text: (2095-2248)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -1703,45 +1703,45 @@ declare function forthirdthird_part1Rest(): void;
         },
         {
           "pos": 506,
-          "end": 840,
+          "end": 866,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 842,
-          "end": 1342,
+          "pos": 868,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1344,
-          "end": 1494,
+          "pos": 1370,
+          "end": 1520,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1344,
-              "end": 1494,
+              "pos": 1370,
+              "end": 1520,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1494,
-          "end": 2062,
+          "pos": 1520,
+          "end": 2095,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1494,
-              "end": 2062,
+              "pos": 1520,
+              "end": 2095,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2062,
-          "end": 2215,
+          "pos": 2095,
+          "end": 2248,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-different-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-different-projects.js
@@ -777,10 +777,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -831,7 +835,7 @@ function forthirdthird_part1Rest() {
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB,KAAK,CAAC;ACXtC,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -860,10 +864,14 @@ sourceFile:../../../first/first_PART1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -893,12 +901,12 @@ sourceFile:../../../first/first_PART1.ts
 4 >      = 
 5 >        "Hello, world"
 6 >                      ;
-1 >Emitted(33, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(5, 7) + SourceIndex(0)
-3 >Emitted(33, 6) Source(5, 8) + SourceIndex(0)
-4 >Emitted(33, 9) Source(5, 11) + SourceIndex(0)
-5 >Emitted(33, 23) Source(5, 25) + SourceIndex(0)
-6 >Emitted(33, 24) Source(5, 26) + SourceIndex(0)
+1 >Emitted(37, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(5, 7) + SourceIndex(0)
+3 >Emitted(37, 6) Source(5, 8) + SourceIndex(0)
+4 >Emitted(37, 9) Source(5, 11) + SourceIndex(0)
+5 >Emitted(37, 23) Source(5, 25) + SourceIndex(0)
+6 >Emitted(37, 24) Source(5, 26) + SourceIndex(0)
 ---
 >>>console.log(s);
 1 >
@@ -924,14 +932,14 @@ sourceFile:../../../first/first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1 >Emitted(34, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(34, 8) Source(11, 8) + SourceIndex(0)
-3 >Emitted(34, 9) Source(11, 9) + SourceIndex(0)
-4 >Emitted(34, 12) Source(11, 12) + SourceIndex(0)
-5 >Emitted(34, 13) Source(11, 13) + SourceIndex(0)
-6 >Emitted(34, 14) Source(11, 14) + SourceIndex(0)
-7 >Emitted(34, 15) Source(11, 15) + SourceIndex(0)
-8 >Emitted(34, 16) Source(11, 16) + SourceIndex(0)
+1 >Emitted(38, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(38, 8) Source(11, 8) + SourceIndex(0)
+3 >Emitted(38, 9) Source(11, 9) + SourceIndex(0)
+4 >Emitted(38, 12) Source(11, 12) + SourceIndex(0)
+5 >Emitted(38, 13) Source(11, 13) + SourceIndex(0)
+6 >Emitted(38, 14) Source(11, 14) + SourceIndex(0)
+7 >Emitted(38, 15) Source(11, 15) + SourceIndex(0)
+8 >Emitted(38, 16) Source(11, 16) + SourceIndex(0)
 ---
 >>>function forfirstfirst_PART1Rest() { }
 1->
@@ -945,11 +953,11 @@ sourceFile:../../../first/first_PART1.ts
 3 >         forfirstfirst_PART1Rest
 4 >                                () { 
 5 >                                     }
-1->Emitted(35, 1) Source(12, 1) + SourceIndex(0)
-2 >Emitted(35, 10) Source(12, 10) + SourceIndex(0)
-3 >Emitted(35, 33) Source(12, 33) + SourceIndex(0)
-4 >Emitted(35, 38) Source(12, 38) + SourceIndex(0)
-5 >Emitted(35, 39) Source(12, 39) + SourceIndex(0)
+1->Emitted(39, 1) Source(12, 1) + SourceIndex(0)
+2 >Emitted(39, 10) Source(12, 10) + SourceIndex(0)
+3 >Emitted(39, 33) Source(12, 33) + SourceIndex(0)
+4 >Emitted(39, 38) Source(12, 38) + SourceIndex(0)
+5 >Emitted(39, 39) Source(12, 39) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -974,15 +982,15 @@ sourceFile:../../../first/first_part2.ts
 7 >             ()
 8 >               )
 9 >                ;
-1 >Emitted(36, 1) Source(1, 1) + SourceIndex(1)
-2 >Emitted(36, 8) Source(1, 8) + SourceIndex(1)
-3 >Emitted(36, 9) Source(1, 9) + SourceIndex(1)
-4 >Emitted(36, 12) Source(1, 12) + SourceIndex(1)
-5 >Emitted(36, 13) Source(1, 13) + SourceIndex(1)
-6 >Emitted(36, 14) Source(1, 14) + SourceIndex(1)
-7 >Emitted(36, 16) Source(1, 16) + SourceIndex(1)
-8 >Emitted(36, 17) Source(1, 17) + SourceIndex(1)
-9 >Emitted(36, 18) Source(1, 18) + SourceIndex(1)
+1 >Emitted(40, 1) Source(1, 1) + SourceIndex(1)
+2 >Emitted(40, 8) Source(1, 8) + SourceIndex(1)
+3 >Emitted(40, 9) Source(1, 9) + SourceIndex(1)
+4 >Emitted(40, 12) Source(1, 12) + SourceIndex(1)
+5 >Emitted(40, 13) Source(1, 13) + SourceIndex(1)
+6 >Emitted(40, 14) Source(1, 14) + SourceIndex(1)
+7 >Emitted(40, 16) Source(1, 16) + SourceIndex(1)
+8 >Emitted(40, 17) Source(1, 17) + SourceIndex(1)
+9 >Emitted(40, 18) Source(1, 18) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -996,9 +1004,9 @@ sourceFile:../../../first/first_part3.ts
 1 >
 2 >function 
 3 >         f
-1 >Emitted(37, 1) Source(1, 1) + SourceIndex(2)
-2 >Emitted(37, 10) Source(1, 10) + SourceIndex(2)
-3 >Emitted(37, 11) Source(1, 11) + SourceIndex(2)
+1 >Emitted(41, 1) Source(1, 1) + SourceIndex(2)
+2 >Emitted(41, 10) Source(1, 10) + SourceIndex(2)
+3 >Emitted(41, 11) Source(1, 11) + SourceIndex(2)
 ---
 >>>    return "JS does hoists";
 1->^^^^
@@ -1010,10 +1018,10 @@ sourceFile:../../../first/first_part3.ts
 2 >    return 
 3 >           "JS does hoists"
 4 >                           ;
-1->Emitted(38, 5) Source(2, 5) + SourceIndex(2)
-2 >Emitted(38, 12) Source(2, 12) + SourceIndex(2)
-3 >Emitted(38, 28) Source(2, 28) + SourceIndex(2)
-4 >Emitted(38, 29) Source(2, 29) + SourceIndex(2)
+1->Emitted(42, 5) Source(2, 5) + SourceIndex(2)
+2 >Emitted(42, 12) Source(2, 12) + SourceIndex(2)
+3 >Emitted(42, 28) Source(2, 28) + SourceIndex(2)
+4 >Emitted(42, 29) Source(2, 29) + SourceIndex(2)
 ---
 >>>}
 1 >
@@ -1022,8 +1030,8 @@ sourceFile:../../../first/first_part3.ts
 1 >
   >
 2 >}
-1 >Emitted(39, 1) Source(3, 1) + SourceIndex(2)
-2 >Emitted(39, 2) Source(3, 2) + SourceIndex(2)
+1 >Emitted(43, 1) Source(3, 1) + SourceIndex(2)
+2 >Emitted(43, 2) Source(3, 2) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1049,10 +1057,10 @@ sourceFile:../../../second/second_part1.ts
   >     
   >         f();
   >     }
-1->Emitted(40, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(40, 5) Source(5, 11) + SourceIndex(3)
-3 >Emitted(40, 6) Source(5, 12) + SourceIndex(3)
-4 >Emitted(40, 7) Source(11, 2) + SourceIndex(3)
+1->Emitted(44, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(44, 5) Source(5, 11) + SourceIndex(3)
+3 >Emitted(44, 6) Source(5, 12) + SourceIndex(3)
+4 >Emitted(44, 7) Source(11, 2) + SourceIndex(3)
 ---
 >>>(function (N) {
 1->
@@ -1062,9 +1070,9 @@ sourceFile:../../../second/second_part1.ts
 1->
 2 >namespace 
 3 >           N
-1->Emitted(41, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(41, 12) Source(5, 11) + SourceIndex(3)
-3 >Emitted(41, 13) Source(5, 12) + SourceIndex(3)
+1->Emitted(45, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(45, 12) Source(5, 11) + SourceIndex(3)
+3 >Emitted(45, 13) Source(5, 12) + SourceIndex(3)
 ---
 >>>    function f() {
 1->^^^^
@@ -1075,9 +1083,9 @@ sourceFile:../../../second/second_part1.ts
   >    
 2 >    function 
 3 >             f
-1->Emitted(42, 5) Source(6, 5) + SourceIndex(3)
-2 >Emitted(42, 14) Source(6, 14) + SourceIndex(3)
-3 >Emitted(42, 15) Source(6, 15) + SourceIndex(3)
+1->Emitted(46, 5) Source(6, 5) + SourceIndex(3)
+2 >Emitted(46, 14) Source(6, 14) + SourceIndex(3)
+3 >Emitted(46, 15) Source(6, 15) + SourceIndex(3)
 ---
 >>>        console.log('testing');
 1->^^^^^^^^
@@ -1097,14 +1105,14 @@ sourceFile:../../../second/second_part1.ts
 6 >                    'testing'
 7 >                             )
 8 >                              ;
-1->Emitted(43, 9) Source(7, 9) + SourceIndex(3)
-2 >Emitted(43, 16) Source(7, 16) + SourceIndex(3)
-3 >Emitted(43, 17) Source(7, 17) + SourceIndex(3)
-4 >Emitted(43, 20) Source(7, 20) + SourceIndex(3)
-5 >Emitted(43, 21) Source(7, 21) + SourceIndex(3)
-6 >Emitted(43, 30) Source(7, 30) + SourceIndex(3)
-7 >Emitted(43, 31) Source(7, 31) + SourceIndex(3)
-8 >Emitted(43, 32) Source(7, 32) + SourceIndex(3)
+1->Emitted(47, 9) Source(7, 9) + SourceIndex(3)
+2 >Emitted(47, 16) Source(7, 16) + SourceIndex(3)
+3 >Emitted(47, 17) Source(7, 17) + SourceIndex(3)
+4 >Emitted(47, 20) Source(7, 20) + SourceIndex(3)
+5 >Emitted(47, 21) Source(7, 21) + SourceIndex(3)
+6 >Emitted(47, 30) Source(7, 30) + SourceIndex(3)
+7 >Emitted(47, 31) Source(7, 31) + SourceIndex(3)
+8 >Emitted(47, 32) Source(7, 32) + SourceIndex(3)
 ---
 >>>    }
 1 >^^^^
@@ -1113,8 +1121,8 @@ sourceFile:../../../second/second_part1.ts
 1 >
   >    
 2 >    }
-1 >Emitted(44, 5) Source(8, 5) + SourceIndex(3)
-2 >Emitted(44, 6) Source(8, 6) + SourceIndex(3)
+1 >Emitted(48, 5) Source(8, 5) + SourceIndex(3)
+2 >Emitted(48, 6) Source(8, 6) + SourceIndex(3)
 ---
 >>>    f();
 1->^^^^
@@ -1128,10 +1136,10 @@ sourceFile:../../../second/second_part1.ts
 2 >    f
 3 >     ()
 4 >       ;
-1->Emitted(45, 5) Source(10, 5) + SourceIndex(3)
-2 >Emitted(45, 6) Source(10, 6) + SourceIndex(3)
-3 >Emitted(45, 8) Source(10, 8) + SourceIndex(3)
-4 >Emitted(45, 9) Source(10, 9) + SourceIndex(3)
+1->Emitted(49, 5) Source(10, 5) + SourceIndex(3)
+2 >Emitted(49, 6) Source(10, 6) + SourceIndex(3)
+3 >Emitted(49, 8) Source(10, 8) + SourceIndex(3)
+4 >Emitted(49, 9) Source(10, 9) + SourceIndex(3)
 ---
 >>>})(N || (N = {}));
 1->
@@ -1156,13 +1164,13 @@ sourceFile:../../../second/second_part1.ts
   >          
   >              f();
   >          }
-1->Emitted(46, 1) Source(11, 1) + SourceIndex(3)
-2 >Emitted(46, 2) Source(11, 2) + SourceIndex(3)
-3 >Emitted(46, 4) Source(5, 11) + SourceIndex(3)
-4 >Emitted(46, 5) Source(5, 12) + SourceIndex(3)
-5 >Emitted(46, 10) Source(5, 11) + SourceIndex(3)
-6 >Emitted(46, 11) Source(5, 12) + SourceIndex(3)
-7 >Emitted(46, 19) Source(11, 2) + SourceIndex(3)
+1->Emitted(50, 1) Source(11, 1) + SourceIndex(3)
+2 >Emitted(50, 2) Source(11, 2) + SourceIndex(3)
+3 >Emitted(50, 4) Source(5, 11) + SourceIndex(3)
+4 >Emitted(50, 5) Source(5, 12) + SourceIndex(3)
+5 >Emitted(50, 10) Source(5, 11) + SourceIndex(3)
+6 >Emitted(50, 11) Source(5, 12) + SourceIndex(3)
+7 >Emitted(50, 19) Source(11, 2) + SourceIndex(3)
 ---
 >>>function secondsecond_part1Spread() {
 1->
@@ -1173,9 +1181,9 @@ sourceFile:../../../second/second_part1.ts
   >
 2 >function 
 3 >         secondsecond_part1Spread
-1->Emitted(47, 1) Source(13, 1) + SourceIndex(3)
-2 >Emitted(47, 10) Source(13, 10) + SourceIndex(3)
-3 >Emitted(47, 34) Source(13, 34) + SourceIndex(3)
+1->Emitted(51, 1) Source(13, 1) + SourceIndex(3)
+2 >Emitted(51, 10) Source(13, 10) + SourceIndex(3)
+3 >Emitted(51, 34) Source(13, 34) + SourceIndex(3)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -1183,8 +1191,8 @@ sourceFile:../../../second/second_part1.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(48, 5) Source(13, 35) + SourceIndex(3)
-2 >Emitted(48, 16) Source(13, 49) + SourceIndex(3)
+1 >Emitted(52, 5) Source(13, 35) + SourceIndex(3)
+2 >Emitted(52, 16) Source(13, 49) + SourceIndex(3)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1199,20 +1207,20 @@ sourceFile:../../../second/second_part1.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(49, 10) Source(13, 35) + SourceIndex(3)
-2 >Emitted(49, 20) Source(13, 49) + SourceIndex(3)
-3 >Emitted(49, 22) Source(13, 35) + SourceIndex(3)
-4 >Emitted(49, 43) Source(13, 49) + SourceIndex(3)
-5 >Emitted(49, 45) Source(13, 35) + SourceIndex(3)
-6 >Emitted(49, 49) Source(13, 49) + SourceIndex(3)
+1->Emitted(53, 10) Source(13, 35) + SourceIndex(3)
+2 >Emitted(53, 20) Source(13, 49) + SourceIndex(3)
+3 >Emitted(53, 22) Source(13, 35) + SourceIndex(3)
+4 >Emitted(53, 43) Source(13, 49) + SourceIndex(3)
+5 >Emitted(53, 45) Source(13, 35) + SourceIndex(3)
+6 >Emitted(53, 49) Source(13, 49) + SourceIndex(3)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(50, 9) Source(13, 35) + SourceIndex(3)
-2 >Emitted(50, 31) Source(13, 49) + SourceIndex(3)
+1 >Emitted(54, 9) Source(13, 35) + SourceIndex(3)
+2 >Emitted(54, 31) Source(13, 49) + SourceIndex(3)
 ---
 >>>    }
 >>>}
@@ -1221,8 +1229,8 @@ sourceFile:../../../second/second_part1.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(52, 1) Source(13, 53) + SourceIndex(3)
-2 >Emitted(52, 2) Source(13, 54) + SourceIndex(3)
+1 >Emitted(56, 1) Source(13, 53) + SourceIndex(3)
+2 >Emitted(56, 2) Source(13, 54) + SourceIndex(3)
 ---
 >>>var secondsecond_part1_ar = [20, 30];
 1->
@@ -1247,16 +1255,16 @@ sourceFile:../../../second/second_part1.ts
 8 >                                 30
 9 >                                   ]
 10>                                    ;
-1->Emitted(53, 1) Source(14, 1) + SourceIndex(3)
-2 >Emitted(53, 5) Source(14, 7) + SourceIndex(3)
-3 >Emitted(53, 26) Source(14, 28) + SourceIndex(3)
-4 >Emitted(53, 29) Source(14, 31) + SourceIndex(3)
-5 >Emitted(53, 30) Source(14, 32) + SourceIndex(3)
-6 >Emitted(53, 32) Source(14, 34) + SourceIndex(3)
-7 >Emitted(53, 34) Source(14, 36) + SourceIndex(3)
-8 >Emitted(53, 36) Source(14, 38) + SourceIndex(3)
-9 >Emitted(53, 37) Source(14, 39) + SourceIndex(3)
-10>Emitted(53, 38) Source(14, 40) + SourceIndex(3)
+1->Emitted(57, 1) Source(14, 1) + SourceIndex(3)
+2 >Emitted(57, 5) Source(14, 7) + SourceIndex(3)
+3 >Emitted(57, 26) Source(14, 28) + SourceIndex(3)
+4 >Emitted(57, 29) Source(14, 31) + SourceIndex(3)
+5 >Emitted(57, 30) Source(14, 32) + SourceIndex(3)
+6 >Emitted(57, 32) Source(14, 34) + SourceIndex(3)
+7 >Emitted(57, 34) Source(14, 36) + SourceIndex(3)
+8 >Emitted(57, 36) Source(14, 38) + SourceIndex(3)
+9 >Emitted(57, 37) Source(14, 39) + SourceIndex(3)
+10>Emitted(57, 38) Source(14, 40) + SourceIndex(3)
 ---
 >>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
 1->
@@ -1274,13 +1282,13 @@ sourceFile:../../../second/second_part1.ts
 5 >                                                        , ...
 6 >                                                                  secondsecond_part1_ar
 7 >                                                                                       );
-1->Emitted(54, 1) Source(15, 1) + SourceIndex(3)
-2 >Emitted(54, 25) Source(15, 25) + SourceIndex(3)
-3 >Emitted(54, 55) Source(15, 26) + SourceIndex(3)
-4 >Emitted(54, 57) Source(15, 28) + SourceIndex(3)
-5 >Emitted(54, 67) Source(15, 33) + SourceIndex(3)
-6 >Emitted(54, 88) Source(15, 54) + SourceIndex(3)
-7 >Emitted(54, 92) Source(15, 56) + SourceIndex(3)
+1->Emitted(58, 1) Source(15, 1) + SourceIndex(3)
+2 >Emitted(58, 25) Source(15, 25) + SourceIndex(3)
+3 >Emitted(58, 55) Source(15, 26) + SourceIndex(3)
+4 >Emitted(58, 57) Source(15, 28) + SourceIndex(3)
+5 >Emitted(58, 67) Source(15, 33) + SourceIndex(3)
+6 >Emitted(58, 88) Source(15, 54) + SourceIndex(3)
+7 >Emitted(58, 92) Source(15, 56) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1290,13 +1298,13 @@ sourceFile:../../../second/second_part2.ts
 1 >
 2 >^^^^^^^^^^^^^^^^^^^->
 1 >
-1 >Emitted(55, 1) Source(1, 1) + SourceIndex(4)
+1 >Emitted(59, 1) Source(1, 1) + SourceIndex(4)
 ---
 >>>    function C() {
 1->^^^^
 2 >    ^^->
 1->
-1->Emitted(56, 5) Source(1, 1) + SourceIndex(4)
+1->Emitted(60, 5) Source(1, 1) + SourceIndex(4)
 ---
 >>>    }
 1->^^^^
@@ -1308,8 +1316,8 @@ sourceFile:../../../second/second_part2.ts
   >    }
   >
 2 >    }
-1->Emitted(57, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(57, 6) Source(5, 2) + SourceIndex(4)
+1->Emitted(61, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(61, 6) Source(5, 2) + SourceIndex(4)
 ---
 >>>    C.prototype.doSomething = function () {
 1->^^^^
@@ -1319,9 +1327,9 @@ sourceFile:../../../second/second_part2.ts
 1->
 2 >    doSomething
 3 >                           
-1->Emitted(58, 5) Source(2, 5) + SourceIndex(4)
-2 >Emitted(58, 28) Source(2, 16) + SourceIndex(4)
-3 >Emitted(58, 31) Source(2, 5) + SourceIndex(4)
+1->Emitted(62, 5) Source(2, 5) + SourceIndex(4)
+2 >Emitted(62, 28) Source(2, 16) + SourceIndex(4)
+3 >Emitted(62, 31) Source(2, 5) + SourceIndex(4)
 ---
 >>>        console.log("something got done");
 1->^^^^^^^^
@@ -1341,14 +1349,14 @@ sourceFile:../../../second/second_part2.ts
 6 >                    "something got done"
 7 >                                        )
 8 >                                         ;
-1->Emitted(59, 9) Source(3, 9) + SourceIndex(4)
-2 >Emitted(59, 16) Source(3, 16) + SourceIndex(4)
-3 >Emitted(59, 17) Source(3, 17) + SourceIndex(4)
-4 >Emitted(59, 20) Source(3, 20) + SourceIndex(4)
-5 >Emitted(59, 21) Source(3, 21) + SourceIndex(4)
-6 >Emitted(59, 41) Source(3, 41) + SourceIndex(4)
-7 >Emitted(59, 42) Source(3, 42) + SourceIndex(4)
-8 >Emitted(59, 43) Source(3, 43) + SourceIndex(4)
+1->Emitted(63, 9) Source(3, 9) + SourceIndex(4)
+2 >Emitted(63, 16) Source(3, 16) + SourceIndex(4)
+3 >Emitted(63, 17) Source(3, 17) + SourceIndex(4)
+4 >Emitted(63, 20) Source(3, 20) + SourceIndex(4)
+5 >Emitted(63, 21) Source(3, 21) + SourceIndex(4)
+6 >Emitted(63, 41) Source(3, 41) + SourceIndex(4)
+7 >Emitted(63, 42) Source(3, 42) + SourceIndex(4)
+8 >Emitted(63, 43) Source(3, 43) + SourceIndex(4)
 ---
 >>>    };
 1 >^^^^
@@ -1357,8 +1365,8 @@ sourceFile:../../../second/second_part2.ts
 1 >
   >    
 2 >    }
-1 >Emitted(60, 5) Source(4, 5) + SourceIndex(4)
-2 >Emitted(60, 6) Source(4, 6) + SourceIndex(4)
+1 >Emitted(64, 5) Source(4, 5) + SourceIndex(4)
+2 >Emitted(64, 6) Source(4, 6) + SourceIndex(4)
 ---
 >>>    return C;
 1->^^^^
@@ -1366,8 +1374,8 @@ sourceFile:../../../second/second_part2.ts
 1->
   >
 2 >    }
-1->Emitted(61, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(61, 13) Source(5, 2) + SourceIndex(4)
+1->Emitted(65, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(65, 13) Source(5, 2) + SourceIndex(4)
 ---
 >>>}());
 1 >
@@ -1383,10 +1391,10 @@ sourceFile:../../../second/second_part2.ts
   >         console.log("something got done");
   >     }
   > }
-1 >Emitted(62, 1) Source(5, 1) + SourceIndex(4)
-2 >Emitted(62, 2) Source(5, 2) + SourceIndex(4)
-3 >Emitted(62, 2) Source(1, 1) + SourceIndex(4)
-4 >Emitted(62, 6) Source(5, 2) + SourceIndex(4)
+1 >Emitted(66, 1) Source(5, 1) + SourceIndex(4)
+2 >Emitted(66, 2) Source(5, 2) + SourceIndex(4)
+3 >Emitted(66, 2) Source(1, 1) + SourceIndex(4)
+4 >Emitted(66, 6) Source(5, 2) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -1410,14 +1418,14 @@ sourceFile:../../third_part1.ts
 6 >            C
 7 >             ()
 8 >               ;
-1->Emitted(63, 1) Source(1, 1) + SourceIndex(5)
-2 >Emitted(63, 5) Source(1, 5) + SourceIndex(5)
-3 >Emitted(63, 6) Source(1, 6) + SourceIndex(5)
-4 >Emitted(63, 9) Source(1, 9) + SourceIndex(5)
-5 >Emitted(63, 13) Source(1, 13) + SourceIndex(5)
-6 >Emitted(63, 14) Source(1, 14) + SourceIndex(5)
-7 >Emitted(63, 16) Source(1, 16) + SourceIndex(5)
-8 >Emitted(63, 17) Source(1, 17) + SourceIndex(5)
+1->Emitted(67, 1) Source(1, 1) + SourceIndex(5)
+2 >Emitted(67, 5) Source(1, 5) + SourceIndex(5)
+3 >Emitted(67, 6) Source(1, 6) + SourceIndex(5)
+4 >Emitted(67, 9) Source(1, 9) + SourceIndex(5)
+5 >Emitted(67, 13) Source(1, 13) + SourceIndex(5)
+6 >Emitted(67, 14) Source(1, 14) + SourceIndex(5)
+7 >Emitted(67, 16) Source(1, 16) + SourceIndex(5)
+8 >Emitted(67, 17) Source(1, 17) + SourceIndex(5)
 ---
 >>>c.doSomething();
 1->
@@ -1434,12 +1442,12 @@ sourceFile:../../third_part1.ts
 4 >  doSomething
 5 >             ()
 6 >               ;
-1->Emitted(64, 1) Source(2, 1) + SourceIndex(5)
-2 >Emitted(64, 2) Source(2, 2) + SourceIndex(5)
-3 >Emitted(64, 3) Source(2, 3) + SourceIndex(5)
-4 >Emitted(64, 14) Source(2, 14) + SourceIndex(5)
-5 >Emitted(64, 16) Source(2, 16) + SourceIndex(5)
-6 >Emitted(64, 17) Source(2, 17) + SourceIndex(5)
+1->Emitted(68, 1) Source(2, 1) + SourceIndex(5)
+2 >Emitted(68, 2) Source(2, 2) + SourceIndex(5)
+3 >Emitted(68, 3) Source(2, 3) + SourceIndex(5)
+4 >Emitted(68, 14) Source(2, 14) + SourceIndex(5)
+5 >Emitted(68, 16) Source(2, 16) + SourceIndex(5)
+6 >Emitted(68, 17) Source(2, 17) + SourceIndex(5)
 ---
 >>>function forthirdthird_part1Rest() {
 1->
@@ -1450,9 +1458,9 @@ sourceFile:../../third_part1.ts
   >
 2 >function 
 3 >         forthirdthird_part1Rest
-1->Emitted(65, 1) Source(3, 1) + SourceIndex(5)
-2 >Emitted(65, 10) Source(3, 10) + SourceIndex(5)
-3 >Emitted(65, 33) Source(3, 33) + SourceIndex(5)
+1->Emitted(69, 1) Source(3, 1) + SourceIndex(5)
+2 >Emitted(69, 10) Source(3, 10) + SourceIndex(5)
+3 >Emitted(69, 33) Source(3, 33) + SourceIndex(5)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -1506,31 +1514,31 @@ sourceFile:../../third_part1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(66, 5) Source(4, 1) + SourceIndex(5)
-2 >Emitted(66, 9) Source(4, 7) + SourceIndex(5)
-3 >Emitted(66, 14) Source(4, 24) + SourceIndex(5)
-4 >Emitted(66, 16) Source(4, 26) + SourceIndex(5)
-5 >Emitted(66, 17) Source(4, 27) + SourceIndex(5)
-6 >Emitted(66, 19) Source(4, 29) + SourceIndex(5)
-7 >Emitted(66, 21) Source(4, 31) + SourceIndex(5)
-8 >Emitted(66, 23) Source(4, 33) + SourceIndex(5)
-9 >Emitted(66, 24) Source(4, 34) + SourceIndex(5)
-10>Emitted(66, 26) Source(4, 36) + SourceIndex(5)
-11>Emitted(66, 28) Source(4, 38) + SourceIndex(5)
-12>Emitted(66, 30) Source(4, 40) + SourceIndex(5)
-13>Emitted(66, 32) Source(4, 42) + SourceIndex(5)
-14>Emitted(66, 34) Source(4, 44) + SourceIndex(5)
-15>Emitted(66, 36) Source(4, 46) + SourceIndex(5)
-16>Emitted(66, 38) Source(4, 48) + SourceIndex(5)
-17>Emitted(66, 40) Source(4, 9) + SourceIndex(5)
-18>Emitted(66, 41) Source(4, 10) + SourceIndex(5)
-19>Emitted(66, 48) Source(4, 10) + SourceIndex(5)
-20>Emitted(66, 50) Source(4, 15) + SourceIndex(5)
-21>Emitted(66, 54) Source(4, 19) + SourceIndex(5)
-22>Emitted(66, 68) Source(4, 7) + SourceIndex(5)
-23>Emitted(66, 73) Source(4, 21) + SourceIndex(5)
-24>Emitted(66, 74) Source(4, 48) + SourceIndex(5)
-25>Emitted(66, 75) Source(4, 49) + SourceIndex(5)
+1->Emitted(70, 5) Source(4, 1) + SourceIndex(5)
+2 >Emitted(70, 9) Source(4, 7) + SourceIndex(5)
+3 >Emitted(70, 14) Source(4, 24) + SourceIndex(5)
+4 >Emitted(70, 16) Source(4, 26) + SourceIndex(5)
+5 >Emitted(70, 17) Source(4, 27) + SourceIndex(5)
+6 >Emitted(70, 19) Source(4, 29) + SourceIndex(5)
+7 >Emitted(70, 21) Source(4, 31) + SourceIndex(5)
+8 >Emitted(70, 23) Source(4, 33) + SourceIndex(5)
+9 >Emitted(70, 24) Source(4, 34) + SourceIndex(5)
+10>Emitted(70, 26) Source(4, 36) + SourceIndex(5)
+11>Emitted(70, 28) Source(4, 38) + SourceIndex(5)
+12>Emitted(70, 30) Source(4, 40) + SourceIndex(5)
+13>Emitted(70, 32) Source(4, 42) + SourceIndex(5)
+14>Emitted(70, 34) Source(4, 44) + SourceIndex(5)
+15>Emitted(70, 36) Source(4, 46) + SourceIndex(5)
+16>Emitted(70, 38) Source(4, 48) + SourceIndex(5)
+17>Emitted(70, 40) Source(4, 9) + SourceIndex(5)
+18>Emitted(70, 41) Source(4, 10) + SourceIndex(5)
+19>Emitted(70, 48) Source(4, 10) + SourceIndex(5)
+20>Emitted(70, 50) Source(4, 15) + SourceIndex(5)
+21>Emitted(70, 54) Source(4, 19) + SourceIndex(5)
+22>Emitted(70, 68) Source(4, 7) + SourceIndex(5)
+23>Emitted(70, 73) Source(4, 21) + SourceIndex(5)
+24>Emitted(70, 74) Source(4, 48) + SourceIndex(5)
+25>Emitted(70, 75) Source(4, 49) + SourceIndex(5)
 ---
 >>>}
 1 >
@@ -1539,13 +1547,13 @@ sourceFile:../../third_part1.ts
 1 >
   >
 2 >}
-1 >Emitted(67, 1) Source(5, 1) + SourceIndex(5)
-2 >Emitted(67, 2) Source(5, 2) + SourceIndex(5)
+1 >Emitted(71, 1) Source(5, 1) + SourceIndex(5)
+2 >Emitted(71, 2) Source(5, 2) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":697,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":699,"end":1199,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1201,"end":1351,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1201,"end":1351,"kind":"text"}]},{"pos":1351,"end":1919,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1351,"end":1919,"kind":"text"}]},{"pos":1919,"end":2072,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1342,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1344,"end":1494,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1494,"kind":"text"}]},{"pos":1494,"end":2062,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1494,"end":2062,"kind":"text"}]},{"pos":2062,"end":2215,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1569,14 +1577,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-697):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (506-840):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-emitHelpers: (699-1199):: typescript:rest
+emitHelpers: (842-1342):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1589,9 +1601,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1201-1351):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1344-1494):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1201-1351)
+text: (1344-1494)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() { }
@@ -1601,9 +1613,9 @@ function f() {
 }
 
 ----------------------------------------------------------------------
-prepend: (1351-1919):: ../../../2/second-output.js texts:: 1
+prepend: (1494-2062):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1351-1919)
+text: (1494-2062)
 var N;
 (function (N) {
     function f() {
@@ -1629,7 +1641,7 @@ var C = (function () {
 }());
 
 ----------------------------------------------------------------------
-text: (1919-2072)
+text: (2062-2215)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -1691,45 +1703,45 @@ declare function forthirdthird_part1Rest(): void;
         },
         {
           "pos": 506,
-          "end": 697,
+          "end": 840,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 699,
-          "end": 1199,
+          "pos": 842,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1201,
-          "end": 1351,
+          "pos": 1344,
+          "end": 1494,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1201,
-              "end": 1351,
+              "pos": 1344,
+              "end": 1494,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1351,
-          "end": 1919,
+          "pos": 1494,
+          "end": 2062,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1351,
-              "end": 1919,
+              "pos": 1494,
+              "end": 2062,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1919,
-          "end": 2072,
+          "pos": 2062,
+          "end": 2215,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-all-projects.js
@@ -379,10 +379,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var N;
 (function (N) {
@@ -413,7 +417,7 @@ secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_p
 //# sourceMappingURL=second-output.js.map
 
 //// [/src/2/second-output.js.map]
-{"version":3,"file":"second-output.js","sourceRoot":"","sources":["../second/second_part1.ts","../second/second_part2.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE"}
+{"version":3,"file":"second-output.js","sourceRoot":"","sources":["../second/second_part1.ts","../second/second_part2.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE"}
 
 //// [/src/2/second-output.js.map.baseline.txt]
 ===================================================================
@@ -453,10 +457,14 @@ sourceFile:../second/second_part1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var N;
 1 >
@@ -478,10 +486,10 @@ sourceFile:../second/second_part1.ts
   >     
   >         f();
   >     }
-1 >Emitted(33, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(5, 11) + SourceIndex(0)
-3 >Emitted(33, 6) Source(5, 12) + SourceIndex(0)
-4 >Emitted(33, 7) Source(11, 2) + SourceIndex(0)
+1 >Emitted(37, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(5, 11) + SourceIndex(0)
+3 >Emitted(37, 6) Source(5, 12) + SourceIndex(0)
+4 >Emitted(37, 7) Source(11, 2) + SourceIndex(0)
 ---
 >>>(function (N) {
 1->
@@ -491,9 +499,9 @@ sourceFile:../second/second_part1.ts
 1->
 2 >namespace 
 3 >           N
-1->Emitted(34, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(34, 12) Source(5, 11) + SourceIndex(0)
-3 >Emitted(34, 13) Source(5, 12) + SourceIndex(0)
+1->Emitted(38, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(38, 12) Source(5, 11) + SourceIndex(0)
+3 >Emitted(38, 13) Source(5, 12) + SourceIndex(0)
 ---
 >>>    function f() {
 1->^^^^
@@ -504,9 +512,9 @@ sourceFile:../second/second_part1.ts
   >    
 2 >    function 
 3 >             f
-1->Emitted(35, 5) Source(6, 5) + SourceIndex(0)
-2 >Emitted(35, 14) Source(6, 14) + SourceIndex(0)
-3 >Emitted(35, 15) Source(6, 15) + SourceIndex(0)
+1->Emitted(39, 5) Source(6, 5) + SourceIndex(0)
+2 >Emitted(39, 14) Source(6, 14) + SourceIndex(0)
+3 >Emitted(39, 15) Source(6, 15) + SourceIndex(0)
 ---
 >>>        console.log('testing');
 1->^^^^^^^^
@@ -526,14 +534,14 @@ sourceFile:../second/second_part1.ts
 6 >                    'testing'
 7 >                             )
 8 >                              ;
-1->Emitted(36, 9) Source(7, 9) + SourceIndex(0)
-2 >Emitted(36, 16) Source(7, 16) + SourceIndex(0)
-3 >Emitted(36, 17) Source(7, 17) + SourceIndex(0)
-4 >Emitted(36, 20) Source(7, 20) + SourceIndex(0)
-5 >Emitted(36, 21) Source(7, 21) + SourceIndex(0)
-6 >Emitted(36, 30) Source(7, 30) + SourceIndex(0)
-7 >Emitted(36, 31) Source(7, 31) + SourceIndex(0)
-8 >Emitted(36, 32) Source(7, 32) + SourceIndex(0)
+1->Emitted(40, 9) Source(7, 9) + SourceIndex(0)
+2 >Emitted(40, 16) Source(7, 16) + SourceIndex(0)
+3 >Emitted(40, 17) Source(7, 17) + SourceIndex(0)
+4 >Emitted(40, 20) Source(7, 20) + SourceIndex(0)
+5 >Emitted(40, 21) Source(7, 21) + SourceIndex(0)
+6 >Emitted(40, 30) Source(7, 30) + SourceIndex(0)
+7 >Emitted(40, 31) Source(7, 31) + SourceIndex(0)
+8 >Emitted(40, 32) Source(7, 32) + SourceIndex(0)
 ---
 >>>    }
 1 >^^^^
@@ -542,8 +550,8 @@ sourceFile:../second/second_part1.ts
 1 >
   >    
 2 >    }
-1 >Emitted(37, 5) Source(8, 5) + SourceIndex(0)
-2 >Emitted(37, 6) Source(8, 6) + SourceIndex(0)
+1 >Emitted(41, 5) Source(8, 5) + SourceIndex(0)
+2 >Emitted(41, 6) Source(8, 6) + SourceIndex(0)
 ---
 >>>    f();
 1->^^^^
@@ -557,10 +565,10 @@ sourceFile:../second/second_part1.ts
 2 >    f
 3 >     ()
 4 >       ;
-1->Emitted(38, 5) Source(10, 5) + SourceIndex(0)
-2 >Emitted(38, 6) Source(10, 6) + SourceIndex(0)
-3 >Emitted(38, 8) Source(10, 8) + SourceIndex(0)
-4 >Emitted(38, 9) Source(10, 9) + SourceIndex(0)
+1->Emitted(42, 5) Source(10, 5) + SourceIndex(0)
+2 >Emitted(42, 6) Source(10, 6) + SourceIndex(0)
+3 >Emitted(42, 8) Source(10, 8) + SourceIndex(0)
+4 >Emitted(42, 9) Source(10, 9) + SourceIndex(0)
 ---
 >>>})(N || (N = {}));
 1->
@@ -585,13 +593,13 @@ sourceFile:../second/second_part1.ts
   >          
   >              f();
   >          }
-1->Emitted(39, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(39, 2) Source(11, 2) + SourceIndex(0)
-3 >Emitted(39, 4) Source(5, 11) + SourceIndex(0)
-4 >Emitted(39, 5) Source(5, 12) + SourceIndex(0)
-5 >Emitted(39, 10) Source(5, 11) + SourceIndex(0)
-6 >Emitted(39, 11) Source(5, 12) + SourceIndex(0)
-7 >Emitted(39, 19) Source(11, 2) + SourceIndex(0)
+1->Emitted(43, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(43, 2) Source(11, 2) + SourceIndex(0)
+3 >Emitted(43, 4) Source(5, 11) + SourceIndex(0)
+4 >Emitted(43, 5) Source(5, 12) + SourceIndex(0)
+5 >Emitted(43, 10) Source(5, 11) + SourceIndex(0)
+6 >Emitted(43, 11) Source(5, 12) + SourceIndex(0)
+7 >Emitted(43, 19) Source(11, 2) + SourceIndex(0)
 ---
 >>>function forsecondsecond_part1Rest() {
 1->
@@ -602,9 +610,9 @@ sourceFile:../second/second_part1.ts
   >
 2 >function 
 3 >         forsecondsecond_part1Rest
-1->Emitted(40, 1) Source(12, 1) + SourceIndex(0)
-2 >Emitted(40, 10) Source(12, 10) + SourceIndex(0)
-3 >Emitted(40, 35) Source(12, 35) + SourceIndex(0)
+1->Emitted(44, 1) Source(12, 1) + SourceIndex(0)
+2 >Emitted(44, 10) Source(12, 10) + SourceIndex(0)
+3 >Emitted(44, 35) Source(12, 35) + SourceIndex(0)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -658,31 +666,31 @@ sourceFile:../second/second_part1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(41, 5) Source(13, 1) + SourceIndex(0)
-2 >Emitted(41, 9) Source(13, 7) + SourceIndex(0)
-3 >Emitted(41, 14) Source(13, 24) + SourceIndex(0)
-4 >Emitted(41, 16) Source(13, 26) + SourceIndex(0)
-5 >Emitted(41, 17) Source(13, 27) + SourceIndex(0)
-6 >Emitted(41, 19) Source(13, 29) + SourceIndex(0)
-7 >Emitted(41, 21) Source(13, 31) + SourceIndex(0)
-8 >Emitted(41, 23) Source(13, 33) + SourceIndex(0)
-9 >Emitted(41, 24) Source(13, 34) + SourceIndex(0)
-10>Emitted(41, 26) Source(13, 36) + SourceIndex(0)
-11>Emitted(41, 28) Source(13, 38) + SourceIndex(0)
-12>Emitted(41, 30) Source(13, 40) + SourceIndex(0)
-13>Emitted(41, 32) Source(13, 42) + SourceIndex(0)
-14>Emitted(41, 34) Source(13, 44) + SourceIndex(0)
-15>Emitted(41, 36) Source(13, 46) + SourceIndex(0)
-16>Emitted(41, 38) Source(13, 48) + SourceIndex(0)
-17>Emitted(41, 40) Source(13, 9) + SourceIndex(0)
-18>Emitted(41, 41) Source(13, 10) + SourceIndex(0)
-19>Emitted(41, 48) Source(13, 10) + SourceIndex(0)
-20>Emitted(41, 50) Source(13, 15) + SourceIndex(0)
-21>Emitted(41, 54) Source(13, 19) + SourceIndex(0)
-22>Emitted(41, 68) Source(13, 7) + SourceIndex(0)
-23>Emitted(41, 73) Source(13, 21) + SourceIndex(0)
-24>Emitted(41, 74) Source(13, 48) + SourceIndex(0)
-25>Emitted(41, 75) Source(13, 49) + SourceIndex(0)
+1->Emitted(45, 5) Source(13, 1) + SourceIndex(0)
+2 >Emitted(45, 9) Source(13, 7) + SourceIndex(0)
+3 >Emitted(45, 14) Source(13, 24) + SourceIndex(0)
+4 >Emitted(45, 16) Source(13, 26) + SourceIndex(0)
+5 >Emitted(45, 17) Source(13, 27) + SourceIndex(0)
+6 >Emitted(45, 19) Source(13, 29) + SourceIndex(0)
+7 >Emitted(45, 21) Source(13, 31) + SourceIndex(0)
+8 >Emitted(45, 23) Source(13, 33) + SourceIndex(0)
+9 >Emitted(45, 24) Source(13, 34) + SourceIndex(0)
+10>Emitted(45, 26) Source(13, 36) + SourceIndex(0)
+11>Emitted(45, 28) Source(13, 38) + SourceIndex(0)
+12>Emitted(45, 30) Source(13, 40) + SourceIndex(0)
+13>Emitted(45, 32) Source(13, 42) + SourceIndex(0)
+14>Emitted(45, 34) Source(13, 44) + SourceIndex(0)
+15>Emitted(45, 36) Source(13, 46) + SourceIndex(0)
+16>Emitted(45, 38) Source(13, 48) + SourceIndex(0)
+17>Emitted(45, 40) Source(13, 9) + SourceIndex(0)
+18>Emitted(45, 41) Source(13, 10) + SourceIndex(0)
+19>Emitted(45, 48) Source(13, 10) + SourceIndex(0)
+20>Emitted(45, 50) Source(13, 15) + SourceIndex(0)
+21>Emitted(45, 54) Source(13, 19) + SourceIndex(0)
+22>Emitted(45, 68) Source(13, 7) + SourceIndex(0)
+23>Emitted(45, 73) Source(13, 21) + SourceIndex(0)
+24>Emitted(45, 74) Source(13, 48) + SourceIndex(0)
+25>Emitted(45, 75) Source(13, 49) + SourceIndex(0)
 ---
 >>>}
 1 >
@@ -691,8 +699,8 @@ sourceFile:../second/second_part1.ts
 1 >
   >
 2 >}
-1 >Emitted(42, 1) Source(14, 1) + SourceIndex(0)
-2 >Emitted(42, 2) Source(14, 2) + SourceIndex(0)
+1 >Emitted(46, 1) Source(14, 1) + SourceIndex(0)
+2 >Emitted(46, 2) Source(14, 2) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/2/second-output.js
@@ -702,13 +710,13 @@ sourceFile:../second/second_part2.ts
 1->
 2 >^^^^^^^^^^^^^^^^^^^->
 1->
-1->Emitted(43, 1) Source(1, 1) + SourceIndex(1)
+1->Emitted(47, 1) Source(1, 1) + SourceIndex(1)
 ---
 >>>    function C() {
 1->^^^^
 2 >    ^^->
 1->
-1->Emitted(44, 5) Source(1, 1) + SourceIndex(1)
+1->Emitted(48, 5) Source(1, 1) + SourceIndex(1)
 ---
 >>>    }
 1->^^^^
@@ -720,8 +728,8 @@ sourceFile:../second/second_part2.ts
   >    }
   >
 2 >    }
-1->Emitted(45, 5) Source(5, 1) + SourceIndex(1)
-2 >Emitted(45, 6) Source(5, 2) + SourceIndex(1)
+1->Emitted(49, 5) Source(5, 1) + SourceIndex(1)
+2 >Emitted(49, 6) Source(5, 2) + SourceIndex(1)
 ---
 >>>    C.prototype.doSomething = function () {
 1->^^^^
@@ -731,9 +739,9 @@ sourceFile:../second/second_part2.ts
 1->
 2 >    doSomething
 3 >                           
-1->Emitted(46, 5) Source(2, 5) + SourceIndex(1)
-2 >Emitted(46, 28) Source(2, 16) + SourceIndex(1)
-3 >Emitted(46, 31) Source(2, 5) + SourceIndex(1)
+1->Emitted(50, 5) Source(2, 5) + SourceIndex(1)
+2 >Emitted(50, 28) Source(2, 16) + SourceIndex(1)
+3 >Emitted(50, 31) Source(2, 5) + SourceIndex(1)
 ---
 >>>        console.log("something got done");
 1->^^^^^^^^
@@ -753,14 +761,14 @@ sourceFile:../second/second_part2.ts
 6 >                    "something got done"
 7 >                                        )
 8 >                                         ;
-1->Emitted(47, 9) Source(3, 9) + SourceIndex(1)
-2 >Emitted(47, 16) Source(3, 16) + SourceIndex(1)
-3 >Emitted(47, 17) Source(3, 17) + SourceIndex(1)
-4 >Emitted(47, 20) Source(3, 20) + SourceIndex(1)
-5 >Emitted(47, 21) Source(3, 21) + SourceIndex(1)
-6 >Emitted(47, 41) Source(3, 41) + SourceIndex(1)
-7 >Emitted(47, 42) Source(3, 42) + SourceIndex(1)
-8 >Emitted(47, 43) Source(3, 43) + SourceIndex(1)
+1->Emitted(51, 9) Source(3, 9) + SourceIndex(1)
+2 >Emitted(51, 16) Source(3, 16) + SourceIndex(1)
+3 >Emitted(51, 17) Source(3, 17) + SourceIndex(1)
+4 >Emitted(51, 20) Source(3, 20) + SourceIndex(1)
+5 >Emitted(51, 21) Source(3, 21) + SourceIndex(1)
+6 >Emitted(51, 41) Source(3, 41) + SourceIndex(1)
+7 >Emitted(51, 42) Source(3, 42) + SourceIndex(1)
+8 >Emitted(51, 43) Source(3, 43) + SourceIndex(1)
 ---
 >>>    };
 1 >^^^^
@@ -769,8 +777,8 @@ sourceFile:../second/second_part2.ts
 1 >
   >    
 2 >    }
-1 >Emitted(48, 5) Source(4, 5) + SourceIndex(1)
-2 >Emitted(48, 6) Source(4, 6) + SourceIndex(1)
+1 >Emitted(52, 5) Source(4, 5) + SourceIndex(1)
+2 >Emitted(52, 6) Source(4, 6) + SourceIndex(1)
 ---
 >>>    return C;
 1->^^^^
@@ -778,8 +786,8 @@ sourceFile:../second/second_part2.ts
 1->
   >
 2 >    }
-1->Emitted(49, 5) Source(5, 1) + SourceIndex(1)
-2 >Emitted(49, 13) Source(5, 2) + SourceIndex(1)
+1->Emitted(53, 5) Source(5, 1) + SourceIndex(1)
+2 >Emitted(53, 13) Source(5, 2) + SourceIndex(1)
 ---
 >>>}());
 1 >
@@ -795,10 +803,10 @@ sourceFile:../second/second_part2.ts
   >         console.log("something got done");
   >     }
   > }
-1 >Emitted(50, 1) Source(5, 1) + SourceIndex(1)
-2 >Emitted(50, 2) Source(5, 2) + SourceIndex(1)
-3 >Emitted(50, 2) Source(1, 1) + SourceIndex(1)
-4 >Emitted(50, 6) Source(5, 2) + SourceIndex(1)
+1 >Emitted(54, 1) Source(5, 1) + SourceIndex(1)
+2 >Emitted(54, 2) Source(5, 2) + SourceIndex(1)
+3 >Emitted(54, 2) Source(1, 1) + SourceIndex(1)
+4 >Emitted(54, 6) Source(5, 2) + SourceIndex(1)
 ---
 >>>function secondsecond_part2Spread() {
 1->
@@ -809,9 +817,9 @@ sourceFile:../second/second_part2.ts
   >
 2 >function 
 3 >         secondsecond_part2Spread
-1->Emitted(51, 1) Source(7, 1) + SourceIndex(1)
-2 >Emitted(51, 10) Source(7, 10) + SourceIndex(1)
-3 >Emitted(51, 34) Source(7, 34) + SourceIndex(1)
+1->Emitted(55, 1) Source(7, 1) + SourceIndex(1)
+2 >Emitted(55, 10) Source(7, 10) + SourceIndex(1)
+3 >Emitted(55, 34) Source(7, 34) + SourceIndex(1)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -819,8 +827,8 @@ sourceFile:../second/second_part2.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(52, 5) Source(7, 35) + SourceIndex(1)
-2 >Emitted(52, 16) Source(7, 49) + SourceIndex(1)
+1 >Emitted(56, 5) Source(7, 35) + SourceIndex(1)
+2 >Emitted(56, 16) Source(7, 49) + SourceIndex(1)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -835,20 +843,20 @@ sourceFile:../second/second_part2.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(53, 10) Source(7, 35) + SourceIndex(1)
-2 >Emitted(53, 20) Source(7, 49) + SourceIndex(1)
-3 >Emitted(53, 22) Source(7, 35) + SourceIndex(1)
-4 >Emitted(53, 43) Source(7, 49) + SourceIndex(1)
-5 >Emitted(53, 45) Source(7, 35) + SourceIndex(1)
-6 >Emitted(53, 49) Source(7, 49) + SourceIndex(1)
+1->Emitted(57, 10) Source(7, 35) + SourceIndex(1)
+2 >Emitted(57, 20) Source(7, 49) + SourceIndex(1)
+3 >Emitted(57, 22) Source(7, 35) + SourceIndex(1)
+4 >Emitted(57, 43) Source(7, 49) + SourceIndex(1)
+5 >Emitted(57, 45) Source(7, 35) + SourceIndex(1)
+6 >Emitted(57, 49) Source(7, 49) + SourceIndex(1)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(54, 9) Source(7, 35) + SourceIndex(1)
-2 >Emitted(54, 31) Source(7, 49) + SourceIndex(1)
+1 >Emitted(58, 9) Source(7, 35) + SourceIndex(1)
+2 >Emitted(58, 31) Source(7, 49) + SourceIndex(1)
 ---
 >>>    }
 >>>}
@@ -857,8 +865,8 @@ sourceFile:../second/second_part2.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(56, 1) Source(7, 53) + SourceIndex(1)
-2 >Emitted(56, 2) Source(7, 54) + SourceIndex(1)
+1 >Emitted(60, 1) Source(7, 53) + SourceIndex(1)
+2 >Emitted(60, 2) Source(7, 54) + SourceIndex(1)
 ---
 >>>var secondsecond_part2_ar = [20, 30];
 1->
@@ -883,16 +891,16 @@ sourceFile:../second/second_part2.ts
 8 >                                 30
 9 >                                   ]
 10>                                    ;
-1->Emitted(57, 1) Source(8, 1) + SourceIndex(1)
-2 >Emitted(57, 5) Source(8, 7) + SourceIndex(1)
-3 >Emitted(57, 26) Source(8, 28) + SourceIndex(1)
-4 >Emitted(57, 29) Source(8, 31) + SourceIndex(1)
-5 >Emitted(57, 30) Source(8, 32) + SourceIndex(1)
-6 >Emitted(57, 32) Source(8, 34) + SourceIndex(1)
-7 >Emitted(57, 34) Source(8, 36) + SourceIndex(1)
-8 >Emitted(57, 36) Source(8, 38) + SourceIndex(1)
-9 >Emitted(57, 37) Source(8, 39) + SourceIndex(1)
-10>Emitted(57, 38) Source(8, 40) + SourceIndex(1)
+1->Emitted(61, 1) Source(8, 1) + SourceIndex(1)
+2 >Emitted(61, 5) Source(8, 7) + SourceIndex(1)
+3 >Emitted(61, 26) Source(8, 28) + SourceIndex(1)
+4 >Emitted(61, 29) Source(8, 31) + SourceIndex(1)
+5 >Emitted(61, 30) Source(8, 32) + SourceIndex(1)
+6 >Emitted(61, 32) Source(8, 34) + SourceIndex(1)
+7 >Emitted(61, 34) Source(8, 36) + SourceIndex(1)
+8 >Emitted(61, 36) Source(8, 38) + SourceIndex(1)
+9 >Emitted(61, 37) Source(8, 39) + SourceIndex(1)
+10>Emitted(61, 38) Source(8, 40) + SourceIndex(1)
 ---
 >>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
 1->
@@ -910,18 +918,18 @@ sourceFile:../second/second_part2.ts
 5 >                                                        , ...
 6 >                                                                  secondsecond_part2_ar
 7 >                                                                                       );
-1->Emitted(58, 1) Source(9, 1) + SourceIndex(1)
-2 >Emitted(58, 25) Source(9, 25) + SourceIndex(1)
-3 >Emitted(58, 55) Source(9, 26) + SourceIndex(1)
-4 >Emitted(58, 57) Source(9, 28) + SourceIndex(1)
-5 >Emitted(58, 67) Source(9, 33) + SourceIndex(1)
-6 >Emitted(58, 88) Source(9, 54) + SourceIndex(1)
-7 >Emitted(58, 92) Source(9, 56) + SourceIndex(1)
+1->Emitted(62, 1) Source(9, 1) + SourceIndex(1)
+2 >Emitted(62, 25) Source(9, 25) + SourceIndex(1)
+3 >Emitted(62, 55) Source(9, 26) + SourceIndex(1)
+4 >Emitted(62, 57) Source(9, 28) + SourceIndex(1)
+5 >Emitted(62, 67) Source(9, 33) + SourceIndex(1)
+6 >Emitted(62, 88) Source(9, 54) + SourceIndex(1)
+7 >Emitted(62, 92) Source(9, 56) + SourceIndex(1)
 ---
 >>>//# sourceMappingURL=second-output.js.map
 
 //// [/src/2/second-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1199,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1201,"end":1888,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":267,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":2031,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":267,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/2/second-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -958,14 +966,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1199):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (1008-1342):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (1201-1888)
+text: (1344-2031)
 var N;
 (function (N) {
     function f() {
@@ -1035,13 +1047,13 @@ declare const secondsecond_part2_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1199,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1201,
-          "end": 1888,
+          "pos": 1344,
+          "end": 2031,
           "kind": "text"
         }
       ],
@@ -1312,10 +1324,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var s = "Hello, world";
 console.log(s);
@@ -1337,7 +1353,7 @@ firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3
 //# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.js.map]
-{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
 
 //// [/src/first/bin/first-output.js.map.baseline.txt]
 ===================================================================
@@ -1377,10 +1393,14 @@ sourceFile:../first_PART1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -1399,12 +1419,12 @@ sourceFile:../first_PART1.ts
 4 >      = 
 5 >        "Hello, world"
 6 >                      ;
-1 >Emitted(33, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(5, 7) + SourceIndex(0)
-3 >Emitted(33, 6) Source(5, 8) + SourceIndex(0)
-4 >Emitted(33, 9) Source(5, 11) + SourceIndex(0)
-5 >Emitted(33, 23) Source(5, 25) + SourceIndex(0)
-6 >Emitted(33, 24) Source(5, 26) + SourceIndex(0)
+1 >Emitted(37, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(5, 7) + SourceIndex(0)
+3 >Emitted(37, 6) Source(5, 8) + SourceIndex(0)
+4 >Emitted(37, 9) Source(5, 11) + SourceIndex(0)
+5 >Emitted(37, 23) Source(5, 25) + SourceIndex(0)
+6 >Emitted(37, 24) Source(5, 26) + SourceIndex(0)
 ---
 >>>console.log(s);
 1 >
@@ -1430,14 +1450,14 @@ sourceFile:../first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1 >Emitted(34, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(34, 8) Source(11, 8) + SourceIndex(0)
-3 >Emitted(34, 9) Source(11, 9) + SourceIndex(0)
-4 >Emitted(34, 12) Source(11, 12) + SourceIndex(0)
-5 >Emitted(34, 13) Source(11, 13) + SourceIndex(0)
-6 >Emitted(34, 14) Source(11, 14) + SourceIndex(0)
-7 >Emitted(34, 15) Source(11, 15) + SourceIndex(0)
-8 >Emitted(34, 16) Source(11, 16) + SourceIndex(0)
+1 >Emitted(38, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(38, 8) Source(11, 8) + SourceIndex(0)
+3 >Emitted(38, 9) Source(11, 9) + SourceIndex(0)
+4 >Emitted(38, 12) Source(11, 12) + SourceIndex(0)
+5 >Emitted(38, 13) Source(11, 13) + SourceIndex(0)
+6 >Emitted(38, 14) Source(11, 14) + SourceIndex(0)
+7 >Emitted(38, 15) Source(11, 15) + SourceIndex(0)
+8 >Emitted(38, 16) Source(11, 16) + SourceIndex(0)
 ---
 >>>function forfirstfirst_PART1Rest() {
 1->
@@ -1448,9 +1468,9 @@ sourceFile:../first_PART1.ts
   >
 2 >function 
 3 >         forfirstfirst_PART1Rest
-1->Emitted(35, 1) Source(12, 1) + SourceIndex(0)
-2 >Emitted(35, 10) Source(12, 10) + SourceIndex(0)
-3 >Emitted(35, 33) Source(12, 33) + SourceIndex(0)
+1->Emitted(39, 1) Source(12, 1) + SourceIndex(0)
+2 >Emitted(39, 10) Source(12, 10) + SourceIndex(0)
+3 >Emitted(39, 33) Source(12, 33) + SourceIndex(0)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -1504,31 +1524,31 @@ sourceFile:../first_PART1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(36, 5) Source(13, 1) + SourceIndex(0)
-2 >Emitted(36, 9) Source(13, 7) + SourceIndex(0)
-3 >Emitted(36, 14) Source(13, 24) + SourceIndex(0)
-4 >Emitted(36, 16) Source(13, 26) + SourceIndex(0)
-5 >Emitted(36, 17) Source(13, 27) + SourceIndex(0)
-6 >Emitted(36, 19) Source(13, 29) + SourceIndex(0)
-7 >Emitted(36, 21) Source(13, 31) + SourceIndex(0)
-8 >Emitted(36, 23) Source(13, 33) + SourceIndex(0)
-9 >Emitted(36, 24) Source(13, 34) + SourceIndex(0)
-10>Emitted(36, 26) Source(13, 36) + SourceIndex(0)
-11>Emitted(36, 28) Source(13, 38) + SourceIndex(0)
-12>Emitted(36, 30) Source(13, 40) + SourceIndex(0)
-13>Emitted(36, 32) Source(13, 42) + SourceIndex(0)
-14>Emitted(36, 34) Source(13, 44) + SourceIndex(0)
-15>Emitted(36, 36) Source(13, 46) + SourceIndex(0)
-16>Emitted(36, 38) Source(13, 48) + SourceIndex(0)
-17>Emitted(36, 40) Source(13, 9) + SourceIndex(0)
-18>Emitted(36, 41) Source(13, 10) + SourceIndex(0)
-19>Emitted(36, 48) Source(13, 10) + SourceIndex(0)
-20>Emitted(36, 50) Source(13, 15) + SourceIndex(0)
-21>Emitted(36, 54) Source(13, 19) + SourceIndex(0)
-22>Emitted(36, 68) Source(13, 7) + SourceIndex(0)
-23>Emitted(36, 73) Source(13, 21) + SourceIndex(0)
-24>Emitted(36, 74) Source(13, 48) + SourceIndex(0)
-25>Emitted(36, 75) Source(13, 49) + SourceIndex(0)
+1->Emitted(40, 5) Source(13, 1) + SourceIndex(0)
+2 >Emitted(40, 9) Source(13, 7) + SourceIndex(0)
+3 >Emitted(40, 14) Source(13, 24) + SourceIndex(0)
+4 >Emitted(40, 16) Source(13, 26) + SourceIndex(0)
+5 >Emitted(40, 17) Source(13, 27) + SourceIndex(0)
+6 >Emitted(40, 19) Source(13, 29) + SourceIndex(0)
+7 >Emitted(40, 21) Source(13, 31) + SourceIndex(0)
+8 >Emitted(40, 23) Source(13, 33) + SourceIndex(0)
+9 >Emitted(40, 24) Source(13, 34) + SourceIndex(0)
+10>Emitted(40, 26) Source(13, 36) + SourceIndex(0)
+11>Emitted(40, 28) Source(13, 38) + SourceIndex(0)
+12>Emitted(40, 30) Source(13, 40) + SourceIndex(0)
+13>Emitted(40, 32) Source(13, 42) + SourceIndex(0)
+14>Emitted(40, 34) Source(13, 44) + SourceIndex(0)
+15>Emitted(40, 36) Source(13, 46) + SourceIndex(0)
+16>Emitted(40, 38) Source(13, 48) + SourceIndex(0)
+17>Emitted(40, 40) Source(13, 9) + SourceIndex(0)
+18>Emitted(40, 41) Source(13, 10) + SourceIndex(0)
+19>Emitted(40, 48) Source(13, 10) + SourceIndex(0)
+20>Emitted(40, 50) Source(13, 15) + SourceIndex(0)
+21>Emitted(40, 54) Source(13, 19) + SourceIndex(0)
+22>Emitted(40, 68) Source(13, 7) + SourceIndex(0)
+23>Emitted(40, 73) Source(13, 21) + SourceIndex(0)
+24>Emitted(40, 74) Source(13, 48) + SourceIndex(0)
+25>Emitted(40, 75) Source(13, 49) + SourceIndex(0)
 ---
 >>>}
 1 >
@@ -1537,8 +1557,8 @@ sourceFile:../first_PART1.ts
 1 >
   >
 2 >}
-1 >Emitted(37, 1) Source(14, 1) + SourceIndex(0)
-2 >Emitted(37, 2) Source(14, 2) + SourceIndex(0)
+1 >Emitted(41, 1) Source(14, 1) + SourceIndex(0)
+2 >Emitted(41, 2) Source(14, 2) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/first/bin/first-output.js
@@ -1563,15 +1583,15 @@ sourceFile:../first_part2.ts
 7 >             ()
 8 >               )
 9 >                ;
-1->Emitted(38, 1) Source(1, 1) + SourceIndex(1)
-2 >Emitted(38, 8) Source(1, 8) + SourceIndex(1)
-3 >Emitted(38, 9) Source(1, 9) + SourceIndex(1)
-4 >Emitted(38, 12) Source(1, 12) + SourceIndex(1)
-5 >Emitted(38, 13) Source(1, 13) + SourceIndex(1)
-6 >Emitted(38, 14) Source(1, 14) + SourceIndex(1)
-7 >Emitted(38, 16) Source(1, 16) + SourceIndex(1)
-8 >Emitted(38, 17) Source(1, 17) + SourceIndex(1)
-9 >Emitted(38, 18) Source(1, 18) + SourceIndex(1)
+1->Emitted(42, 1) Source(1, 1) + SourceIndex(1)
+2 >Emitted(42, 8) Source(1, 8) + SourceIndex(1)
+3 >Emitted(42, 9) Source(1, 9) + SourceIndex(1)
+4 >Emitted(42, 12) Source(1, 12) + SourceIndex(1)
+5 >Emitted(42, 13) Source(1, 13) + SourceIndex(1)
+6 >Emitted(42, 14) Source(1, 14) + SourceIndex(1)
+7 >Emitted(42, 16) Source(1, 16) + SourceIndex(1)
+8 >Emitted(42, 17) Source(1, 17) + SourceIndex(1)
+9 >Emitted(42, 18) Source(1, 18) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/first/bin/first-output.js
@@ -1585,9 +1605,9 @@ sourceFile:../first_part3.ts
 1 >
 2 >function 
 3 >         f
-1 >Emitted(39, 1) Source(1, 1) + SourceIndex(2)
-2 >Emitted(39, 10) Source(1, 10) + SourceIndex(2)
-3 >Emitted(39, 11) Source(1, 11) + SourceIndex(2)
+1 >Emitted(43, 1) Source(1, 1) + SourceIndex(2)
+2 >Emitted(43, 10) Source(1, 10) + SourceIndex(2)
+3 >Emitted(43, 11) Source(1, 11) + SourceIndex(2)
 ---
 >>>    return "JS does hoists";
 1->^^^^
@@ -1599,10 +1619,10 @@ sourceFile:../first_part3.ts
 2 >    return 
 3 >           "JS does hoists"
 4 >                           ;
-1->Emitted(40, 5) Source(2, 5) + SourceIndex(2)
-2 >Emitted(40, 12) Source(2, 12) + SourceIndex(2)
-3 >Emitted(40, 28) Source(2, 28) + SourceIndex(2)
-4 >Emitted(40, 29) Source(2, 29) + SourceIndex(2)
+1->Emitted(44, 5) Source(2, 5) + SourceIndex(2)
+2 >Emitted(44, 12) Source(2, 12) + SourceIndex(2)
+3 >Emitted(44, 28) Source(2, 28) + SourceIndex(2)
+4 >Emitted(44, 29) Source(2, 29) + SourceIndex(2)
 ---
 >>>}
 1 >
@@ -1611,8 +1631,8 @@ sourceFile:../first_part3.ts
 1 >
   >
 2 >}
-1 >Emitted(41, 1) Source(3, 1) + SourceIndex(2)
-2 >Emitted(41, 2) Source(3, 2) + SourceIndex(2)
+1 >Emitted(45, 1) Source(3, 1) + SourceIndex(2)
+2 >Emitted(45, 2) Source(3, 2) + SourceIndex(2)
 ---
 >>>function firstfirst_part3Spread() {
 1->
@@ -1622,9 +1642,9 @@ sourceFile:../first_part3.ts
   >
 2 >function 
 3 >         firstfirst_part3Spread
-1->Emitted(42, 1) Source(4, 1) + SourceIndex(2)
-2 >Emitted(42, 10) Source(4, 10) + SourceIndex(2)
-3 >Emitted(42, 32) Source(4, 32) + SourceIndex(2)
+1->Emitted(46, 1) Source(4, 1) + SourceIndex(2)
+2 >Emitted(46, 10) Source(4, 10) + SourceIndex(2)
+3 >Emitted(46, 32) Source(4, 32) + SourceIndex(2)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -1632,8 +1652,8 @@ sourceFile:../first_part3.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(43, 5) Source(4, 33) + SourceIndex(2)
-2 >Emitted(43, 16) Source(4, 47) + SourceIndex(2)
+1 >Emitted(47, 5) Source(4, 33) + SourceIndex(2)
+2 >Emitted(47, 16) Source(4, 47) + SourceIndex(2)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -1648,20 +1668,20 @@ sourceFile:../first_part3.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(44, 10) Source(4, 33) + SourceIndex(2)
-2 >Emitted(44, 20) Source(4, 47) + SourceIndex(2)
-3 >Emitted(44, 22) Source(4, 33) + SourceIndex(2)
-4 >Emitted(44, 43) Source(4, 47) + SourceIndex(2)
-5 >Emitted(44, 45) Source(4, 33) + SourceIndex(2)
-6 >Emitted(44, 49) Source(4, 47) + SourceIndex(2)
+1->Emitted(48, 10) Source(4, 33) + SourceIndex(2)
+2 >Emitted(48, 20) Source(4, 47) + SourceIndex(2)
+3 >Emitted(48, 22) Source(4, 33) + SourceIndex(2)
+4 >Emitted(48, 43) Source(4, 47) + SourceIndex(2)
+5 >Emitted(48, 45) Source(4, 33) + SourceIndex(2)
+6 >Emitted(48, 49) Source(4, 47) + SourceIndex(2)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(45, 9) Source(4, 33) + SourceIndex(2)
-2 >Emitted(45, 31) Source(4, 47) + SourceIndex(2)
+1 >Emitted(49, 9) Source(4, 33) + SourceIndex(2)
+2 >Emitted(49, 31) Source(4, 47) + SourceIndex(2)
 ---
 >>>    }
 >>>}
@@ -1670,8 +1690,8 @@ sourceFile:../first_part3.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(47, 1) Source(4, 51) + SourceIndex(2)
-2 >Emitted(47, 2) Source(4, 52) + SourceIndex(2)
+1 >Emitted(51, 1) Source(4, 51) + SourceIndex(2)
+2 >Emitted(51, 2) Source(4, 52) + SourceIndex(2)
 ---
 >>>var firstfirst_part3_ar = [20, 30];
 1->
@@ -1696,16 +1716,16 @@ sourceFile:../first_part3.ts
 8 >                               30
 9 >                                 ]
 10>                                  ;
-1->Emitted(48, 1) Source(5, 1) + SourceIndex(2)
-2 >Emitted(48, 5) Source(5, 7) + SourceIndex(2)
-3 >Emitted(48, 24) Source(5, 26) + SourceIndex(2)
-4 >Emitted(48, 27) Source(5, 29) + SourceIndex(2)
-5 >Emitted(48, 28) Source(5, 30) + SourceIndex(2)
-6 >Emitted(48, 30) Source(5, 32) + SourceIndex(2)
-7 >Emitted(48, 32) Source(5, 34) + SourceIndex(2)
-8 >Emitted(48, 34) Source(5, 36) + SourceIndex(2)
-9 >Emitted(48, 35) Source(5, 37) + SourceIndex(2)
-10>Emitted(48, 36) Source(5, 38) + SourceIndex(2)
+1->Emitted(52, 1) Source(5, 1) + SourceIndex(2)
+2 >Emitted(52, 5) Source(5, 7) + SourceIndex(2)
+3 >Emitted(52, 24) Source(5, 26) + SourceIndex(2)
+4 >Emitted(52, 27) Source(5, 29) + SourceIndex(2)
+5 >Emitted(52, 28) Source(5, 30) + SourceIndex(2)
+6 >Emitted(52, 30) Source(5, 32) + SourceIndex(2)
+7 >Emitted(52, 32) Source(5, 34) + SourceIndex(2)
+8 >Emitted(52, 34) Source(5, 36) + SourceIndex(2)
+9 >Emitted(52, 35) Source(5, 37) + SourceIndex(2)
+10>Emitted(52, 36) Source(5, 38) + SourceIndex(2)
 ---
 >>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
 1->
@@ -1723,18 +1743,18 @@ sourceFile:../first_part3.ts
 5 >                                                      , ...
 6 >                                                                firstfirst_part3_ar
 7 >                                                                                   );
-1->Emitted(49, 1) Source(6, 1) + SourceIndex(2)
-2 >Emitted(49, 23) Source(6, 23) + SourceIndex(2)
-3 >Emitted(49, 53) Source(6, 24) + SourceIndex(2)
-4 >Emitted(49, 55) Source(6, 26) + SourceIndex(2)
-5 >Emitted(49, 65) Source(6, 31) + SourceIndex(2)
-6 >Emitted(49, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(49, 88) Source(6, 52) + SourceIndex(2)
+1->Emitted(53, 1) Source(6, 1) + SourceIndex(2)
+2 >Emitted(53, 23) Source(6, 23) + SourceIndex(2)
+3 >Emitted(53, 53) Source(6, 24) + SourceIndex(2)
+4 >Emitted(53, 55) Source(6, 26) + SourceIndex(2)
+5 >Emitted(53, 65) Source(6, 31) + SourceIndex(2)
+6 >Emitted(53, 84) Source(6, 50) + SourceIndex(2)
+7 >Emitted(53, 88) Source(6, 52) + SourceIndex(2)
 ---
 >>>//# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1199,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1201,"end":1703,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1846,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/first/bin/first-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1771,14 +1791,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1199):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (1008-1342):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (1201-1703)
+text: (1344-1846)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -1841,13 +1865,13 @@ declare const firstfirst_part3_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1199,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1201,
-          "end": 1703,
+          "pos": 1344,
+          "end": 1846,
           "kind": "text"
         }
       ],
@@ -2384,10 +2408,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var s = "Hello, world";
 console.log(s);
@@ -2448,7 +2476,7 @@ thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -2488,10 +2516,14 @@ sourceFile:../../../first/first_PART1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -2510,12 +2542,12 @@ sourceFile:../../../first/first_PART1.ts
 4 >      = 
 5 >        "Hello, world"
 6 >                      ;
-1 >Emitted(33, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(5, 7) + SourceIndex(0)
-3 >Emitted(33, 6) Source(5, 8) + SourceIndex(0)
-4 >Emitted(33, 9) Source(5, 11) + SourceIndex(0)
-5 >Emitted(33, 23) Source(5, 25) + SourceIndex(0)
-6 >Emitted(33, 24) Source(5, 26) + SourceIndex(0)
+1 >Emitted(37, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(5, 7) + SourceIndex(0)
+3 >Emitted(37, 6) Source(5, 8) + SourceIndex(0)
+4 >Emitted(37, 9) Source(5, 11) + SourceIndex(0)
+5 >Emitted(37, 23) Source(5, 25) + SourceIndex(0)
+6 >Emitted(37, 24) Source(5, 26) + SourceIndex(0)
 ---
 >>>console.log(s);
 1 >
@@ -2541,14 +2573,14 @@ sourceFile:../../../first/first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1 >Emitted(34, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(34, 8) Source(11, 8) + SourceIndex(0)
-3 >Emitted(34, 9) Source(11, 9) + SourceIndex(0)
-4 >Emitted(34, 12) Source(11, 12) + SourceIndex(0)
-5 >Emitted(34, 13) Source(11, 13) + SourceIndex(0)
-6 >Emitted(34, 14) Source(11, 14) + SourceIndex(0)
-7 >Emitted(34, 15) Source(11, 15) + SourceIndex(0)
-8 >Emitted(34, 16) Source(11, 16) + SourceIndex(0)
+1 >Emitted(38, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(38, 8) Source(11, 8) + SourceIndex(0)
+3 >Emitted(38, 9) Source(11, 9) + SourceIndex(0)
+4 >Emitted(38, 12) Source(11, 12) + SourceIndex(0)
+5 >Emitted(38, 13) Source(11, 13) + SourceIndex(0)
+6 >Emitted(38, 14) Source(11, 14) + SourceIndex(0)
+7 >Emitted(38, 15) Source(11, 15) + SourceIndex(0)
+8 >Emitted(38, 16) Source(11, 16) + SourceIndex(0)
 ---
 >>>function forfirstfirst_PART1Rest() {
 1->
@@ -2559,9 +2591,9 @@ sourceFile:../../../first/first_PART1.ts
   >
 2 >function 
 3 >         forfirstfirst_PART1Rest
-1->Emitted(35, 1) Source(12, 1) + SourceIndex(0)
-2 >Emitted(35, 10) Source(12, 10) + SourceIndex(0)
-3 >Emitted(35, 33) Source(12, 33) + SourceIndex(0)
+1->Emitted(39, 1) Source(12, 1) + SourceIndex(0)
+2 >Emitted(39, 10) Source(12, 10) + SourceIndex(0)
+3 >Emitted(39, 33) Source(12, 33) + SourceIndex(0)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -2615,31 +2647,31 @@ sourceFile:../../../first/first_PART1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(36, 5) Source(13, 1) + SourceIndex(0)
-2 >Emitted(36, 9) Source(13, 7) + SourceIndex(0)
-3 >Emitted(36, 14) Source(13, 24) + SourceIndex(0)
-4 >Emitted(36, 16) Source(13, 26) + SourceIndex(0)
-5 >Emitted(36, 17) Source(13, 27) + SourceIndex(0)
-6 >Emitted(36, 19) Source(13, 29) + SourceIndex(0)
-7 >Emitted(36, 21) Source(13, 31) + SourceIndex(0)
-8 >Emitted(36, 23) Source(13, 33) + SourceIndex(0)
-9 >Emitted(36, 24) Source(13, 34) + SourceIndex(0)
-10>Emitted(36, 26) Source(13, 36) + SourceIndex(0)
-11>Emitted(36, 28) Source(13, 38) + SourceIndex(0)
-12>Emitted(36, 30) Source(13, 40) + SourceIndex(0)
-13>Emitted(36, 32) Source(13, 42) + SourceIndex(0)
-14>Emitted(36, 34) Source(13, 44) + SourceIndex(0)
-15>Emitted(36, 36) Source(13, 46) + SourceIndex(0)
-16>Emitted(36, 38) Source(13, 48) + SourceIndex(0)
-17>Emitted(36, 40) Source(13, 9) + SourceIndex(0)
-18>Emitted(36, 41) Source(13, 10) + SourceIndex(0)
-19>Emitted(36, 48) Source(13, 10) + SourceIndex(0)
-20>Emitted(36, 50) Source(13, 15) + SourceIndex(0)
-21>Emitted(36, 54) Source(13, 19) + SourceIndex(0)
-22>Emitted(36, 68) Source(13, 7) + SourceIndex(0)
-23>Emitted(36, 73) Source(13, 21) + SourceIndex(0)
-24>Emitted(36, 74) Source(13, 48) + SourceIndex(0)
-25>Emitted(36, 75) Source(13, 49) + SourceIndex(0)
+1->Emitted(40, 5) Source(13, 1) + SourceIndex(0)
+2 >Emitted(40, 9) Source(13, 7) + SourceIndex(0)
+3 >Emitted(40, 14) Source(13, 24) + SourceIndex(0)
+4 >Emitted(40, 16) Source(13, 26) + SourceIndex(0)
+5 >Emitted(40, 17) Source(13, 27) + SourceIndex(0)
+6 >Emitted(40, 19) Source(13, 29) + SourceIndex(0)
+7 >Emitted(40, 21) Source(13, 31) + SourceIndex(0)
+8 >Emitted(40, 23) Source(13, 33) + SourceIndex(0)
+9 >Emitted(40, 24) Source(13, 34) + SourceIndex(0)
+10>Emitted(40, 26) Source(13, 36) + SourceIndex(0)
+11>Emitted(40, 28) Source(13, 38) + SourceIndex(0)
+12>Emitted(40, 30) Source(13, 40) + SourceIndex(0)
+13>Emitted(40, 32) Source(13, 42) + SourceIndex(0)
+14>Emitted(40, 34) Source(13, 44) + SourceIndex(0)
+15>Emitted(40, 36) Source(13, 46) + SourceIndex(0)
+16>Emitted(40, 38) Source(13, 48) + SourceIndex(0)
+17>Emitted(40, 40) Source(13, 9) + SourceIndex(0)
+18>Emitted(40, 41) Source(13, 10) + SourceIndex(0)
+19>Emitted(40, 48) Source(13, 10) + SourceIndex(0)
+20>Emitted(40, 50) Source(13, 15) + SourceIndex(0)
+21>Emitted(40, 54) Source(13, 19) + SourceIndex(0)
+22>Emitted(40, 68) Source(13, 7) + SourceIndex(0)
+23>Emitted(40, 73) Source(13, 21) + SourceIndex(0)
+24>Emitted(40, 74) Source(13, 48) + SourceIndex(0)
+25>Emitted(40, 75) Source(13, 49) + SourceIndex(0)
 ---
 >>>}
 1 >
@@ -2648,8 +2680,8 @@ sourceFile:../../../first/first_PART1.ts
 1 >
   >
 2 >}
-1 >Emitted(37, 1) Source(14, 1) + SourceIndex(0)
-2 >Emitted(37, 2) Source(14, 2) + SourceIndex(0)
+1 >Emitted(41, 1) Source(14, 1) + SourceIndex(0)
+2 >Emitted(41, 2) Source(14, 2) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2674,15 +2706,15 @@ sourceFile:../../../first/first_part2.ts
 7 >             ()
 8 >               )
 9 >                ;
-1->Emitted(38, 1) Source(1, 1) + SourceIndex(1)
-2 >Emitted(38, 8) Source(1, 8) + SourceIndex(1)
-3 >Emitted(38, 9) Source(1, 9) + SourceIndex(1)
-4 >Emitted(38, 12) Source(1, 12) + SourceIndex(1)
-5 >Emitted(38, 13) Source(1, 13) + SourceIndex(1)
-6 >Emitted(38, 14) Source(1, 14) + SourceIndex(1)
-7 >Emitted(38, 16) Source(1, 16) + SourceIndex(1)
-8 >Emitted(38, 17) Source(1, 17) + SourceIndex(1)
-9 >Emitted(38, 18) Source(1, 18) + SourceIndex(1)
+1->Emitted(42, 1) Source(1, 1) + SourceIndex(1)
+2 >Emitted(42, 8) Source(1, 8) + SourceIndex(1)
+3 >Emitted(42, 9) Source(1, 9) + SourceIndex(1)
+4 >Emitted(42, 12) Source(1, 12) + SourceIndex(1)
+5 >Emitted(42, 13) Source(1, 13) + SourceIndex(1)
+6 >Emitted(42, 14) Source(1, 14) + SourceIndex(1)
+7 >Emitted(42, 16) Source(1, 16) + SourceIndex(1)
+8 >Emitted(42, 17) Source(1, 17) + SourceIndex(1)
+9 >Emitted(42, 18) Source(1, 18) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2696,9 +2728,9 @@ sourceFile:../../../first/first_part3.ts
 1 >
 2 >function 
 3 >         f
-1 >Emitted(39, 1) Source(1, 1) + SourceIndex(2)
-2 >Emitted(39, 10) Source(1, 10) + SourceIndex(2)
-3 >Emitted(39, 11) Source(1, 11) + SourceIndex(2)
+1 >Emitted(43, 1) Source(1, 1) + SourceIndex(2)
+2 >Emitted(43, 10) Source(1, 10) + SourceIndex(2)
+3 >Emitted(43, 11) Source(1, 11) + SourceIndex(2)
 ---
 >>>    return "JS does hoists";
 1->^^^^
@@ -2710,10 +2742,10 @@ sourceFile:../../../first/first_part3.ts
 2 >    return 
 3 >           "JS does hoists"
 4 >                           ;
-1->Emitted(40, 5) Source(2, 5) + SourceIndex(2)
-2 >Emitted(40, 12) Source(2, 12) + SourceIndex(2)
-3 >Emitted(40, 28) Source(2, 28) + SourceIndex(2)
-4 >Emitted(40, 29) Source(2, 29) + SourceIndex(2)
+1->Emitted(44, 5) Source(2, 5) + SourceIndex(2)
+2 >Emitted(44, 12) Source(2, 12) + SourceIndex(2)
+3 >Emitted(44, 28) Source(2, 28) + SourceIndex(2)
+4 >Emitted(44, 29) Source(2, 29) + SourceIndex(2)
 ---
 >>>}
 1 >
@@ -2722,8 +2754,8 @@ sourceFile:../../../first/first_part3.ts
 1 >
   >
 2 >}
-1 >Emitted(41, 1) Source(3, 1) + SourceIndex(2)
-2 >Emitted(41, 2) Source(3, 2) + SourceIndex(2)
+1 >Emitted(45, 1) Source(3, 1) + SourceIndex(2)
+2 >Emitted(45, 2) Source(3, 2) + SourceIndex(2)
 ---
 >>>function firstfirst_part3Spread() {
 1->
@@ -2733,9 +2765,9 @@ sourceFile:../../../first/first_part3.ts
   >
 2 >function 
 3 >         firstfirst_part3Spread
-1->Emitted(42, 1) Source(4, 1) + SourceIndex(2)
-2 >Emitted(42, 10) Source(4, 10) + SourceIndex(2)
-3 >Emitted(42, 32) Source(4, 32) + SourceIndex(2)
+1->Emitted(46, 1) Source(4, 1) + SourceIndex(2)
+2 >Emitted(46, 10) Source(4, 10) + SourceIndex(2)
+3 >Emitted(46, 32) Source(4, 32) + SourceIndex(2)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -2743,8 +2775,8 @@ sourceFile:../../../first/first_part3.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(43, 5) Source(4, 33) + SourceIndex(2)
-2 >Emitted(43, 16) Source(4, 47) + SourceIndex(2)
+1 >Emitted(47, 5) Source(4, 33) + SourceIndex(2)
+2 >Emitted(47, 16) Source(4, 47) + SourceIndex(2)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -2759,20 +2791,20 @@ sourceFile:../../../first/first_part3.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(44, 10) Source(4, 33) + SourceIndex(2)
-2 >Emitted(44, 20) Source(4, 47) + SourceIndex(2)
-3 >Emitted(44, 22) Source(4, 33) + SourceIndex(2)
-4 >Emitted(44, 43) Source(4, 47) + SourceIndex(2)
-5 >Emitted(44, 45) Source(4, 33) + SourceIndex(2)
-6 >Emitted(44, 49) Source(4, 47) + SourceIndex(2)
+1->Emitted(48, 10) Source(4, 33) + SourceIndex(2)
+2 >Emitted(48, 20) Source(4, 47) + SourceIndex(2)
+3 >Emitted(48, 22) Source(4, 33) + SourceIndex(2)
+4 >Emitted(48, 43) Source(4, 47) + SourceIndex(2)
+5 >Emitted(48, 45) Source(4, 33) + SourceIndex(2)
+6 >Emitted(48, 49) Source(4, 47) + SourceIndex(2)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(45, 9) Source(4, 33) + SourceIndex(2)
-2 >Emitted(45, 31) Source(4, 47) + SourceIndex(2)
+1 >Emitted(49, 9) Source(4, 33) + SourceIndex(2)
+2 >Emitted(49, 31) Source(4, 47) + SourceIndex(2)
 ---
 >>>    }
 >>>}
@@ -2781,8 +2813,8 @@ sourceFile:../../../first/first_part3.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(47, 1) Source(4, 51) + SourceIndex(2)
-2 >Emitted(47, 2) Source(4, 52) + SourceIndex(2)
+1 >Emitted(51, 1) Source(4, 51) + SourceIndex(2)
+2 >Emitted(51, 2) Source(4, 52) + SourceIndex(2)
 ---
 >>>var firstfirst_part3_ar = [20, 30];
 1->
@@ -2807,16 +2839,16 @@ sourceFile:../../../first/first_part3.ts
 8 >                               30
 9 >                                 ]
 10>                                  ;
-1->Emitted(48, 1) Source(5, 1) + SourceIndex(2)
-2 >Emitted(48, 5) Source(5, 7) + SourceIndex(2)
-3 >Emitted(48, 24) Source(5, 26) + SourceIndex(2)
-4 >Emitted(48, 27) Source(5, 29) + SourceIndex(2)
-5 >Emitted(48, 28) Source(5, 30) + SourceIndex(2)
-6 >Emitted(48, 30) Source(5, 32) + SourceIndex(2)
-7 >Emitted(48, 32) Source(5, 34) + SourceIndex(2)
-8 >Emitted(48, 34) Source(5, 36) + SourceIndex(2)
-9 >Emitted(48, 35) Source(5, 37) + SourceIndex(2)
-10>Emitted(48, 36) Source(5, 38) + SourceIndex(2)
+1->Emitted(52, 1) Source(5, 1) + SourceIndex(2)
+2 >Emitted(52, 5) Source(5, 7) + SourceIndex(2)
+3 >Emitted(52, 24) Source(5, 26) + SourceIndex(2)
+4 >Emitted(52, 27) Source(5, 29) + SourceIndex(2)
+5 >Emitted(52, 28) Source(5, 30) + SourceIndex(2)
+6 >Emitted(52, 30) Source(5, 32) + SourceIndex(2)
+7 >Emitted(52, 32) Source(5, 34) + SourceIndex(2)
+8 >Emitted(52, 34) Source(5, 36) + SourceIndex(2)
+9 >Emitted(52, 35) Source(5, 37) + SourceIndex(2)
+10>Emitted(52, 36) Source(5, 38) + SourceIndex(2)
 ---
 >>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
 1->
@@ -2834,13 +2866,13 @@ sourceFile:../../../first/first_part3.ts
 5 >                                                      , ...
 6 >                                                                firstfirst_part3_ar
 7 >                                                                                   );
-1->Emitted(49, 1) Source(6, 1) + SourceIndex(2)
-2 >Emitted(49, 23) Source(6, 23) + SourceIndex(2)
-3 >Emitted(49, 53) Source(6, 24) + SourceIndex(2)
-4 >Emitted(49, 55) Source(6, 26) + SourceIndex(2)
-5 >Emitted(49, 65) Source(6, 31) + SourceIndex(2)
-6 >Emitted(49, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(49, 88) Source(6, 52) + SourceIndex(2)
+1->Emitted(53, 1) Source(6, 1) + SourceIndex(2)
+2 >Emitted(53, 23) Source(6, 23) + SourceIndex(2)
+3 >Emitted(53, 53) Source(6, 24) + SourceIndex(2)
+4 >Emitted(53, 55) Source(6, 26) + SourceIndex(2)
+5 >Emitted(53, 65) Source(6, 31) + SourceIndex(2)
+6 >Emitted(53, 84) Source(6, 50) + SourceIndex(2)
+7 >Emitted(53, 88) Source(6, 52) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2866,10 +2898,10 @@ sourceFile:../../../second/second_part1.ts
   >     
   >         f();
   >     }
-1 >Emitted(50, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(50, 5) Source(5, 11) + SourceIndex(3)
-3 >Emitted(50, 6) Source(5, 12) + SourceIndex(3)
-4 >Emitted(50, 7) Source(11, 2) + SourceIndex(3)
+1 >Emitted(54, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(54, 5) Source(5, 11) + SourceIndex(3)
+3 >Emitted(54, 6) Source(5, 12) + SourceIndex(3)
+4 >Emitted(54, 7) Source(11, 2) + SourceIndex(3)
 ---
 >>>(function (N) {
 1->
@@ -2879,9 +2911,9 @@ sourceFile:../../../second/second_part1.ts
 1->
 2 >namespace 
 3 >           N
-1->Emitted(51, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(51, 12) Source(5, 11) + SourceIndex(3)
-3 >Emitted(51, 13) Source(5, 12) + SourceIndex(3)
+1->Emitted(55, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(55, 12) Source(5, 11) + SourceIndex(3)
+3 >Emitted(55, 13) Source(5, 12) + SourceIndex(3)
 ---
 >>>    function f() {
 1->^^^^
@@ -2892,9 +2924,9 @@ sourceFile:../../../second/second_part1.ts
   >    
 2 >    function 
 3 >             f
-1->Emitted(52, 5) Source(6, 5) + SourceIndex(3)
-2 >Emitted(52, 14) Source(6, 14) + SourceIndex(3)
-3 >Emitted(52, 15) Source(6, 15) + SourceIndex(3)
+1->Emitted(56, 5) Source(6, 5) + SourceIndex(3)
+2 >Emitted(56, 14) Source(6, 14) + SourceIndex(3)
+3 >Emitted(56, 15) Source(6, 15) + SourceIndex(3)
 ---
 >>>        console.log('testing');
 1->^^^^^^^^
@@ -2914,14 +2946,14 @@ sourceFile:../../../second/second_part1.ts
 6 >                    'testing'
 7 >                             )
 8 >                              ;
-1->Emitted(53, 9) Source(7, 9) + SourceIndex(3)
-2 >Emitted(53, 16) Source(7, 16) + SourceIndex(3)
-3 >Emitted(53, 17) Source(7, 17) + SourceIndex(3)
-4 >Emitted(53, 20) Source(7, 20) + SourceIndex(3)
-5 >Emitted(53, 21) Source(7, 21) + SourceIndex(3)
-6 >Emitted(53, 30) Source(7, 30) + SourceIndex(3)
-7 >Emitted(53, 31) Source(7, 31) + SourceIndex(3)
-8 >Emitted(53, 32) Source(7, 32) + SourceIndex(3)
+1->Emitted(57, 9) Source(7, 9) + SourceIndex(3)
+2 >Emitted(57, 16) Source(7, 16) + SourceIndex(3)
+3 >Emitted(57, 17) Source(7, 17) + SourceIndex(3)
+4 >Emitted(57, 20) Source(7, 20) + SourceIndex(3)
+5 >Emitted(57, 21) Source(7, 21) + SourceIndex(3)
+6 >Emitted(57, 30) Source(7, 30) + SourceIndex(3)
+7 >Emitted(57, 31) Source(7, 31) + SourceIndex(3)
+8 >Emitted(57, 32) Source(7, 32) + SourceIndex(3)
 ---
 >>>    }
 1 >^^^^
@@ -2930,8 +2962,8 @@ sourceFile:../../../second/second_part1.ts
 1 >
   >    
 2 >    }
-1 >Emitted(54, 5) Source(8, 5) + SourceIndex(3)
-2 >Emitted(54, 6) Source(8, 6) + SourceIndex(3)
+1 >Emitted(58, 5) Source(8, 5) + SourceIndex(3)
+2 >Emitted(58, 6) Source(8, 6) + SourceIndex(3)
 ---
 >>>    f();
 1->^^^^
@@ -2945,10 +2977,10 @@ sourceFile:../../../second/second_part1.ts
 2 >    f
 3 >     ()
 4 >       ;
-1->Emitted(55, 5) Source(10, 5) + SourceIndex(3)
-2 >Emitted(55, 6) Source(10, 6) + SourceIndex(3)
-3 >Emitted(55, 8) Source(10, 8) + SourceIndex(3)
-4 >Emitted(55, 9) Source(10, 9) + SourceIndex(3)
+1->Emitted(59, 5) Source(10, 5) + SourceIndex(3)
+2 >Emitted(59, 6) Source(10, 6) + SourceIndex(3)
+3 >Emitted(59, 8) Source(10, 8) + SourceIndex(3)
+4 >Emitted(59, 9) Source(10, 9) + SourceIndex(3)
 ---
 >>>})(N || (N = {}));
 1->
@@ -2973,13 +3005,13 @@ sourceFile:../../../second/second_part1.ts
   >          
   >              f();
   >          }
-1->Emitted(56, 1) Source(11, 1) + SourceIndex(3)
-2 >Emitted(56, 2) Source(11, 2) + SourceIndex(3)
-3 >Emitted(56, 4) Source(5, 11) + SourceIndex(3)
-4 >Emitted(56, 5) Source(5, 12) + SourceIndex(3)
-5 >Emitted(56, 10) Source(5, 11) + SourceIndex(3)
-6 >Emitted(56, 11) Source(5, 12) + SourceIndex(3)
-7 >Emitted(56, 19) Source(11, 2) + SourceIndex(3)
+1->Emitted(60, 1) Source(11, 1) + SourceIndex(3)
+2 >Emitted(60, 2) Source(11, 2) + SourceIndex(3)
+3 >Emitted(60, 4) Source(5, 11) + SourceIndex(3)
+4 >Emitted(60, 5) Source(5, 12) + SourceIndex(3)
+5 >Emitted(60, 10) Source(5, 11) + SourceIndex(3)
+6 >Emitted(60, 11) Source(5, 12) + SourceIndex(3)
+7 >Emitted(60, 19) Source(11, 2) + SourceIndex(3)
 ---
 >>>function forsecondsecond_part1Rest() {
 1->
@@ -2990,9 +3022,9 @@ sourceFile:../../../second/second_part1.ts
   >
 2 >function 
 3 >         forsecondsecond_part1Rest
-1->Emitted(57, 1) Source(12, 1) + SourceIndex(3)
-2 >Emitted(57, 10) Source(12, 10) + SourceIndex(3)
-3 >Emitted(57, 35) Source(12, 35) + SourceIndex(3)
+1->Emitted(61, 1) Source(12, 1) + SourceIndex(3)
+2 >Emitted(61, 10) Source(12, 10) + SourceIndex(3)
+3 >Emitted(61, 35) Source(12, 35) + SourceIndex(3)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -3046,31 +3078,31 @@ sourceFile:../../../second/second_part1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(58, 5) Source(13, 1) + SourceIndex(3)
-2 >Emitted(58, 9) Source(13, 7) + SourceIndex(3)
-3 >Emitted(58, 14) Source(13, 24) + SourceIndex(3)
-4 >Emitted(58, 16) Source(13, 26) + SourceIndex(3)
-5 >Emitted(58, 17) Source(13, 27) + SourceIndex(3)
-6 >Emitted(58, 19) Source(13, 29) + SourceIndex(3)
-7 >Emitted(58, 21) Source(13, 31) + SourceIndex(3)
-8 >Emitted(58, 23) Source(13, 33) + SourceIndex(3)
-9 >Emitted(58, 24) Source(13, 34) + SourceIndex(3)
-10>Emitted(58, 26) Source(13, 36) + SourceIndex(3)
-11>Emitted(58, 28) Source(13, 38) + SourceIndex(3)
-12>Emitted(58, 30) Source(13, 40) + SourceIndex(3)
-13>Emitted(58, 32) Source(13, 42) + SourceIndex(3)
-14>Emitted(58, 34) Source(13, 44) + SourceIndex(3)
-15>Emitted(58, 36) Source(13, 46) + SourceIndex(3)
-16>Emitted(58, 38) Source(13, 48) + SourceIndex(3)
-17>Emitted(58, 40) Source(13, 9) + SourceIndex(3)
-18>Emitted(58, 41) Source(13, 10) + SourceIndex(3)
-19>Emitted(58, 48) Source(13, 10) + SourceIndex(3)
-20>Emitted(58, 50) Source(13, 15) + SourceIndex(3)
-21>Emitted(58, 54) Source(13, 19) + SourceIndex(3)
-22>Emitted(58, 68) Source(13, 7) + SourceIndex(3)
-23>Emitted(58, 73) Source(13, 21) + SourceIndex(3)
-24>Emitted(58, 74) Source(13, 48) + SourceIndex(3)
-25>Emitted(58, 75) Source(13, 49) + SourceIndex(3)
+1->Emitted(62, 5) Source(13, 1) + SourceIndex(3)
+2 >Emitted(62, 9) Source(13, 7) + SourceIndex(3)
+3 >Emitted(62, 14) Source(13, 24) + SourceIndex(3)
+4 >Emitted(62, 16) Source(13, 26) + SourceIndex(3)
+5 >Emitted(62, 17) Source(13, 27) + SourceIndex(3)
+6 >Emitted(62, 19) Source(13, 29) + SourceIndex(3)
+7 >Emitted(62, 21) Source(13, 31) + SourceIndex(3)
+8 >Emitted(62, 23) Source(13, 33) + SourceIndex(3)
+9 >Emitted(62, 24) Source(13, 34) + SourceIndex(3)
+10>Emitted(62, 26) Source(13, 36) + SourceIndex(3)
+11>Emitted(62, 28) Source(13, 38) + SourceIndex(3)
+12>Emitted(62, 30) Source(13, 40) + SourceIndex(3)
+13>Emitted(62, 32) Source(13, 42) + SourceIndex(3)
+14>Emitted(62, 34) Source(13, 44) + SourceIndex(3)
+15>Emitted(62, 36) Source(13, 46) + SourceIndex(3)
+16>Emitted(62, 38) Source(13, 48) + SourceIndex(3)
+17>Emitted(62, 40) Source(13, 9) + SourceIndex(3)
+18>Emitted(62, 41) Source(13, 10) + SourceIndex(3)
+19>Emitted(62, 48) Source(13, 10) + SourceIndex(3)
+20>Emitted(62, 50) Source(13, 15) + SourceIndex(3)
+21>Emitted(62, 54) Source(13, 19) + SourceIndex(3)
+22>Emitted(62, 68) Source(13, 7) + SourceIndex(3)
+23>Emitted(62, 73) Source(13, 21) + SourceIndex(3)
+24>Emitted(62, 74) Source(13, 48) + SourceIndex(3)
+25>Emitted(62, 75) Source(13, 49) + SourceIndex(3)
 ---
 >>>}
 1 >
@@ -3079,8 +3111,8 @@ sourceFile:../../../second/second_part1.ts
 1 >
   >
 2 >}
-1 >Emitted(59, 1) Source(14, 1) + SourceIndex(3)
-2 >Emitted(59, 2) Source(14, 2) + SourceIndex(3)
+1 >Emitted(63, 1) Source(14, 1) + SourceIndex(3)
+2 >Emitted(63, 2) Source(14, 2) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -3090,13 +3122,13 @@ sourceFile:../../../second/second_part2.ts
 1->
 2 >^^^^^^^^^^^^^^^^^^^->
 1->
-1->Emitted(60, 1) Source(1, 1) + SourceIndex(4)
+1->Emitted(64, 1) Source(1, 1) + SourceIndex(4)
 ---
 >>>    function C() {
 1->^^^^
 2 >    ^^->
 1->
-1->Emitted(61, 5) Source(1, 1) + SourceIndex(4)
+1->Emitted(65, 5) Source(1, 1) + SourceIndex(4)
 ---
 >>>    }
 1->^^^^
@@ -3108,8 +3140,8 @@ sourceFile:../../../second/second_part2.ts
   >    }
   >
 2 >    }
-1->Emitted(62, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(62, 6) Source(5, 2) + SourceIndex(4)
+1->Emitted(66, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(66, 6) Source(5, 2) + SourceIndex(4)
 ---
 >>>    C.prototype.doSomething = function () {
 1->^^^^
@@ -3119,9 +3151,9 @@ sourceFile:../../../second/second_part2.ts
 1->
 2 >    doSomething
 3 >                           
-1->Emitted(63, 5) Source(2, 5) + SourceIndex(4)
-2 >Emitted(63, 28) Source(2, 16) + SourceIndex(4)
-3 >Emitted(63, 31) Source(2, 5) + SourceIndex(4)
+1->Emitted(67, 5) Source(2, 5) + SourceIndex(4)
+2 >Emitted(67, 28) Source(2, 16) + SourceIndex(4)
+3 >Emitted(67, 31) Source(2, 5) + SourceIndex(4)
 ---
 >>>        console.log("something got done");
 1->^^^^^^^^
@@ -3141,14 +3173,14 @@ sourceFile:../../../second/second_part2.ts
 6 >                    "something got done"
 7 >                                        )
 8 >                                         ;
-1->Emitted(64, 9) Source(3, 9) + SourceIndex(4)
-2 >Emitted(64, 16) Source(3, 16) + SourceIndex(4)
-3 >Emitted(64, 17) Source(3, 17) + SourceIndex(4)
-4 >Emitted(64, 20) Source(3, 20) + SourceIndex(4)
-5 >Emitted(64, 21) Source(3, 21) + SourceIndex(4)
-6 >Emitted(64, 41) Source(3, 41) + SourceIndex(4)
-7 >Emitted(64, 42) Source(3, 42) + SourceIndex(4)
-8 >Emitted(64, 43) Source(3, 43) + SourceIndex(4)
+1->Emitted(68, 9) Source(3, 9) + SourceIndex(4)
+2 >Emitted(68, 16) Source(3, 16) + SourceIndex(4)
+3 >Emitted(68, 17) Source(3, 17) + SourceIndex(4)
+4 >Emitted(68, 20) Source(3, 20) + SourceIndex(4)
+5 >Emitted(68, 21) Source(3, 21) + SourceIndex(4)
+6 >Emitted(68, 41) Source(3, 41) + SourceIndex(4)
+7 >Emitted(68, 42) Source(3, 42) + SourceIndex(4)
+8 >Emitted(68, 43) Source(3, 43) + SourceIndex(4)
 ---
 >>>    };
 1 >^^^^
@@ -3157,8 +3189,8 @@ sourceFile:../../../second/second_part2.ts
 1 >
   >    
 2 >    }
-1 >Emitted(65, 5) Source(4, 5) + SourceIndex(4)
-2 >Emitted(65, 6) Source(4, 6) + SourceIndex(4)
+1 >Emitted(69, 5) Source(4, 5) + SourceIndex(4)
+2 >Emitted(69, 6) Source(4, 6) + SourceIndex(4)
 ---
 >>>    return C;
 1->^^^^
@@ -3166,8 +3198,8 @@ sourceFile:../../../second/second_part2.ts
 1->
   >
 2 >    }
-1->Emitted(66, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(66, 13) Source(5, 2) + SourceIndex(4)
+1->Emitted(70, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(70, 13) Source(5, 2) + SourceIndex(4)
 ---
 >>>}());
 1 >
@@ -3183,10 +3215,10 @@ sourceFile:../../../second/second_part2.ts
   >         console.log("something got done");
   >     }
   > }
-1 >Emitted(67, 1) Source(5, 1) + SourceIndex(4)
-2 >Emitted(67, 2) Source(5, 2) + SourceIndex(4)
-3 >Emitted(67, 2) Source(1, 1) + SourceIndex(4)
-4 >Emitted(67, 6) Source(5, 2) + SourceIndex(4)
+1 >Emitted(71, 1) Source(5, 1) + SourceIndex(4)
+2 >Emitted(71, 2) Source(5, 2) + SourceIndex(4)
+3 >Emitted(71, 2) Source(1, 1) + SourceIndex(4)
+4 >Emitted(71, 6) Source(5, 2) + SourceIndex(4)
 ---
 >>>function secondsecond_part2Spread() {
 1->
@@ -3197,9 +3229,9 @@ sourceFile:../../../second/second_part2.ts
   >
 2 >function 
 3 >         secondsecond_part2Spread
-1->Emitted(68, 1) Source(7, 1) + SourceIndex(4)
-2 >Emitted(68, 10) Source(7, 10) + SourceIndex(4)
-3 >Emitted(68, 34) Source(7, 34) + SourceIndex(4)
+1->Emitted(72, 1) Source(7, 1) + SourceIndex(4)
+2 >Emitted(72, 10) Source(7, 10) + SourceIndex(4)
+3 >Emitted(72, 34) Source(7, 34) + SourceIndex(4)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -3207,8 +3239,8 @@ sourceFile:../../../second/second_part2.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(69, 5) Source(7, 35) + SourceIndex(4)
-2 >Emitted(69, 16) Source(7, 49) + SourceIndex(4)
+1 >Emitted(73, 5) Source(7, 35) + SourceIndex(4)
+2 >Emitted(73, 16) Source(7, 49) + SourceIndex(4)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -3223,20 +3255,20 @@ sourceFile:../../../second/second_part2.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(70, 10) Source(7, 35) + SourceIndex(4)
-2 >Emitted(70, 20) Source(7, 49) + SourceIndex(4)
-3 >Emitted(70, 22) Source(7, 35) + SourceIndex(4)
-4 >Emitted(70, 43) Source(7, 49) + SourceIndex(4)
-5 >Emitted(70, 45) Source(7, 35) + SourceIndex(4)
-6 >Emitted(70, 49) Source(7, 49) + SourceIndex(4)
+1->Emitted(74, 10) Source(7, 35) + SourceIndex(4)
+2 >Emitted(74, 20) Source(7, 49) + SourceIndex(4)
+3 >Emitted(74, 22) Source(7, 35) + SourceIndex(4)
+4 >Emitted(74, 43) Source(7, 49) + SourceIndex(4)
+5 >Emitted(74, 45) Source(7, 35) + SourceIndex(4)
+6 >Emitted(74, 49) Source(7, 49) + SourceIndex(4)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(71, 9) Source(7, 35) + SourceIndex(4)
-2 >Emitted(71, 31) Source(7, 49) + SourceIndex(4)
+1 >Emitted(75, 9) Source(7, 35) + SourceIndex(4)
+2 >Emitted(75, 31) Source(7, 49) + SourceIndex(4)
 ---
 >>>    }
 >>>}
@@ -3245,8 +3277,8 @@ sourceFile:../../../second/second_part2.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(73, 1) Source(7, 53) + SourceIndex(4)
-2 >Emitted(73, 2) Source(7, 54) + SourceIndex(4)
+1 >Emitted(77, 1) Source(7, 53) + SourceIndex(4)
+2 >Emitted(77, 2) Source(7, 54) + SourceIndex(4)
 ---
 >>>var secondsecond_part2_ar = [20, 30];
 1->
@@ -3271,16 +3303,16 @@ sourceFile:../../../second/second_part2.ts
 8 >                                 30
 9 >                                   ]
 10>                                    ;
-1->Emitted(74, 1) Source(8, 1) + SourceIndex(4)
-2 >Emitted(74, 5) Source(8, 7) + SourceIndex(4)
-3 >Emitted(74, 26) Source(8, 28) + SourceIndex(4)
-4 >Emitted(74, 29) Source(8, 31) + SourceIndex(4)
-5 >Emitted(74, 30) Source(8, 32) + SourceIndex(4)
-6 >Emitted(74, 32) Source(8, 34) + SourceIndex(4)
-7 >Emitted(74, 34) Source(8, 36) + SourceIndex(4)
-8 >Emitted(74, 36) Source(8, 38) + SourceIndex(4)
-9 >Emitted(74, 37) Source(8, 39) + SourceIndex(4)
-10>Emitted(74, 38) Source(8, 40) + SourceIndex(4)
+1->Emitted(78, 1) Source(8, 1) + SourceIndex(4)
+2 >Emitted(78, 5) Source(8, 7) + SourceIndex(4)
+3 >Emitted(78, 26) Source(8, 28) + SourceIndex(4)
+4 >Emitted(78, 29) Source(8, 31) + SourceIndex(4)
+5 >Emitted(78, 30) Source(8, 32) + SourceIndex(4)
+6 >Emitted(78, 32) Source(8, 34) + SourceIndex(4)
+7 >Emitted(78, 34) Source(8, 36) + SourceIndex(4)
+8 >Emitted(78, 36) Source(8, 38) + SourceIndex(4)
+9 >Emitted(78, 37) Source(8, 39) + SourceIndex(4)
+10>Emitted(78, 38) Source(8, 40) + SourceIndex(4)
 ---
 >>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
 1->
@@ -3298,13 +3330,13 @@ sourceFile:../../../second/second_part2.ts
 5 >                                                        , ...
 6 >                                                                  secondsecond_part2_ar
 7 >                                                                                       );
-1->Emitted(75, 1) Source(9, 1) + SourceIndex(4)
-2 >Emitted(75, 25) Source(9, 25) + SourceIndex(4)
-3 >Emitted(75, 55) Source(9, 26) + SourceIndex(4)
-4 >Emitted(75, 57) Source(9, 28) + SourceIndex(4)
-5 >Emitted(75, 67) Source(9, 33) + SourceIndex(4)
-6 >Emitted(75, 88) Source(9, 54) + SourceIndex(4)
-7 >Emitted(75, 92) Source(9, 56) + SourceIndex(4)
+1->Emitted(79, 1) Source(9, 1) + SourceIndex(4)
+2 >Emitted(79, 25) Source(9, 25) + SourceIndex(4)
+3 >Emitted(79, 55) Source(9, 26) + SourceIndex(4)
+4 >Emitted(79, 57) Source(9, 28) + SourceIndex(4)
+5 >Emitted(79, 67) Source(9, 33) + SourceIndex(4)
+6 >Emitted(79, 88) Source(9, 54) + SourceIndex(4)
+7 >Emitted(79, 92) Source(9, 56) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -3328,14 +3360,14 @@ sourceFile:../../third_part1.ts
 6 >            C
 7 >             ()
 8 >               ;
-1 >Emitted(76, 1) Source(1, 1) + SourceIndex(5)
-2 >Emitted(76, 5) Source(1, 5) + SourceIndex(5)
-3 >Emitted(76, 6) Source(1, 6) + SourceIndex(5)
-4 >Emitted(76, 9) Source(1, 9) + SourceIndex(5)
-5 >Emitted(76, 13) Source(1, 13) + SourceIndex(5)
-6 >Emitted(76, 14) Source(1, 14) + SourceIndex(5)
-7 >Emitted(76, 16) Source(1, 16) + SourceIndex(5)
-8 >Emitted(76, 17) Source(1, 17) + SourceIndex(5)
+1 >Emitted(80, 1) Source(1, 1) + SourceIndex(5)
+2 >Emitted(80, 5) Source(1, 5) + SourceIndex(5)
+3 >Emitted(80, 6) Source(1, 6) + SourceIndex(5)
+4 >Emitted(80, 9) Source(1, 9) + SourceIndex(5)
+5 >Emitted(80, 13) Source(1, 13) + SourceIndex(5)
+6 >Emitted(80, 14) Source(1, 14) + SourceIndex(5)
+7 >Emitted(80, 16) Source(1, 16) + SourceIndex(5)
+8 >Emitted(80, 17) Source(1, 17) + SourceIndex(5)
 ---
 >>>c.doSomething();
 1->
@@ -3352,12 +3384,12 @@ sourceFile:../../third_part1.ts
 4 >  doSomething
 5 >             ()
 6 >               ;
-1->Emitted(77, 1) Source(2, 1) + SourceIndex(5)
-2 >Emitted(77, 2) Source(2, 2) + SourceIndex(5)
-3 >Emitted(77, 3) Source(2, 3) + SourceIndex(5)
-4 >Emitted(77, 14) Source(2, 14) + SourceIndex(5)
-5 >Emitted(77, 16) Source(2, 16) + SourceIndex(5)
-6 >Emitted(77, 17) Source(2, 17) + SourceIndex(5)
+1->Emitted(81, 1) Source(2, 1) + SourceIndex(5)
+2 >Emitted(81, 2) Source(2, 2) + SourceIndex(5)
+3 >Emitted(81, 3) Source(2, 3) + SourceIndex(5)
+4 >Emitted(81, 14) Source(2, 14) + SourceIndex(5)
+5 >Emitted(81, 16) Source(2, 16) + SourceIndex(5)
+6 >Emitted(81, 17) Source(2, 17) + SourceIndex(5)
 ---
 >>>function forthirdthird_part1Rest() {
 1->
@@ -3368,9 +3400,9 @@ sourceFile:../../third_part1.ts
   >
 2 >function 
 3 >         forthirdthird_part1Rest
-1->Emitted(78, 1) Source(3, 1) + SourceIndex(5)
-2 >Emitted(78, 10) Source(3, 10) + SourceIndex(5)
-3 >Emitted(78, 33) Source(3, 33) + SourceIndex(5)
+1->Emitted(82, 1) Source(3, 1) + SourceIndex(5)
+2 >Emitted(82, 10) Source(3, 10) + SourceIndex(5)
+3 >Emitted(82, 33) Source(3, 33) + SourceIndex(5)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -3424,31 +3456,31 @@ sourceFile:../../third_part1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(79, 5) Source(4, 1) + SourceIndex(5)
-2 >Emitted(79, 9) Source(4, 7) + SourceIndex(5)
-3 >Emitted(79, 14) Source(4, 24) + SourceIndex(5)
-4 >Emitted(79, 16) Source(4, 26) + SourceIndex(5)
-5 >Emitted(79, 17) Source(4, 27) + SourceIndex(5)
-6 >Emitted(79, 19) Source(4, 29) + SourceIndex(5)
-7 >Emitted(79, 21) Source(4, 31) + SourceIndex(5)
-8 >Emitted(79, 23) Source(4, 33) + SourceIndex(5)
-9 >Emitted(79, 24) Source(4, 34) + SourceIndex(5)
-10>Emitted(79, 26) Source(4, 36) + SourceIndex(5)
-11>Emitted(79, 28) Source(4, 38) + SourceIndex(5)
-12>Emitted(79, 30) Source(4, 40) + SourceIndex(5)
-13>Emitted(79, 32) Source(4, 42) + SourceIndex(5)
-14>Emitted(79, 34) Source(4, 44) + SourceIndex(5)
-15>Emitted(79, 36) Source(4, 46) + SourceIndex(5)
-16>Emitted(79, 38) Source(4, 48) + SourceIndex(5)
-17>Emitted(79, 40) Source(4, 9) + SourceIndex(5)
-18>Emitted(79, 41) Source(4, 10) + SourceIndex(5)
-19>Emitted(79, 48) Source(4, 10) + SourceIndex(5)
-20>Emitted(79, 50) Source(4, 15) + SourceIndex(5)
-21>Emitted(79, 54) Source(4, 19) + SourceIndex(5)
-22>Emitted(79, 68) Source(4, 7) + SourceIndex(5)
-23>Emitted(79, 73) Source(4, 21) + SourceIndex(5)
-24>Emitted(79, 74) Source(4, 48) + SourceIndex(5)
-25>Emitted(79, 75) Source(4, 49) + SourceIndex(5)
+1->Emitted(83, 5) Source(4, 1) + SourceIndex(5)
+2 >Emitted(83, 9) Source(4, 7) + SourceIndex(5)
+3 >Emitted(83, 14) Source(4, 24) + SourceIndex(5)
+4 >Emitted(83, 16) Source(4, 26) + SourceIndex(5)
+5 >Emitted(83, 17) Source(4, 27) + SourceIndex(5)
+6 >Emitted(83, 19) Source(4, 29) + SourceIndex(5)
+7 >Emitted(83, 21) Source(4, 31) + SourceIndex(5)
+8 >Emitted(83, 23) Source(4, 33) + SourceIndex(5)
+9 >Emitted(83, 24) Source(4, 34) + SourceIndex(5)
+10>Emitted(83, 26) Source(4, 36) + SourceIndex(5)
+11>Emitted(83, 28) Source(4, 38) + SourceIndex(5)
+12>Emitted(83, 30) Source(4, 40) + SourceIndex(5)
+13>Emitted(83, 32) Source(4, 42) + SourceIndex(5)
+14>Emitted(83, 34) Source(4, 44) + SourceIndex(5)
+15>Emitted(83, 36) Source(4, 46) + SourceIndex(5)
+16>Emitted(83, 38) Source(4, 48) + SourceIndex(5)
+17>Emitted(83, 40) Source(4, 9) + SourceIndex(5)
+18>Emitted(83, 41) Source(4, 10) + SourceIndex(5)
+19>Emitted(83, 48) Source(4, 10) + SourceIndex(5)
+20>Emitted(83, 50) Source(4, 15) + SourceIndex(5)
+21>Emitted(83, 54) Source(4, 19) + SourceIndex(5)
+22>Emitted(83, 68) Source(4, 7) + SourceIndex(5)
+23>Emitted(83, 73) Source(4, 21) + SourceIndex(5)
+24>Emitted(83, 74) Source(4, 48) + SourceIndex(5)
+25>Emitted(83, 75) Source(4, 49) + SourceIndex(5)
 ---
 >>>}
 1 >
@@ -3457,8 +3489,8 @@ sourceFile:../../third_part1.ts
 1 >
   >
 2 >}
-1 >Emitted(80, 1) Source(5, 1) + SourceIndex(5)
-2 >Emitted(80, 2) Source(5, 2) + SourceIndex(5)
+1 >Emitted(84, 1) Source(5, 1) + SourceIndex(5)
+2 >Emitted(84, 2) Source(5, 2) + SourceIndex(5)
 ---
 >>>function thirdthird_part1Spread() {
 1->
@@ -3468,9 +3500,9 @@ sourceFile:../../third_part1.ts
   >
 2 >function 
 3 >         thirdthird_part1Spread
-1->Emitted(81, 1) Source(6, 1) + SourceIndex(5)
-2 >Emitted(81, 10) Source(6, 10) + SourceIndex(5)
-3 >Emitted(81, 32) Source(6, 32) + SourceIndex(5)
+1->Emitted(85, 1) Source(6, 1) + SourceIndex(5)
+2 >Emitted(85, 10) Source(6, 10) + SourceIndex(5)
+3 >Emitted(85, 32) Source(6, 32) + SourceIndex(5)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -3478,8 +3510,8 @@ sourceFile:../../third_part1.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(82, 5) Source(6, 33) + SourceIndex(5)
-2 >Emitted(82, 16) Source(6, 47) + SourceIndex(5)
+1 >Emitted(86, 5) Source(6, 33) + SourceIndex(5)
+2 >Emitted(86, 16) Source(6, 47) + SourceIndex(5)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -3494,20 +3526,20 @@ sourceFile:../../third_part1.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(83, 10) Source(6, 33) + SourceIndex(5)
-2 >Emitted(83, 20) Source(6, 47) + SourceIndex(5)
-3 >Emitted(83, 22) Source(6, 33) + SourceIndex(5)
-4 >Emitted(83, 43) Source(6, 47) + SourceIndex(5)
-5 >Emitted(83, 45) Source(6, 33) + SourceIndex(5)
-6 >Emitted(83, 49) Source(6, 47) + SourceIndex(5)
+1->Emitted(87, 10) Source(6, 33) + SourceIndex(5)
+2 >Emitted(87, 20) Source(6, 47) + SourceIndex(5)
+3 >Emitted(87, 22) Source(6, 33) + SourceIndex(5)
+4 >Emitted(87, 43) Source(6, 47) + SourceIndex(5)
+5 >Emitted(87, 45) Source(6, 33) + SourceIndex(5)
+6 >Emitted(87, 49) Source(6, 47) + SourceIndex(5)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(84, 9) Source(6, 33) + SourceIndex(5)
-2 >Emitted(84, 31) Source(6, 47) + SourceIndex(5)
+1 >Emitted(88, 9) Source(6, 33) + SourceIndex(5)
+2 >Emitted(88, 31) Source(6, 47) + SourceIndex(5)
 ---
 >>>    }
 >>>}
@@ -3516,8 +3548,8 @@ sourceFile:../../third_part1.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(86, 1) Source(6, 51) + SourceIndex(5)
-2 >Emitted(86, 2) Source(6, 52) + SourceIndex(5)
+1 >Emitted(90, 1) Source(6, 51) + SourceIndex(5)
+2 >Emitted(90, 2) Source(6, 52) + SourceIndex(5)
 ---
 >>>var thirdthird_part1_ar = [20, 30];
 1->
@@ -3542,16 +3574,16 @@ sourceFile:../../third_part1.ts
 8 >                               30
 9 >                                 ]
 10>                                  ;
-1->Emitted(87, 1) Source(7, 1) + SourceIndex(5)
-2 >Emitted(87, 5) Source(7, 7) + SourceIndex(5)
-3 >Emitted(87, 24) Source(7, 26) + SourceIndex(5)
-4 >Emitted(87, 27) Source(7, 29) + SourceIndex(5)
-5 >Emitted(87, 28) Source(7, 30) + SourceIndex(5)
-6 >Emitted(87, 30) Source(7, 32) + SourceIndex(5)
-7 >Emitted(87, 32) Source(7, 34) + SourceIndex(5)
-8 >Emitted(87, 34) Source(7, 36) + SourceIndex(5)
-9 >Emitted(87, 35) Source(7, 37) + SourceIndex(5)
-10>Emitted(87, 36) Source(7, 38) + SourceIndex(5)
+1->Emitted(91, 1) Source(7, 1) + SourceIndex(5)
+2 >Emitted(91, 5) Source(7, 7) + SourceIndex(5)
+3 >Emitted(91, 24) Source(7, 26) + SourceIndex(5)
+4 >Emitted(91, 27) Source(7, 29) + SourceIndex(5)
+5 >Emitted(91, 28) Source(7, 30) + SourceIndex(5)
+6 >Emitted(91, 30) Source(7, 32) + SourceIndex(5)
+7 >Emitted(91, 32) Source(7, 34) + SourceIndex(5)
+8 >Emitted(91, 34) Source(7, 36) + SourceIndex(5)
+9 >Emitted(91, 35) Source(7, 37) + SourceIndex(5)
+10>Emitted(91, 36) Source(7, 38) + SourceIndex(5)
 ---
 >>>thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
 1->
@@ -3569,18 +3601,18 @@ sourceFile:../../third_part1.ts
 5 >                                                      , ...
 6 >                                                                thirdthird_part1_ar
 7 >                                                                                   );
-1->Emitted(88, 1) Source(8, 1) + SourceIndex(5)
-2 >Emitted(88, 23) Source(8, 23) + SourceIndex(5)
-3 >Emitted(88, 53) Source(8, 24) + SourceIndex(5)
-4 >Emitted(88, 55) Source(8, 26) + SourceIndex(5)
-5 >Emitted(88, 65) Source(8, 31) + SourceIndex(5)
-6 >Emitted(88, 84) Source(8, 50) + SourceIndex(5)
-7 >Emitted(88, 88) Source(8, 52) + SourceIndex(5)
+1->Emitted(92, 1) Source(8, 1) + SourceIndex(5)
+2 >Emitted(92, 23) Source(8, 23) + SourceIndex(5)
+3 >Emitted(92, 53) Source(8, 24) + SourceIndex(5)
+4 >Emitted(92, 55) Source(8, 26) + SourceIndex(5)
+5 >Emitted(92, 65) Source(8, 31) + SourceIndex(5)
+6 >Emitted(92, 84) Source(8, 50) + SourceIndex(5)
+7 >Emitted(92, 88) Source(8, 52) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1199,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1201,"end":1703,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1201,"end":1703,"kind":"text"}]},{"pos":1703,"end":2390,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1703,"end":2390,"kind":"text"}]},{"pos":2390,"end":2818,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1846,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1846,"kind":"text"}]},{"pos":1846,"end":2533,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1846,"end":2533,"kind":"text"}]},{"pos":2533,"end":2961,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -3617,16 +3649,20 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1199):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (1008-1342):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-prepend: (1201-1703):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1344-1846):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1201-1703)
+text: (1344-1846)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -3646,9 +3682,9 @@ var firstfirst_part3_ar = [20, 30];
 firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
 
 ----------------------------------------------------------------------
-prepend: (1703-2390):: ../../../2/second-output.js texts:: 1
+prepend: (1846-2533):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1703-2390)
+text: (1846-2533)
 var N;
 (function (N) {
     function f() {
@@ -3677,7 +3713,7 @@ var secondsecond_part2_ar = [20, 30];
 secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
 
 ----------------------------------------------------------------------
-text: (2390-2818)
+text: (2533-2961)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -3758,39 +3794,39 @@ declare const thirdthird_part1_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1199,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1201,
-          "end": 1703,
+          "pos": 1344,
+          "end": 1846,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1201,
-              "end": 1703,
+              "pos": 1344,
+              "end": 1846,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1703,
-          "end": 2390,
+          "pos": 1846,
+          "end": 2533,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1703,
-              "end": 2390,
+              "pos": 1846,
+              "end": 2533,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2390,
-          "end": 2818,
+          "pos": 2533,
+          "end": 2961,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-all-projects.js
@@ -380,7 +380,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -413,11 +413,11 @@ function secondsecond_part2Spread() {
     }
 }
 var secondsecond_part2_ar = [20, 30];
-secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 //# sourceMappingURL=second-output.js.map
 
 //// [/src/2/second-output.js.map]
-{"version":3,"file":"second-output.js","sourceRoot":"","sources":["../second/second_part1.ts","../second/second_part2.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE"}
+{"version":3,"file":"second-output.js","sourceRoot":"","sources":["../second/second_part1.ts","../second/second_part2.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,WAAE"}
 
 //// [/src/2/second-output.js.map.baseline.txt]
 ===================================================================
@@ -458,7 +458,7 @@ sourceFile:../second/second_part1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -879,7 +879,7 @@ sourceFile:../second/second_part2.ts
 8 >                                 ^^
 9 >                                   ^
 10>                                    ^
-11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -902,14 +902,14 @@ sourceFile:../second/second_part2.ts
 9 >Emitted(61, 37) Source(8, 39) + SourceIndex(1)
 10>Emitted(61, 38) Source(8, 40) + SourceIndex(1)
 ---
->>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+>>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^^^
 3 >                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                      ^^
 5 >                                                        ^^^^^^^^^^
 6 >                                                                  ^^^^^^^^^^^^^^^^^^^^^
-7 >                                                                                       ^^^^
+7 >                                                                                       ^^^^^^^^^^^
 1->
   >
 2 >secondsecond_part2Spread
@@ -924,12 +924,12 @@ sourceFile:../second/second_part2.ts
 4 >Emitted(62, 57) Source(9, 28) + SourceIndex(1)
 5 >Emitted(62, 67) Source(9, 33) + SourceIndex(1)
 6 >Emitted(62, 88) Source(9, 54) + SourceIndex(1)
-7 >Emitted(62, 92) Source(9, 56) + SourceIndex(1)
+7 >Emitted(62, 99) Source(9, 56) + SourceIndex(1)
 ---
 >>>//# sourceMappingURL=second-output.js.map
 
 //// [/src/2/second-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":2031,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":267,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":2064,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":267,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/2/second-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -966,9 +966,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1342):: typescript:spreadArray
+emitHelpers: (1008-1368):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -977,7 +977,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (1344-2031)
+text: (1370-2064)
 var N;
 (function (N) {
     function f() {
@@ -1003,7 +1003,7 @@ function secondsecond_part2Spread() {
     }
 }
 var secondsecond_part2_ar = [20, 30];
-secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 
 ======================================================================
 ======================================================================
@@ -1047,13 +1047,13 @@ declare const secondsecond_part2_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1342,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1344,
-          "end": 2031,
+          "pos": 1370,
+          "end": 2064,
           "kind": "text"
         }
       ],
@@ -1325,7 +1325,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1349,11 +1349,11 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 //# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.js.map]
-{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"first-output.js","sourceRoot":"","sources":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,WAAE"}
 
 //// [/src/first/bin/first-output.js.map.baseline.txt]
 ===================================================================
@@ -1394,7 +1394,7 @@ sourceFile:../first_PART1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -1704,7 +1704,7 @@ sourceFile:../first_part3.ts
 8 >                               ^^
 9 >                                 ^
 10>                                  ^
-11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -1727,14 +1727,14 @@ sourceFile:../first_part3.ts
 9 >Emitted(52, 35) Source(5, 37) + SourceIndex(2)
 10>Emitted(52, 36) Source(5, 38) + SourceIndex(2)
 ---
->>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+>>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^
 3 >                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                    ^^
 5 >                                                      ^^^^^^^^^^
 6 >                                                                ^^^^^^^^^^^^^^^^^^^
-7 >                                                                                   ^^^^
+7 >                                                                                   ^^^^^^^^^^^
 1->
   >
 2 >firstfirst_part3Spread
@@ -1749,12 +1749,12 @@ sourceFile:../first_part3.ts
 4 >Emitted(53, 55) Source(6, 26) + SourceIndex(2)
 5 >Emitted(53, 65) Source(6, 31) + SourceIndex(2)
 6 >Emitted(53, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(53, 88) Source(6, 52) + SourceIndex(2)
+7 >Emitted(53, 95) Source(6, 52) + SourceIndex(2)
 ---
 >>>//# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1846,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1879,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/first/bin/first-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1791,9 +1791,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1342):: typescript:spreadArray
+emitHelpers: (1008-1368):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1802,7 +1802,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (1344-1846)
+text: (1370-1879)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -1819,7 +1819,7 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 
 ======================================================================
 ======================================================================
@@ -1865,13 +1865,13 @@ declare const firstfirst_part3_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1342,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1344,
-          "end": 1846,
+          "pos": 1370,
+          "end": 1879,
           "kind": "text"
         }
       ],
@@ -2409,7 +2409,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -2433,7 +2433,7 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 var N;
 (function (N) {
     function f() {
@@ -2459,7 +2459,7 @@ function secondsecond_part2Spread() {
     }
 }
 var secondsecond_part2_ar = [20, 30];
-secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -2472,11 +2472,11 @@ function thirdthird_part1Spread() {
     }
 }
 var thirdthird_part1_ar = [20, 30];
-thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
+thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar), false));
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,IAAE"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,WAAE;ACDnD,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AACD,SAAS,yBAAyB;IAClC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,WAAE;ACRvD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;AACD,SAAS,sBAAsB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACnD,IAAM,mBAAmB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACrC,sBAAsB,8BAAC,EAAE,UAAK,mBAAmB,WAAE"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -2517,7 +2517,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -2827,7 +2827,7 @@ sourceFile:../../../first/first_part3.ts
 8 >                               ^^
 9 >                                 ^
 10>                                  ^
-11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -2850,14 +2850,14 @@ sourceFile:../../../first/first_part3.ts
 9 >Emitted(52, 35) Source(5, 37) + SourceIndex(2)
 10>Emitted(52, 36) Source(5, 38) + SourceIndex(2)
 ---
->>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+>>>firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^
 3 >                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                    ^^
 5 >                                                      ^^^^^^^^^^
 6 >                                                                ^^^^^^^^^^^^^^^^^^^
-7 >                                                                                   ^^^^
+7 >                                                                                   ^^^^^^^^^^^
 1->
   >
 2 >firstfirst_part3Spread
@@ -2872,7 +2872,7 @@ sourceFile:../../../first/first_part3.ts
 4 >Emitted(53, 55) Source(6, 26) + SourceIndex(2)
 5 >Emitted(53, 65) Source(6, 31) + SourceIndex(2)
 6 >Emitted(53, 84) Source(6, 50) + SourceIndex(2)
-7 >Emitted(53, 88) Source(6, 52) + SourceIndex(2)
+7 >Emitted(53, 95) Source(6, 52) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -3291,7 +3291,7 @@ sourceFile:../../../second/second_part2.ts
 8 >                                 ^^
 9 >                                   ^
 10>                                    ^
-11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -3314,14 +3314,14 @@ sourceFile:../../../second/second_part2.ts
 9 >Emitted(78, 37) Source(8, 39) + SourceIndex(4)
 10>Emitted(78, 38) Source(8, 40) + SourceIndex(4)
 ---
->>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+>>>secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^^^
 3 >                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                      ^^
 5 >                                                        ^^^^^^^^^^
 6 >                                                                  ^^^^^^^^^^^^^^^^^^^^^
-7 >                                                                                       ^^^^
+7 >                                                                                       ^^^^^^^^^^^
 1->
   >
 2 >secondsecond_part2Spread
@@ -3336,7 +3336,7 @@ sourceFile:../../../second/second_part2.ts
 4 >Emitted(79, 57) Source(9, 28) + SourceIndex(4)
 5 >Emitted(79, 67) Source(9, 33) + SourceIndex(4)
 6 >Emitted(79, 88) Source(9, 54) + SourceIndex(4)
-7 >Emitted(79, 92) Source(9, 56) + SourceIndex(4)
+7 >Emitted(79, 99) Source(9, 56) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -3562,7 +3562,7 @@ sourceFile:../../third_part1.ts
 8 >                               ^^
 9 >                                 ^
 10>                                  ^
-11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -3585,14 +3585,14 @@ sourceFile:../../third_part1.ts
 9 >Emitted(91, 35) Source(7, 37) + SourceIndex(5)
 10>Emitted(91, 36) Source(7, 38) + SourceIndex(5)
 ---
->>>thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
+>>>thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^
 3 >                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                    ^^
 5 >                                                      ^^^^^^^^^^
 6 >                                                                ^^^^^^^^^^^^^^^^^^^
-7 >                                                                                   ^^^^
+7 >                                                                                   ^^^^^^^^^^^
 1->
   >
 2 >thirdthird_part1Spread
@@ -3607,12 +3607,12 @@ sourceFile:../../third_part1.ts
 4 >Emitted(92, 55) Source(8, 26) + SourceIndex(5)
 5 >Emitted(92, 65) Source(8, 31) + SourceIndex(5)
 6 >Emitted(92, 84) Source(8, 50) + SourceIndex(5)
-7 >Emitted(92, 88) Source(8, 52) + SourceIndex(5)
+7 >Emitted(92, 95) Source(8, 52) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1846,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1846,"kind":"text"}]},{"pos":1846,"end":2533,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1846,"end":2533,"kind":"text"}]},{"pos":2533,"end":2961,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1879,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1879,"kind":"text"}]},{"pos":1879,"end":2573,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1879,"end":2573,"kind":"text"}]},{"pos":2573,"end":3008,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -3649,9 +3649,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1342):: typescript:spreadArray
+emitHelpers: (1008-1368):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -3660,9 +3660,9 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-prepend: (1344-1846):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1370-1879):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1344-1846)
+text: (1370-1879)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -3679,12 +3679,12 @@ function firstfirst_part3Spread() {
     }
 }
 var firstfirst_part3_ar = [20, 30];
-firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar)));
+firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 
 ----------------------------------------------------------------------
-prepend: (1846-2533):: ../../../2/second-output.js texts:: 1
+prepend: (1879-2573):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1846-2533)
+text: (1879-2573)
 var N;
 (function (N) {
     function f() {
@@ -3710,10 +3710,10 @@ function secondsecond_part2Spread() {
     }
 }
 var secondsecond_part2_ar = [20, 30];
-secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar)));
+secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 
 ----------------------------------------------------------------------
-text: (2533-2961)
+text: (2573-3008)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -3726,7 +3726,7 @@ function thirdthird_part1Spread() {
     }
 }
 var thirdthird_part1_ar = [20, 30];
-thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar)));
+thirdthird_part1Spread.apply(void 0, __spreadArray([10], __read(thirdthird_part1_ar), false));
 
 ======================================================================
 ======================================================================
@@ -3794,39 +3794,39 @@ declare const thirdthird_part1_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1342,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1344,
-          "end": 1846,
+          "pos": 1370,
+          "end": 1879,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1344,
-              "end": 1846,
+              "pos": 1370,
+              "end": 1879,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1846,
-          "end": 2533,
+          "pos": 1879,
+          "end": 2573,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1846,
-              "end": 2533,
+              "pos": 1879,
+              "end": 2573,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2533,
-          "end": 2961,
+          "pos": 2573,
+          "end": 3008,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-different-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-different-projects.js
@@ -341,7 +341,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -363,7 +363,7 @@ function secondsecond_part1Spread() {
     }
 }
 var secondsecond_part1_ar = [20, 30];
-secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 var C = (function () {
     function C() {
     }
@@ -375,7 +375,7 @@ var C = (function () {
 //# sourceMappingURL=second-output.js.map
 
 //// [/src/2/second-output.js.map]
-{"version":3,"file":"second-output.js","sourceRoot":"","sources":["../second/second_part1.ts","../second/second_part2.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC"}
+{"version":3,"file":"second-output.js","sourceRoot":"","sources":["../second/second_part1.ts","../second/second_part2.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,WAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC"}
 
 //// [/src/2/second-output.js.map.baseline.txt]
 ===================================================================
@@ -405,7 +405,7 @@ sourceFile:../second/second_part1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -619,7 +619,7 @@ sourceFile:../second/second_part1.ts
 8 >                                 ^^
 9 >                                   ^
 10>                                    ^
-11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -642,14 +642,14 @@ sourceFile:../second/second_part1.ts
 9 >Emitted(39, 37) Source(14, 39) + SourceIndex(0)
 10>Emitted(39, 38) Source(14, 40) + SourceIndex(0)
 ---
->>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+>>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^^^
 3 >                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                      ^^
 5 >                                                        ^^^^^^^^^^
 6 >                                                                  ^^^^^^^^^^^^^^^^^^^^^
-7 >                                                                                       ^^^^
+7 >                                                                                       ^^^^^^^^^^^
 1->
   >
 2 >secondsecond_part1Spread
@@ -664,7 +664,7 @@ sourceFile:../second/second_part1.ts
 4 >Emitted(40, 57) Source(15, 28) + SourceIndex(0)
 5 >Emitted(40, 67) Source(15, 33) + SourceIndex(0)
 6 >Emitted(40, 88) Source(15, 54) + SourceIndex(0)
-7 >Emitted(40, 92) Source(15, 56) + SourceIndex(0)
+7 >Emitted(40, 99) Source(15, 56) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/2/second-output.js
@@ -775,7 +775,7 @@ sourceFile:../second/second_part2.ts
 >>>//# sourceMappingURL=second-output.js.map
 
 //// [/src/2/second-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1410,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":214,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1443,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":214,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/2/second-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -799,9 +799,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-840):: typescript:spreadArray
+emitHelpers: (506-866):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -810,7 +810,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (842-1410)
+text: (868-1443)
 var N;
 (function (N) {
     function f() {
@@ -825,7 +825,7 @@ function secondsecond_part1Spread() {
     }
 }
 var secondsecond_part1_ar = [20, 30];
-secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 var C = (function () {
     function C() {
     }
@@ -870,13 +870,13 @@ declare class C {
         },
         {
           "pos": 506,
-          "end": 840,
+          "end": 866,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 842,
-          "end": 1410,
+          "pos": 868,
+          "end": 1443,
           "kind": "text"
         }
       ],
@@ -1824,7 +1824,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -1855,7 +1855,7 @@ function secondsecond_part1Spread() {
     }
 }
 var secondsecond_part1_ar = [20, 30];
-secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 var C = (function () {
     function C() {
     }
@@ -1872,7 +1872,7 @@ function forthirdthird_part1Rest() {
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,WAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -1913,7 +1913,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>    return ar;
 >>>};
 >>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
->>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
 >>>        if (ar || !(i in from)) {
 >>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
 >>>            ar[i] = from[i];
@@ -2363,7 +2363,7 @@ sourceFile:../../../second/second_part1.ts
 8 >                                 ^^
 9 >                                   ^
 10>                                    ^
-11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+11>                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1->
   >
 2 >const 
@@ -2386,14 +2386,14 @@ sourceFile:../../../second/second_part1.ts
 9 >Emitted(59, 37) Source(14, 39) + SourceIndex(3)
 10>Emitted(59, 38) Source(14, 40) + SourceIndex(3)
 ---
->>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+>>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 1->
 2 >^^^^^^^^^^^^^^^^^^^^^^^^
 3 >                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 >                                                      ^^
 5 >                                                        ^^^^^^^^^^
 6 >                                                                  ^^^^^^^^^^^^^^^^^^^^^
-7 >                                                                                       ^^^^
+7 >                                                                                       ^^^^^^^^^^^
 1->
   >
 2 >secondsecond_part1Spread
@@ -2408,7 +2408,7 @@ sourceFile:../../../second/second_part1.ts
 4 >Emitted(60, 57) Source(15, 28) + SourceIndex(3)
 5 >Emitted(60, 67) Source(15, 33) + SourceIndex(3)
 6 >Emitted(60, 88) Source(15, 54) + SourceIndex(3)
-7 >Emitted(60, 92) Source(15, 56) + SourceIndex(3)
+7 >Emitted(60, 99) Source(15, 56) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2673,7 +2673,7 @@ sourceFile:../../third_part1.ts
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1571,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1571,"kind":"text"}]},{"pos":1571,"end":2139,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1571,"end":2139,"kind":"text"}]},{"pos":2139,"end":2292,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1597,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1597,"kind":"text"}]},{"pos":1597,"end":2172,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1597,"end":2172,"kind":"text"}]},{"pos":2172,"end":2325,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -2710,9 +2710,9 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1342):: typescript:spreadArray
+emitHelpers: (1008-1368):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -2721,9 +2721,9 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-prepend: (1344-1571):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1370-1597):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1344-1571)
+text: (1370-1597)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -2735,9 +2735,9 @@ function f() {
 }
 
 ----------------------------------------------------------------------
-prepend: (1571-2139):: ../../../2/second-output.js texts:: 1
+prepend: (1597-2172):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1571-2139)
+text: (1597-2172)
 var N;
 (function (N) {
     function f() {
@@ -2752,7 +2752,7 @@ function secondsecond_part1Spread() {
     }
 }
 var secondsecond_part1_ar = [20, 30];
-secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
+secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar), false));
 var C = (function () {
     function C() {
     }
@@ -2763,7 +2763,7 @@ var C = (function () {
 }());
 
 ----------------------------------------------------------------------
-text: (2139-2292)
+text: (2172-2325)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -2831,39 +2831,39 @@ declare function forthirdthird_part1Rest(): void;
         },
         {
           "pos": 1008,
-          "end": 1342,
+          "end": 1368,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1344,
-          "end": 1571,
+          "pos": 1370,
+          "end": 1597,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1344,
-              "end": 1571,
+              "pos": 1370,
+              "end": 1597,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1571,
-          "end": 2139,
+          "pos": 1597,
+          "end": 2172,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1571,
-              "end": 2139,
+              "pos": 1597,
+              "end": 2172,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2139,
-          "end": 2292,
+          "pos": 2172,
+          "end": 2325,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-different-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-different-projects.js
@@ -340,10 +340,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var N;
 (function (N) {
@@ -371,7 +375,7 @@ var C = (function () {
 //# sourceMappingURL=second-output.js.map
 
 //// [/src/2/second-output.js.map]
-{"version":3,"file":"second-output.js","sourceRoot":"","sources":["../second/second_part1.ts","../second/second_part2.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;AAIA,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC"}
+{"version":3,"file":"second-output.js","sourceRoot":"","sources":["../second/second_part1.ts","../second/second_part2.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC"}
 
 //// [/src/2/second-output.js.map.baseline.txt]
 ===================================================================
@@ -400,10 +404,14 @@ sourceFile:../second/second_part1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var N;
 1 >
@@ -425,10 +433,10 @@ sourceFile:../second/second_part1.ts
   >     
   >         f();
   >     }
-1 >Emitted(22, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(22, 5) Source(5, 11) + SourceIndex(0)
-3 >Emitted(22, 6) Source(5, 12) + SourceIndex(0)
-4 >Emitted(22, 7) Source(11, 2) + SourceIndex(0)
+1 >Emitted(26, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(26, 5) Source(5, 11) + SourceIndex(0)
+3 >Emitted(26, 6) Source(5, 12) + SourceIndex(0)
+4 >Emitted(26, 7) Source(11, 2) + SourceIndex(0)
 ---
 >>>(function (N) {
 1->
@@ -438,9 +446,9 @@ sourceFile:../second/second_part1.ts
 1->
 2 >namespace 
 3 >           N
-1->Emitted(23, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(23, 12) Source(5, 11) + SourceIndex(0)
-3 >Emitted(23, 13) Source(5, 12) + SourceIndex(0)
+1->Emitted(27, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(27, 12) Source(5, 11) + SourceIndex(0)
+3 >Emitted(27, 13) Source(5, 12) + SourceIndex(0)
 ---
 >>>    function f() {
 1->^^^^
@@ -451,9 +459,9 @@ sourceFile:../second/second_part1.ts
   >    
 2 >    function 
 3 >             f
-1->Emitted(24, 5) Source(6, 5) + SourceIndex(0)
-2 >Emitted(24, 14) Source(6, 14) + SourceIndex(0)
-3 >Emitted(24, 15) Source(6, 15) + SourceIndex(0)
+1->Emitted(28, 5) Source(6, 5) + SourceIndex(0)
+2 >Emitted(28, 14) Source(6, 14) + SourceIndex(0)
+3 >Emitted(28, 15) Source(6, 15) + SourceIndex(0)
 ---
 >>>        console.log('testing');
 1->^^^^^^^^
@@ -473,14 +481,14 @@ sourceFile:../second/second_part1.ts
 6 >                    'testing'
 7 >                             )
 8 >                              ;
-1->Emitted(25, 9) Source(7, 9) + SourceIndex(0)
-2 >Emitted(25, 16) Source(7, 16) + SourceIndex(0)
-3 >Emitted(25, 17) Source(7, 17) + SourceIndex(0)
-4 >Emitted(25, 20) Source(7, 20) + SourceIndex(0)
-5 >Emitted(25, 21) Source(7, 21) + SourceIndex(0)
-6 >Emitted(25, 30) Source(7, 30) + SourceIndex(0)
-7 >Emitted(25, 31) Source(7, 31) + SourceIndex(0)
-8 >Emitted(25, 32) Source(7, 32) + SourceIndex(0)
+1->Emitted(29, 9) Source(7, 9) + SourceIndex(0)
+2 >Emitted(29, 16) Source(7, 16) + SourceIndex(0)
+3 >Emitted(29, 17) Source(7, 17) + SourceIndex(0)
+4 >Emitted(29, 20) Source(7, 20) + SourceIndex(0)
+5 >Emitted(29, 21) Source(7, 21) + SourceIndex(0)
+6 >Emitted(29, 30) Source(7, 30) + SourceIndex(0)
+7 >Emitted(29, 31) Source(7, 31) + SourceIndex(0)
+8 >Emitted(29, 32) Source(7, 32) + SourceIndex(0)
 ---
 >>>    }
 1 >^^^^
@@ -489,8 +497,8 @@ sourceFile:../second/second_part1.ts
 1 >
   >    
 2 >    }
-1 >Emitted(26, 5) Source(8, 5) + SourceIndex(0)
-2 >Emitted(26, 6) Source(8, 6) + SourceIndex(0)
+1 >Emitted(30, 5) Source(8, 5) + SourceIndex(0)
+2 >Emitted(30, 6) Source(8, 6) + SourceIndex(0)
 ---
 >>>    f();
 1->^^^^
@@ -504,10 +512,10 @@ sourceFile:../second/second_part1.ts
 2 >    f
 3 >     ()
 4 >       ;
-1->Emitted(27, 5) Source(10, 5) + SourceIndex(0)
-2 >Emitted(27, 6) Source(10, 6) + SourceIndex(0)
-3 >Emitted(27, 8) Source(10, 8) + SourceIndex(0)
-4 >Emitted(27, 9) Source(10, 9) + SourceIndex(0)
+1->Emitted(31, 5) Source(10, 5) + SourceIndex(0)
+2 >Emitted(31, 6) Source(10, 6) + SourceIndex(0)
+3 >Emitted(31, 8) Source(10, 8) + SourceIndex(0)
+4 >Emitted(31, 9) Source(10, 9) + SourceIndex(0)
 ---
 >>>})(N || (N = {}));
 1->
@@ -532,13 +540,13 @@ sourceFile:../second/second_part1.ts
   >          
   >              f();
   >          }
-1->Emitted(28, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(28, 2) Source(11, 2) + SourceIndex(0)
-3 >Emitted(28, 4) Source(5, 11) + SourceIndex(0)
-4 >Emitted(28, 5) Source(5, 12) + SourceIndex(0)
-5 >Emitted(28, 10) Source(5, 11) + SourceIndex(0)
-6 >Emitted(28, 11) Source(5, 12) + SourceIndex(0)
-7 >Emitted(28, 19) Source(11, 2) + SourceIndex(0)
+1->Emitted(32, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(32, 2) Source(11, 2) + SourceIndex(0)
+3 >Emitted(32, 4) Source(5, 11) + SourceIndex(0)
+4 >Emitted(32, 5) Source(5, 12) + SourceIndex(0)
+5 >Emitted(32, 10) Source(5, 11) + SourceIndex(0)
+6 >Emitted(32, 11) Source(5, 12) + SourceIndex(0)
+7 >Emitted(32, 19) Source(11, 2) + SourceIndex(0)
 ---
 >>>function secondsecond_part1Spread() {
 1->
@@ -549,9 +557,9 @@ sourceFile:../second/second_part1.ts
   >
 2 >function 
 3 >         secondsecond_part1Spread
-1->Emitted(29, 1) Source(13, 1) + SourceIndex(0)
-2 >Emitted(29, 10) Source(13, 10) + SourceIndex(0)
-3 >Emitted(29, 34) Source(13, 34) + SourceIndex(0)
+1->Emitted(33, 1) Source(13, 1) + SourceIndex(0)
+2 >Emitted(33, 10) Source(13, 10) + SourceIndex(0)
+3 >Emitted(33, 34) Source(13, 34) + SourceIndex(0)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -559,8 +567,8 @@ sourceFile:../second/second_part1.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(30, 5) Source(13, 35) + SourceIndex(0)
-2 >Emitted(30, 16) Source(13, 49) + SourceIndex(0)
+1 >Emitted(34, 5) Source(13, 35) + SourceIndex(0)
+2 >Emitted(34, 16) Source(13, 49) + SourceIndex(0)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -575,20 +583,20 @@ sourceFile:../second/second_part1.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(31, 10) Source(13, 35) + SourceIndex(0)
-2 >Emitted(31, 20) Source(13, 49) + SourceIndex(0)
-3 >Emitted(31, 22) Source(13, 35) + SourceIndex(0)
-4 >Emitted(31, 43) Source(13, 49) + SourceIndex(0)
-5 >Emitted(31, 45) Source(13, 35) + SourceIndex(0)
-6 >Emitted(31, 49) Source(13, 49) + SourceIndex(0)
+1->Emitted(35, 10) Source(13, 35) + SourceIndex(0)
+2 >Emitted(35, 20) Source(13, 49) + SourceIndex(0)
+3 >Emitted(35, 22) Source(13, 35) + SourceIndex(0)
+4 >Emitted(35, 43) Source(13, 49) + SourceIndex(0)
+5 >Emitted(35, 45) Source(13, 35) + SourceIndex(0)
+6 >Emitted(35, 49) Source(13, 49) + SourceIndex(0)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(32, 9) Source(13, 35) + SourceIndex(0)
-2 >Emitted(32, 31) Source(13, 49) + SourceIndex(0)
+1 >Emitted(36, 9) Source(13, 35) + SourceIndex(0)
+2 >Emitted(36, 31) Source(13, 49) + SourceIndex(0)
 ---
 >>>    }
 >>>}
@@ -597,8 +605,8 @@ sourceFile:../second/second_part1.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(34, 1) Source(13, 53) + SourceIndex(0)
-2 >Emitted(34, 2) Source(13, 54) + SourceIndex(0)
+1 >Emitted(38, 1) Source(13, 53) + SourceIndex(0)
+2 >Emitted(38, 2) Source(13, 54) + SourceIndex(0)
 ---
 >>>var secondsecond_part1_ar = [20, 30];
 1->
@@ -623,16 +631,16 @@ sourceFile:../second/second_part1.ts
 8 >                                 30
 9 >                                   ]
 10>                                    ;
-1->Emitted(35, 1) Source(14, 1) + SourceIndex(0)
-2 >Emitted(35, 5) Source(14, 7) + SourceIndex(0)
-3 >Emitted(35, 26) Source(14, 28) + SourceIndex(0)
-4 >Emitted(35, 29) Source(14, 31) + SourceIndex(0)
-5 >Emitted(35, 30) Source(14, 32) + SourceIndex(0)
-6 >Emitted(35, 32) Source(14, 34) + SourceIndex(0)
-7 >Emitted(35, 34) Source(14, 36) + SourceIndex(0)
-8 >Emitted(35, 36) Source(14, 38) + SourceIndex(0)
-9 >Emitted(35, 37) Source(14, 39) + SourceIndex(0)
-10>Emitted(35, 38) Source(14, 40) + SourceIndex(0)
+1->Emitted(39, 1) Source(14, 1) + SourceIndex(0)
+2 >Emitted(39, 5) Source(14, 7) + SourceIndex(0)
+3 >Emitted(39, 26) Source(14, 28) + SourceIndex(0)
+4 >Emitted(39, 29) Source(14, 31) + SourceIndex(0)
+5 >Emitted(39, 30) Source(14, 32) + SourceIndex(0)
+6 >Emitted(39, 32) Source(14, 34) + SourceIndex(0)
+7 >Emitted(39, 34) Source(14, 36) + SourceIndex(0)
+8 >Emitted(39, 36) Source(14, 38) + SourceIndex(0)
+9 >Emitted(39, 37) Source(14, 39) + SourceIndex(0)
+10>Emitted(39, 38) Source(14, 40) + SourceIndex(0)
 ---
 >>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
 1->
@@ -650,13 +658,13 @@ sourceFile:../second/second_part1.ts
 5 >                                                        , ...
 6 >                                                                  secondsecond_part1_ar
 7 >                                                                                       );
-1->Emitted(36, 1) Source(15, 1) + SourceIndex(0)
-2 >Emitted(36, 25) Source(15, 25) + SourceIndex(0)
-3 >Emitted(36, 55) Source(15, 26) + SourceIndex(0)
-4 >Emitted(36, 57) Source(15, 28) + SourceIndex(0)
-5 >Emitted(36, 67) Source(15, 33) + SourceIndex(0)
-6 >Emitted(36, 88) Source(15, 54) + SourceIndex(0)
-7 >Emitted(36, 92) Source(15, 56) + SourceIndex(0)
+1->Emitted(40, 1) Source(15, 1) + SourceIndex(0)
+2 >Emitted(40, 25) Source(15, 25) + SourceIndex(0)
+3 >Emitted(40, 55) Source(15, 26) + SourceIndex(0)
+4 >Emitted(40, 57) Source(15, 28) + SourceIndex(0)
+5 >Emitted(40, 67) Source(15, 33) + SourceIndex(0)
+6 >Emitted(40, 88) Source(15, 54) + SourceIndex(0)
+7 >Emitted(40, 92) Source(15, 56) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/2/second-output.js
@@ -666,13 +674,13 @@ sourceFile:../second/second_part2.ts
 1 >
 2 >^^^^^^^^^^^^^^^^^^^->
 1 >
-1 >Emitted(37, 1) Source(1, 1) + SourceIndex(1)
+1 >Emitted(41, 1) Source(1, 1) + SourceIndex(1)
 ---
 >>>    function C() {
 1->^^^^
 2 >    ^^->
 1->
-1->Emitted(38, 5) Source(1, 1) + SourceIndex(1)
+1->Emitted(42, 5) Source(1, 1) + SourceIndex(1)
 ---
 >>>    }
 1->^^^^
@@ -684,8 +692,8 @@ sourceFile:../second/second_part2.ts
   >    }
   >
 2 >    }
-1->Emitted(39, 5) Source(5, 1) + SourceIndex(1)
-2 >Emitted(39, 6) Source(5, 2) + SourceIndex(1)
+1->Emitted(43, 5) Source(5, 1) + SourceIndex(1)
+2 >Emitted(43, 6) Source(5, 2) + SourceIndex(1)
 ---
 >>>    C.prototype.doSomething = function () {
 1->^^^^
@@ -695,9 +703,9 @@ sourceFile:../second/second_part2.ts
 1->
 2 >    doSomething
 3 >                           
-1->Emitted(40, 5) Source(2, 5) + SourceIndex(1)
-2 >Emitted(40, 28) Source(2, 16) + SourceIndex(1)
-3 >Emitted(40, 31) Source(2, 5) + SourceIndex(1)
+1->Emitted(44, 5) Source(2, 5) + SourceIndex(1)
+2 >Emitted(44, 28) Source(2, 16) + SourceIndex(1)
+3 >Emitted(44, 31) Source(2, 5) + SourceIndex(1)
 ---
 >>>        console.log("something got done");
 1->^^^^^^^^
@@ -717,14 +725,14 @@ sourceFile:../second/second_part2.ts
 6 >                    "something got done"
 7 >                                        )
 8 >                                         ;
-1->Emitted(41, 9) Source(3, 9) + SourceIndex(1)
-2 >Emitted(41, 16) Source(3, 16) + SourceIndex(1)
-3 >Emitted(41, 17) Source(3, 17) + SourceIndex(1)
-4 >Emitted(41, 20) Source(3, 20) + SourceIndex(1)
-5 >Emitted(41, 21) Source(3, 21) + SourceIndex(1)
-6 >Emitted(41, 41) Source(3, 41) + SourceIndex(1)
-7 >Emitted(41, 42) Source(3, 42) + SourceIndex(1)
-8 >Emitted(41, 43) Source(3, 43) + SourceIndex(1)
+1->Emitted(45, 9) Source(3, 9) + SourceIndex(1)
+2 >Emitted(45, 16) Source(3, 16) + SourceIndex(1)
+3 >Emitted(45, 17) Source(3, 17) + SourceIndex(1)
+4 >Emitted(45, 20) Source(3, 20) + SourceIndex(1)
+5 >Emitted(45, 21) Source(3, 21) + SourceIndex(1)
+6 >Emitted(45, 41) Source(3, 41) + SourceIndex(1)
+7 >Emitted(45, 42) Source(3, 42) + SourceIndex(1)
+8 >Emitted(45, 43) Source(3, 43) + SourceIndex(1)
 ---
 >>>    };
 1 >^^^^
@@ -733,8 +741,8 @@ sourceFile:../second/second_part2.ts
 1 >
   >    
 2 >    }
-1 >Emitted(42, 5) Source(4, 5) + SourceIndex(1)
-2 >Emitted(42, 6) Source(4, 6) + SourceIndex(1)
+1 >Emitted(46, 5) Source(4, 5) + SourceIndex(1)
+2 >Emitted(46, 6) Source(4, 6) + SourceIndex(1)
 ---
 >>>    return C;
 1->^^^^
@@ -742,8 +750,8 @@ sourceFile:../second/second_part2.ts
 1->
   >
 2 >    }
-1->Emitted(43, 5) Source(5, 1) + SourceIndex(1)
-2 >Emitted(43, 13) Source(5, 2) + SourceIndex(1)
+1->Emitted(47, 5) Source(5, 1) + SourceIndex(1)
+2 >Emitted(47, 13) Source(5, 2) + SourceIndex(1)
 ---
 >>>}());
 1 >
@@ -759,15 +767,15 @@ sourceFile:../second/second_part2.ts
   >         console.log("something got done");
   >     }
   > }
-1 >Emitted(44, 1) Source(5, 1) + SourceIndex(1)
-2 >Emitted(44, 2) Source(5, 2) + SourceIndex(1)
-3 >Emitted(44, 2) Source(1, 1) + SourceIndex(1)
-4 >Emitted(44, 6) Source(5, 2) + SourceIndex(1)
+1 >Emitted(48, 1) Source(5, 1) + SourceIndex(1)
+2 >Emitted(48, 2) Source(5, 2) + SourceIndex(1)
+3 >Emitted(48, 2) Source(1, 1) + SourceIndex(1)
+4 >Emitted(48, 6) Source(5, 2) + SourceIndex(1)
 ---
 >>>//# sourceMappingURL=second-output.js.map
 
 //// [/src/2/second-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":697,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":699,"end":1267,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":214,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":840,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":842,"end":1410,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":214,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/2/second-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -791,14 +799,18 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-697):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (506-840):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-text: (699-1267)
+text: (842-1410)
 var N;
 (function (N) {
     function f() {
@@ -858,13 +870,13 @@ declare class C {
         },
         {
           "pos": 506,
-          "end": 697,
+          "end": 840,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 699,
-          "end": 1267,
+          "pos": 842,
+          "end": 1410,
           "kind": "text"
         }
       ],
@@ -1811,10 +1823,14 @@ var __read = (this && this.__read) || function (o, n) {
     }
     return ar;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var s = "Hello, world";
 console.log(s);
@@ -1856,7 +1872,7 @@ function forthirdthird_part1Rest() {
 //# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.js.map]
-{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
+{"version":3,"file":"third-output.js","sourceRoot":"","sources":["../../../first/first_PART1.ts","../../../first/first_part2.ts","../../../first/first_part3.ts","../../../second/second_part1.ts","../../../second/second_part2.ts","../../third_part1.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAIA,IAAM,CAAC,GAAG,cAAc,CAAC;AAMzB,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC;AACf,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC;ACbD,OAAO,CAAC,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC;ACAjB,SAAS,CAAC;IACN,OAAO,gBAAgB,CAAC;AAC5B,CAAC;ACED,IAAU,CAAC,CAMV;AAND,WAAU,CAAC;IACP,SAAS,CAAC;QACN,OAAO,CAAC,GAAG,CAAC,SAAS,CAAC,CAAC;IAC3B,CAAC;IAED,CAAC,EAAE,CAAC;AACR,CAAC,EANS,CAAC,KAAD,CAAC,QAMV;AAED,SAAS,wBAAwB;IAAC,WAAc;SAAd,UAAc,EAAd,qBAAc,EAAd,IAAc;QAAd,sBAAc;;AAAI,CAAC;AACrD,IAAM,qBAAqB,GAAG,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AACvC,wBAAwB,8BAAC,EAAE,UAAK,qBAAqB,IAAE;ACdvD;IAAA;IAIA,CAAC;IAHG,uBAAW,GAAX;QACI,OAAO,CAAC,GAAG,CAAC,oBAAoB,CAAC,CAAC;IACtC,CAAC;IACL,QAAC;AAAD,CAAC,AAJD,IAIC;ACJD,IAAI,CAAC,GAAG,IAAI,CAAC,EAAE,CAAC;AAChB,CAAC,CAAC,WAAW,EAAE,CAAC;AAChB,SAAS,uBAAuB;IAChC,IAAM,KAAiB,EAAE,CAAC,EAAE,EAAE,EAAE,CAAC,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAE,EAAvC,CAAC,OAAA,EAAK,IAAI,cAAZ,KAAc,CAA2B,CAAC;AAChD,CAAC"}
 
 //// [/src/third/thirdjs/output/third-output.js.map.baseline.txt]
 ===================================================================
@@ -1896,10 +1912,14 @@ sourceFile:../../../first/first_PART1.ts
 >>>    }
 >>>    return ar;
 >>>};
->>>var __spreadArray = (this && this.__spreadArray) || function (to, from) {
->>>    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
->>>        to[j] = from[i];
->>>    return to;
+>>>var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+>>>    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+>>>        if (ar || !(i in from)) {
+>>>            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+>>>            ar[i] = from[i];
+>>>        }
+>>>    }
+>>>    return to.concat(ar || from);
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -1918,12 +1938,12 @@ sourceFile:../../../first/first_PART1.ts
 4 >      = 
 5 >        "Hello, world"
 6 >                      ;
-1 >Emitted(33, 1) Source(5, 1) + SourceIndex(0)
-2 >Emitted(33, 5) Source(5, 7) + SourceIndex(0)
-3 >Emitted(33, 6) Source(5, 8) + SourceIndex(0)
-4 >Emitted(33, 9) Source(5, 11) + SourceIndex(0)
-5 >Emitted(33, 23) Source(5, 25) + SourceIndex(0)
-6 >Emitted(33, 24) Source(5, 26) + SourceIndex(0)
+1 >Emitted(37, 1) Source(5, 1) + SourceIndex(0)
+2 >Emitted(37, 5) Source(5, 7) + SourceIndex(0)
+3 >Emitted(37, 6) Source(5, 8) + SourceIndex(0)
+4 >Emitted(37, 9) Source(5, 11) + SourceIndex(0)
+5 >Emitted(37, 23) Source(5, 25) + SourceIndex(0)
+6 >Emitted(37, 24) Source(5, 26) + SourceIndex(0)
 ---
 >>>console.log(s);
 1 >
@@ -1949,14 +1969,14 @@ sourceFile:../../../first/first_PART1.ts
 6 >            s
 7 >             )
 8 >              ;
-1 >Emitted(34, 1) Source(11, 1) + SourceIndex(0)
-2 >Emitted(34, 8) Source(11, 8) + SourceIndex(0)
-3 >Emitted(34, 9) Source(11, 9) + SourceIndex(0)
-4 >Emitted(34, 12) Source(11, 12) + SourceIndex(0)
-5 >Emitted(34, 13) Source(11, 13) + SourceIndex(0)
-6 >Emitted(34, 14) Source(11, 14) + SourceIndex(0)
-7 >Emitted(34, 15) Source(11, 15) + SourceIndex(0)
-8 >Emitted(34, 16) Source(11, 16) + SourceIndex(0)
+1 >Emitted(38, 1) Source(11, 1) + SourceIndex(0)
+2 >Emitted(38, 8) Source(11, 8) + SourceIndex(0)
+3 >Emitted(38, 9) Source(11, 9) + SourceIndex(0)
+4 >Emitted(38, 12) Source(11, 12) + SourceIndex(0)
+5 >Emitted(38, 13) Source(11, 13) + SourceIndex(0)
+6 >Emitted(38, 14) Source(11, 14) + SourceIndex(0)
+7 >Emitted(38, 15) Source(11, 15) + SourceIndex(0)
+8 >Emitted(38, 16) Source(11, 16) + SourceIndex(0)
 ---
 >>>function forfirstfirst_PART1Rest() {
 1->
@@ -1967,9 +1987,9 @@ sourceFile:../../../first/first_PART1.ts
   >
 2 >function 
 3 >         forfirstfirst_PART1Rest
-1->Emitted(35, 1) Source(12, 1) + SourceIndex(0)
-2 >Emitted(35, 10) Source(12, 10) + SourceIndex(0)
-3 >Emitted(35, 33) Source(12, 33) + SourceIndex(0)
+1->Emitted(39, 1) Source(12, 1) + SourceIndex(0)
+2 >Emitted(39, 10) Source(12, 10) + SourceIndex(0)
+3 >Emitted(39, 33) Source(12, 33) + SourceIndex(0)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -2023,31 +2043,31 @@ sourceFile:../../../first/first_PART1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(36, 5) Source(13, 1) + SourceIndex(0)
-2 >Emitted(36, 9) Source(13, 7) + SourceIndex(0)
-3 >Emitted(36, 14) Source(13, 24) + SourceIndex(0)
-4 >Emitted(36, 16) Source(13, 26) + SourceIndex(0)
-5 >Emitted(36, 17) Source(13, 27) + SourceIndex(0)
-6 >Emitted(36, 19) Source(13, 29) + SourceIndex(0)
-7 >Emitted(36, 21) Source(13, 31) + SourceIndex(0)
-8 >Emitted(36, 23) Source(13, 33) + SourceIndex(0)
-9 >Emitted(36, 24) Source(13, 34) + SourceIndex(0)
-10>Emitted(36, 26) Source(13, 36) + SourceIndex(0)
-11>Emitted(36, 28) Source(13, 38) + SourceIndex(0)
-12>Emitted(36, 30) Source(13, 40) + SourceIndex(0)
-13>Emitted(36, 32) Source(13, 42) + SourceIndex(0)
-14>Emitted(36, 34) Source(13, 44) + SourceIndex(0)
-15>Emitted(36, 36) Source(13, 46) + SourceIndex(0)
-16>Emitted(36, 38) Source(13, 48) + SourceIndex(0)
-17>Emitted(36, 40) Source(13, 9) + SourceIndex(0)
-18>Emitted(36, 41) Source(13, 10) + SourceIndex(0)
-19>Emitted(36, 48) Source(13, 10) + SourceIndex(0)
-20>Emitted(36, 50) Source(13, 15) + SourceIndex(0)
-21>Emitted(36, 54) Source(13, 19) + SourceIndex(0)
-22>Emitted(36, 68) Source(13, 7) + SourceIndex(0)
-23>Emitted(36, 73) Source(13, 21) + SourceIndex(0)
-24>Emitted(36, 74) Source(13, 48) + SourceIndex(0)
-25>Emitted(36, 75) Source(13, 49) + SourceIndex(0)
+1->Emitted(40, 5) Source(13, 1) + SourceIndex(0)
+2 >Emitted(40, 9) Source(13, 7) + SourceIndex(0)
+3 >Emitted(40, 14) Source(13, 24) + SourceIndex(0)
+4 >Emitted(40, 16) Source(13, 26) + SourceIndex(0)
+5 >Emitted(40, 17) Source(13, 27) + SourceIndex(0)
+6 >Emitted(40, 19) Source(13, 29) + SourceIndex(0)
+7 >Emitted(40, 21) Source(13, 31) + SourceIndex(0)
+8 >Emitted(40, 23) Source(13, 33) + SourceIndex(0)
+9 >Emitted(40, 24) Source(13, 34) + SourceIndex(0)
+10>Emitted(40, 26) Source(13, 36) + SourceIndex(0)
+11>Emitted(40, 28) Source(13, 38) + SourceIndex(0)
+12>Emitted(40, 30) Source(13, 40) + SourceIndex(0)
+13>Emitted(40, 32) Source(13, 42) + SourceIndex(0)
+14>Emitted(40, 34) Source(13, 44) + SourceIndex(0)
+15>Emitted(40, 36) Source(13, 46) + SourceIndex(0)
+16>Emitted(40, 38) Source(13, 48) + SourceIndex(0)
+17>Emitted(40, 40) Source(13, 9) + SourceIndex(0)
+18>Emitted(40, 41) Source(13, 10) + SourceIndex(0)
+19>Emitted(40, 48) Source(13, 10) + SourceIndex(0)
+20>Emitted(40, 50) Source(13, 15) + SourceIndex(0)
+21>Emitted(40, 54) Source(13, 19) + SourceIndex(0)
+22>Emitted(40, 68) Source(13, 7) + SourceIndex(0)
+23>Emitted(40, 73) Source(13, 21) + SourceIndex(0)
+24>Emitted(40, 74) Source(13, 48) + SourceIndex(0)
+25>Emitted(40, 75) Source(13, 49) + SourceIndex(0)
 ---
 >>>}
 1 >
@@ -2056,8 +2076,8 @@ sourceFile:../../../first/first_PART1.ts
 1 >
   >
 2 >}
-1 >Emitted(37, 1) Source(14, 1) + SourceIndex(0)
-2 >Emitted(37, 2) Source(14, 2) + SourceIndex(0)
+1 >Emitted(41, 1) Source(14, 1) + SourceIndex(0)
+2 >Emitted(41, 2) Source(14, 2) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2082,15 +2102,15 @@ sourceFile:../../../first/first_part2.ts
 7 >             ()
 8 >               )
 9 >                ;
-1->Emitted(38, 1) Source(1, 1) + SourceIndex(1)
-2 >Emitted(38, 8) Source(1, 8) + SourceIndex(1)
-3 >Emitted(38, 9) Source(1, 9) + SourceIndex(1)
-4 >Emitted(38, 12) Source(1, 12) + SourceIndex(1)
-5 >Emitted(38, 13) Source(1, 13) + SourceIndex(1)
-6 >Emitted(38, 14) Source(1, 14) + SourceIndex(1)
-7 >Emitted(38, 16) Source(1, 16) + SourceIndex(1)
-8 >Emitted(38, 17) Source(1, 17) + SourceIndex(1)
-9 >Emitted(38, 18) Source(1, 18) + SourceIndex(1)
+1->Emitted(42, 1) Source(1, 1) + SourceIndex(1)
+2 >Emitted(42, 8) Source(1, 8) + SourceIndex(1)
+3 >Emitted(42, 9) Source(1, 9) + SourceIndex(1)
+4 >Emitted(42, 12) Source(1, 12) + SourceIndex(1)
+5 >Emitted(42, 13) Source(1, 13) + SourceIndex(1)
+6 >Emitted(42, 14) Source(1, 14) + SourceIndex(1)
+7 >Emitted(42, 16) Source(1, 16) + SourceIndex(1)
+8 >Emitted(42, 17) Source(1, 17) + SourceIndex(1)
+9 >Emitted(42, 18) Source(1, 18) + SourceIndex(1)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2104,9 +2124,9 @@ sourceFile:../../../first/first_part3.ts
 1 >
 2 >function 
 3 >         f
-1 >Emitted(39, 1) Source(1, 1) + SourceIndex(2)
-2 >Emitted(39, 10) Source(1, 10) + SourceIndex(2)
-3 >Emitted(39, 11) Source(1, 11) + SourceIndex(2)
+1 >Emitted(43, 1) Source(1, 1) + SourceIndex(2)
+2 >Emitted(43, 10) Source(1, 10) + SourceIndex(2)
+3 >Emitted(43, 11) Source(1, 11) + SourceIndex(2)
 ---
 >>>    return "JS does hoists";
 1->^^^^
@@ -2118,10 +2138,10 @@ sourceFile:../../../first/first_part3.ts
 2 >    return 
 3 >           "JS does hoists"
 4 >                           ;
-1->Emitted(40, 5) Source(2, 5) + SourceIndex(2)
-2 >Emitted(40, 12) Source(2, 12) + SourceIndex(2)
-3 >Emitted(40, 28) Source(2, 28) + SourceIndex(2)
-4 >Emitted(40, 29) Source(2, 29) + SourceIndex(2)
+1->Emitted(44, 5) Source(2, 5) + SourceIndex(2)
+2 >Emitted(44, 12) Source(2, 12) + SourceIndex(2)
+3 >Emitted(44, 28) Source(2, 28) + SourceIndex(2)
+4 >Emitted(44, 29) Source(2, 29) + SourceIndex(2)
 ---
 >>>}
 1 >
@@ -2130,8 +2150,8 @@ sourceFile:../../../first/first_part3.ts
 1 >
   >
 2 >}
-1 >Emitted(41, 1) Source(3, 1) + SourceIndex(2)
-2 >Emitted(41, 2) Source(3, 2) + SourceIndex(2)
+1 >Emitted(45, 1) Source(3, 1) + SourceIndex(2)
+2 >Emitted(45, 2) Source(3, 2) + SourceIndex(2)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2157,10 +2177,10 @@ sourceFile:../../../second/second_part1.ts
   >     
   >         f();
   >     }
-1->Emitted(42, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(42, 5) Source(5, 11) + SourceIndex(3)
-3 >Emitted(42, 6) Source(5, 12) + SourceIndex(3)
-4 >Emitted(42, 7) Source(11, 2) + SourceIndex(3)
+1->Emitted(46, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(46, 5) Source(5, 11) + SourceIndex(3)
+3 >Emitted(46, 6) Source(5, 12) + SourceIndex(3)
+4 >Emitted(46, 7) Source(11, 2) + SourceIndex(3)
 ---
 >>>(function (N) {
 1->
@@ -2170,9 +2190,9 @@ sourceFile:../../../second/second_part1.ts
 1->
 2 >namespace 
 3 >           N
-1->Emitted(43, 1) Source(5, 1) + SourceIndex(3)
-2 >Emitted(43, 12) Source(5, 11) + SourceIndex(3)
-3 >Emitted(43, 13) Source(5, 12) + SourceIndex(3)
+1->Emitted(47, 1) Source(5, 1) + SourceIndex(3)
+2 >Emitted(47, 12) Source(5, 11) + SourceIndex(3)
+3 >Emitted(47, 13) Source(5, 12) + SourceIndex(3)
 ---
 >>>    function f() {
 1->^^^^
@@ -2183,9 +2203,9 @@ sourceFile:../../../second/second_part1.ts
   >    
 2 >    function 
 3 >             f
-1->Emitted(44, 5) Source(6, 5) + SourceIndex(3)
-2 >Emitted(44, 14) Source(6, 14) + SourceIndex(3)
-3 >Emitted(44, 15) Source(6, 15) + SourceIndex(3)
+1->Emitted(48, 5) Source(6, 5) + SourceIndex(3)
+2 >Emitted(48, 14) Source(6, 14) + SourceIndex(3)
+3 >Emitted(48, 15) Source(6, 15) + SourceIndex(3)
 ---
 >>>        console.log('testing');
 1->^^^^^^^^
@@ -2205,14 +2225,14 @@ sourceFile:../../../second/second_part1.ts
 6 >                    'testing'
 7 >                             )
 8 >                              ;
-1->Emitted(45, 9) Source(7, 9) + SourceIndex(3)
-2 >Emitted(45, 16) Source(7, 16) + SourceIndex(3)
-3 >Emitted(45, 17) Source(7, 17) + SourceIndex(3)
-4 >Emitted(45, 20) Source(7, 20) + SourceIndex(3)
-5 >Emitted(45, 21) Source(7, 21) + SourceIndex(3)
-6 >Emitted(45, 30) Source(7, 30) + SourceIndex(3)
-7 >Emitted(45, 31) Source(7, 31) + SourceIndex(3)
-8 >Emitted(45, 32) Source(7, 32) + SourceIndex(3)
+1->Emitted(49, 9) Source(7, 9) + SourceIndex(3)
+2 >Emitted(49, 16) Source(7, 16) + SourceIndex(3)
+3 >Emitted(49, 17) Source(7, 17) + SourceIndex(3)
+4 >Emitted(49, 20) Source(7, 20) + SourceIndex(3)
+5 >Emitted(49, 21) Source(7, 21) + SourceIndex(3)
+6 >Emitted(49, 30) Source(7, 30) + SourceIndex(3)
+7 >Emitted(49, 31) Source(7, 31) + SourceIndex(3)
+8 >Emitted(49, 32) Source(7, 32) + SourceIndex(3)
 ---
 >>>    }
 1 >^^^^
@@ -2221,8 +2241,8 @@ sourceFile:../../../second/second_part1.ts
 1 >
   >    
 2 >    }
-1 >Emitted(46, 5) Source(8, 5) + SourceIndex(3)
-2 >Emitted(46, 6) Source(8, 6) + SourceIndex(3)
+1 >Emitted(50, 5) Source(8, 5) + SourceIndex(3)
+2 >Emitted(50, 6) Source(8, 6) + SourceIndex(3)
 ---
 >>>    f();
 1->^^^^
@@ -2236,10 +2256,10 @@ sourceFile:../../../second/second_part1.ts
 2 >    f
 3 >     ()
 4 >       ;
-1->Emitted(47, 5) Source(10, 5) + SourceIndex(3)
-2 >Emitted(47, 6) Source(10, 6) + SourceIndex(3)
-3 >Emitted(47, 8) Source(10, 8) + SourceIndex(3)
-4 >Emitted(47, 9) Source(10, 9) + SourceIndex(3)
+1->Emitted(51, 5) Source(10, 5) + SourceIndex(3)
+2 >Emitted(51, 6) Source(10, 6) + SourceIndex(3)
+3 >Emitted(51, 8) Source(10, 8) + SourceIndex(3)
+4 >Emitted(51, 9) Source(10, 9) + SourceIndex(3)
 ---
 >>>})(N || (N = {}));
 1->
@@ -2264,13 +2284,13 @@ sourceFile:../../../second/second_part1.ts
   >          
   >              f();
   >          }
-1->Emitted(48, 1) Source(11, 1) + SourceIndex(3)
-2 >Emitted(48, 2) Source(11, 2) + SourceIndex(3)
-3 >Emitted(48, 4) Source(5, 11) + SourceIndex(3)
-4 >Emitted(48, 5) Source(5, 12) + SourceIndex(3)
-5 >Emitted(48, 10) Source(5, 11) + SourceIndex(3)
-6 >Emitted(48, 11) Source(5, 12) + SourceIndex(3)
-7 >Emitted(48, 19) Source(11, 2) + SourceIndex(3)
+1->Emitted(52, 1) Source(11, 1) + SourceIndex(3)
+2 >Emitted(52, 2) Source(11, 2) + SourceIndex(3)
+3 >Emitted(52, 4) Source(5, 11) + SourceIndex(3)
+4 >Emitted(52, 5) Source(5, 12) + SourceIndex(3)
+5 >Emitted(52, 10) Source(5, 11) + SourceIndex(3)
+6 >Emitted(52, 11) Source(5, 12) + SourceIndex(3)
+7 >Emitted(52, 19) Source(11, 2) + SourceIndex(3)
 ---
 >>>function secondsecond_part1Spread() {
 1->
@@ -2281,9 +2301,9 @@ sourceFile:../../../second/second_part1.ts
   >
 2 >function 
 3 >         secondsecond_part1Spread
-1->Emitted(49, 1) Source(13, 1) + SourceIndex(3)
-2 >Emitted(49, 10) Source(13, 10) + SourceIndex(3)
-3 >Emitted(49, 34) Source(13, 34) + SourceIndex(3)
+1->Emitted(53, 1) Source(13, 1) + SourceIndex(3)
+2 >Emitted(53, 10) Source(13, 10) + SourceIndex(3)
+3 >Emitted(53, 34) Source(13, 34) + SourceIndex(3)
 ---
 >>>    var b = [];
 1 >^^^^
@@ -2291,8 +2311,8 @@ sourceFile:../../../second/second_part1.ts
 3 >               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >(
 2 >    ...b: number[]
-1 >Emitted(50, 5) Source(13, 35) + SourceIndex(3)
-2 >Emitted(50, 16) Source(13, 49) + SourceIndex(3)
+1 >Emitted(54, 5) Source(13, 35) + SourceIndex(3)
+2 >Emitted(54, 16) Source(13, 49) + SourceIndex(3)
 ---
 >>>    for (var _i = 0; _i < arguments.length; _i++) {
 1->^^^^^^^^^
@@ -2307,20 +2327,20 @@ sourceFile:../../../second/second_part1.ts
 4 >                     ...b: number[]
 5 >                                          
 6 >                                            ...b: number[]
-1->Emitted(51, 10) Source(13, 35) + SourceIndex(3)
-2 >Emitted(51, 20) Source(13, 49) + SourceIndex(3)
-3 >Emitted(51, 22) Source(13, 35) + SourceIndex(3)
-4 >Emitted(51, 43) Source(13, 49) + SourceIndex(3)
-5 >Emitted(51, 45) Source(13, 35) + SourceIndex(3)
-6 >Emitted(51, 49) Source(13, 49) + SourceIndex(3)
+1->Emitted(55, 10) Source(13, 35) + SourceIndex(3)
+2 >Emitted(55, 20) Source(13, 49) + SourceIndex(3)
+3 >Emitted(55, 22) Source(13, 35) + SourceIndex(3)
+4 >Emitted(55, 43) Source(13, 49) + SourceIndex(3)
+5 >Emitted(55, 45) Source(13, 35) + SourceIndex(3)
+6 >Emitted(55, 49) Source(13, 49) + SourceIndex(3)
 ---
 >>>        b[_i] = arguments[_i];
 1 >^^^^^^^^
 2 >        ^^^^^^^^^^^^^^^^^^^^^^
 1 >
 2 >        ...b: number[]
-1 >Emitted(52, 9) Source(13, 35) + SourceIndex(3)
-2 >Emitted(52, 31) Source(13, 49) + SourceIndex(3)
+1 >Emitted(56, 9) Source(13, 35) + SourceIndex(3)
+2 >Emitted(56, 31) Source(13, 49) + SourceIndex(3)
 ---
 >>>    }
 >>>}
@@ -2329,8 +2349,8 @@ sourceFile:../../../second/second_part1.ts
 3 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >) { 
 2 >}
-1 >Emitted(54, 1) Source(13, 53) + SourceIndex(3)
-2 >Emitted(54, 2) Source(13, 54) + SourceIndex(3)
+1 >Emitted(58, 1) Source(13, 53) + SourceIndex(3)
+2 >Emitted(58, 2) Source(13, 54) + SourceIndex(3)
 ---
 >>>var secondsecond_part1_ar = [20, 30];
 1->
@@ -2355,16 +2375,16 @@ sourceFile:../../../second/second_part1.ts
 8 >                                 30
 9 >                                   ]
 10>                                    ;
-1->Emitted(55, 1) Source(14, 1) + SourceIndex(3)
-2 >Emitted(55, 5) Source(14, 7) + SourceIndex(3)
-3 >Emitted(55, 26) Source(14, 28) + SourceIndex(3)
-4 >Emitted(55, 29) Source(14, 31) + SourceIndex(3)
-5 >Emitted(55, 30) Source(14, 32) + SourceIndex(3)
-6 >Emitted(55, 32) Source(14, 34) + SourceIndex(3)
-7 >Emitted(55, 34) Source(14, 36) + SourceIndex(3)
-8 >Emitted(55, 36) Source(14, 38) + SourceIndex(3)
-9 >Emitted(55, 37) Source(14, 39) + SourceIndex(3)
-10>Emitted(55, 38) Source(14, 40) + SourceIndex(3)
+1->Emitted(59, 1) Source(14, 1) + SourceIndex(3)
+2 >Emitted(59, 5) Source(14, 7) + SourceIndex(3)
+3 >Emitted(59, 26) Source(14, 28) + SourceIndex(3)
+4 >Emitted(59, 29) Source(14, 31) + SourceIndex(3)
+5 >Emitted(59, 30) Source(14, 32) + SourceIndex(3)
+6 >Emitted(59, 32) Source(14, 34) + SourceIndex(3)
+7 >Emitted(59, 34) Source(14, 36) + SourceIndex(3)
+8 >Emitted(59, 36) Source(14, 38) + SourceIndex(3)
+9 >Emitted(59, 37) Source(14, 39) + SourceIndex(3)
+10>Emitted(59, 38) Source(14, 40) + SourceIndex(3)
 ---
 >>>secondsecond_part1Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part1_ar)));
 1->
@@ -2382,13 +2402,13 @@ sourceFile:../../../second/second_part1.ts
 5 >                                                        , ...
 6 >                                                                  secondsecond_part1_ar
 7 >                                                                                       );
-1->Emitted(56, 1) Source(15, 1) + SourceIndex(3)
-2 >Emitted(56, 25) Source(15, 25) + SourceIndex(3)
-3 >Emitted(56, 55) Source(15, 26) + SourceIndex(3)
-4 >Emitted(56, 57) Source(15, 28) + SourceIndex(3)
-5 >Emitted(56, 67) Source(15, 33) + SourceIndex(3)
-6 >Emitted(56, 88) Source(15, 54) + SourceIndex(3)
-7 >Emitted(56, 92) Source(15, 56) + SourceIndex(3)
+1->Emitted(60, 1) Source(15, 1) + SourceIndex(3)
+2 >Emitted(60, 25) Source(15, 25) + SourceIndex(3)
+3 >Emitted(60, 55) Source(15, 26) + SourceIndex(3)
+4 >Emitted(60, 57) Source(15, 28) + SourceIndex(3)
+5 >Emitted(60, 67) Source(15, 33) + SourceIndex(3)
+6 >Emitted(60, 88) Source(15, 54) + SourceIndex(3)
+7 >Emitted(60, 92) Source(15, 56) + SourceIndex(3)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2398,13 +2418,13 @@ sourceFile:../../../second/second_part2.ts
 1 >
 2 >^^^^^^^^^^^^^^^^^^^->
 1 >
-1 >Emitted(57, 1) Source(1, 1) + SourceIndex(4)
+1 >Emitted(61, 1) Source(1, 1) + SourceIndex(4)
 ---
 >>>    function C() {
 1->^^^^
 2 >    ^^->
 1->
-1->Emitted(58, 5) Source(1, 1) + SourceIndex(4)
+1->Emitted(62, 5) Source(1, 1) + SourceIndex(4)
 ---
 >>>    }
 1->^^^^
@@ -2416,8 +2436,8 @@ sourceFile:../../../second/second_part2.ts
   >    }
   >
 2 >    }
-1->Emitted(59, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(59, 6) Source(5, 2) + SourceIndex(4)
+1->Emitted(63, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(63, 6) Source(5, 2) + SourceIndex(4)
 ---
 >>>    C.prototype.doSomething = function () {
 1->^^^^
@@ -2427,9 +2447,9 @@ sourceFile:../../../second/second_part2.ts
 1->
 2 >    doSomething
 3 >                           
-1->Emitted(60, 5) Source(2, 5) + SourceIndex(4)
-2 >Emitted(60, 28) Source(2, 16) + SourceIndex(4)
-3 >Emitted(60, 31) Source(2, 5) + SourceIndex(4)
+1->Emitted(64, 5) Source(2, 5) + SourceIndex(4)
+2 >Emitted(64, 28) Source(2, 16) + SourceIndex(4)
+3 >Emitted(64, 31) Source(2, 5) + SourceIndex(4)
 ---
 >>>        console.log("something got done");
 1->^^^^^^^^
@@ -2449,14 +2469,14 @@ sourceFile:../../../second/second_part2.ts
 6 >                    "something got done"
 7 >                                        )
 8 >                                         ;
-1->Emitted(61, 9) Source(3, 9) + SourceIndex(4)
-2 >Emitted(61, 16) Source(3, 16) + SourceIndex(4)
-3 >Emitted(61, 17) Source(3, 17) + SourceIndex(4)
-4 >Emitted(61, 20) Source(3, 20) + SourceIndex(4)
-5 >Emitted(61, 21) Source(3, 21) + SourceIndex(4)
-6 >Emitted(61, 41) Source(3, 41) + SourceIndex(4)
-7 >Emitted(61, 42) Source(3, 42) + SourceIndex(4)
-8 >Emitted(61, 43) Source(3, 43) + SourceIndex(4)
+1->Emitted(65, 9) Source(3, 9) + SourceIndex(4)
+2 >Emitted(65, 16) Source(3, 16) + SourceIndex(4)
+3 >Emitted(65, 17) Source(3, 17) + SourceIndex(4)
+4 >Emitted(65, 20) Source(3, 20) + SourceIndex(4)
+5 >Emitted(65, 21) Source(3, 21) + SourceIndex(4)
+6 >Emitted(65, 41) Source(3, 41) + SourceIndex(4)
+7 >Emitted(65, 42) Source(3, 42) + SourceIndex(4)
+8 >Emitted(65, 43) Source(3, 43) + SourceIndex(4)
 ---
 >>>    };
 1 >^^^^
@@ -2465,8 +2485,8 @@ sourceFile:../../../second/second_part2.ts
 1 >
   >    
 2 >    }
-1 >Emitted(62, 5) Source(4, 5) + SourceIndex(4)
-2 >Emitted(62, 6) Source(4, 6) + SourceIndex(4)
+1 >Emitted(66, 5) Source(4, 5) + SourceIndex(4)
+2 >Emitted(66, 6) Source(4, 6) + SourceIndex(4)
 ---
 >>>    return C;
 1->^^^^
@@ -2474,8 +2494,8 @@ sourceFile:../../../second/second_part2.ts
 1->
   >
 2 >    }
-1->Emitted(63, 5) Source(5, 1) + SourceIndex(4)
-2 >Emitted(63, 13) Source(5, 2) + SourceIndex(4)
+1->Emitted(67, 5) Source(5, 1) + SourceIndex(4)
+2 >Emitted(67, 13) Source(5, 2) + SourceIndex(4)
 ---
 >>>}());
 1 >
@@ -2491,10 +2511,10 @@ sourceFile:../../../second/second_part2.ts
   >         console.log("something got done");
   >     }
   > }
-1 >Emitted(64, 1) Source(5, 1) + SourceIndex(4)
-2 >Emitted(64, 2) Source(5, 2) + SourceIndex(4)
-3 >Emitted(64, 2) Source(1, 1) + SourceIndex(4)
-4 >Emitted(64, 6) Source(5, 2) + SourceIndex(4)
+1 >Emitted(68, 1) Source(5, 1) + SourceIndex(4)
+2 >Emitted(68, 2) Source(5, 2) + SourceIndex(4)
+3 >Emitted(68, 2) Source(1, 1) + SourceIndex(4)
+4 >Emitted(68, 6) Source(5, 2) + SourceIndex(4)
 ---
 -------------------------------------------------------------------
 emittedFile:/src/third/thirdjs/output/third-output.js
@@ -2518,14 +2538,14 @@ sourceFile:../../third_part1.ts
 6 >            C
 7 >             ()
 8 >               ;
-1->Emitted(65, 1) Source(1, 1) + SourceIndex(5)
-2 >Emitted(65, 5) Source(1, 5) + SourceIndex(5)
-3 >Emitted(65, 6) Source(1, 6) + SourceIndex(5)
-4 >Emitted(65, 9) Source(1, 9) + SourceIndex(5)
-5 >Emitted(65, 13) Source(1, 13) + SourceIndex(5)
-6 >Emitted(65, 14) Source(1, 14) + SourceIndex(5)
-7 >Emitted(65, 16) Source(1, 16) + SourceIndex(5)
-8 >Emitted(65, 17) Source(1, 17) + SourceIndex(5)
+1->Emitted(69, 1) Source(1, 1) + SourceIndex(5)
+2 >Emitted(69, 5) Source(1, 5) + SourceIndex(5)
+3 >Emitted(69, 6) Source(1, 6) + SourceIndex(5)
+4 >Emitted(69, 9) Source(1, 9) + SourceIndex(5)
+5 >Emitted(69, 13) Source(1, 13) + SourceIndex(5)
+6 >Emitted(69, 14) Source(1, 14) + SourceIndex(5)
+7 >Emitted(69, 16) Source(1, 16) + SourceIndex(5)
+8 >Emitted(69, 17) Source(1, 17) + SourceIndex(5)
 ---
 >>>c.doSomething();
 1->
@@ -2542,12 +2562,12 @@ sourceFile:../../third_part1.ts
 4 >  doSomething
 5 >             ()
 6 >               ;
-1->Emitted(66, 1) Source(2, 1) + SourceIndex(5)
-2 >Emitted(66, 2) Source(2, 2) + SourceIndex(5)
-3 >Emitted(66, 3) Source(2, 3) + SourceIndex(5)
-4 >Emitted(66, 14) Source(2, 14) + SourceIndex(5)
-5 >Emitted(66, 16) Source(2, 16) + SourceIndex(5)
-6 >Emitted(66, 17) Source(2, 17) + SourceIndex(5)
+1->Emitted(70, 1) Source(2, 1) + SourceIndex(5)
+2 >Emitted(70, 2) Source(2, 2) + SourceIndex(5)
+3 >Emitted(70, 3) Source(2, 3) + SourceIndex(5)
+4 >Emitted(70, 14) Source(2, 14) + SourceIndex(5)
+5 >Emitted(70, 16) Source(2, 16) + SourceIndex(5)
+6 >Emitted(70, 17) Source(2, 17) + SourceIndex(5)
 ---
 >>>function forthirdthird_part1Rest() {
 1->
@@ -2558,9 +2578,9 @@ sourceFile:../../third_part1.ts
   >
 2 >function 
 3 >         forthirdthird_part1Rest
-1->Emitted(67, 1) Source(3, 1) + SourceIndex(5)
-2 >Emitted(67, 10) Source(3, 10) + SourceIndex(5)
-3 >Emitted(67, 33) Source(3, 33) + SourceIndex(5)
+1->Emitted(71, 1) Source(3, 1) + SourceIndex(5)
+2 >Emitted(71, 10) Source(3, 10) + SourceIndex(5)
+3 >Emitted(71, 33) Source(3, 33) + SourceIndex(5)
 ---
 >>>    var _a = { a: 10, b: 30, yy: 30 }, b = _a.b, rest = __rest(_a, ["b"]);
 1->^^^^
@@ -2614,31 +2634,31 @@ sourceFile:../../third_part1.ts
 23>                                                                   { b, ...rest }
 24>                                                                         = { a: 10, b: 30, yy: 30 }
 25>                                                                         ;
-1->Emitted(68, 5) Source(4, 1) + SourceIndex(5)
-2 >Emitted(68, 9) Source(4, 7) + SourceIndex(5)
-3 >Emitted(68, 14) Source(4, 24) + SourceIndex(5)
-4 >Emitted(68, 16) Source(4, 26) + SourceIndex(5)
-5 >Emitted(68, 17) Source(4, 27) + SourceIndex(5)
-6 >Emitted(68, 19) Source(4, 29) + SourceIndex(5)
-7 >Emitted(68, 21) Source(4, 31) + SourceIndex(5)
-8 >Emitted(68, 23) Source(4, 33) + SourceIndex(5)
-9 >Emitted(68, 24) Source(4, 34) + SourceIndex(5)
-10>Emitted(68, 26) Source(4, 36) + SourceIndex(5)
-11>Emitted(68, 28) Source(4, 38) + SourceIndex(5)
-12>Emitted(68, 30) Source(4, 40) + SourceIndex(5)
-13>Emitted(68, 32) Source(4, 42) + SourceIndex(5)
-14>Emitted(68, 34) Source(4, 44) + SourceIndex(5)
-15>Emitted(68, 36) Source(4, 46) + SourceIndex(5)
-16>Emitted(68, 38) Source(4, 48) + SourceIndex(5)
-17>Emitted(68, 40) Source(4, 9) + SourceIndex(5)
-18>Emitted(68, 41) Source(4, 10) + SourceIndex(5)
-19>Emitted(68, 48) Source(4, 10) + SourceIndex(5)
-20>Emitted(68, 50) Source(4, 15) + SourceIndex(5)
-21>Emitted(68, 54) Source(4, 19) + SourceIndex(5)
-22>Emitted(68, 68) Source(4, 7) + SourceIndex(5)
-23>Emitted(68, 73) Source(4, 21) + SourceIndex(5)
-24>Emitted(68, 74) Source(4, 48) + SourceIndex(5)
-25>Emitted(68, 75) Source(4, 49) + SourceIndex(5)
+1->Emitted(72, 5) Source(4, 1) + SourceIndex(5)
+2 >Emitted(72, 9) Source(4, 7) + SourceIndex(5)
+3 >Emitted(72, 14) Source(4, 24) + SourceIndex(5)
+4 >Emitted(72, 16) Source(4, 26) + SourceIndex(5)
+5 >Emitted(72, 17) Source(4, 27) + SourceIndex(5)
+6 >Emitted(72, 19) Source(4, 29) + SourceIndex(5)
+7 >Emitted(72, 21) Source(4, 31) + SourceIndex(5)
+8 >Emitted(72, 23) Source(4, 33) + SourceIndex(5)
+9 >Emitted(72, 24) Source(4, 34) + SourceIndex(5)
+10>Emitted(72, 26) Source(4, 36) + SourceIndex(5)
+11>Emitted(72, 28) Source(4, 38) + SourceIndex(5)
+12>Emitted(72, 30) Source(4, 40) + SourceIndex(5)
+13>Emitted(72, 32) Source(4, 42) + SourceIndex(5)
+14>Emitted(72, 34) Source(4, 44) + SourceIndex(5)
+15>Emitted(72, 36) Source(4, 46) + SourceIndex(5)
+16>Emitted(72, 38) Source(4, 48) + SourceIndex(5)
+17>Emitted(72, 40) Source(4, 9) + SourceIndex(5)
+18>Emitted(72, 41) Source(4, 10) + SourceIndex(5)
+19>Emitted(72, 48) Source(4, 10) + SourceIndex(5)
+20>Emitted(72, 50) Source(4, 15) + SourceIndex(5)
+21>Emitted(72, 54) Source(4, 19) + SourceIndex(5)
+22>Emitted(72, 68) Source(4, 7) + SourceIndex(5)
+23>Emitted(72, 73) Source(4, 21) + SourceIndex(5)
+24>Emitted(72, 74) Source(4, 48) + SourceIndex(5)
+25>Emitted(72, 75) Source(4, 49) + SourceIndex(5)
 ---
 >>>}
 1 >
@@ -2647,13 +2667,13 @@ sourceFile:../../third_part1.ts
 1 >
   >
 2 >}
-1 >Emitted(69, 1) Source(5, 1) + SourceIndex(5)
-2 >Emitted(69, 2) Source(5, 2) + SourceIndex(5)
+1 >Emitted(73, 1) Source(5, 1) + SourceIndex(5)
+2 >Emitted(73, 2) Source(5, 2) + SourceIndex(5)
 ---
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1199,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1201,"end":1428,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1201,"end":1428,"kind":"text"}]},{"pos":1428,"end":1996,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1428,"end":1996,"kind":"text"}]},{"pos":1996,"end":2149,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1342,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1344,"end":1571,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1344,"end":1571,"kind":"text"}]},{"pos":1571,"end":2139,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1571,"end":2139,"kind":"text"}]},{"pos":2139,"end":2292,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -2690,16 +2710,20 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1199):: typescript:spreadArray
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+emitHelpers: (1008-1342):: typescript:spreadArray
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 ----------------------------------------------------------------------
-prepend: (1201-1428):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1344-1571):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1201-1428)
+text: (1344-1571)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -2711,9 +2735,9 @@ function f() {
 }
 
 ----------------------------------------------------------------------
-prepend: (1428-1996):: ../../../2/second-output.js texts:: 1
+prepend: (1571-2139):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1428-1996)
+text: (1571-2139)
 var N;
 (function (N) {
     function f() {
@@ -2739,7 +2763,7 @@ var C = (function () {
 }());
 
 ----------------------------------------------------------------------
-text: (1996-2149)
+text: (2139-2292)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -2807,39 +2831,39 @@ declare function forthirdthird_part1Rest(): void;
         },
         {
           "pos": 1008,
-          "end": 1199,
+          "end": 1342,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1201,
-          "end": 1428,
+          "pos": 1344,
+          "end": 1571,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1201,
-              "end": 1428,
+              "pos": 1344,
+              "end": 1571,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1428,
-          "end": 1996,
+          "pos": 1571,
+          "end": 2139,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1428,
-              "end": 1996,
+              "pos": 1571,
+              "end": 2139,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1996,
-          "end": 2149,
+          "pos": 2139,
+          "end": 2292,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsxEmit1.js
+++ b/tests/baselines/reference/tsxEmit1.js
@@ -41,10 +41,14 @@ var whitespace3 = <div>
 
 
 //// [file.jsx]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var p;
 var selfClosed1 = <div />;
@@ -65,10 +69,10 @@ var SomeClass = /** @class */ (function () {
     SomeClass.prototype.f = function () {
         var _this = this;
         var rewrites1 = <div>{function () { return _this; }}</div>;
-        var rewrites2 = <div>{__spreadArray(__spreadArray([p], p), [p])}</div>;
+        var rewrites2 = <div>{__spreadArray(__spreadArray([p], p, true), [p])}</div>;
         var rewrites3 = <div>{{ p: p }}</div>;
         var rewrites4 = <div a={function () { return _this; }}></div>;
-        var rewrites5 = <div a={__spreadArray(__spreadArray([p], p), [p])}></div>;
+        var rewrites5 = <div a={__spreadArray(__spreadArray([p], p, true), [p])}></div>;
         var rewrites6 = <div a={{ p: p }}></div>;
     };
     return SomeClass;

--- a/tests/baselines/reference/tsxEmit1.js
+++ b/tests/baselines/reference/tsxEmit1.js
@@ -42,7 +42,7 @@ var whitespace3 = <div>
 
 //// [file.jsx]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -69,10 +69,10 @@ var SomeClass = /** @class */ (function () {
     SomeClass.prototype.f = function () {
         var _this = this;
         var rewrites1 = <div>{function () { return _this; }}</div>;
-        var rewrites2 = <div>{__spreadArray(__spreadArray([p], p, true), [p])}</div>;
+        var rewrites2 = <div>{__spreadArray(__spreadArray([p], p, true), [p], false)}</div>;
         var rewrites3 = <div>{{ p: p }}</div>;
         var rewrites4 = <div a={function () { return _this; }}></div>;
-        var rewrites5 = <div a={__spreadArray(__spreadArray([p], p, true), [p])}></div>;
+        var rewrites5 = <div a={__spreadArray(__spreadArray([p], p, true), [p], false)}></div>;
         var rewrites6 = <div a={{ p: p }}></div>;
     };
     return SomeClass;

--- a/tests/baselines/reference/tsxReactEmit1.js
+++ b/tests/baselines/reference/tsxReactEmit1.js
@@ -42,10 +42,14 @@ var whitespace3 = <div>
 
 
 //// [file.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var p;
 var selfClosed1 = React.createElement("div", null);
@@ -66,10 +70,10 @@ var SomeClass = /** @class */ (function () {
     SomeClass.prototype.f = function () {
         var _this = this;
         var rewrites1 = React.createElement("div", null, function () { return _this; });
-        var rewrites2 = React.createElement("div", null, __spreadArray(__spreadArray([p], p), [p]));
+        var rewrites2 = React.createElement("div", null, __spreadArray(__spreadArray([p], p, true), [p]));
         var rewrites3 = React.createElement("div", null, { p: p });
         var rewrites4 = React.createElement("div", { a: function () { return _this; } });
-        var rewrites5 = React.createElement("div", { a: __spreadArray(__spreadArray([p], p), [p]) });
+        var rewrites5 = React.createElement("div", { a: __spreadArray(__spreadArray([p], p, true), [p]) });
         var rewrites6 = React.createElement("div", { a: { p: p } });
     };
     return SomeClass;

--- a/tests/baselines/reference/tsxReactEmit1.js
+++ b/tests/baselines/reference/tsxReactEmit1.js
@@ -43,7 +43,7 @@ var whitespace3 = <div>
 
 //// [file.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -70,10 +70,10 @@ var SomeClass = /** @class */ (function () {
     SomeClass.prototype.f = function () {
         var _this = this;
         var rewrites1 = React.createElement("div", null, function () { return _this; });
-        var rewrites2 = React.createElement("div", null, __spreadArray(__spreadArray([p], p, true), [p]));
+        var rewrites2 = React.createElement("div", null, __spreadArray(__spreadArray([p], p, true), [p], false));
         var rewrites3 = React.createElement("div", null, { p: p });
         var rewrites4 = React.createElement("div", { a: function () { return _this; } });
-        var rewrites5 = React.createElement("div", { a: __spreadArray(__spreadArray([p], p, true), [p]) });
+        var rewrites5 = React.createElement("div", { a: __spreadArray(__spreadArray([p], p, true), [p], false) });
         var rewrites6 = React.createElement("div", { a: { p: p } });
     };
     return SomeClass;

--- a/tests/baselines/reference/typedArrays-es5.js
+++ b/tests/baselines/reference/typedArrays-es5.js
@@ -34,7 +34,7 @@ const uint8ClampedArray = new Uint8ClampedArray(1);
 
 //// [typedArrays-es5.js]
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];

--- a/tests/baselines/reference/typedArrays-es5.js
+++ b/tests/baselines/reference/typedArrays-es5.js
@@ -33,28 +33,32 @@ const uint8ClampedArray = new Uint8ClampedArray(1);
 
 
 //// [typedArrays-es5.js]
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 var float32Array = new Float32Array(1);
-__spreadArray([], float32Array);
+__spreadArray([], float32Array, true);
 var float64Array = new Float64Array(1);
-__spreadArray([], float64Array);
+__spreadArray([], float64Array, true);
 var int16Array = new Int16Array(1);
-__spreadArray([], int16Array);
+__spreadArray([], int16Array, true);
 var int32Array = new Int32Array(1);
-__spreadArray([], int32Array);
+__spreadArray([], int32Array, true);
 var int8Array = new Int8Array(1);
-__spreadArray([], int8Array);
+__spreadArray([], int8Array, true);
 var nodeList = new NodeList();
-__spreadArray([], nodeList);
+__spreadArray([], nodeList, true);
 var uint16Array = new Uint16Array(1);
-__spreadArray([], uint16Array);
+__spreadArray([], uint16Array, true);
 var uint32Array = new Uint32Array(1);
-__spreadArray([], uint32Array);
+__spreadArray([], uint32Array, true);
 var uint8Array = new Uint8Array(1);
-__spreadArray([], uint8Array);
+__spreadArray([], uint8Array, true);
 var uint8ClampedArray = new Uint8ClampedArray(1);
-__spreadArray([], uint8ClampedArray);
+__spreadArray([], uint8ClampedArray, true);

--- a/tests/baselines/reference/variadicTuples1.js
+++ b/tests/baselines/reference/variadicTuples1.js
@@ -405,25 +405,29 @@ type U3 = [...[string, number], boolean];
 //// [variadicTuples1.js]
 "use strict";
 // Variadics in tuple types
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 // Variadics in array literals
 function tup2(t, u) {
-    return __spreadArray(__spreadArray(__spreadArray(__spreadArray([1], t), [2]), u), [3]);
+    return __spreadArray(__spreadArray(__spreadArray(__spreadArray([1], t, true), [2]), u, true), [3]);
 }
 var t2 = tup2(['hello'], [10, true]);
 function concat(t, u) {
-    return __spreadArray(__spreadArray([], t), u);
+    return __spreadArray(__spreadArray([], t, true), u, true);
 }
 var tc1 = concat([], []);
 var tc2 = concat(['hello'], [42]);
 var tc3 = concat([1, 2, 3], sa);
 var tc4 = concat(sa, [1, 2, 3]); // Ideally would be [...string[], number, number, number]
 function concat2(t, u) {
-    return __spreadArray(__spreadArray([], t), u); // (T[number] | U[number])[]
+    return __spreadArray(__spreadArray([], t, true), u, true); // (T[number] | U[number])[]
 }
 var tc5 = concat2([1, 2, 3], [4, 5, 6]); // (1 | 2 | 3 | 4 | 5 | 6)[]
 function foo2(t1, t2, a1) {

--- a/tests/baselines/reference/variadicTuples1.js
+++ b/tests/baselines/reference/variadicTuples1.js
@@ -406,7 +406,7 @@ type U3 = [...[string, number], boolean];
 "use strict";
 // Variadics in tuple types
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -416,7 +416,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
 };
 // Variadics in array literals
 function tup2(t, u) {
-    return __spreadArray(__spreadArray(__spreadArray(__spreadArray([1], t, true), [2]), u, true), [3]);
+    return __spreadArray(__spreadArray(__spreadArray(__spreadArray([1], t, true), [2], false), u, true), [3], false);
 }
 var t2 = tup2(['hello'], [10, true]);
 function concat(t, u) {
@@ -432,16 +432,16 @@ function concat2(t, u) {
 var tc5 = concat2([1, 2, 3], [4, 5, 6]); // (1 | 2 | 3 | 4 | 5 | 6)[]
 function foo2(t1, t2, a1) {
     foo1(1, 'abc', true, 42, 43, 44);
-    foo1.apply(void 0, __spreadArray(__spreadArray([], t1), [true, 42, 43, 44]));
-    foo1.apply(void 0, __spreadArray(__spreadArray(__spreadArray([], t1), t2), [42, 43, 44]));
-    foo1.apply(void 0, __spreadArray(__spreadArray(__spreadArray([], t1), t2), a1));
+    foo1.apply(void 0, __spreadArray(__spreadArray([], t1, false), [true, 42, 43, 44], false));
+    foo1.apply(void 0, __spreadArray(__spreadArray(__spreadArray([], t1, false), t2, false), [42, 43, 44], false));
+    foo1.apply(void 0, __spreadArray(__spreadArray(__spreadArray([], t1, false), t2, false), a1, false));
     foo1.apply(void 0, t1); // Error
-    foo1.apply(void 0, __spreadArray(__spreadArray([], t1), [45])); // Error
+    foo1.apply(void 0, __spreadArray(__spreadArray([], t1, false), [45], false)); // Error
 }
 function foo4(u) {
     foo3(1, 2);
     foo3(1, 'hello', true, 2);
-    foo3.apply(void 0, __spreadArray(__spreadArray([1], u), ['hi', 2]));
+    foo3.apply(void 0, __spreadArray(__spreadArray([1], u, false), ['hi', 2], false));
     foo3(1);
 }
 ft1(['hello', 42]); // (string | number)[]
@@ -475,17 +475,17 @@ function f3(t) {
 var tm1 = fm1([['abc'], [42], [true], ['def']]); // [boolean, string]
 function gx1(u, v) {
     fx1('abc'); // []
-    fx1.apply(void 0, __spreadArray(['abc'], u)); // U
-    fx1.apply(void 0, __spreadArray(['abc'], v)); // [...V]
-    fx1.apply(void 0, __spreadArray(['abc'], u)); // U
-    fx1.apply(void 0, __spreadArray(['abc'], v)); // Error
+    fx1.apply(void 0, __spreadArray(['abc'], u, false)); // U
+    fx1.apply(void 0, __spreadArray(['abc'], v, false)); // [...V]
+    fx1.apply(void 0, __spreadArray(['abc'], u, false)); // U
+    fx1.apply(void 0, __spreadArray(['abc'], v, false)); // Error
 }
 function gx2(u, v) {
     fx2('abc'); // []
-    fx2.apply(void 0, __spreadArray(['abc'], u)); // U
-    fx2.apply(void 0, __spreadArray(['abc'], v)); // [...V]
-    fx2.apply(void 0, __spreadArray(['abc'], u)); // U
-    fx2.apply(void 0, __spreadArray(['abc'], v)); // V
+    fx2.apply(void 0, __spreadArray(['abc'], u, false)); // U
+    fx2.apply(void 0, __spreadArray(['abc'], v, false)); // [...V]
+    fx2.apply(void 0, __spreadArray(['abc'], u, false)); // U
+    fx2.apply(void 0, __spreadArray(['abc'], v, false)); // V
 }
 // Relations involving variadic tuple types
 function f10(x, y, z) {
@@ -552,7 +552,7 @@ function curry(f) {
         for (var _i = 0; _i < arguments.length; _i++) {
             b[_i] = arguments[_i];
         }
-        return f.apply(void 0, __spreadArray(__spreadArray([], a), b));
+        return f.apply(void 0, __spreadArray(__spreadArray([], a, false), b, false));
     };
 }
 var fn1 = function (a, b, c, d) { return 0; };
@@ -581,10 +581,10 @@ var fn3 = function () {
 };
 var c20 = curry(fn3); // (...args: string[]) => number
 var c21 = curry(fn3, 'abc', 'def'); // (...args: string[]) => number
-var c22 = curry.apply(void 0, __spreadArray([fn3], sa)); // (...args: string[]) => number
+var c22 = curry.apply(void 0, __spreadArray([fn3], sa, false)); // (...args: string[]) => number
 // No inference to [...T, ...U] when there is no implied arity
 function curry2(f, t, u) {
-    return f.apply(void 0, __spreadArray(__spreadArray([], t), u));
+    return f.apply(void 0, __spreadArray(__spreadArray([], t, false), u, false));
 }
 curry2(fn10, ['hello', 42], [true]);
 curry2(fn10, ['hello'], [42, true]);
@@ -593,13 +593,13 @@ ft([1, 2], [1, 2, 3]);
 ft(['a', 'b'], ['c', 'd']);
 ft(['a', 'b'], ['c', 'd', 42]);
 call('hello', 32, function (a, b) { return 42; });
-call.apply(void 0, __spreadArray(__spreadArray([], sa), [function () {
+call.apply(void 0, __spreadArray(__spreadArray([], sa, false), [function () {
         var x = [];
         for (var _i = 0; _i < arguments.length; _i++) {
             x[_i] = arguments[_i];
         }
         return 42;
-    }]));
+    }], false));
 function f21(args) {
     var v1 = f20(args); // U
     var v2 = f20(["foo", "bar"]); // [string]
@@ -617,7 +617,7 @@ function callApi(method) {
         for (var _i = 0; _i < arguments.length; _i++) {
             args[_i] = arguments[_i];
         }
-        return method.apply(void 0, __spreadArray(__spreadArray([], args), [{}]));
+        return method.apply(void 0, __spreadArray(__spreadArray([], args, false), [{}], false));
     };
 }
 callApi(getUser);

--- a/tests/baselines/reference/variadicTuples2.js
+++ b/tests/baselines/reference/variadicTuples2.js
@@ -135,7 +135,7 @@ const e1 = foo('blah1', 'blah2', 1, 2, 3);  // Error
 "use strict";
 // Declarations
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
             if (!ar) ar = Array.prototype.slice.call(from, 0, i);
             ar[i] = from[i];
@@ -195,14 +195,14 @@ pipe("foo", 123, true, function () {
     }
     x; // [string, number, boolean]
 });
-pipe.apply(void 0, __spreadArray(__spreadArray([], sa), [function () {
+pipe.apply(void 0, __spreadArray(__spreadArray([], sa, false), [function () {
         var x = [];
         for (var _i = 0; _i < arguments.length; _i++) {
             x[_i] = arguments[_i];
         }
         x; // string[]
-    }]));
-pipe.apply(void 0, __spreadArray(__spreadArray([1], sa), [2, function () {
+    }], false));
+pipe.apply(void 0, __spreadArray(__spreadArray([1], sa, false), [2, function () {
         var x = [];
         for (var _i = 0; _i < arguments.length; _i++) {
             x[_i] = arguments[_i];
@@ -210,7 +210,7 @@ pipe.apply(void 0, __spreadArray(__spreadArray([1], sa), [2, function () {
         x; // [number, ...string[], number]
         var qq = x[x.length - 1];
         var ww = x[0];
-    }]));
+    }], false));
 pipe(1, 2, 3, 4); // Error
 pipe.apply(void 0, sa); // Error
 fn1([]); // Error

--- a/tests/baselines/reference/variadicTuples2.js
+++ b/tests/baselines/reference/variadicTuples2.js
@@ -134,10 +134,14 @@ const e1 = foo('blah1', 'blah2', 1, 2, 3);  // Error
 //// [variadicTuples2.js]
 "use strict";
 // Declarations
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || from);
 };
 tt1 = [5];
 tt1 = ['abc', 5];

--- a/tests/cases/conformance/es6/spread/arraySpreadImportHelpers.ts
+++ b/tests/cases/conformance/es6/spread/arraySpreadImportHelpers.ts
@@ -1,0 +1,16 @@
+// @target: es5
+// @importHelpers: true
+// @isolatedModules: true
+// @noTypesAndSymbols: true
+// @noEmit: true
+// @filename: main.ts
+
+export {};
+const k = [1, , 2];
+const o = [3, ...k, 4];
+
+// @filename: tslib.d.ts
+// this is a pre-TS4.4 versions of emit helper, which always forced array packing
+declare module "tslib" {
+    function __spreadArray(to: any[], from: any[]): any[];
+}


### PR DESCRIPTION
This changes `__spreadArray` to use `Array.prototype.concat` and avoids explicitly converting a sparse array to a packed array when such a conversion is unnecessary or unexpected. This also fixes an issue where `[1, , ...a]` would drop the missing element at index 1.

Before this can be merged I need to verify backwards compatibility with `__spreadArray` for older versions of TS. I suspect I may need to change the `if` condition to be backwards compatible (where we always packed the result).

Fixes #44287
