### PR TITLE
[release-3.9] Pass throwIfNoEntry to fs.statSync

### DIFF
--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -679,6 +679,7 @@ namespace ts.server {
         return { getModifiedTime, poll, startWatchTimer, addFile, removeFile };
 
         function getModifiedTime(fileName: string): Date {
+            // Caller guarantees that `fileName` exists, so there'd be no benefit from throwIfNoEntry
             return fs.statSync(fileName).mtime;
         }
 


### PR DESCRIPTION
Ports #41604 to TypeScript 3.9

See https://github.com/nodejs/node/pull/35644 for why we have to do this to avoid potential regressions when users upgrade to Node 16.