### PR TITLE
Don't attach declarations to symbols in mapped types with 'as XXX' clauses

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11148,7 +11148,9 @@ namespace ts {
                         prop.keyType = keyType;
                         if (modifiersProp) {
                             prop.syntheticOrigin = modifiersProp;
-                            prop.declarations = modifiersProp.declarations;
+                            // If the mapped type as an 'as XXX' clause, the property name likely won't match the declaration name and
+                            // multiple properties may map to the same name. Thus, we attach no declarations to the symbol.
+                            prop.declarations = nameType ? undefined : modifiersProp.declarations;
                         }
                         members.set(propName, prop);
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11148,7 +11148,7 @@ namespace ts {
                         prop.keyType = keyType;
                         if (modifiersProp) {
                             prop.syntheticOrigin = modifiersProp;
-                            // If the mapped type as an 'as XXX' clause, the property name likely won't match the declaration name and
+                            // If the mapped type has an `as XXX` clause, the property name likely won't match the declaration name and
                             // multiple properties may map to the same name. Thus, we attach no declarations to the symbol.
                             prop.declarations = nameType ? undefined : modifiersProp.declarations;
                         }

--- a/tests/baselines/reference/mappedTypeAsStringTemplate.errors.txt
+++ b/tests/baselines/reference/mappedTypeAsStringTemplate.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/compiler/mappedTypeAsStringTemplate.ts(7,5): error TS2345: Argument of type '{ x: number; }' is not assignable to parameter of type '{ xy: number; }'.
+  Property 'xy' is missing in type '{ x: number; }' but required in type '{ xy: number; }'.
+
+
+==== tests/cases/compiler/mappedTypeAsStringTemplate.ts (1 errors) ====
+    // Repro from #44220
+    
+    function foo<T extends { [K in keyof T as `${Extract<K, string>}y`]: number }>(foox: T) { }
+    
+    const c = { x: 1 };
+    
+    foo(c);
+        ~
+!!! error TS2345: Argument of type '{ x: number; }' is not assignable to parameter of type '{ xy: number; }'.
+!!! error TS2345:   Property 'xy' is missing in type '{ x: number; }' but required in type '{ xy: number; }'.
+    

--- a/tests/baselines/reference/mappedTypeAsStringTemplate.js
+++ b/tests/baselines/reference/mappedTypeAsStringTemplate.js
@@ -1,0 +1,15 @@
+//// [mappedTypeAsStringTemplate.ts]
+// Repro from #44220
+
+function foo<T extends { [K in keyof T as `${Extract<K, string>}y`]: number }>(foox: T) { }
+
+const c = { x: 1 };
+
+foo(c);
+
+
+//// [mappedTypeAsStringTemplate.js]
+// Repro from #44220
+function foo(foox) { }
+var c = { x: 1 };
+foo(c);

--- a/tests/baselines/reference/mappedTypeAsStringTemplate.symbols
+++ b/tests/baselines/reference/mappedTypeAsStringTemplate.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/mappedTypeAsStringTemplate.ts ===
+// Repro from #44220
+
+function foo<T extends { [K in keyof T as `${Extract<K, string>}y`]: number }>(foox: T) { }
+>foo : Symbol(foo, Decl(mappedTypeAsStringTemplate.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeAsStringTemplate.ts, 2, 13))
+>K : Symbol(K, Decl(mappedTypeAsStringTemplate.ts, 2, 26))
+>T : Symbol(T, Decl(mappedTypeAsStringTemplate.ts, 2, 13))
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>K : Symbol(K, Decl(mappedTypeAsStringTemplate.ts, 2, 26))
+>foox : Symbol(foox, Decl(mappedTypeAsStringTemplate.ts, 2, 79))
+>T : Symbol(T, Decl(mappedTypeAsStringTemplate.ts, 2, 13))
+
+const c = { x: 1 };
+>c : Symbol(c, Decl(mappedTypeAsStringTemplate.ts, 4, 5))
+>x : Symbol(x, Decl(mappedTypeAsStringTemplate.ts, 4, 11))
+
+foo(c);
+>foo : Symbol(foo, Decl(mappedTypeAsStringTemplate.ts, 0, 0))
+>c : Symbol(c, Decl(mappedTypeAsStringTemplate.ts, 4, 5))
+

--- a/tests/baselines/reference/mappedTypeAsStringTemplate.types
+++ b/tests/baselines/reference/mappedTypeAsStringTemplate.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/mappedTypeAsStringTemplate.ts ===
+// Repro from #44220
+
+function foo<T extends { [K in keyof T as `${Extract<K, string>}y`]: number }>(foox: T) { }
+>foo : <T extends { [K in keyof T as `${Extract<K, string>}y`]: number; }>(foox: T) => void
+>foox : T
+
+const c = { x: 1 };
+>c : { x: number; }
+>{ x: 1 } : { x: number; }
+>x : number
+>1 : 1
+
+foo(c);
+>foo(c) : void
+>foo : <T extends { [K in keyof T as `${Extract<K, string>}y`]: number; }>(foox: T) => void
+>c : { x: number; }
+

--- a/tests/cases/compiler/mappedTypeAsStringTemplate.ts
+++ b/tests/cases/compiler/mappedTypeAsStringTemplate.ts
@@ -1,0 +1,7 @@
+// Repro from #44220
+
+function foo<T extends { [K in keyof T as `${Extract<K, string>}y`]: number }>(foox: T) { }
+
+const c = { x: 1 };
+
+foo(c);


### PR DESCRIPTION
Fixes #44220.