### PR TITLE
Infer parameter as number when using Number.is*

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -204,13 +204,13 @@ interface NumberConstructor {
      * number. Only finite values of the type number, result in true.
      * @param number A numeric value.
      */
-    isFinite(number: unknown): boolean;
+    isFinite(number: unknown): number is number;
 
     /**
      * Returns true if the value passed is an integer, false otherwise.
      * @param number A numeric value.
      */
-    isInteger(number: unknown): boolean;
+    isInteger(number: unknown): number is number;
 
     /**
      * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a
@@ -218,13 +218,13 @@ interface NumberConstructor {
      * to a number. Only values of the type number, that are also NaN, result in true.
      * @param number A numeric value.
      */
-    isNaN(number: unknown): boolean;
+    isNaN(number: unknown): number is number;
 
     /**
      * Returns true if the value passed is a safe integer.
      * @param number A numeric value.
      */
-    isSafeInteger(number: unknown): boolean;
+    isSafeInteger(number: unknown): number is number;
 
     /**
      * The value of the largest integer n such that n and n + 1 are both exactly representable as


### PR DESCRIPTION
When using the `Number.is*` (`Number.isFinite`, `Number.isInteger`, `Number.isNaN` and `Number.isSafeInteger`), the parameter's type should be inferred as `number`.

Example:
```typescript
function foo(value: number | null | undefined) {
    if (Number.isFinite(value)) {
        bar(value)
    }
}

function bar (value: number) {
    ...
}
```