### PR TITLE
Fix auto imports in opening JSX tag

### DIFF
--- a/tests/cases/fourslash/completionsImportFromJSXTag.ts
+++ b/tests/cases/fourslash/completionsImportFromJSXTag.ts
@@ -1,0 +1,35 @@
+/// <reference path="fourslash.ts" />
+
+// @jsx: react
+
+// @Filename: /types.d.ts
+//// declare namespace JSX {
+////   interface IntrinsicElements { a }
+//// }
+
+// @Filename: /Box.tsx
+//// export function Box(props: any) { return null; }
+
+// @Filename: /App.tsx
+//// export function App() {
+////   return (
+////     <div className="App">
+////       <Box/**/
+////     </div>
+////   )
+//// }
+
+verify.applyCodeActionFromCompletion("", {
+  name: "Box",
+  source: "/Box",
+  description: `Import 'Box' from module "./Box"`,
+  newFileContent: `import { Box } from "./Box";
+
+export function App() {
+  return (
+    <div className="App">
+      <Box
+    </div>
+  )
+}`
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #44657

Sometime in 4.3 I changed the completion symbol sort text and origin maps to be keyed by the symbol index in the `symbols` array instead of by symbol id (since the same symbol can sometimes be imported in different ways, thus having more than one completion entry). Missed in that refactor was the fact that JSX opening tag completions shift all the intrinsic element symbols onto the beginning of the symbols array, offsetting the indices, such that no origins or sort text were found while creating the final completion entries. Pretty weird that there was no test coverage for that.
