### PR TITLE
Support syntactic diagnostics in partial mode

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1053,14 +1053,13 @@ namespace ts.server {
 
                 const { fileName, project } = item;
 
-                // Ensure the project is upto date before checking if this file is present in the project
+                // Ensure the project is up to date before checking if this file is present in the project.
                 updateProjectIfDirty(project);
                 if (!project.containsFile(fileName, requireOpen)) {
                     return;
                 }
 
                 this.syntacticCheck(fileName, project);
-                // Only try to provide semantic diagnostics if we're clean of syntactic diagnostics.
                 if (this.changeSeq !== seq) {
                     return;
                 }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1171,7 +1171,6 @@ namespace ts {
     }
 
     const invalidOperationsInPartialSemanticMode: readonly (keyof LanguageService)[] = [
-        "getSyntacticDiagnostics",
         "getSemanticDiagnostics",
         "getSuggestionDiagnostics",
         "getCompilerOptionsDiagnostics",

--- a/src/testRunner/unittests/tsserver/partialSemanticServer.ts
+++ b/src/testRunner/unittests/tsserver/partialSemanticServer.ts
@@ -123,7 +123,12 @@ import { something } from "something";
             const expectedErrorMessage = "')' expected.";
 
             const host = createServerHost([file1, libFile, configFile]);
-            const session = createSession(host, { serverMode: LanguageServiceMode.PartialSemantic, useSingleInferredProject: true });
+            const session = createSession(host, {
+                serverMode: LanguageServiceMode.PartialSemantic,
+                useSingleInferredProject: true,
+                logger: createLoggerWithInMemoryLogs()
+            });
+
             const service = session.getProjectService();
             openFilesForSession([file1], session);
             const request: protocol.SyntacticDiagnosticsSyncRequest = {
@@ -141,6 +146,9 @@ import { something } from "something";
             const diagnostics = project.getLanguageService().getSyntacticDiagnostics(file1.path);
             assert.isTrue(diagnostics.length === 1);
             assert.equal(diagnostics[0].messageText, expectedErrorMessage);
+
+            verifyGetErrRequest({ session, host, files: [file1], skip: [{ semantic: true, suggestion: true }] });
+            baselineTsserverLogs("partialSemanticServer", "syntactic diagnostics are returned with no error", session);
         });
 
         it("should not include auto type reference directives", () => {

--- a/src/testRunner/unittests/tsserver/partialSemanticServer.ts
+++ b/src/testRunner/unittests/tsserver/partialSemanticServer.ts
@@ -111,6 +111,38 @@ import { something } from "something";
             assert.isTrue(hasException);
         });
 
+        it("allows syntactic diagnostic commands", () => {
+            const file1: File = {
+                path: `${tscWatch.projectRoot}/a.ts`,
+                content: `if (a < (b + c) { }`
+            };
+            const configFile: File = {
+                path: `${tscWatch.projectRoot}/tsconfig.json`,
+                content: `{}`
+            };
+            const expectedErrorMessage = "')' expected.";
+
+            const host = createServerHost([file1, libFile, configFile]);
+            const session = createSession(host, { serverMode: LanguageServiceMode.PartialSemantic, useSingleInferredProject: true });
+            const service = session.getProjectService();
+            openFilesForSession([file1], session);
+            const request: protocol.SyntacticDiagnosticsSyncRequest = {
+                type: "request",
+                seq: 1,
+                command: protocol.CommandTypes.SyntacticDiagnosticsSync,
+                arguments: { file: file1.path }
+            };
+            const response = session.executeCommandSeq(request).response as protocol.SyntacticDiagnosticsSyncResponse["body"];
+            assert.isDefined(response);
+            assert.equal(response!.length, 1);
+            assert.equal((response![0] as protocol.Diagnostic).text, expectedErrorMessage);
+
+            const project = service.inferredProjects[0];
+            const diagnostics = project.getLanguageService().getSyntacticDiagnostics(file1.path);
+            assert.isTrue(diagnostics.length === 1);
+            assert.equal(diagnostics[0].messageText, expectedErrorMessage);
+        });
+
         it("should not include auto type reference directives", () => {
             const { host, session, file1 } = setup();
             const atTypes: File = {

--- a/tests/baselines/reference/tsserver/partialSemanticServer/syntactic-diagnostics-are-returned-with-no-error.js
+++ b/tests/baselines/reference/tsserver/partialSemanticServer/syntactic-diagnostics-are-returned-with-no-error.js
@@ -1,0 +1,31 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/a.ts"}}
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/a.ts
+
+
+	a/lib/lib.d.ts
+	  Default library for target 'es5'
+	user/username/projects/myproject/a.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/a.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"type":"request","seq":1,"command":"syntacticDiagnosticsSync","arguments":{"file":"/user/username/projects/myproject/a.ts"}}
+response:{"response":[{"start":{"line":1,"offset":17},"end":{"line":1,"offset":18},"text":"')' expected.","code":1005,"category":"error"}],"responseRequired":true}
+request:{"command":"geterr","arguments":{"delay":0,"files":["/user/username/projects/myproject/a.ts"]},"seq":2,"type":"request"}
+response:{"responseRequired":false}
+Session does not support events: ignored event: {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"/user/username/projects/myproject/a.ts","diagnostics":[{"start":{"line":1,"offset":17},"end":{"line":1,"offset":18},"text":"')' expected.","code":1005,"category":"error"}]}}
+Session does not support events: ignored event: {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":2}}


### PR DESCRIPTION
Fixes #44835

This PR adds support for syntactic diagnostics under partial mode by providing only `syntaxDiag` events on `geterr` requests, and by providing results for `getSyntacticDiagnosticsSync` requests.

The former allows editors like Visual Studio Code to send `geterr` requests without worrying about pulling on semantic information. The latter allows editors like Visual Studio to send `getSyntacticDiagnosticsSync` requests if it decides to support partial semantic mode in the future.