### PR TITLE
Fix types in the boolean trivial lint rule

### DIFF
--- a/scripts/eslint/rules/boolean-trivia.ts
+++ b/scripts/eslint/rules/boolean-trivia.ts
@@ -23,7 +23,7 @@ export = createRule({
         const sourceCodeText = sourceCode.getText();
 
         const isSetOrAssert = (name: string): boolean => name.startsWith("set") || name.startsWith("assert");
-        const isTrivia = (node: TSESTree.CallExpressionArgument): boolean => {
+        const isTrivia = (node: TSESTree.Node): boolean => {
             if (node.type === AST_NODE_TYPES.Identifier) {
                 return node.name === "undefined";
             }
@@ -69,7 +69,7 @@ export = createRule({
             return false;
         };
 
-        const checkArg = (node: TSESTree.CallExpressionArgument): void => {
+        const checkArg = (node: TSESTree.Node): void => {
             if (!isTrivia(node)) {
                 return;
             }


### PR DESCRIPTION
Main is currently broken, typescript-eslint stopped exporting the type `CallExpressionArgument`. A quick look [in the typescript-eslint codebase](https://github.com/typescript-eslint/typescript-eslint/search?q=CallExpressionArgument) shows it existing in a different package. 

However, when I looked at how we used it, we weren't using anything which isn't defined on the base class of `Node` - so I switched it to that rather than digging into another module for the type.
