### PR TITLE
Add disposition field to SecurityPolicyViolationEvent interface

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -14654,6 +14654,7 @@ interface SecurityPolicyViolationEvent extends Event {
     readonly sourceFile: string;
     readonly statusCode: number;
     readonly violatedDirective: string;
+    readonly disposition: "enforce" | "report";
 }
 
 declare var SecurityPolicyViolationEvent: {

--- a/tests/baselines/reference/intersectionsOfLargeUnions2.errors.txt
+++ b/tests/baselines/reference/intersectionsOfLargeUnions2.errors.txt
@@ -10,7 +10,7 @@ tests/cases/compiler/intersectionsOfLargeUnions2.ts(31,15): error TS2536: Type '
         interface ElementTagNameMap {
                   ~~~~~~~~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'ElementTagNameMap'.
-!!! related TS6203 /.ts/lib.dom.d.ts:19225:6: 'ElementTagNameMap' was also declared here.
+!!! related TS6203 /.ts/lib.dom.d.ts:19226:6: 'ElementTagNameMap' was also declared here.
             [index: number]: HTMLElement
         }
     


### PR DESCRIPTION
According to https://www.w3.org/TR/CSP3/#violation-events, the interface SecurityPolicyViolationEvent has a field called disposition. This field is present in Chrome, Firefox, Safari.