### PR TITLE
`services/utilities/getMeaningFromLocation()`: fix w/ export specifiers

### DIFF
--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -23,6 +23,10 @@ namespace FourSlashInterface {
             return this.state.getRanges();
         }
 
+        public rangesInFile(fileName?: string): FourSlash.Range[] {
+            return this.state.getRangesInFile(fileName);
+        }
+
         public spans(): ts.TextSpan[] {
             return this.ranges().map(r => ts.createTextSpan(r.pos, r.end - r.pos));
         }

--- a/tests/cases/fourslash/documentHighlightInTypeExport.ts
+++ b/tests/cases/fourslash/documentHighlightInTypeExport.ts
@@ -1,0 +1,55 @@
+﻿/// <reference path='fourslash.ts'/>
+
+// @Filename: /1.ts
+//// type [|A|] = 1;
+//// export { [|A|] as [|B|] };
+
+{
+    const [AType, AExport, asB] = test.rangesInFile("/1.ts");
+    verify.documentHighlightsOf(AType, [AType, AExport, asB]);
+    verify.documentHighlightsOf(AExport, [AType, AExport, asB]);
+    verify.documentHighlightsOf(asB, [asB]);
+}
+
+// @Filename: /2.ts
+//// type [|A|] = 1;
+//// let [|A|]: [|A|] = 1;
+//// export { [|A|] as [|B|] };
+
+{ // a little strange, but the the type/value namespaces work too
+    const [AType, ALet, ADecl, AExport, asB] = test.rangesInFile("/2.ts");
+    verify.documentHighlightsOf(AType, [AType, ADecl, AExport, asB]);
+    verify.documentHighlightsOf(ADecl, [AType, ADecl, AExport, asB]);
+    verify.documentHighlightsOf(ALet, [ALet, AExport, asB]);
+    verify.documentHighlightsOf(AExport, [AType, ALet, ADecl, AExport, asB]);
+    verify.documentHighlightsOf(asB, [asB]);
+}
+
+// @Filename: /3.ts
+//// type [|A|] = 1;
+//// let [|A|]: [|A|] = 1;
+//// export type { [|A|] as [|B|] };
+
+{ // properly handle type only
+    const [AType, ALet, ADecl, AExport, asB] = test.rangesInFile("/3.ts");
+    verify.documentHighlightsOf(AType, [AType, ADecl, AExport, asB]);
+    verify.documentHighlightsOf(ADecl, [AType, ADecl, AExport, asB]);
+    verify.documentHighlightsOf(AExport, [AType, ADecl, AExport, asB]);
+    verify.documentHighlightsOf(ALet, [ALet]);
+    verify.documentHighlightsOf(asB, [asB]);
+}
+
+// would be nice if this could work the same for imports too, but getSymbolAtLocation()
+// of the imported symbol (when aliased) returns undefined
+
+// // @Filename: /4.ts
+// //// import type { [|Tee|] as [|T|] } from "whatEveh";
+// //// let [|T|]: [|T|];
+//
+// {
+//     const [TeeImport, asT, TLet, TDecl] = test.rangesInFile("/4.ts");
+//     verify.documentHighlightsOf(TeeImport, [TeeImport, asT, TDecl]);
+//     // verify.documentHighlightsOf(asT, [TeeImport, asT, TDecl]);
+//     // verify.documentHighlightsOf(TDecl, [TeeImport, asT, TDecl]);
+//     // verify.documentHighlightsOf(TLet, [TLet]);
+// }

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -187,6 +187,7 @@ declare namespace FourSlashInterface {
         markerName(m: Marker): string;
         marker(name?: string): Marker;
         ranges(): Range[];
+        rangesInFile(fileName?: string): Range[];
         spans(): Array<{ start: number, length: number }>;
         rangesByText(): ts.Map<Range[]>;
         markerByName(s: string): Marker;


### PR DESCRIPTION
Fixes #44167, but also two other things:

* On an import/export, climb upto the declaration, and use
  `SemanticMeaning.Type` if it's a `type` only import/export.

* Add a `test.rangesInFile()` to fourslash, so it is easy to do multiple
  files in one test without an awkward filter (which was done in one
  more test).
