### PR TITLE
Add disposition field to SecurityPolicyViolationEvent interface

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -14674,6 +14674,7 @@ interface SecurityPolicyViolationEvent extends Event {
     readonly sourceFile: string;
     readonly statusCode: number;
     readonly violatedDirective: string;
+    readonly disposition: "enforce" | "report";
 }
 
 declare var SecurityPolicyViolationEvent: {


### PR DESCRIPTION
According to https://www.w3.org/TR/CSP3/#violation-events, the interface `SecurityPolicyViolationEvent` has a field called `disposition`. This field is present in Chrome, Firefox, Safari.