### PR TITLE
Expose text property of SourceFileLike for some Public APIs

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3460,12 +3460,12 @@ namespace ts {
         name?: string;
     }
 
-    /* @internal */
     /**
      * Subset of properties from SourceFile that are used in multiple utility functions
      */
     export interface SourceFileLike {
         readonly text: string;
+        /* @internal */
         lineMap?: readonly number[];
         /* @internal */
         getPositionOfLineAndCharacter?(line: number, character: number, allowEdits?: true): number;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1960,6 +1960,12 @@ declare namespace ts {
         path: string;
         name?: string;
     }
+    /**
+     * Subset of properties from SourceFile that are used in multiple utility functions
+     */
+    export interface SourceFileLike {
+        readonly text: string;
+    }
     export interface SourceFile extends Declaration {
         readonly kind: SyntaxKind.SourceFile;
         readonly statements: NodeArray<Statement>;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1960,6 +1960,12 @@ declare namespace ts {
         path: string;
         name?: string;
     }
+    /**
+     * Subset of properties from SourceFile that are used in multiple utility functions
+     */
+    export interface SourceFileLike {
+        readonly text: string;
+    }
     export interface SourceFile extends Declaration {
         readonly kind: SyntaxKind.SourceFile;
         readonly statements: NodeArray<Statement>;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #44250

This change makes two APIs available like this: [Playground](https://www.typescriptlang.org/play?ts=4.3.2#code/JYWwDg9gTgLgBDAznAZlCI4HIYE8wCmiAxlMGDFgNwCwAUPcRAHaLxMAmBcAvHAAb04cJqwgAbAgDpxEAOYAKLABUAFsGQa4AQwRFKASlp1+x+gHpzcNVpQBXZsRjAWcLXcQF741NDiIMbhgCAA94FGBJZG1mDn8IOFcFACM7eGB0xGYcHQA3bUjtZMk4B2cfCJCCOJhVbg1EOwIDRhY2OABvOHFgZgIAGhFVbShtJwIoOABfXgREKTkCGAAZXoIAQViAYWHR8agAeRQABQhEDJdmBS6hPTCALhEILkHLa3VkRFUIO3E45O4Y2IBAo1XoU0GAEYAAxGegWKw2ZD2RzOVxabTiAKlTzeOCtVjwSDIPhIBZLU7nNHMI6rPqbDg7EZjYJQa63YIPJ4vOBvJH+b6-f6A4jA0EccGDHp9QbEXYsiZwuhAA)
