### PR TITLE
Allow for class static vars to be called static

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1817,7 +1817,6 @@ namespace ts {
                 case SyntaxKind.DefaultKeyword:
                     return nextTokenCanFollowDefaultKeyword();
                 case SyntaxKind.StaticKeyword:
-                    return nextTokenIsOnSameLineAndCanFollowModifier();
                 case SyntaxKind.GetKeyword:
                 case SyntaxKind.SetKeyword:
                     nextToken();
@@ -6701,7 +6700,7 @@ namespace ts {
             return list && createNodeArray(list, pos);
         }
 
-        function tryParseModifier(permitInvalidConstAsModifier?: boolean, stopOnStartOfClassStaticBlock?: boolean): Modifier | undefined {
+        function tryParseModifier(permitInvalidConstAsModifier?: boolean, stopOnStartOfClassStaticBlock?: boolean, hasSeenStaticModifier?: boolean): Modifier | undefined {
             const pos = getNodePos();
             const kind = token();
 
@@ -6713,6 +6712,9 @@ namespace ts {
                 }
             }
             else if (stopOnStartOfClassStaticBlock && token() === SyntaxKind.StaticKeyword && lookAhead(nextTokenIsOpenBrace)) {
+                return undefined;
+            }
+            else if (hasSeenStaticModifier && token() === SyntaxKind.StaticKeyword) {
                 return undefined;
             }
             else {
@@ -6733,8 +6735,9 @@ namespace ts {
          */
         function parseModifiers(permitInvalidConstAsModifier?: boolean, stopOnStartOfClassStaticBlock?: boolean): NodeArray<Modifier> | undefined {
             const pos = getNodePos();
-            let list, modifier;
-            while (modifier = tryParseModifier(permitInvalidConstAsModifier, stopOnStartOfClassStaticBlock)) {
+            let list, modifier, hasSeenStatic = false;
+            while (modifier = tryParseModifier(permitInvalidConstAsModifier, stopOnStartOfClassStaticBlock, hasSeenStatic)) {
+                if (modifier.kind === SyntaxKind.StaticKeyword) hasSeenStatic = true;
                 list = append(list, modifier);
             }
             return list && createNodeArray(list, pos);

--- a/tests/baselines/reference/multipleClassPropertyModifiersErrors.errors.txt
+++ b/tests/baselines/reference/multipleClassPropertyModifiersErrors.errors.txt
@@ -1,27 +1,15 @@
-tests/cases/compiler/multipleClassPropertyModifiersErrors.ts(2,9): error TS1028: Accessibility modifier already seen.
-tests/cases/compiler/multipleClassPropertyModifiersErrors.ts(3,10): error TS1028: Accessibility modifier already seen.
-tests/cases/compiler/multipleClassPropertyModifiersErrors.ts(4,9): error TS1030: 'static' modifier already seen.
-tests/cases/compiler/multipleClassPropertyModifiersErrors.ts(5,9): error TS1028: Accessibility modifier already seen.
-tests/cases/compiler/multipleClassPropertyModifiersErrors.ts(6,10): error TS1028: Accessibility modifier already seen.
+tests/cases/compiler/multipleClassPropertyModifiersErrors.ts(4,16): error TS1005: ';' expected.
 
 
-==== tests/cases/compiler/multipleClassPropertyModifiersErrors.ts (5 errors) ====
+==== tests/cases/compiler/multipleClassPropertyModifiersErrors.ts (1 errors) ====
     class C {
     	public public p1;
-    	       ~~~~~~
-!!! error TS1028: Accessibility modifier already seen.
     	private private p2;
-    	        ~~~~~~~
-!!! error TS1028: Accessibility modifier already seen.
     	static static p3;
-    	       ~~~~~~
-!!! error TS1030: 'static' modifier already seen.
+    	              ~~
+!!! error TS1005: ';' expected.
     	public private p4;
-    	       ~~~~~~~
-!!! error TS1028: Accessibility modifier already seen.
     	private public p5;
-    	        ~~~~~~
-!!! error TS1028: Accessibility modifier already seen.
     	public static p6;
     	private static p7;
     }

--- a/tests/baselines/reference/multipleClassPropertyModifiersErrors.symbols
+++ b/tests/baselines/reference/multipleClassPropertyModifiersErrors.symbols
@@ -9,7 +9,8 @@ class C {
 >p2 : Symbol(C.p2, Decl(multipleClassPropertyModifiersErrors.ts, 1, 18))
 
 	static static p3;
->p3 : Symbol(C.p3, Decl(multipleClassPropertyModifiersErrors.ts, 2, 20))
+>static : Symbol(C.static, Decl(multipleClassPropertyModifiersErrors.ts, 2, 20))
+>p3 : Symbol(C.p3, Decl(multipleClassPropertyModifiersErrors.ts, 3, 14))
 
 	public private p4;
 >p4 : Symbol(C.p4, Decl(multipleClassPropertyModifiersErrors.ts, 3, 18))

--- a/tests/baselines/reference/multipleClassPropertyModifiersErrors.types
+++ b/tests/baselines/reference/multipleClassPropertyModifiersErrors.types
@@ -9,6 +9,7 @@ class C {
 >p2 : any
 
 	static static p3;
+>static : any
 >p3 : any
 
 	public private p4;

--- a/tests/baselines/reference/parserIndexMemberDeclaration10.errors.txt
+++ b/tests/baselines/reference/parserIndexMemberDeclaration10.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration10.ts(2,11): error TS1030: 'static' modifier already seen.
+tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration10.ts(2,18): error TS1005: ';' expected.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration10.ts (1 errors) ====
     class C {
        static static [x: string]: string;
-              ~~~~~~
-!!! error TS1030: 'static' modifier already seen.
+                     ~
+!!! error TS1005: ';' expected.
     }

--- a/tests/baselines/reference/parserIndexMemberDeclaration10.symbols
+++ b/tests/baselines/reference/parserIndexMemberDeclaration10.symbols
@@ -3,5 +3,6 @@ class C {
 >C : Symbol(C, Decl(parserIndexMemberDeclaration10.ts, 0, 0))
 
    static static [x: string]: string;
+>static : Symbol(C.static, Decl(parserIndexMemberDeclaration10.ts, 0, 9))
 >x : Symbol(x, Decl(parserIndexMemberDeclaration10.ts, 1, 18))
 }

--- a/tests/baselines/reference/parserIndexMemberDeclaration10.types
+++ b/tests/baselines/reference/parserIndexMemberDeclaration10.types
@@ -3,5 +3,6 @@ class C {
 >C : C
 
    static static [x: string]: string;
+>static : any
 >x : string
 }

--- a/tests/baselines/reference/parserMemberAccessorDeclaration8.errors.txt
+++ b/tests/baselines/reference/parserMemberAccessorDeclaration8.errors.txt
@@ -1,12 +1,12 @@
-tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration8.ts(2,12): error TS1030: 'static' modifier already seen.
+tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration8.ts(2,19): error TS1005: ';' expected.
 tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration8.ts(2,23): error TS2378: A 'get' accessor must return a value.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration8.ts (2 errors) ====
     class C {
         static static get Foo() { }
-               ~~~~~~
-!!! error TS1030: 'static' modifier already seen.
+                      ~~~
+!!! error TS1005: ';' expected.
                           ~~~
 !!! error TS2378: A 'get' accessor must return a value.
     }

--- a/tests/baselines/reference/parserMemberAccessorDeclaration8.js
+++ b/tests/baselines/reference/parserMemberAccessorDeclaration8.js
@@ -7,7 +7,7 @@ class C {
 var C = /** @class */ (function () {
     function C() {
     }
-    Object.defineProperty(C, "Foo", {
+    Object.defineProperty(C.prototype, "Foo", {
         get: function () { },
         enumerable: false,
         configurable: true

--- a/tests/baselines/reference/parserMemberAccessorDeclaration8.symbols
+++ b/tests/baselines/reference/parserMemberAccessorDeclaration8.symbols
@@ -3,5 +3,6 @@ class C {
 >C : Symbol(C, Decl(parserMemberAccessorDeclaration8.ts, 0, 0))
 
     static static get Foo() { }
->Foo : Symbol(C.Foo, Decl(parserMemberAccessorDeclaration8.ts, 0, 9))
+>static : Symbol(C.static, Decl(parserMemberAccessorDeclaration8.ts, 0, 9))
+>Foo : Symbol(C.Foo, Decl(parserMemberAccessorDeclaration8.ts, 1, 17))
 }

--- a/tests/baselines/reference/parserMemberAccessorDeclaration8.types
+++ b/tests/baselines/reference/parserMemberAccessorDeclaration8.types
@@ -3,5 +3,6 @@ class C {
 >C : C
 
     static static get Foo() { }
+>static : any
 >Foo : void
 }

--- a/tests/baselines/reference/parserMemberFunctionDeclaration2.errors.txt
+++ b/tests/baselines/reference/parserMemberFunctionDeclaration2.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration2.ts(2,12): error TS1030: 'static' modifier already seen.
+tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration2.ts(2,19): error TS1005: ';' expected.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration2.ts (1 errors) ====
     class C {
         static static Foo() { }
-               ~~~~~~
-!!! error TS1030: 'static' modifier already seen.
+                      ~~~
+!!! error TS1005: ';' expected.
     }

--- a/tests/baselines/reference/parserMemberFunctionDeclaration2.js
+++ b/tests/baselines/reference/parserMemberFunctionDeclaration2.js
@@ -7,6 +7,6 @@ class C {
 var C = /** @class */ (function () {
     function C() {
     }
-    C.Foo = function () { };
+    C.prototype.Foo = function () { };
     return C;
 }());

--- a/tests/baselines/reference/parserMemberFunctionDeclaration2.symbols
+++ b/tests/baselines/reference/parserMemberFunctionDeclaration2.symbols
@@ -3,5 +3,6 @@ class C {
 >C : Symbol(C, Decl(parserMemberFunctionDeclaration2.ts, 0, 0))
 
     static static Foo() { }
->Foo : Symbol(C.Foo, Decl(parserMemberFunctionDeclaration2.ts, 0, 9))
+>static : Symbol(C.static, Decl(parserMemberFunctionDeclaration2.ts, 0, 9))
+>Foo : Symbol(C.Foo, Decl(parserMemberFunctionDeclaration2.ts, 1, 17))
 }

--- a/tests/baselines/reference/parserMemberFunctionDeclaration2.types
+++ b/tests/baselines/reference/parserMemberFunctionDeclaration2.types
@@ -3,5 +3,6 @@ class C {
 >C : C
 
     static static Foo() { }
+>static : any
 >Foo : () => void
 }

--- a/tests/baselines/reference/parserMemberVariableDeclaration2.errors.txt
+++ b/tests/baselines/reference/parserMemberVariableDeclaration2.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration2.ts(2,10): error TS1030: 'static' modifier already seen.
+tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration2.ts(2,17): error TS1005: ';' expected.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration2.ts (1 errors) ====
     class C {
       static static Foo;
-             ~~~~~~
-!!! error TS1030: 'static' modifier already seen.
+                    ~~~
+!!! error TS1005: ';' expected.
     }

--- a/tests/baselines/reference/parserMemberVariableDeclaration2.symbols
+++ b/tests/baselines/reference/parserMemberVariableDeclaration2.symbols
@@ -3,5 +3,6 @@ class C {
 >C : Symbol(C, Decl(parserMemberVariableDeclaration2.ts, 0, 0))
 
   static static Foo;
->Foo : Symbol(C.Foo, Decl(parserMemberVariableDeclaration2.ts, 0, 9))
+>static : Symbol(C.static, Decl(parserMemberVariableDeclaration2.ts, 0, 9))
+>Foo : Symbol(C.Foo, Decl(parserMemberVariableDeclaration2.ts, 1, 15))
 }

--- a/tests/baselines/reference/parserMemberVariableDeclaration2.types
+++ b/tests/baselines/reference/parserMemberVariableDeclaration2.types
@@ -3,5 +3,6 @@ class C {
 >C : C
 
   static static Foo;
+>static : any
 >Foo : any
 }

--- a/tests/baselines/reference/staticAsIdentifier.errors.txt
+++ b/tests/baselines/reference/staticAsIdentifier.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/staticAsIdentifier.ts(12,12): error TS1030: 'static' modifier already seen.
-tests/cases/compiler/staticAsIdentifier.ts(16,12): error TS1030: 'static' modifier already seen.
+tests/cases/compiler/staticAsIdentifier.ts(12,19): error TS1005: ';' expected.
+tests/cases/compiler/staticAsIdentifier.ts(16,19): error TS1005: ';' expected.
 
 
 ==== tests/cases/compiler/staticAsIdentifier.ts (2 errors) ====
@@ -15,13 +15,28 @@ tests/cases/compiler/staticAsIdentifier.ts(16,12): error TS1030: 'static' modifi
     
     class C3 {
         static static p: string;
-               ~~~~~~
-!!! error TS1030: 'static' modifier already seen.
+                      ~
+!!! error TS1005: ';' expected.
     }
     
     class C4 {
         static static foo() {}
-               ~~~~~~
-!!! error TS1030: 'static' modifier already seen.
+                      ~~~
+!!! error TS1005: ';' expected.
     }
+    
+    class C5 {
+        static static
+    }
+    
+    class C6 {
+        static 
+        static
+    }
+    
+    class C7 extends C6 {
+        static override static
+    }
+    
+    
     

--- a/tests/baselines/reference/staticAsIdentifier.js
+++ b/tests/baselines/reference/staticAsIdentifier.js
@@ -17,8 +17,38 @@ class C4 {
     static static foo() {}
 }
 
+class C5 {
+    static static
+}
+
+class C6 {
+    static 
+    static
+}
+
+class C7 extends C6 {
+    static override static
+}
+
+
+
 
 //// [staticAsIdentifier.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
 var C1 = /** @class */ (function () {
     function C1() {
     }
@@ -38,6 +68,23 @@ var C3 = /** @class */ (function () {
 var C4 = /** @class */ (function () {
     function C4() {
     }
-    C4.foo = function () { };
+    C4.prototype.foo = function () { };
     return C4;
 }());
+var C5 = /** @class */ (function () {
+    function C5() {
+    }
+    return C5;
+}());
+var C6 = /** @class */ (function () {
+    function C6() {
+    }
+    return C6;
+}());
+var C7 = /** @class */ (function (_super) {
+    __extends(C7, _super);
+    function C7() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C7;
+}(C6));

--- a/tests/baselines/reference/staticAsIdentifier.symbols
+++ b/tests/baselines/reference/staticAsIdentifier.symbols
@@ -23,13 +23,40 @@ class C3 {
 >C3 : Symbol(C3, Decl(staticAsIdentifier.ts, 8, 1))
 
     static static p: string;
->p : Symbol(C3.p, Decl(staticAsIdentifier.ts, 10, 10))
+>static : Symbol(C3.static, Decl(staticAsIdentifier.ts, 10, 10))
+>p : Symbol(C3.p, Decl(staticAsIdentifier.ts, 11, 17))
 }
 
 class C4 {
 >C4 : Symbol(C4, Decl(staticAsIdentifier.ts, 12, 1))
 
     static static foo() {}
->foo : Symbol(C4.foo, Decl(staticAsIdentifier.ts, 14, 10))
+>static : Symbol(C4.static, Decl(staticAsIdentifier.ts, 14, 10))
+>foo : Symbol(C4.foo, Decl(staticAsIdentifier.ts, 15, 17))
 }
+
+class C5 {
+>C5 : Symbol(C5, Decl(staticAsIdentifier.ts, 16, 1))
+
+    static static
+>static : Symbol(C5.static, Decl(staticAsIdentifier.ts, 18, 10))
+}
+
+class C6 {
+>C6 : Symbol(C6, Decl(staticAsIdentifier.ts, 20, 1))
+
+    static 
+    static
+>static : Symbol(C6.static, Decl(staticAsIdentifier.ts, 22, 10))
+}
+
+class C7 extends C6 {
+>C7 : Symbol(C7, Decl(staticAsIdentifier.ts, 25, 1))
+>C6 : Symbol(C6, Decl(staticAsIdentifier.ts, 20, 1))
+
+    static override static
+>static : Symbol(C7.static, Decl(staticAsIdentifier.ts, 27, 21))
+}
+
+
 

--- a/tests/baselines/reference/staticAsIdentifier.types
+++ b/tests/baselines/reference/staticAsIdentifier.types
@@ -23,6 +23,7 @@ class C3 {
 >C3 : C3
 
     static static p: string;
+>static : any
 >p : string
 }
 
@@ -30,6 +31,32 @@ class C4 {
 >C4 : C4
 
     static static foo() {}
+>static : any
 >foo : () => void
 }
+
+class C5 {
+>C5 : C5
+
+    static static
+>static : any
+}
+
+class C6 {
+>C6 : C6
+
+    static 
+    static
+>static : any
+}
+
+class C7 extends C6 {
+>C7 : C7
+>C6 : C6
+
+    static override static
+>static : any
+}
+
+
 

--- a/tests/baselines/reference/staticModifierAlreadySeen.errors.txt
+++ b/tests/baselines/reference/staticModifierAlreadySeen.errors.txt
@@ -1,13 +1,16 @@
-tests/cases/compiler/staticModifierAlreadySeen.ts(2,12): error TS1030: 'static' modifier already seen.
-tests/cases/compiler/staticModifierAlreadySeen.ts(3,19): error TS1030: 'static' modifier already seen.
+tests/cases/compiler/staticModifierAlreadySeen.ts(2,19): error TS1005: ';' expected.
+tests/cases/compiler/staticModifierAlreadySeen.ts(3,19): error TS2300: Duplicate identifier 'static'.
+tests/cases/compiler/staticModifierAlreadySeen.ts(3,26): error TS1005: ';' expected.
 
 
-==== tests/cases/compiler/staticModifierAlreadySeen.ts (2 errors) ====
+==== tests/cases/compiler/staticModifierAlreadySeen.ts (3 errors) ====
     class C {
         static static foo = 1;
-               ~~~~~~
-!!! error TS1030: 'static' modifier already seen.
+                      ~~~
+!!! error TS1005: ';' expected.
         public static static bar() { }
                       ~~~~~~
-!!! error TS1030: 'static' modifier already seen.
+!!! error TS2300: Duplicate identifier 'static'.
+                             ~~~
+!!! error TS1005: ';' expected.
     }

--- a/tests/baselines/reference/staticModifierAlreadySeen.js
+++ b/tests/baselines/reference/staticModifierAlreadySeen.js
@@ -7,8 +7,8 @@ class C {
 //// [staticModifierAlreadySeen.js]
 var C = /** @class */ (function () {
     function C() {
+        this.foo = 1;
     }
-    C.bar = function () { };
-    C.foo = 1;
+    C.prototype.bar = function () { };
     return C;
 }());

--- a/tests/baselines/reference/staticModifierAlreadySeen.symbols
+++ b/tests/baselines/reference/staticModifierAlreadySeen.symbols
@@ -3,8 +3,10 @@ class C {
 >C : Symbol(C, Decl(staticModifierAlreadySeen.ts, 0, 0))
 
     static static foo = 1;
->foo : Symbol(C.foo, Decl(staticModifierAlreadySeen.ts, 0, 9))
+>static : Symbol(C.static, Decl(staticModifierAlreadySeen.ts, 0, 9), Decl(staticModifierAlreadySeen.ts, 1, 26))
+>foo : Symbol(C.foo, Decl(staticModifierAlreadySeen.ts, 1, 17))
 
     public static static bar() { }
->bar : Symbol(C.bar, Decl(staticModifierAlreadySeen.ts, 1, 26))
+>static : Symbol(C.static, Decl(staticModifierAlreadySeen.ts, 0, 9), Decl(staticModifierAlreadySeen.ts, 1, 26))
+>bar : Symbol(C.bar, Decl(staticModifierAlreadySeen.ts, 2, 24))
 }

--- a/tests/baselines/reference/staticModifierAlreadySeen.types
+++ b/tests/baselines/reference/staticModifierAlreadySeen.types
@@ -3,9 +3,11 @@ class C {
 >C : C
 
     static static foo = 1;
+>static : any
 >foo : number
 >1 : 1
 
     public static static bar() { }
+>static : any
 >bar : () => void
 }

--- a/tests/cases/compiler/staticAsIdentifier.ts
+++ b/tests/cases/compiler/staticAsIdentifier.ts
@@ -15,3 +15,18 @@ class C3 {
 class C4 {
     static static foo() {}
 }
+
+class C5 {
+    static static
+}
+
+class C6 {
+    static 
+    static
+}
+
+class C7 extends C6 {
+    static override static
+}
+
+


### PR DESCRIPTION
Fixes #43836 - due to the implementation of #41127 which ended up triggering the bug

Now you can have a static variable called static, and code like `static static p: string` doesn't work because that's `static static` and `p: string` but you need to add a `;` to correctly disambiguate.

/cc @weswigham 