### PR TITLE
fix: clone redirected `SourceFile`'s prototype

### DIFF
--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -5040,10 +5040,17 @@ namespace ts {
             libReferences: readonly FileReference[]
         ) {
             const node = baseFactory.createBaseSourceFileNode(SyntaxKind.SourceFile) as Mutable<SourceFile>;
-            for (const p in source) {
-                if (p === "emitNode" || hasProperty(node, p) || !hasProperty(source, p)) continue;
-                (node as any)[p] = (source as any)[p];
+
+            // Climb the prototype chain to clone `SourceFile`s created by createRedirectSourceFile
+            let sourceNode = source;
+            while (isSourceFile(sourceNode)) {
+                for (const p in sourceNode) {
+                    if (p === "emitNode" || hasProperty(node, p) || !hasProperty(sourceNode, p)) continue;
+                    (node as any)[p] = (sourceNode as any)[p];
+                }
+                sourceNode = Object.getPrototypeOf(sourceNode);
             }
+
             node.flags |= source.flags;
             node.statements = createNodeArray(statements);
             node.endOfFileToken = source.endOfFileToken;


### PR DESCRIPTION
When `cloneSourceFileWithChanges` clones a `SourceFile` it doesn't climb the prototype chain causing it to clone `SourceFile`s created by `createRedirectSourceFile` incorrectly.

I tried to write a test but was unable to figure it out so going to need some assistance on that, tested on the commit before https://github.com/tophat/monodeploy/commit/b2d532d6f3b1e0686d2857d1195409149591b4eb to confirm that it works

cc @armanio123 - the assignee on #41717  

Fixes #41717

