### PR TITLE
fix(44637): TypeScript formatter doesn't format export= properly

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -459,6 +459,9 @@ namespace ts.formatting {
             // equal in import a = module('a');
             // falls through
             case SyntaxKind.ImportEqualsDeclaration:
+            // equal in export = 1
+            // falls through
+            case SyntaxKind.ExportAssignment:
             // equal in let a = 0
             // falls through
             case SyntaxKind.VariableDeclaration:

--- a/tests/cases/fourslash/formatExportAssignment.ts
+++ b/tests/cases/fourslash/formatExportAssignment.ts
@@ -1,0 +1,6 @@
+/// <reference path="fourslash.ts"/>
+
+////export='foo';
+
+format.document();
+verify.currentFileContentIs(`export = 'foo';`);


### PR DESCRIPTION
Fixes #44637