### PR TITLE
[release-4.0] Pass throwIfNoEntry to fs.statSync

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1235,8 +1235,8 @@ namespace ts {
                 },
                 getFileSize(path) {
                     try {
-                        const stat = _fs.statSync(path);
-                        if (stat.isFile()) {
+                        const stat = statSync(path);
+                        if (stat?.isFile()) {
                             return stat.size;
                         }
                     }
@@ -1282,6 +1282,16 @@ namespace ts {
                 }
             };
             return nodeSystem;
+
+            /**
+             * `throwIfNoEntry` was added so recently that it's not in the node types.
+             * This helper encapsulates the mitigating usage of `any`.
+             * See https://github.com/nodejs/node/pull/33716
+             */
+            function statSync(path: string): import("fs").Stats | undefined {
+                // throwIfNoEntry will be ignored by older versions of node
+                return (_fs as any).statSync(path, { throwIfNoEntry: false });
+            }
 
             /**
              * Uses the builtin inspector APIs to capture a CPU profile
@@ -1341,7 +1351,7 @@ namespace ts {
                     activeSession.post("Profiler.stop", (err, { profile }) => {
                         if (!err) {
                             try {
-                                if (_fs.statSync(profilePath).isDirectory()) {
+                                if (statSync(profilePath)?.isDirectory()) {
                                     profilePath = _path.join(profilePath, `${(new Date()).toISOString().replace(/:/g, "-")}+P${process.pid}.cpuprofile`);
                                 }
                             }
@@ -1631,7 +1641,10 @@ namespace ts {
                             const name = combinePaths(path, entry);
 
                             try {
-                                stat = _fs.statSync(name);
+                                stat = statSync(name);
+                                if (!stat) {
+                                    continue;
+                                }
                             }
                             catch (e) {
                                 continue;
@@ -1668,7 +1681,10 @@ namespace ts {
                 Error.stackTraceLimit = 0;
 
                 try {
-                    const stat = _fs.statSync(path);
+                    const stat = statSync(path);
+                    if (!stat) {
+                        return false;
+                    }
                     switch (entryKind) {
                         case FileSystemEntryKind.File: return stat.isFile();
                         case FileSystemEntryKind.Directory: return stat.isDirectory();
@@ -1706,7 +1722,7 @@ namespace ts {
 
             function getModifiedTime(path: string) {
                 try {
-                    return _fs.statSync(path).mtime;
+                    return statSync(path)?.mtime;
                 }
                 catch (e) {
                     return undefined;

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -680,6 +680,7 @@ namespace ts.server {
         return { getModifiedTime, poll, startWatchTimer, addFile, removeFile };
 
         function getModifiedTime(fileName: string): Date {
+            // Caller guarantees that `fileName` exists, so there'd be no benefit from throwIfNoEntry
             return fs.statSync(fileName).mtime;
         }
 


### PR DESCRIPTION
Ports #41604 to TypeScript 4.0

See https://github.com/nodejs/node/pull/35644 for why we have to do this to avoid potential regressions when users upgrade to Node 16.