### PR TITLE
fix(44639): Transpilation of optional chaining combined with type casting results in function call losing its context

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3964,7 +3964,14 @@ namespace ts {
         // Transformation nodes
 
         function emitPartiallyEmittedExpression(node: PartiallyEmittedExpression) {
+            const emitFlags = getEmitFlags(node);
+            if (!(emitFlags & EmitFlags.NoLeadingComments) && node.pos !== node.expression.pos) {
+                emitTrailingCommentsOfPosition(node.expression.pos);
+            }
             emitExpression(node.expression);
+            if (!(emitFlags & EmitFlags.NoTrailingComments) && node.end !== node.expression.end) {
+                emitLeadingCommentsOfPosition(node.expression.end);
+            }
         }
 
         function emitCommaList(node: CommaListExpression) {
@@ -4352,10 +4359,8 @@ namespace ts {
                     // Emit this child.
                     previousSourceFileTextKind = recordBundleFileInternalSectionStart(child);
                     if (shouldEmitInterveningComments) {
-                        if (emitTrailingCommentsOfPosition) {
-                            const commentRange = getCommentRange(child);
-                            emitTrailingCommentsOfPosition(commentRange.pos);
-                        }
+                        const commentRange = getCommentRange(child);
+                        emitTrailingCommentsOfPosition(commentRange.pos);
                     }
                     else {
                         shouldEmitInterveningComments = mayEmitInterveningComments;
@@ -4723,7 +4728,7 @@ namespace ts {
         function writeLineSeparatorsAndIndentBefore(node: Node, parent: Node): boolean {
             const leadingNewlines = preserveSourceNewlines && getLeadingLineTerminatorCount(parent, [node], ListFormat.None);
             if (leadingNewlines) {
-                writeLinesAndIndent(leadingNewlines, /*writeLinesIfNotIndenting*/ false);
+                writeLinesAndIndent(leadingNewlines, /*writeSpaceIfNotIndenting*/ false);
             }
             return !!leadingNewlines;
         }

--- a/src/compiler/transformers/es2020.ts
+++ b/src/compiler/transformers/es2020.ts
@@ -122,11 +122,11 @@ namespace ts {
 
         function visitOptionalExpression(node: OptionalChain, captureThisArg: boolean, isDelete: boolean): Expression {
             const { expression, chain } = flattenChain(node);
-            const left = visitNonOptionalExpression(expression, isCallChain(chain[0]), /*isDelete*/ false);
+            const left = visitNonOptionalExpression(skipPartiallyEmittedExpressions(expression), isCallChain(chain[0]), /*isDelete*/ false);
             const leftThisArg = isSyntheticReference(left) ? left.thisArg : undefined;
-            let leftExpression = isSyntheticReference(left) ? left.expression : left;
-            let capturedLeft: Expression = leftExpression;
-            if (!isSimpleCopiableExpression(leftExpression)) {
+            let capturedLeft = isSyntheticReference(left) ? left.expression : left;
+            let leftExpression = factory.restoreOuterExpressions(expression, capturedLeft, OuterExpressionKinds.PartiallyEmittedExpressions);
+            if (!isSimpleCopiableExpression(capturedLeft)) {
                 capturedLeft = factory.createTempVariable(hoistVariableDeclaration);
                 leftExpression = factory.createAssignment(capturedLeft, leftExpression);
             }

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -2237,11 +2237,10 @@ namespace ts {
                 // we can safely elide the parentheses here, as a new synthetic
                 // ParenthesizedExpression will be inserted if we remove parentheses too
                 // aggressively.
-                // HOWEVER - if there are leading comments on the expression itself, to handle ASI
-                // correctly for return and throw, we must keep the parenthesis
-                if (length(getLeadingCommentRangesOfNode(expression, currentSourceFile))) {
-                    return factory.updateParenthesizedExpression(node, expression);
-                }
+                //
+                // If there are leading comments on the expression itself, the emitter will handle ASI
+                // for return, throw, and yield by re-introducing parenthesis during emit on an as-need
+                // basis.
                 return factory.createPartiallyEmittedExpression(expression, node);
             }
 

--- a/tests/baselines/reference/optionalChainingInTypeAssertions(target=es2015).js
+++ b/tests/baselines/reference/optionalChainingInTypeAssertions(target=es2015).js
@@ -20,5 +20,5 @@ class Foo {
 const foo = new Foo();
 (_a = foo.m) === null || _a === void 0 ? void 0 : _a.call(foo);
 (_b = foo.m) === null || _b === void 0 ? void 0 : _b.call(foo);
-/*a1*/ (_c = foo.m /*a3*/ /*a4*/) === null || _c === void 0 ? void 0 : _c.call(/*a2*/ foo);
-/*b1*/ (_d = foo.m /*b3*/ /*b4*/) === null || _d === void 0 ? void 0 : _d.call(foo);
+/*a1*/ (_c = /*a2*/ foo.m /*a3*/ /*a4*/) === null || _c === void 0 ? void 0 : _c.call(foo);
+/*b1*/ (_d = /*b2*/ foo.m /*b3*/ /*b4*/) === null || _d === void 0 ? void 0 : _d.call(foo);

--- a/tests/baselines/reference/optionalChainingInTypeAssertions(target=es2015).js
+++ b/tests/baselines/reference/optionalChainingInTypeAssertions(target=es2015).js
@@ -1,0 +1,24 @@
+//// [optionalChainingInTypeAssertions.ts]
+class Foo {
+    m() {}
+}
+
+const foo = new Foo();
+
+(foo.m as any)?.();
+(<any>foo.m)?.();
+
+/*a1*/(/*a2*/foo.m as any/*a3*/)/*a4*/?.();
+/*b1*/(/*b2*/<any>foo.m/*b3*/)/*b4*/?.();
+
+
+//// [optionalChainingInTypeAssertions.js]
+var _a, _b, _c, _d;
+class Foo {
+    m() { }
+}
+const foo = new Foo();
+(_a = foo.m) === null || _a === void 0 ? void 0 : _a.call(foo);
+(_b = foo.m) === null || _b === void 0 ? void 0 : _b.call(foo);
+/*a1*/ (_c = foo.m /*a3*/ /*a4*/) === null || _c === void 0 ? void 0 : _c.call(/*a2*/ foo);
+/*b1*/ (_d = foo.m /*b3*/ /*b4*/) === null || _d === void 0 ? void 0 : _d.call(foo);

--- a/tests/baselines/reference/optionalChainingInTypeAssertions(target=es2015).symbols
+++ b/tests/baselines/reference/optionalChainingInTypeAssertions(target=es2015).symbols
@@ -1,0 +1,32 @@
+=== tests/cases/conformance/expressions/optionalChaining/optionalChainingInTypeAssertions.ts ===
+class Foo {
+>Foo : Symbol(Foo, Decl(optionalChainingInTypeAssertions.ts, 0, 0))
+
+    m() {}
+>m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+}
+
+const foo = new Foo();
+>foo : Symbol(foo, Decl(optionalChainingInTypeAssertions.ts, 4, 5))
+>Foo : Symbol(Foo, Decl(optionalChainingInTypeAssertions.ts, 0, 0))
+
+(foo.m as any)?.();
+>foo.m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+>foo : Symbol(foo, Decl(optionalChainingInTypeAssertions.ts, 4, 5))
+>m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+
+(<any>foo.m)?.();
+>foo.m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+>foo : Symbol(foo, Decl(optionalChainingInTypeAssertions.ts, 4, 5))
+>m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+
+/*a1*/(/*a2*/foo.m as any/*a3*/)/*a4*/?.();
+>foo.m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+>foo : Symbol(foo, Decl(optionalChainingInTypeAssertions.ts, 4, 5))
+>m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+
+/*b1*/(/*b2*/<any>foo.m/*b3*/)/*b4*/?.();
+>foo.m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+>foo : Symbol(foo, Decl(optionalChainingInTypeAssertions.ts, 4, 5))
+>m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+

--- a/tests/baselines/reference/optionalChainingInTypeAssertions(target=es2015).types
+++ b/tests/baselines/reference/optionalChainingInTypeAssertions(target=es2015).types
@@ -1,0 +1,45 @@
+=== tests/cases/conformance/expressions/optionalChaining/optionalChainingInTypeAssertions.ts ===
+class Foo {
+>Foo : Foo
+
+    m() {}
+>m : () => void
+}
+
+const foo = new Foo();
+>foo : Foo
+>new Foo() : Foo
+>Foo : typeof Foo
+
+(foo.m as any)?.();
+>(foo.m as any)?.() : any
+>(foo.m as any) : any
+>foo.m as any : any
+>foo.m : () => void
+>foo : Foo
+>m : () => void
+
+(<any>foo.m)?.();
+>(<any>foo.m)?.() : any
+>(<any>foo.m) : any
+><any>foo.m : any
+>foo.m : () => void
+>foo : Foo
+>m : () => void
+
+/*a1*/(/*a2*/foo.m as any/*a3*/)/*a4*/?.();
+>(/*a2*/foo.m as any/*a3*/)/*a4*/?.() : any
+>(/*a2*/foo.m as any/*a3*/) : any
+>foo.m as any : any
+>foo.m : () => void
+>foo : Foo
+>m : () => void
+
+/*b1*/(/*b2*/<any>foo.m/*b3*/)/*b4*/?.();
+>(/*b2*/<any>foo.m/*b3*/)/*b4*/?.() : any
+>(/*b2*/<any>foo.m/*b3*/) : any
+><any>foo.m : any
+>foo.m : () => void
+>foo : Foo
+>m : () => void
+

--- a/tests/baselines/reference/optionalChainingInTypeAssertions(target=esnext).js
+++ b/tests/baselines/reference/optionalChainingInTypeAssertions(target=esnext).js
@@ -19,5 +19,5 @@ class Foo {
 const foo = new Foo();
 foo.m?.();
 foo.m?.();
-/*a1*/ foo.m /*a3*/ /*a4*/?.();
-/*b1*/ foo.m /*b3*/ /*b4*/?.();
+/*a1*/ /*a2*/ foo.m /*a3*/ /*a4*/?.();
+/*b1*/ /*b2*/ foo.m /*b3*/ /*b4*/?.();

--- a/tests/baselines/reference/optionalChainingInTypeAssertions(target=esnext).js
+++ b/tests/baselines/reference/optionalChainingInTypeAssertions(target=esnext).js
@@ -1,0 +1,23 @@
+//// [optionalChainingInTypeAssertions.ts]
+class Foo {
+    m() {}
+}
+
+const foo = new Foo();
+
+(foo.m as any)?.();
+(<any>foo.m)?.();
+
+/*a1*/(/*a2*/foo.m as any/*a3*/)/*a4*/?.();
+/*b1*/(/*b2*/<any>foo.m/*b3*/)/*b4*/?.();
+
+
+//// [optionalChainingInTypeAssertions.js]
+class Foo {
+    m() { }
+}
+const foo = new Foo();
+foo.m?.();
+foo.m?.();
+/*a1*/ foo.m /*a3*/ /*a4*/?.();
+/*b1*/ foo.m /*b3*/ /*b4*/?.();

--- a/tests/baselines/reference/optionalChainingInTypeAssertions(target=esnext).symbols
+++ b/tests/baselines/reference/optionalChainingInTypeAssertions(target=esnext).symbols
@@ -1,0 +1,32 @@
+=== tests/cases/conformance/expressions/optionalChaining/optionalChainingInTypeAssertions.ts ===
+class Foo {
+>Foo : Symbol(Foo, Decl(optionalChainingInTypeAssertions.ts, 0, 0))
+
+    m() {}
+>m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+}
+
+const foo = new Foo();
+>foo : Symbol(foo, Decl(optionalChainingInTypeAssertions.ts, 4, 5))
+>Foo : Symbol(Foo, Decl(optionalChainingInTypeAssertions.ts, 0, 0))
+
+(foo.m as any)?.();
+>foo.m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+>foo : Symbol(foo, Decl(optionalChainingInTypeAssertions.ts, 4, 5))
+>m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+
+(<any>foo.m)?.();
+>foo.m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+>foo : Symbol(foo, Decl(optionalChainingInTypeAssertions.ts, 4, 5))
+>m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+
+/*a1*/(/*a2*/foo.m as any/*a3*/)/*a4*/?.();
+>foo.m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+>foo : Symbol(foo, Decl(optionalChainingInTypeAssertions.ts, 4, 5))
+>m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+
+/*b1*/(/*b2*/<any>foo.m/*b3*/)/*b4*/?.();
+>foo.m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+>foo : Symbol(foo, Decl(optionalChainingInTypeAssertions.ts, 4, 5))
+>m : Symbol(Foo.m, Decl(optionalChainingInTypeAssertions.ts, 0, 11))
+

--- a/tests/baselines/reference/optionalChainingInTypeAssertions(target=esnext).types
+++ b/tests/baselines/reference/optionalChainingInTypeAssertions(target=esnext).types
@@ -1,0 +1,45 @@
+=== tests/cases/conformance/expressions/optionalChaining/optionalChainingInTypeAssertions.ts ===
+class Foo {
+>Foo : Foo
+
+    m() {}
+>m : () => void
+}
+
+const foo = new Foo();
+>foo : Foo
+>new Foo() : Foo
+>Foo : typeof Foo
+
+(foo.m as any)?.();
+>(foo.m as any)?.() : any
+>(foo.m as any) : any
+>foo.m as any : any
+>foo.m : () => void
+>foo : Foo
+>m : () => void
+
+(<any>foo.m)?.();
+>(<any>foo.m)?.() : any
+>(<any>foo.m) : any
+><any>foo.m : any
+>foo.m : () => void
+>foo : Foo
+>m : () => void
+
+/*a1*/(/*a2*/foo.m as any/*a3*/)/*a4*/?.();
+>(/*a2*/foo.m as any/*a3*/)/*a4*/?.() : any
+>(/*a2*/foo.m as any/*a3*/) : any
+>foo.m as any : any
+>foo.m : () => void
+>foo : Foo
+>m : () => void
+
+/*b1*/(/*b2*/<any>foo.m/*b3*/)/*b4*/?.();
+>(/*b2*/<any>foo.m/*b3*/)/*b4*/?.() : any
+>(/*b2*/<any>foo.m/*b3*/) : any
+><any>foo.m : any
+>foo.m : () => void
+>foo : Foo
+>m : () => void
+

--- a/tests/cases/conformance/expressions/optionalChaining/optionalChainingInTypeAssertions.ts
+++ b/tests/cases/conformance/expressions/optionalChaining/optionalChainingInTypeAssertions.ts
@@ -1,0 +1,13 @@
+// @target: es2015, esnext
+
+class Foo {
+    m() {}
+}
+
+const foo = new Foo();
+
+(foo.m as any)?.();
+(<any>foo.m)?.();
+
+/*a1*/(/*a2*/foo.m as any/*a3*/)/*a4*/?.();
+/*b1*/(/*b2*/<any>foo.m/*b3*/)/*b4*/?.();


### PR DESCRIPTION
Fixes #44639