### PR TITLE
Give the JSDocTagInfo type a consistent `text` type

### DIFF
--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1054,7 +1054,7 @@ namespace ts {
 
     export interface JSDocTagInfo {
         name: string;
-        text?: SymbolDisplayPart[];
+        text?: string | SymbolDisplayPart[];
     }
 
     export interface QuickInfo {


### PR DESCRIPTION
I think the reason why we ended up with `[object object]` in the Playground for JSDoc results occasionally is due to me first spotting `JSDocTagInfo` with `text?: string` and ignoring the later version of `text?: string | SymbolDisplayPart` ( see https://github.com/microsoft/monaco-typescript/pull/81 )

This should make them consistent, if that makes sense I'll get this PR green 👍🏻 