### PR TITLE
Dev: Have a clickable link for a new baseline created

### DIFF
--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -25,6 +25,7 @@ namespace Harness {
         tryEnableSourceMapsForHost?(): void;
         getEnvironmentVariable?(name: string): string;
         getMemoryUsage?(): number | undefined;
+        join(...components: string[]): string
     }
 
     export let IO: IO;
@@ -60,6 +61,10 @@ namespace Harness {
             const dirPath = pathModule.dirname(path);
             // Node will just continue to repeat the root path, rather than return null
             return dirPath === path ? undefined : dirPath;
+        }
+
+        function join(...components: string[]) {
+            return pathModule.join(...components);
         }
 
         function enumerateTestFiles(runner: RunnerBase) {
@@ -156,6 +161,7 @@ namespace Harness {
             tryEnableSourceMapsForHost: () => ts.sys.tryEnableSourceMapsForHost && ts.sys.tryEnableSourceMapsForHost(),
             getMemoryUsage: () => ts.sys.getMemoryUsage && ts.sys.getMemoryUsage(),
             getEnvironmentVariable: name => ts.sys.getEnvironmentVariable(name),
+            join
         };
     }
 
@@ -1388,7 +1394,12 @@ namespace Harness {
                     throw new Error(`The baseline file ${relativeFileName} has changed.${ts.ForegroundColorEscapeSequences.Grey}\n\n${patch}`);
                 }
                 else {
-                    throw new Error(`The baseline file ${relativeFileName} has changed.`);
+                    if (!IO.fileExists(expected)) {
+                        throw new Error(`New baseline created at ${IO.join("tests", "baselines","local", relativeFileName)}`);
+                    }
+                    else {
+                        throw new Error(`The baseline file ${relativeFileName} has changed.`);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Improves the test logging for when you make a new baseline giving a clickable link in terminals

![Screen Shot 2021-06-11 at 4 17 39 PM](https://user-images.githubusercontent.com/49038/121710048-1426e100-cad1-11eb-824d-ff35c5f771e7.png)

