### PR TITLE
Apply disableReferencedProjectLoad to getOriginalLocationEnsuringConfiguredProject

### DIFF
--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -1457,10 +1457,10 @@ const b: B = new B();`
             baselineDisableReferencedProjectLoad(true,        false,   true,    false); // Pre-loaded |              | lib/index.d.ts      | Even though project is loaded
             baselineDisableReferencedProjectLoad(true,        false,   false,   true);  // Pre-loaded |              | index.ts, helper.ts |
             baselineDisableReferencedProjectLoad(true,        false,   false,   false); // Pre-loaded |              | index.ts, helper.ts |
-            baselineDisableReferencedProjectLoad(false,       true,    true,    true);  // Not loaded |              | lib/index.d.ts      | Even though map is present -- used to load and find all
+            baselineDisableReferencedProjectLoad(false,       true,    true,    true);  // Not loaded |              | lib/index.d.ts      | Even though map is present
             baselineDisableReferencedProjectLoad(false,       true,    true,    false); // Not loaded |              | lib/index.d.ts      |
-            baselineDisableReferencedProjectLoad(false,       true,    false,   true);  // Not loaded |              | index.ts            | But not helper.ts, which is not referenced from a -- used to load and find all
-            baselineDisableReferencedProjectLoad(false,       true,    false,   false); // Not loaded |              | index.ts            | But not helper.ts, which is not referenced from a -- used to load and find all
+            baselineDisableReferencedProjectLoad(false,       true,    false,   true);  // Not loaded |              | index.ts            | But not helper.ts, which is not referenced from a
+            baselineDisableReferencedProjectLoad(false,       true,    false,   false); // Not loaded |              | index.ts            | But not helper.ts, which is not referenced from a
             baselineDisableReferencedProjectLoad(false,       false,   true,    true);  // Loaded     | Via map      | index.ts, helper.ts | Via map and newly loaded project
             baselineDisableReferencedProjectLoad(false,       false,   true,    false); // Not loaded |              | lib/index.d.ts      |
             baselineDisableReferencedProjectLoad(false,       false,   false,   true);  // Loaded     | Via redirect | index.ts, helper.ts |

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -1353,5 +1353,120 @@ bar;`
             });
             baselineTsserverLogs("projectReferences", `when files from two projects are open and one project references`, session);
         });
+
+        describe("find refs to symbol from other project", () => {
+            const indexA: File = {
+                path: `${tscWatch.projectRoot}/a/index.ts`,
+                content: `import { B } from "../b/lib";
+
+const b: B = new B();`
+            };
+
+            const configB: File = {
+                path: `${tscWatch.projectRoot}/b/tsconfig.json`,
+                content: `{
+"compilerOptions": {
+    "declarationMap": true,
+    "outDir": "lib",
+    "composite": true
+}
+}`
+            };
+
+            const indexB: File = {
+                path: `${tscWatch.projectRoot}/b/index.ts`,
+                content: `export class B {
+    M() {}
+}`
+            };
+
+            const helperB: File = {
+                path: `${tscWatch.projectRoot}/b/helper.ts`,
+                content: `import { B } from ".";
+
+const b: B = new B();`
+            };
+
+            const dtsB: File = {
+                path: `${tscWatch.projectRoot}/b/lib/index.d.ts`,
+                content: `export declare class B {
+    M(): void;
+}
+//# sourceMappingURL=index.d.ts.map`
+            };
+
+            const dtsMapB: File = {
+                path: `${tscWatch.projectRoot}/b/lib/index.d.ts.map`,
+                content: `{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../index.ts"],"names":[],"mappings":"AAAA,qBAAa,CAAC;IACV,CAAC;CACJ"}`
+            };
+
+            function baselineDisableReferencedProjectLoad(
+                projectAlreadyLoaded: boolean,
+                disableReferencedProjectLoad: boolean,
+                disableSourceOfProjectReferenceRedirect: boolean,
+                dtsMapPresent: boolean) {
+
+                // Mangled to stay under windows path length limit
+                const subScenario =
+                    `when proj ${projectAlreadyLoaded ? "is" : "is not"} loaded ` +
+                    ` and refd proj loading is ${disableReferencedProjectLoad ? "disabled" : "enabled"}` +
+                    ` and proj ref redirects are ${disableSourceOfProjectReferenceRedirect ? "disabled" : "enabled"}` +
+                    ` and a decl map is ${dtsMapPresent ? "present" : "missing"}`;
+                const compilerOptions: CompilerOptions = {
+                    disableReferencedProjectLoad,
+                    disableSourceOfProjectReferenceRedirect,
+                    composite: true
+                };
+
+                it(subScenario, () => {
+                    const configA: File = {
+                        path: `${tscWatch.projectRoot}/a/tsconfig.json`,
+                        content: `{
+        "compilerOptions": ${JSON.stringify(compilerOptions)},
+        "references": [{ "path": "../b" }]
+    }`
+                    };
+
+                    const host = createServerHost([configA, indexA, configB, indexB, helperB, dtsB, ...(dtsMapPresent ? [dtsMapB] : [])]);
+                    const session = createSession(host, { logger: createLoggerWithInMemoryLogs() });
+                    openFilesForSession([indexA, ...(projectAlreadyLoaded ? [helperB] : [])], session);
+
+                    session.executeCommandSeq<protocol.ReferencesRequest>({
+                        command: protocol.CommandTypes.References,
+                        arguments: protocolFileLocationFromSubstring(indexA, `B`, { index: 1 })
+                    });
+                    baselineTsserverLogs("projectReferences", `find all references to a symbol declared in another project ${subScenario}`, session);
+                });
+            }
+
+            /* eslint-disable boolean-trivia */
+
+            // Pre-loaded = A file from project B is already open when FAR is invoked
+            // dRPL = Project A has disableReferencedProjectLoad
+            // dSOPRR = Project A has disableSourceOfProjectReferenceRedirect
+            // Map = The declaration map file b/lib/index.d.ts.map exists
+            // B refs = files under directory b in which references are found (all scenarios find all references in a/index.ts)
+
+            //                                   Pre-loaded | dRPL   | dSOPRR | Map      | B state    | Notes        | B refs              | Notes
+            //                                   -----------+--------+--------+----------+------------+--------------+---------------------+---------------------------------------------------
+            baselineDisableReferencedProjectLoad(true,        true,    true,    true);  // Pre-loaded |              | index.ts, helper.ts | Via map and pre-loaded project
+            baselineDisableReferencedProjectLoad(true,        true,    true,    false); // Pre-loaded |              | lib/index.d.ts      | Even though project is loaded
+            baselineDisableReferencedProjectLoad(true,        true,    false,   true);  // Pre-loaded |              | index.ts, helper.ts |
+            baselineDisableReferencedProjectLoad(true,        true,    false,   false); // Pre-loaded |              | index.ts, helper.ts |
+            baselineDisableReferencedProjectLoad(true,        false,   true,    true);  // Pre-loaded |              | index.ts, helper.ts | Via map and pre-loaded project
+            baselineDisableReferencedProjectLoad(true,        false,   true,    false); // Pre-loaded |              | lib/index.d.ts      | Even though project is loaded
+            baselineDisableReferencedProjectLoad(true,        false,   false,   true);  // Pre-loaded |              | index.ts, helper.ts |
+            baselineDisableReferencedProjectLoad(true,        false,   false,   false); // Pre-loaded |              | index.ts, helper.ts |
+            baselineDisableReferencedProjectLoad(false,       true,    true,    true);  // Not loaded |              | lib/index.d.ts      | Even though map is present -- used to load and find all
+            baselineDisableReferencedProjectLoad(false,       true,    true,    false); // Not loaded |              | lib/index.d.ts      |
+            baselineDisableReferencedProjectLoad(false,       true,    false,   true);  // Not loaded |              | index.ts            | But not helper.ts, which is not referenced from a -- used to load and find all
+            baselineDisableReferencedProjectLoad(false,       true,    false,   false); // Not loaded |              | index.ts            | But not helper.ts, which is not referenced from a -- used to load and find all
+            baselineDisableReferencedProjectLoad(false,       false,   true,    true);  // Loaded     | Via map      | index.ts, helper.ts | Via map and newly loaded project
+            baselineDisableReferencedProjectLoad(false,       false,   true,    false); // Not loaded |              | lib/index.d.ts      |
+            baselineDisableReferencedProjectLoad(false,       false,   false,   true);  // Loaded     | Via redirect | index.ts, helper.ts |
+            baselineDisableReferencedProjectLoad(false,       false,   false,   false); // Loaded     | Via redirect | index.ts, helper.ts |
+
+            /* eslint-enable boolean-trivia */
+        });
     });
 }

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-missing.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-missing.js
@@ -1,0 +1,122 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "disableSourceOfProjectReferenceRedirect": true,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/lib/index.d.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/lib/index.d.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/b/helper.ts"}}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/helper.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+	FileName: /user/username/projects/myproject/b/helper.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts.map 2000 undefined WatchType: Missing source map file
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/lib/index.d.ts","start":{"line":1,"offset":22},"end":{"line":1,"offset":23},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export declare class B {","isWriteAccess":true,"isDefinition":true}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-present.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-present.js
@@ -1,0 +1,126 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "disableSourceOfProjectReferenceRedirect": true,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/lib/index.d.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/lib/index.d.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/b/helper.ts"}}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/helper.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+	FileName: /user/username/projects/myproject/b/helper.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts.map 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":23},"lineText":"import { B } from \".\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-missing.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-missing.js
@@ -1,0 +1,124 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "disableSourceOfProjectReferenceRedirect": false,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/index.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/b/helper.ts"}}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/helper.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+	FileName: /user/username/projects/myproject/b/helper.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":23},"lineText":"import { B } from \".\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-present.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-present.js
@@ -1,0 +1,124 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "disableSourceOfProjectReferenceRedirect": false,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/index.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/b/helper.ts"}}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/helper.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+	FileName: /user/username/projects/myproject/b/helper.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":23},"lineText":"import { B } from \".\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-missing.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-missing.js
@@ -1,0 +1,122 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": false,
+  "disableSourceOfProjectReferenceRedirect": true,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/lib/index.d.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/lib/index.d.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/b/helper.ts"}}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/helper.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+	FileName: /user/username/projects/myproject/b/helper.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts.map 2000 undefined WatchType: Missing source map file
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/lib/index.d.ts","start":{"line":1,"offset":22},"end":{"line":1,"offset":23},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export declare class B {","isWriteAccess":true,"isDefinition":true}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-present.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-present.js
@@ -1,0 +1,126 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": false,
+  "disableSourceOfProjectReferenceRedirect": true,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/lib/index.d.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/lib/index.d.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/b/helper.ts"}}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/helper.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+	FileName: /user/username/projects/myproject/b/helper.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts.map 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":23},"lineText":"import { B } from \".\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-missing.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-missing.js
@@ -1,0 +1,124 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": false,
+  "disableSourceOfProjectReferenceRedirect": false,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/index.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/b/helper.ts"}}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/helper.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+	FileName: /user/username/projects/myproject/b/helper.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":23},"lineText":"import { B } from \".\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-present.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-present.js
@@ -1,0 +1,124 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": false,
+  "disableSourceOfProjectReferenceRedirect": false,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/index.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/b/helper.ts"}}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/helper.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+	FileName: /user/username/projects/myproject/b/helper.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/b/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":23},"lineText":"import { B } from \".\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-missing.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-missing.js
@@ -1,0 +1,76 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "disableSourceOfProjectReferenceRedirect": true,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/lib/index.d.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/lib/index.d.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts.map 2000 undefined WatchType: Missing source map file
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/lib/index.d.ts","start":{"line":1,"offset":22},"end":{"line":1,"offset":23},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export declare class B {","isWriteAccess":true,"isDefinition":true}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-present.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-present.js
@@ -1,0 +1,81 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "disableSourceOfProjectReferenceRedirect": true,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/lib/index.d.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/lib/index.d.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts.map 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/lib/index.d.ts","start":{"line":1,"offset":22},"end":{"line":1,"offset":23},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export declare class B {","isWriteAccess":true,"isDefinition":true}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-missing.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-missing.js
@@ -1,0 +1,79 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "disableSourceOfProjectReferenceRedirect": false,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/index.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-present.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-disabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-present.js
@@ -1,0 +1,79 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": true,
+  "disableSourceOfProjectReferenceRedirect": false,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/index.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-missing.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-missing.js
@@ -1,0 +1,76 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": false,
+  "disableSourceOfProjectReferenceRedirect": true,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/lib/index.d.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/lib/index.d.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts.map 2000 undefined WatchType: Missing source map file
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/lib/index.d.ts","start":{"line":1,"offset":22},"end":{"line":1,"offset":23},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export declare class B {","isWriteAccess":true,"isDefinition":true}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-present.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-disabled-and-a-decl-map-is-present.js
@@ -1,0 +1,108 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": false,
+  "disableSourceOfProjectReferenceRedirect": true,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/lib/index.d.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/lib/index.d.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/lib/index.d.ts.map 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/helper.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":23},"lineText":"import { B } from \".\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-missing.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-missing.js
@@ -1,0 +1,106 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": false,
+  "disableSourceOfProjectReferenceRedirect": false,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/index.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/helper.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":23},"lineText":"import { B } from \".\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-present.js
+++ b/tests/baselines/reference/tsserver/projectReferences/find-all-references-to-a-symbol-declared-in-another-project-when-proj-is-not-loaded--and-refd-proj-loading-is-enabled-and-proj-ref-redirects-are-enabled-and-a-decl-map-is-present.js
@@ -1,0 +1,106 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a/index.ts"}}
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/index.ts :: Config file name: /user/username/projects/myproject/a/tsconfig.json
+Creating configuration project /user/username/projects/myproject/a/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/a/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/a/index.ts"
+ ],
+ "options": {
+  "disableReferencedProjectLoad": false,
+  "disableSourceOfProjectReferenceRedirect": false,
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/a/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/user/username/projects/myproject/b",
+   "originalPath": "../b"
+  }
+ ]
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a 1 undefined Config: /user/username/projects/myproject/a/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json
+Config: /user/username/projects/myproject/b/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/b/helper.ts",
+  "/user/username/projects/myproject/b/index.ts"
+ ],
+ "options": {
+  "declarationMap": true,
+  "outDir": "/user/username/projects/myproject/b/lib",
+  "composite": true,
+  "configFilePath": "/user/username/projects/myproject/b/tsconfig.json"
+ }
+}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Config: /user/username/projects/myproject/b/tsconfig.json WatchType: Wild card directory
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/index.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/a/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/a/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/a/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/a/index.ts
+
+
+	../b/index.ts
+	  Imported via "../b/lib" from file 'index.ts'
+	index.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/a
+For info: /user/username/projects/myproject/a/tsconfig.json :: No config files found.
+Project '/user/username/projects/myproject/a/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a/index.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/a/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"references","arguments":{"file":"/user/username/projects/myproject/a/index.ts","line":3,"offset":10},"seq":1,"type":"request"}
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+Creating configuration project /user/username/projects/myproject/b/tsconfig.json
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/helper.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b 0 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Missing file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/b/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/b/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/b/tsconfig.json' (Configured)
+	Files (2)
+	/user/username/projects/myproject/b/index.ts
+	/user/username/projects/myproject/b/helper.ts
+
+
+	index.ts
+	  Imported via "." from file 'helper.ts'
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+	helper.ts
+	  Matched by include pattern '**/*' in 'tsconfig.json'
+
+-----------------------------------------------
+Search path: /user/username/projects/myproject/b
+For info: /user/username/projects/myproject/b/index.ts :: Config file name: /user/username/projects/myproject/b/tsconfig.json
+response:{"response":{"refs":[{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":30},"lineText":"import { B } from \"../b/lib\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/a/index.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/index.ts","start":{"line":1,"offset":14},"end":{"line":1,"offset":15},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":3,"offset":2},"lineText":"export class B {","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":1,"offset":10},"end":{"line":1,"offset":11},"contextStart":{"line":1,"offset":1},"contextEnd":{"line":1,"offset":23},"lineText":"import { B } from \".\";","isWriteAccess":true,"isDefinition":true},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":10},"end":{"line":3,"offset":11},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false},{"file":"/user/username/projects/myproject/b/helper.ts","start":{"line":3,"offset":18},"end":{"line":3,"offset":19},"lineText":"const b: B = new B();","isWriteAccess":false,"isDefinition":false}],"symbolName":"B","symbolStartOffset":10,"symbolDisplayString":"(alias) class B\nimport B"},"responseRequired":true}


### PR DESCRIPTION
`disableReferencedProjectLoad` was intended to prevent project loading during find-all-references (FAR), as an escape valve for teams with very large solutions.  However, there's a case it doesn't cover - when the declaration is actually in another project but was pulled into the open project by project reference redirects, the "default" configured project containing the declaring file will be loaded, possibly causing a long delay or an OOM crash.

Note that, while we don't want to load the declaring project, we _do_ want to search it if it's already open.

There's also a weird corner case where `disableSourceOfProjectReferenceRedirect` is enabled, but a .d.ts.map file exists, which causes the .ts file from the referenced project to be discovered anyway.  When this happens, we use the .ts file if it's in some open project and the .d.ts file (which is definitely in an open project, or we wouldn't have found it) otherwise.