### PR TITLE
Add collision check for 'Reflect' when using super in static initializers

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -959,6 +959,7 @@ namespace ts {
         const potentialThisCollisions: Node[] = [];
         const potentialNewTargetCollisions: Node[] = [];
         const potentialWeakMapSetCollisions: Node[] = [];
+        const potentialReflectCollisions: Node[] = [];
         const awaitedTypeStack: number[] = [];
 
         const diagnostics = createDiagnosticCollection();
@@ -24873,6 +24874,18 @@ namespace ts {
 
             if (isStatic(container) || isCallExpression) {
                 nodeCheckFlag = NodeCheckFlags.SuperStatic;
+                if (!isCallExpression &&
+                    languageVersion >= ScriptTarget.ES2015 && languageVersion <= ScriptTarget.ES2021 &&
+                    (isPropertyDeclaration(container) || isClassStaticBlockDeclaration(container))) {
+                    // for `super.x` or `super[x]` in a static initializer, mark all enclosing
+                    // block scope containers so that we can report potential collisions with
+                    // `Reflect`.
+                    forEachEnclosingBlockScopeContainer(node.parent, current => {
+                        if (!isSourceFile(current) || isExternalOrCommonJsModule(current)) {
+                            getNodeLinks(current).flags |= NodeCheckFlags.ContainsSuperPropertyInStaticInitializer;
+                        }
+                    });
+                }
             }
             else {
                 nodeCheckFlag = NodeCheckFlags.SuperInstance;
@@ -31159,6 +31172,10 @@ namespace ts {
             Debug.assert(node.kind !== SyntaxKind.MethodDeclaration || isObjectLiteralMethod(node));
             checkNodeDeferred(node);
 
+            if (isFunctionExpression(node)) {
+                checkCollisionsForDeclarationName(node, node.name);
+            }
+
             // The identityMapper object is used to indicate that function expressions are wildcards
             if (checkMode && checkMode & CheckMode.SkipContextSensitive && isContextSensitive(node)) {
                 // Skip parameters, return signature with return type that retains noncontextual parts so inferences can still be drawn in an early stage
@@ -34946,8 +34963,7 @@ namespace ts {
             if (produceDiagnostics) {
                 checkFunctionOrMethodDeclaration(node);
                 checkGrammarForGenerator(node);
-                checkCollisionWithRequireExportsInGeneratedCode(node, node.name!);
-                checkCollisionWithGlobalPromiseInGeneratedCode(node, node.name!);
+                checkCollisionsForDeclarationName(node, node.name);
             }
         }
 
@@ -35470,8 +35486,13 @@ namespace ts {
             });
         }
 
+        /**
+         * Checks whether an {@link Identifier}, in the context of another {@link Node}, would collide with a runtime value
+         * of {@link name} in an outer scope. This is used to check for collisions for downlevel transformations that
+         * require names like `Object`, `Promise`, `Reflect`, `require`, `exports`, etc.
+         */
         function needCollisionCheckForIdentifier(node: Node, identifier: Identifier | undefined, name: string): boolean {
-            if (!(identifier && identifier.escapedText === name)) {
+            if (identifier?.escapedText !== name) {
                 return false;
             }
 
@@ -35480,8 +35501,9 @@ namespace ts {
                 node.kind === SyntaxKind.MethodDeclaration ||
                 node.kind === SyntaxKind.MethodSignature ||
                 node.kind === SyntaxKind.GetAccessor ||
-                node.kind === SyntaxKind.SetAccessor) {
-                // it is ok to have member named '_super' or '_this' - member access is always qualified
+                node.kind === SyntaxKind.SetAccessor ||
+                node.kind === SyntaxKind.PropertyAssignment) {
+                // it is ok to have member named '_super', '_this', `Promise`, etc. - member access is always qualified
                 return false;
             }
 
@@ -35490,8 +35512,15 @@ namespace ts {
                 return false;
             }
 
+            if (isImportClause(node) || isImportEqualsDeclaration(node) || isImportSpecifier(node)) {
+                // type-only imports do not require collision checks against runtime values.
+                if (isTypeOnlyImportOrExportDeclaration(node)) {
+                    return false;
+                }
+            }
+
             const root = getRootDeclaration(node);
-            if (root.kind === SyntaxKind.Parameter && nodeIsMissing((root.parent as FunctionLikeDeclaration).body)) {
+            if (isParameter(root) && nodeIsMissing((root.parent as FunctionLikeDeclaration).body)) {
                 // just an overload - no codegen impact
                 return false;
             }
@@ -35532,21 +35561,13 @@ namespace ts {
             });
         }
 
-        function checkWeakMapSetCollision(node: Node) {
-            const enclosingBlockScope = getEnclosingBlockScopeContainer(node);
-            if (getNodeCheckFlags(enclosingBlockScope) & NodeCheckFlags.ContainsClassWithPrivateIdentifiers) {
-                Debug.assert(isNamedDeclaration(node) && isIdentifier(node.name) && typeof node.name.escapedText === "string", "The target of a WeakMap/WeakSet collision check should be an identifier");
-                errorSkippedOn("noEmit", node, Diagnostics.Compiler_reserves_name_0_when_emitting_private_identifier_downlevel, node.name.escapedText);
-            }
-        }
-
-        function checkCollisionWithRequireExportsInGeneratedCode(node: Node, name: Identifier) {
+       function checkCollisionWithRequireExportsInGeneratedCode(node: Node, name: Identifier | undefined) {
             // No need to check for require or exports for ES6 modules and later
             if (moduleKind >= ModuleKind.ES2015) {
                 return;
             }
 
-            if (!needCollisionCheckForIdentifier(node, name, "require") && !needCollisionCheckForIdentifier(node, name, "exports")) {
+            if (!name || !needCollisionCheckForIdentifier(node, name, "require") && !needCollisionCheckForIdentifier(node, name, "exports")) {
                 return;
             }
 
@@ -35564,8 +35585,8 @@ namespace ts {
             }
         }
 
-        function checkCollisionWithGlobalPromiseInGeneratedCode(node: Node, name: Identifier): void {
-            if (languageVersion >= ScriptTarget.ES2017 || !needCollisionCheckForIdentifier(node, name, "Promise")) {
+        function checkCollisionWithGlobalPromiseInGeneratedCode(node: Node, name: Identifier | undefined): void {
+            if (!name || languageVersion >= ScriptTarget.ES2017 || !needCollisionCheckForIdentifier(node, name, "Promise")) {
                 return;
             }
 
@@ -35583,7 +35604,77 @@ namespace ts {
             }
         }
 
-        function checkVarDeclaredNamesNotShadowed(node: VariableDeclaration | BindingElement) {
+        function recordPotentialCollisionWithWeakMapSetInGeneratedCode(node: Node, name: Identifier): void {
+            if (languageVersion <= ScriptTarget.ES2021
+                && (needCollisionCheckForIdentifier(node, name, "WeakMap") || needCollisionCheckForIdentifier(node, name, "WeakSet"))) {
+                potentialWeakMapSetCollisions.push(node);
+            }
+        }
+
+        function checkWeakMapSetCollision(node: Node) {
+            const enclosingBlockScope = getEnclosingBlockScopeContainer(node);
+            if (getNodeCheckFlags(enclosingBlockScope) & NodeCheckFlags.ContainsClassWithPrivateIdentifiers) {
+                Debug.assert(isNamedDeclaration(node) && isIdentifier(node.name) && typeof node.name.escapedText === "string", "The target of a WeakMap/WeakSet collision check should be an identifier");
+                errorSkippedOn("noEmit", node, Diagnostics.Compiler_reserves_name_0_when_emitting_private_identifier_downlevel, node.name.escapedText);
+            }
+        }
+
+        function recordPotentialCollisionWithReflectInGeneratedCode(node: Node, name: Identifier | undefined): void {
+            if (name && languageVersion >= ScriptTarget.ES2015 && languageVersion <= ScriptTarget.ES2021
+                && needCollisionCheckForIdentifier(node, name, "Reflect")) {
+                potentialReflectCollisions.push(node);
+            }
+        }
+
+        function checkReflectCollision(node: Node) {
+            let hasCollision = false;
+            if (isClassExpression(node)) {
+                // ClassExpression names don't contribute to their containers, but do matter for any of their block-scoped members.
+                for (const member of node.members) {
+                    if (getNodeCheckFlags(member) & NodeCheckFlags.ContainsSuperPropertyInStaticInitializer) {
+                        hasCollision = true;
+                        break;
+                    }
+                }
+            }
+            else if (isFunctionExpression(node)) {
+                // FunctionExpression names don't contribute to their containers, but do matter for their contents
+                if (getNodeCheckFlags(node) & NodeCheckFlags.ContainsSuperPropertyInStaticInitializer) {
+                    hasCollision = true;
+                }
+            }
+            else {
+                const container = getEnclosingBlockScopeContainer(node);
+                if (container && getNodeCheckFlags(container) & NodeCheckFlags.ContainsSuperPropertyInStaticInitializer) {
+                    hasCollision = true;
+                }
+            }
+            if (hasCollision) {
+                Debug.assert(isNamedDeclaration(node) && isIdentifier(node.name), "The target of a Reflect collision check should be an identifier");
+                errorSkippedOn("noEmit", node, Diagnostics.Duplicate_identifier_0_Compiler_reserves_name_1_when_emitting_super_references_in_static_initializers,
+                    declarationNameToString(node.name),
+                    "Reflect");
+            }
+        }
+
+        function checkCollisionsForDeclarationName(node: Node, name: Identifier | undefined) {
+            if (!name) return;
+            checkCollisionWithRequireExportsInGeneratedCode(node, name);
+            checkCollisionWithGlobalPromiseInGeneratedCode(node, name);
+            // recordPotentialCollisionWithWeakMapSetInGeneratedCode(node, name);
+            recordPotentialCollisionWithReflectInGeneratedCode(node, name);
+            if (isClassLike(node)) {
+                checkTypeNameIsReserved(name, Diagnostics.Class_name_cannot_be_0);
+                if (!(node.flags & NodeFlags.Ambient)) {
+                    checkClassNameCollisionWithObject(name);
+                }
+            }
+            else if (isEnumDeclaration(node)) {
+                checkTypeNameIsReserved(name, Diagnostics.Enum_name_cannot_be_0);
+            }
+        }
+
+         function checkVarDeclaredNamesNotShadowed(node: VariableDeclaration | BindingElement) {
             // - ScriptBody : StatementList
             // It is a Syntax Error if any element of the LexicallyDeclaredNames of StatementList
             // also occurs in the VarDeclaredNames of StatementList.
@@ -35801,12 +35892,9 @@ namespace ts {
                 if (node.kind === SyntaxKind.VariableDeclaration || node.kind === SyntaxKind.BindingElement) {
                     checkVarDeclaredNamesNotShadowed(node);
                 }
-                checkCollisionWithRequireExportsInGeneratedCode(node, node.name);
-                checkCollisionWithGlobalPromiseInGeneratedCode(node, node.name);
-                if (languageVersion < ScriptTarget.ESNext
-                    && (needCollisionCheckForIdentifier(node, node.name, "WeakMap") || needCollisionCheckForIdentifier(node, node.name, "WeakSet"))) {
-                    potentialWeakMapSetCollisions.push(node);
-                }
+                checkCollisionsForDeclarationName(node, node.name);
+                // TODO(rbuckton): remove next line when merged into above function.
+                recordPotentialCollisionWithWeakMapSetInGeneratedCode(node, node.name);
             }
         }
 
@@ -37365,14 +37453,7 @@ namespace ts {
         function checkClassLikeDeclaration(node: ClassLikeDeclaration) {
             checkGrammarClassLikeDeclaration(node);
             checkDecorators(node);
-            if (node.name) {
-                checkTypeNameIsReserved(node.name, Diagnostics.Class_name_cannot_be_0);
-                checkCollisionWithRequireExportsInGeneratedCode(node, node.name);
-                checkCollisionWithGlobalPromiseInGeneratedCode(node, node.name);
-                if (!(node.flags & NodeFlags.Ambient)) {
-                    checkClassNameCollisionWithObject(node.name);
-                }
-            }
+            checkCollisionsForDeclarationName(node, node.name);
             checkTypeParameters(getEffectiveTypeParameterDeclarations(node));
             checkExportsOnMergedDeclarations(node);
             const symbol = getSymbolOfNode(node);
@@ -38099,9 +38180,7 @@ namespace ts {
             // Grammar checking
             checkGrammarDecoratorsAndModifiers(node);
 
-            checkTypeNameIsReserved(node.name, Diagnostics.Enum_name_cannot_be_0);
-            checkCollisionWithRequireExportsInGeneratedCode(node, node.name);
-            checkCollisionWithGlobalPromiseInGeneratedCode(node, node.name);
+            checkCollisionsForDeclarationName(node, node.name);
             checkExportsOnMergedDeclarations(node);
             node.members.forEach(checkEnumMember);
 
@@ -38210,8 +38289,7 @@ namespace ts {
                 }
 
                 if (isIdentifier(node.name)) {
-                    checkCollisionWithRequireExportsInGeneratedCode(node, node.name);
-                    checkCollisionWithGlobalPromiseInGeneratedCode(node, node.name);
+                    checkCollisionsForDeclarationName(node, node.name);
                 }
 
                 checkExportsOnMergedDeclarations(node);
@@ -38428,8 +38506,7 @@ namespace ts {
         }
 
         function checkImportBinding(node: ImportEqualsDeclaration | ImportClause | NamespaceImport | ImportSpecifier) {
-            checkCollisionWithRequireExportsInGeneratedCode(node, node.name!);
-            checkCollisionWithGlobalPromiseInGeneratedCode(node, node.name!);
+            checkCollisionsForDeclarationName(node, node.name);
             checkAliasSymbol(node);
             if (node.kind === SyntaxKind.ImportSpecifier &&
                 idText(node.propertyName || node.name) === "default" &&
@@ -39147,6 +39224,7 @@ namespace ts {
                 clear(potentialThisCollisions);
                 clear(potentialNewTargetCollisions);
                 clear(potentialWeakMapSetCollisions);
+                clear(potentialReflectCollisions);
 
                 forEach(node.statements, checkSourceElement);
                 checkSourceElement(node.endOfFileToken);
@@ -39189,6 +39267,11 @@ namespace ts {
                 if (potentialWeakMapSetCollisions.length) {
                     forEach(potentialWeakMapSetCollisions, checkWeakMapSetCollision);
                     clear(potentialWeakMapSetCollisions);
+                }
+
+                if (potentialReflectCollisions.length) {
+                    forEach(potentialReflectCollisions, checkReflectCollision);
+                    clear(potentialReflectCollisions);
                 }
 
                 links.flags |= NodeCheckFlags.TypeChecked;
@@ -40303,7 +40386,9 @@ namespace ts {
         }
 
         function getNodeCheckFlags(node: Node): NodeCheckFlags {
-            return getNodeLinks(node).flags || 0;
+            const nodeId = node.id || 0;
+            if (nodeId < 0 || nodeId >= nodeLinks.length) return 0;
+            return nodeLinks[nodeId]?.flags || 0;
         }
 
         function getEnumMemberValue(node: EnumMember): string | number | undefined {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -35561,7 +35561,7 @@ namespace ts {
             });
         }
 
-       function checkCollisionWithRequireExportsInGeneratedCode(node: Node, name: Identifier | undefined) {
+        function checkCollisionWithRequireExportsInGeneratedCode(node: Node, name: Identifier | undefined) {
             // No need to check for require or exports for ES6 modules and later
             if (moduleKind >= ModuleKind.ES2015) {
                 return;
@@ -35661,7 +35661,7 @@ namespace ts {
             if (!name) return;
             checkCollisionWithRequireExportsInGeneratedCode(node, name);
             checkCollisionWithGlobalPromiseInGeneratedCode(node, name);
-            // recordPotentialCollisionWithWeakMapSetInGeneratedCode(node, name);
+            recordPotentialCollisionWithWeakMapSetInGeneratedCode(node, name);
             recordPotentialCollisionWithReflectInGeneratedCode(node, name);
             if (isClassLike(node)) {
                 checkTypeNameIsReserved(name, Diagnostics.Class_name_cannot_be_0);
@@ -35674,7 +35674,7 @@ namespace ts {
             }
         }
 
-         function checkVarDeclaredNamesNotShadowed(node: VariableDeclaration | BindingElement) {
+        function checkVarDeclaredNamesNotShadowed(node: VariableDeclaration | BindingElement) {
             // - ScriptBody : StatementList
             // It is a Syntax Error if any element of the LexicallyDeclaredNames of StatementList
             // also occurs in the VarDeclaredNames of StatementList.
@@ -35893,8 +35893,6 @@ namespace ts {
                     checkVarDeclaredNamesNotShadowed(node);
                 }
                 checkCollisionsForDeclarationName(node, node.name);
-                // TODO(rbuckton): remove next line when merged into above function.
-                recordPotentialCollisionWithWeakMapSetInGeneratedCode(node, node.name);
             }
         }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3352,6 +3352,10 @@
         "category": "Error",
         "code": 2817
     },
+    "Duplicate identifier '{0}'. Compiler reserves name '{1}' when emitting 'super' references in static initializers.": {
+        "category": "Error",
+        "code": 2818
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4983,29 +4983,30 @@ namespace ts {
 
     /* @internal */
     export const enum NodeCheckFlags {
-        TypeChecked                         = 0x00000001,  // Node has been type checked
-        LexicalThis                         = 0x00000002,  // Lexical 'this' reference
-        CaptureThis                         = 0x00000004,  // Lexical 'this' used in body
-        CaptureNewTarget                    = 0x00000008,  // Lexical 'new.target' used in body
-        SuperInstance                       = 0x00000100,  // Instance 'super' reference
-        SuperStatic                         = 0x00000200,  // Static 'super' reference
-        ContextChecked                      = 0x00000400,  // Contextual types have been assigned
-        AsyncMethodWithSuper                = 0x00000800,  // An async method that reads a value from a member of 'super'.
-        AsyncMethodWithSuperBinding         = 0x00001000,  // An async method that assigns a value to a member of 'super'.
-        CaptureArguments                    = 0x00002000,  // Lexical 'arguments' used in body
-        EnumValuesComputed                  = 0x00004000,  // Values for enum members have been computed, and any errors have been reported for them.
-        LexicalModuleMergesWithClass        = 0x00008000,  // Instantiated lexical module declaration is merged with a previous class declaration.
-        LoopWithCapturedBlockScopedBinding  = 0x00010000,  // Loop that contains block scoped variable captured in closure
-        ContainsCapturedBlockScopeBinding   = 0x00020000,  // Part of a loop that contains block scoped variable captured in closure
-        CapturedBlockScopedBinding          = 0x00040000,  // Block-scoped binding that is captured in some function
-        BlockScopedBindingInLoop            = 0x00080000,  // Block-scoped binding with declaration nested inside iteration statement
-        ClassWithBodyScopedClassBinding     = 0x00100000,  // Decorated class that contains a binding to itself inside of the class body.
-        BodyScopedClassBinding              = 0x00200000,  // Binding to a decorated class inside of the class's body.
-        NeedsLoopOutParameter               = 0x00400000,  // Block scoped binding whose value should be explicitly copied outside of the converted loop
-        AssignmentsMarked                   = 0x00800000,  // Parameter assignments have been marked
-        ClassWithConstructorReference       = 0x01000000,  // Class that contains a binding to its constructor inside of the class body.
-        ConstructorReferenceInClass         = 0x02000000,  // Binding to a class constructor inside of the class's body.
-        ContainsClassWithPrivateIdentifiers = 0x04000000,  // Marked on all block-scoped containers containing a class with private identifiers.
+        TypeChecked                              = 0x00000001,  // Node has been type checked
+        LexicalThis                              = 0x00000002,  // Lexical 'this' reference
+        CaptureThis                              = 0x00000004,  // Lexical 'this' used in body
+        CaptureNewTarget                         = 0x00000008,  // Lexical 'new.target' used in body
+        SuperInstance                            = 0x00000100,  // Instance 'super' reference
+        SuperStatic                              = 0x00000200,  // Static 'super' reference
+        ContextChecked                           = 0x00000400,  // Contextual types have been assigned
+        AsyncMethodWithSuper                     = 0x00000800,  // An async method that reads a value from a member of 'super'.
+        AsyncMethodWithSuperBinding              = 0x00001000,  // An async method that assigns a value to a member of 'super'.
+        CaptureArguments                         = 0x00002000,  // Lexical 'arguments' used in body
+        EnumValuesComputed                       = 0x00004000,  // Values for enum members have been computed, and any errors have been reported for them.
+        LexicalModuleMergesWithClass             = 0x00008000,  // Instantiated lexical module declaration is merged with a previous class declaration.
+        LoopWithCapturedBlockScopedBinding       = 0x00010000,  // Loop that contains block scoped variable captured in closure
+        ContainsCapturedBlockScopeBinding        = 0x00020000,  // Part of a loop that contains block scoped variable captured in closure
+        CapturedBlockScopedBinding               = 0x00040000,  // Block-scoped binding that is captured in some function
+        BlockScopedBindingInLoop                 = 0x00080000,  // Block-scoped binding with declaration nested inside iteration statement
+        ClassWithBodyScopedClassBinding          = 0x00100000,  // Decorated class that contains a binding to itself inside of the class body.
+        BodyScopedClassBinding                   = 0x00200000,  // Binding to a decorated class inside of the class's body.
+        NeedsLoopOutParameter                    = 0x00400000,  // Block scoped binding whose value should be explicitly copied outside of the converted loop
+        AssignmentsMarked                        = 0x00800000,  // Parameter assignments have been marked
+        ClassWithConstructorReference            = 0x01000000,  // Class that contains a binding to its constructor inside of the class body.
+        ConstructorReferenceInClass              = 0x02000000,  // Binding to a class constructor inside of the class's body.
+        ContainsClassWithPrivateIdentifiers      = 0x04000000,  // Marked on all block-scoped containers containing a class with private identifiers.
+        ContainsSuperPropertyInStaticInitializer = 0x08000000,  // Marked on all block-scoped containers containing a static initializer with 'super.x' or 'super[x]'.
     }
 
     /* @internal */

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -285,7 +285,6 @@ namespace ts {
             case SyntaxKind.ForStatement:
             case SyntaxKind.ForInStatement:
             case SyntaxKind.ForOfStatement:
-            case SyntaxKind.ClassStaticBlockDeclaration:
                 return true;
         }
         return false;
@@ -833,7 +832,7 @@ namespace ts {
         return false;
     }
 
-    export function isBlockScope(node: Node, parentNode: Node): boolean {
+    export function isBlockScope(node: Node, parentNode: Node | undefined): boolean {
         switch (node.kind) {
             case SyntaxKind.SourceFile:
             case SyntaxKind.CaseBlock:
@@ -849,6 +848,8 @@ namespace ts {
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.FunctionExpression:
             case SyntaxKind.ArrowFunction:
+            case SyntaxKind.PropertyDeclaration:
+            case SyntaxKind.ClassStaticBlockDeclaration:
                 return true;
 
             case SyntaxKind.Block:
@@ -941,6 +942,14 @@ namespace ts {
     // as a descendant, that is not the provided node.
     export function getEnclosingBlockScopeContainer(node: Node): Node {
         return findAncestor(node.parent, current => isBlockScope(current, current.parent))!;
+    }
+
+    export function forEachEnclosingBlockScopeContainer(node: Node, cb: (container: Node) => void): void {
+        let container = getEnclosingBlockScopeContainer(node);
+        while (container) {
+            cb(container);
+            container = getEnclosingBlockScopeContainer(container);
+        }
     }
 
     // Return display name of an identifier
@@ -1114,6 +1123,7 @@ namespace ts {
             case SyntaxKind.TypeAliasDeclaration:
             case SyntaxKind.PropertyDeclaration:
             case SyntaxKind.PropertySignature:
+            case SyntaxKind.NamespaceImport:
                 errorNode = (node as NamedDeclaration).name;
                 break;
             case SyntaxKind.ArrowFunction:

--- a/tests/baselines/reference/es6ImportNameSpaceImportMergeErrors.errors.txt
+++ b/tests/baselines/reference/es6ImportNameSpaceImportMergeErrors.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/es6ImportNameSpaceImportMergeErrors_1.ts(4,13): error TS2300: Duplicate identifier 'nameSpaceBinding1'.
 tests/cases/compiler/es6ImportNameSpaceImportMergeErrors_1.ts(5,13): error TS2300: Duplicate identifier 'nameSpaceBinding1'.
-tests/cases/compiler/es6ImportNameSpaceImportMergeErrors_1.ts(7,8): error TS2440: Import declaration conflicts with local declaration of 'nameSpaceBinding3'.
+tests/cases/compiler/es6ImportNameSpaceImportMergeErrors_1.ts(7,13): error TS2440: Import declaration conflicts with local declaration of 'nameSpaceBinding3'.
 
 
 ==== tests/cases/compiler/es6ImportNameSpaceImportMergeErrors_0.ts (0 errors) ====
@@ -18,7 +18,7 @@ tests/cases/compiler/es6ImportNameSpaceImportMergeErrors_1.ts(7,8): error TS2440
 !!! error TS2300: Duplicate identifier 'nameSpaceBinding1'.
     
     import * as nameSpaceBinding3 from "./es6ImportNameSpaceImportMergeErrors_0"; // should be error
-           ~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~~~~~~~~
 !!! error TS2440: Import declaration conflicts with local declaration of 'nameSpaceBinding3'.
     var nameSpaceBinding3 = 10;
     

--- a/tests/baselines/reference/exportDefault.errors.txt
+++ b/tests/baselines/reference/exportDefault.errors.txt
@@ -20,7 +20,7 @@
     new types.A(); // Error
         ~~~~~
 !!! error TS1361: 'types' cannot be used as a value because it was imported using 'import type'.
-!!! related TS1376 /b.ts:1:13: 'types' was imported here.
+!!! related TS1376 /b.ts:1:18: 'types' was imported here.
     
 ==== /e.ts (1 errors) ====
     import types = require('./b');

--- a/tests/baselines/reference/extendsClause.errors.txt
+++ b/tests/baselines/reference/extendsClause.errors.txt
@@ -26,5 +26,5 @@ tests/cases/conformance/externalModules/typeOnly/index.ts(10,17): error TS1361: 
     class V extends types.C {} // Error
                     ~~~~~
 !!! error TS1361: 'types' cannot be used as a value because it was imported using 'import type'.
-!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/ns.ts:1:13: 'types' was imported here.
+!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/ns.ts:1:18: 'types' was imported here.
     

--- a/tests/baselines/reference/importClause_namespaceImport.errors.txt
+++ b/tests/baselines/reference/importClause_namespaceImport.errors.txt
@@ -37,5 +37,5 @@
     const d = { types };
                 ~~~~~
 !!! error TS1361: 'types' cannot be used as a value because it was imported using 'import type'.
-!!! related TS1376 /b.ts:1:13: 'types' was imported here.
+!!! related TS1376 /b.ts:1:18: 'types' was imported here.
     

--- a/tests/baselines/reference/importClause_namespaceImport.errors.txt
+++ b/tests/baselines/reference/importClause_namespaceImport.errors.txt
@@ -17,11 +17,11 @@
     types;
     ~~~~~
 !!! error TS1361: 'types' cannot be used as a value because it was imported using 'import type'.
-!!! related TS1376 /b.ts:1:13: 'types' was imported here.
+!!! related TS1376 /b.ts:1:18: 'types' was imported here.
     types.Value;
     ~~~~~
 !!! error TS1361: 'types' cannot be used as a value because it was imported using 'import type'.
-!!! related TS1376 /b.ts:1:13: 'types' was imported here.
+!!! related TS1376 /b.ts:1:18: 'types' was imported here.
     let v: types.Value;
                  ~~~~~
 !!! error TS2694: Namespace '"/a"' has no exported member 'Value'.

--- a/tests/baselines/reference/importEquals1.errors.txt
+++ b/tests/baselines/reference/importEquals1.errors.txt
@@ -20,21 +20,21 @@
     new types.A(); // Error
         ~~~~~
 !!! error TS1361: 'types' cannot be used as a value because it was imported using 'import type'.
-!!! related TS1376 /b.ts:1:13: 'types' was imported here.
+!!! related TS1376 /b.ts:1:18: 'types' was imported here.
     
 ==== /e.ts (1 errors) ====
     import types = require('./b');
     new types.A(); // Error
         ~~~~~
 !!! error TS1361: 'types' cannot be used as a value because it was imported using 'import type'.
-!!! related TS1376 /b.ts:1:13: 'types' was imported here.
+!!! related TS1376 /b.ts:1:18: 'types' was imported here.
     
 ==== /f.ts (1 errors) ====
     import * as types from './b';
     new types.A(); // Error
         ~~~~~
 !!! error TS1361: 'types' cannot be used as a value because it was imported using 'import type'.
-!!! related TS1376 /b.ts:1:13: 'types' was imported here.
+!!! related TS1376 /b.ts:1:18: 'types' was imported here.
     
 ==== /g.ts (1 errors) ====
     import type types from './c'

--- a/tests/baselines/reference/importEquals3.errors.txt
+++ b/tests/baselines/reference/importEquals3.errors.txt
@@ -12,11 +12,11 @@ tests/cases/conformance/externalModules/typeOnly/c.ts(3,13): error TS1380: An im
     import A = a.A; // Error
                ~~~
 !!! error TS1380: An import alias cannot reference a declaration that was imported using 'import type'.
-!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/b.ts:1:13: 'a' was imported here.
+!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/b.ts:1:18: 'a' was imported here.
     import aa = a;  // Error
                 ~
 !!! error TS1380: An import alias cannot reference a declaration that was imported using 'import type'.
-!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/b.ts:1:13: 'a' was imported here.
+!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/b.ts:1:18: 'a' was imported here.
     
     const x = 0;
     export { a, A, x };
@@ -26,11 +26,11 @@ tests/cases/conformance/externalModules/typeOnly/c.ts(3,13): error TS1380: An im
     import A = b.a.A; // Error
                ~~~~~
 !!! error TS1380: An import alias cannot reference a declaration that was imported using 'import type'.
-!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/b.ts:1:13: 'a' was imported here.
+!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/b.ts:1:18: 'a' was imported here.
     import AA = b.A; // Error
                 ~~~
 !!! error TS1380: An import alias cannot reference a declaration that was imported using 'import type'.
-!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/b.ts:1:13: 'a' was imported here.
+!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/b.ts:1:18: 'a' was imported here.
     
     import x = b.x;
     console.log(x);

--- a/tests/baselines/reference/namespaceMergedWithImportAliasNoCrash.errors.txt
+++ b/tests/baselines/reference/namespaceMergedWithImportAliasNoCrash.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/file1.ts(5,1): error TS2708: Cannot use namespace 'Library' as a value.
-tests/cases/compiler/file2.ts(1,8): error TS2440: Import declaration conflicts with local declaration of 'Lib'.
+tests/cases/compiler/file2.ts(1,13): error TS2440: Import declaration conflicts with local declaration of 'Lib'.
 tests/cases/compiler/file2.ts(6,12): error TS2694: Namespace 'Lib' has no exported member 'Bar'.
 
 
@@ -13,7 +13,7 @@ tests/cases/compiler/file2.ts(6,12): error TS2694: Namespace 'Lib' has no export
 !!! error TS2708: Cannot use namespace 'Library' as a value.
 ==== tests/cases/compiler/file2.ts (2 errors) ====
     import * as Lib from './file1';
-           ~~~~~~~~
+                ~~~
 !!! error TS2440: Import declaration conflicts with local declaration of 'Lib'.
     namespace Lib { // should fail to merge
         export const foo: string = "";

--- a/tests/baselines/reference/superInStaticMembers1(target=es2015).errors.txt
+++ b/tests/baselines/reference/superInStaticMembers1(target=es2015).errors.txt
@@ -1,0 +1,630 @@
+tests/cases/conformance/classes/members/instanceAndStaticMembers/classDeclInContainingScopeStaticBlock.ts(3,7): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/classDeclInContainingScopeStaticField.ts(3,7): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/constEnumInContainingScopeStaticBlock.ts(3,12): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/constEnumInContainingScopeStaticField.ts(3,12): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/defaultImportInContainingScopeStaticBlock.ts(3,8): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/defaultImportInContainingScopeStaticField.ts(3,8): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/enumInContainingScopeStaticBlock.ts(3,6): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/enumInContainingScopeStaticField.ts(3,6): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/funcDeclInContainingScopeStaticBlock.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/funcDeclInContainingScopeStaticField.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingClassExprStaticBlock.ts(3,8): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingClassExprStaticField.ts(3,8): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingFuncExprStaticBlock.ts(3,11): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingFuncExprStaticField.ts(3,11): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(6,17): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(10,19): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(14,18): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(18,19): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(22,22): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(26,18): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(30,24): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(52,15): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(57,14): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(62,13): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(67,15): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(72,18): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(77,14): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(82,20): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportInContainingScopeStaticBlock.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportInContainingScopeStaticField.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfConstEnumInContainingScopeStaticBlock.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfConstEnumInContainingScopeStaticField.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfInterfaceInContainingScopeStaticBlock.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfInterfaceInContainingScopeStaticField.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namespaceImportInContainingScopeStaticBlock.ts(3,13): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namespaceImportInContainingScopeStaticField.ts(3,13): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/valueNamespaceInContainingScopeStaticBlock.ts(3,11): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/valueNamespaceInContainingScopeStaticField.ts(3,11): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock1.ts(3,5): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock2.ts(3,7): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock3.ts(3,6): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField1.ts(3,5): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField2.ts(3,7): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField3.ts(3,6): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+
+
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/external.ts (0 errors) ====
+    export class Reflect {}
+    export interface Foo {}
+    export declare namespace Bar { type _ = unknown; }
+    export const enum Baz {}
+    export default class {};
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts (14 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    class C extends B {
+        static _ = [
+            (() => {
+                var Reflect; // collision (es2015-es2021 only)
+                    ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+                      ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                var [Reflect] = [null]; // collision (es2015-es2021 only)
+                     ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                class Reflect {} // collision (es2015-es2021 only)
+                      ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                function Reflect() {} // collision (es2015-es2021 only)
+                         ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                enum Reflect {} // collision (es2015-es2021 only)
+                     ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                const enum Reflect {} // collision (es2015-es2021 only)
+                           ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                type Reflect = unknown; // no collision
+                super.w();
+            })(),
+            (() => {
+                interface Reflect {}; // no collision
+                super.w();
+            })(),
+            (() => {
+                (class Reflect {}); // no collision
+                super.w();
+            })(),
+            (() => {
+                (function Reflect() {}); // no collision
+                super.w();
+            })(),
+        ];
+    
+        static {
+            var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+                  ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            var [Reflect] = [null]; // collision (es2015-es2021 only)
+                 ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            var Reflect; // collision (es2015-es2021 only)
+                ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            class Reflect {} // collision (es2015-es2021 only)
+                  ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            function Reflect() {} // collision (es2015-es2021 only)
+                     ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            enum Reflect {} // collision (es2015-es2021 only)
+                 ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            const enum Reflect {} // collision (es2015-es2021 only)
+                       ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            type Reflect = unknown; // no collision
+            super.w();
+        }
+    
+        static {
+            interface Reflect {} // no collision
+            super.w();
+        }
+    
+        static {
+            (class Reflect {}) // no collision
+            super.w();
+        }
+    
+        static {
+            (function Reflect() {}) // no collision
+            super.w();
+        }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField1.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var Reflect = null; // collision (es2015-es2021 only)
+        ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField2.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+          ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField3.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var [Reflect] = [null]; // collision (es2015-es2021 only)
+         ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock1.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var Reflect = null; // collision (es2015-es2021 only)
+        ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock2.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+          ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock3.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var [Reflect] = [null]; // collision (es2015-es2021 only)
+         ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/classDeclInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    class Reflect {} // collision (es2015-es2021 only)
+          ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/classDeclInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    class Reflect {} // collision (es2015-es2021 only)
+          ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/funcDeclInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    function Reflect() {} // collision (es2015-es2021 only)
+             ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/funcDeclInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    function Reflect() {} // collision (es2015-es2021 only)
+             ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/valueNamespaceInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    namespace Reflect {} // collision (es2015-es2021 only)
+              ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/valueNamespaceInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    namespace Reflect {} // collision (es2015-es2021 only)
+              ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/enumInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    enum Reflect {} // collision (es2015-es2021 only)
+         ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/enumInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    enum Reflect {} // collision (es2015-es2021 only)
+         ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/constEnumInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    const enum Reflect {} // collision (es2015-es2021 only)
+               ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/constEnumInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    const enum Reflect {} // collision (es2015-es2021 only)
+               ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namespaceImportInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import * as Reflect from "./external"; // collision (es2015-es2021 only)
+                ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namespaceImportInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import * as Reflect from "./external"; // collision (es2015-es2021 only)
+                ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Reflect } from "./external"; // collision (es2015-es2021 only)
+             ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Reflect } from "./external"; // collision (es2015-es2021 only)
+             ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfInterfaceInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfInterfaceInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfConstEnumInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfConstEnumInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOnlyNamedImportInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import type { Reflect } from "./external"; // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOnlyNamedImportInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import type { Reflect } from "./external"; // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/defaultImportInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import Reflect from "./external"; // collision (es2015-es2021 only)
+           ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/defaultImportInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import Reflect from "./external"; // collision (es2015-es2021 only)
+           ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOnlyDefaultImportInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import type Reflect from "./external"; // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOnlyDefaultImportInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import type Reflect from "./external"; // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    type Reflect = unknown; // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    type Reflect = unknown; // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/interfaceInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    interface Reflect {}; // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/interfaceInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    interface Reflect {}; // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/uninstantiatedNamespaceInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    declare namespace Reflect { type _ = unknown; }; // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/uninstantiatedNamespaceInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    declare namespace Reflect { type _ = unknown; }; // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/classExprInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (class Reflect {}); // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/classExprInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (class Reflect {}); // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingClassExprStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (class Reflect { // collision (es2015-es2021 only)
+           ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+        static {
+            class C extends B {
+                static _ = super.w();
+            }
+        }
+    });
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingClassExprStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (class Reflect { // collision (es2015-es2021 only)
+           ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+        static {
+            class C extends B {
+                static { super.w(); }
+            }
+        }
+    });
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/funcExprInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (function Reflect() {}); // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/funcExprInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (function Reflect() {}); // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingFuncExprStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (function Reflect() { // collision (es2015-es2021 only)
+              ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+        class C extends B {
+            static _ = super.w();
+        }
+    });
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingFuncExprStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (function Reflect() { // collision (es2015-es2021 only)
+              ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+        class C extends B {
+            static { super.w(); }
+        }
+    });
+    

--- a/tests/baselines/reference/superInStaticMembers1(target=es2015).js
+++ b/tests/baselines/reference/superInStaticMembers1(target=es2015).js
@@ -1,0 +1,1010 @@
+//// [tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts] ////
+
+//// [external.ts]
+export class Reflect {}
+export interface Foo {}
+export declare namespace Bar { type _ = unknown; }
+export const enum Baz {}
+export default class {};
+
+//// [locals.ts]
+export {};
+declare class B { static w(): number; }
+class C extends B {
+    static _ = [
+        (() => {
+            var Reflect; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var [Reflect] = [null]; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            class Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            function Reflect() {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            enum Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            const enum Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            type Reflect = unknown; // no collision
+            super.w();
+        })(),
+        (() => {
+            interface Reflect {}; // no collision
+            super.w();
+        })(),
+        (() => {
+            (class Reflect {}); // no collision
+            super.w();
+        })(),
+        (() => {
+            (function Reflect() {}); // no collision
+            super.w();
+        })(),
+    ];
+
+    static {
+        var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        var [Reflect] = [null]; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        var Reflect; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        class Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        function Reflect() {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        enum Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        const enum Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        type Reflect = unknown; // no collision
+        super.w();
+    }
+
+    static {
+        interface Reflect {} // no collision
+        super.w();
+    }
+
+    static {
+        (class Reflect {}) // no collision
+        super.w();
+    }
+
+    static {
+        (function Reflect() {}) // no collision
+        super.w();
+    }
+}
+
+//// [varInContainingScopeStaticField1.ts]
+export {};
+declare class B { static w(): number; }
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticField2.ts]
+export {};
+declare class B { static w(): number; }
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticField3.ts]
+export {};
+declare class B { static w(): number; }
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticBlock1.ts]
+export {};
+declare class B { static w(): number; }
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [varInContainingScopeStaticBlock2.ts]
+export {};
+declare class B { static w(): number; }
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [varInContainingScopeStaticBlock3.ts]
+export {};
+declare class B { static w(): number; }
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [classDeclInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+class Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [classDeclInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+class Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [funcDeclInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+function Reflect() {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [funcDeclInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+function Reflect() {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [valueNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+namespace Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [valueNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+namespace Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [enumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [enumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [constEnumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+const enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [constEnumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+const enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namespaceImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import * as Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namespaceImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import * as Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfInterfaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfInterfaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfConstEnumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfConstEnumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeOnlyNamedImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import type { Reflect } from "./external"; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeOnlyNamedImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import type { Reflect } from "./external"; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [defaultImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [defaultImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeOnlyDefaultImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import type Reflect from "./external"; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeOnlyDefaultImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import type Reflect from "./external"; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+type Reflect = unknown; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+type Reflect = unknown; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [interfaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+interface Reflect {}; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [interfaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+interface Reflect {}; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [uninstantiatedNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+declare namespace Reflect { type _ = unknown; }; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [uninstantiatedNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+declare namespace Reflect { type _ = unknown; }; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [classExprInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect {}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [classExprInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect {}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [inContainingClassExprStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect { // collision (es2015-es2021 only)
+    static {
+        class C extends B {
+            static _ = super.w();
+        }
+    }
+});
+
+//// [inContainingClassExprStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect { // collision (es2015-es2021 only)
+    static {
+        class C extends B {
+            static { super.w(); }
+        }
+    }
+});
+
+//// [funcExprInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() {}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [funcExprInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() {}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [inContainingFuncExprStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() { // collision (es2015-es2021 only)
+    class C extends B {
+        static _ = super.w();
+    }
+});
+
+//// [inContainingFuncExprStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() { // collision (es2015-es2021 only)
+    class C extends B {
+        static { super.w(); }
+    }
+});
+
+
+//// [external.js]
+export class Reflect {
+}
+export default class {
+}
+;
+//// [locals.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = [
+    (() => {
+        var Reflect; // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        var [Reflect] = [null]; // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        class Reflect {
+        } // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        function Reflect() { } // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        let Reflect;
+        (function (Reflect) {
+        })(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        ; // no collision
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        (class Reflect {
+        }); // no collision
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        (function Reflect() { }); // no collision
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+];
+(() => {
+    var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    var [Reflect] = [null]; // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    var Reflect; // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    class Reflect {
+    } // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    function Reflect() { } // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    let Reflect;
+    (function (Reflect) {
+    })(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    (class Reflect {
+    }); // no collision
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    (function Reflect() { }); // no collision
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [varInContainingScopeStaticField1.js]
+var _a, _b;
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [varInContainingScopeStaticField2.js]
+var _a, _b;
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [varInContainingScopeStaticField3.js]
+var _a, _b;
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [varInContainingScopeStaticBlock1.js]
+var _a, _b;
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [varInContainingScopeStaticBlock2.js]
+var _a, _b;
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [varInContainingScopeStaticBlock3.js]
+var _a, _b;
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [classDeclInContainingScopeStaticField.js]
+var _a, _b;
+class Reflect {
+} // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [classDeclInContainingScopeStaticBlock.js]
+var _a, _b;
+class Reflect {
+} // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [funcDeclInContainingScopeStaticField.js]
+var _a, _b;
+function Reflect() { } // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [funcDeclInContainingScopeStaticBlock.js]
+var _a, _b;
+function Reflect() { } // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [valueNamespaceInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [valueNamespaceInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [enumInContainingScopeStaticField.js]
+var _a, _b;
+var Reflect;
+(function (Reflect) {
+})(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [enumInContainingScopeStaticBlock.js]
+var _a, _b;
+var Reflect;
+(function (Reflect) {
+})(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [constEnumInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [constEnumInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [namespaceImportInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [namespaceImportInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [namedImportInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [namedImportInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [namedImportOfInterfaceInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [namedImportOfInterfaceInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [namedImportOfConstEnumInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [namedImportOfConstEnumInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [typeOnlyNamedImportInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [typeOnlyNamedImportInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [defaultImportInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [defaultImportInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [typeOnlyDefaultImportInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [typeOnlyDefaultImportInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [typeInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [typeInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [interfaceInContainingScopeStaticField.js]
+var _a, _b;
+; // no collision
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [interfaceInContainingScopeStaticBlock.js]
+var _a, _b;
+; // no collision
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [uninstantiatedNamespaceInContainingScopeStaticField.js]
+var _a, _b;
+; // no collision
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [uninstantiatedNamespaceInContainingScopeStaticBlock.js]
+var _a, _b;
+; // no collision
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [classExprInContainingScopeStaticField.js]
+var _a, _b;
+(class Reflect {
+}); // no collision
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [classExprInContainingScopeStaticBlock.js]
+var _a, _b;
+(class Reflect {
+}); // no collision
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [inContainingClassExprStaticField.js]
+var _a;
+(_a = class Reflect {
+    },
+    (() => {
+        var _a, _b;
+        class C extends (_b = B) {
+        }
+        _a = C;
+        C._ = Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    _a);
+export {};
+//// [inContainingClassExprStaticBlock.js]
+var _a;
+(_a = class Reflect {
+    },
+    (() => {
+        var _a, _b;
+        class C extends (_b = B) {
+        }
+        _a = C;
+        (() => {
+            Reflect.get(_b, "w", _a).call(_a);
+        })();
+    })(),
+    _a);
+export {};
+//// [funcExprInContainingScopeStaticField.js]
+var _a, _b;
+(function Reflect() { }); // no collision
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [funcExprInContainingScopeStaticBlock.js]
+var _a, _b;
+(function Reflect() { }); // no collision
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [inContainingFuncExprStaticField.js]
+(function Reflect() {
+    var _a, _b;
+    class C extends (_b = B) {
+    }
+    _a = C;
+    C._ = Reflect.get(_b, "w", _a).call(_a);
+});
+export {};
+//// [inContainingFuncExprStaticBlock.js]
+(function Reflect() {
+    var _a, _b;
+    class C extends (_b = B) {
+    }
+    _a = C;
+    (() => {
+        Reflect.get(_b, "w", _a).call(_a);
+    })();
+});
+export {};

--- a/tests/baselines/reference/superInStaticMembers1(target=es2021).errors.txt
+++ b/tests/baselines/reference/superInStaticMembers1(target=es2021).errors.txt
@@ -1,0 +1,630 @@
+tests/cases/conformance/classes/members/instanceAndStaticMembers/classDeclInContainingScopeStaticBlock.ts(3,7): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/classDeclInContainingScopeStaticField.ts(3,7): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/constEnumInContainingScopeStaticBlock.ts(3,12): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/constEnumInContainingScopeStaticField.ts(3,12): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/defaultImportInContainingScopeStaticBlock.ts(3,8): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/defaultImportInContainingScopeStaticField.ts(3,8): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/enumInContainingScopeStaticBlock.ts(3,6): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/enumInContainingScopeStaticField.ts(3,6): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/funcDeclInContainingScopeStaticBlock.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/funcDeclInContainingScopeStaticField.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingClassExprStaticBlock.ts(3,8): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingClassExprStaticField.ts(3,8): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingFuncExprStaticBlock.ts(3,11): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingFuncExprStaticField.ts(3,11): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(6,17): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(10,19): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(14,18): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(18,19): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(22,22): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(26,18): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(30,24): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(52,15): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(57,14): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(62,13): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(67,15): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(72,18): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(77,14): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts(82,20): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportInContainingScopeStaticBlock.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportInContainingScopeStaticField.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfConstEnumInContainingScopeStaticBlock.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfConstEnumInContainingScopeStaticField.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfInterfaceInContainingScopeStaticBlock.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfInterfaceInContainingScopeStaticField.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.ts(3,10): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namespaceImportInContainingScopeStaticBlock.ts(3,13): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/namespaceImportInContainingScopeStaticField.ts(3,13): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/valueNamespaceInContainingScopeStaticBlock.ts(3,11): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/valueNamespaceInContainingScopeStaticField.ts(3,11): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock1.ts(3,5): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock2.ts(3,7): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock3.ts(3,6): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField1.ts(3,5): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField2.ts(3,7): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField3.ts(3,6): error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+
+
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/external.ts (0 errors) ====
+    export class Reflect {}
+    export interface Foo {}
+    export declare namespace Bar { type _ = unknown; }
+    export const enum Baz {}
+    export default class {};
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/locals.ts (14 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    class C extends B {
+        static _ = [
+            (() => {
+                var Reflect; // collision (es2015-es2021 only)
+                    ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+                      ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                var [Reflect] = [null]; // collision (es2015-es2021 only)
+                     ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                class Reflect {} // collision (es2015-es2021 only)
+                      ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                function Reflect() {} // collision (es2015-es2021 only)
+                         ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                enum Reflect {} // collision (es2015-es2021 only)
+                     ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                const enum Reflect {} // collision (es2015-es2021 only)
+                           ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+                super.w();
+            })(),
+            (() => {
+                type Reflect = unknown; // no collision
+                super.w();
+            })(),
+            (() => {
+                interface Reflect {}; // no collision
+                super.w();
+            })(),
+            (() => {
+                (class Reflect {}); // no collision
+                super.w();
+            })(),
+            (() => {
+                (function Reflect() {}); // no collision
+                super.w();
+            })(),
+        ];
+    
+        static {
+            var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+                  ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            var [Reflect] = [null]; // collision (es2015-es2021 only)
+                 ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            var Reflect; // collision (es2015-es2021 only)
+                ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            class Reflect {} // collision (es2015-es2021 only)
+                  ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            function Reflect() {} // collision (es2015-es2021 only)
+                     ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            enum Reflect {} // collision (es2015-es2021 only)
+                 ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            const enum Reflect {} // collision (es2015-es2021 only)
+                       ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+            super.w();
+        }
+    
+        static {
+            type Reflect = unknown; // no collision
+            super.w();
+        }
+    
+        static {
+            interface Reflect {} // no collision
+            super.w();
+        }
+    
+        static {
+            (class Reflect {}) // no collision
+            super.w();
+        }
+    
+        static {
+            (function Reflect() {}) // no collision
+            super.w();
+        }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField1.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var Reflect = null; // collision (es2015-es2021 only)
+        ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField2.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+          ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticField3.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var [Reflect] = [null]; // collision (es2015-es2021 only)
+         ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock1.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var Reflect = null; // collision (es2015-es2021 only)
+        ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock2.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+          ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/varInContainingScopeStaticBlock3.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    var [Reflect] = [null]; // collision (es2015-es2021 only)
+         ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/classDeclInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    class Reflect {} // collision (es2015-es2021 only)
+          ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/classDeclInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    class Reflect {} // collision (es2015-es2021 only)
+          ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/funcDeclInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    function Reflect() {} // collision (es2015-es2021 only)
+             ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/funcDeclInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    function Reflect() {} // collision (es2015-es2021 only)
+             ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/valueNamespaceInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    namespace Reflect {} // collision (es2015-es2021 only)
+              ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/valueNamespaceInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    namespace Reflect {} // collision (es2015-es2021 only)
+              ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/enumInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    enum Reflect {} // collision (es2015-es2021 only)
+         ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/enumInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    enum Reflect {} // collision (es2015-es2021 only)
+         ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/constEnumInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    const enum Reflect {} // collision (es2015-es2021 only)
+               ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/constEnumInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    const enum Reflect {} // collision (es2015-es2021 only)
+               ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namespaceImportInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import * as Reflect from "./external"; // collision (es2015-es2021 only)
+                ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namespaceImportInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import * as Reflect from "./external"; // collision (es2015-es2021 only)
+                ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Reflect } from "./external"; // collision (es2015-es2021 only)
+             ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Reflect } from "./external"; // collision (es2015-es2021 only)
+             ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfInterfaceInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfInterfaceInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfConstEnumInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/namedImportOfConstEnumInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+             ~~~~~~~~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOnlyNamedImportInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import type { Reflect } from "./external"; // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOnlyNamedImportInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import type { Reflect } from "./external"; // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/defaultImportInContainingScopeStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import Reflect from "./external"; // collision (es2015-es2021 only)
+           ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/defaultImportInContainingScopeStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import Reflect from "./external"; // collision (es2015-es2021 only)
+           ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOnlyDefaultImportInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import type Reflect from "./external"; // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOnlyDefaultImportInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    import type Reflect from "./external"; // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    type Reflect = unknown; // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/typeInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    type Reflect = unknown; // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/interfaceInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    interface Reflect {}; // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/interfaceInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    interface Reflect {}; // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/uninstantiatedNamespaceInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    declare namespace Reflect { type _ = unknown; }; // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/uninstantiatedNamespaceInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    declare namespace Reflect { type _ = unknown; }; // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/classExprInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (class Reflect {}); // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/classExprInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (class Reflect {}); // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingClassExprStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (class Reflect { // collision (es2015-es2021 only)
+           ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+        static {
+            class C extends B {
+                static _ = super.w();
+            }
+        }
+    });
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingClassExprStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (class Reflect { // collision (es2015-es2021 only)
+           ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+        static {
+            class C extends B {
+                static { super.w(); }
+            }
+        }
+    });
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/funcExprInContainingScopeStaticField.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (function Reflect() {}); // no collision
+    class C extends B {
+        static _ = super.w();
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/funcExprInContainingScopeStaticBlock.ts (0 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (function Reflect() {}); // no collision
+    class C extends B {
+        static { super.w(); }
+    }
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingFuncExprStaticField.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (function Reflect() { // collision (es2015-es2021 only)
+              ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+        class C extends B {
+            static _ = super.w();
+        }
+    });
+    
+==== tests/cases/conformance/classes/members/instanceAndStaticMembers/inContainingFuncExprStaticBlock.ts (1 errors) ====
+    export {};
+    declare class B { static w(): number; }
+    (function Reflect() { // collision (es2015-es2021 only)
+              ~~~~~~~
+!!! error TS2818: Duplicate identifier 'Reflect'. Compiler reserves name 'Reflect' when emitting 'super' references in static initializers.
+        class C extends B {
+            static { super.w(); }
+        }
+    });
+    

--- a/tests/baselines/reference/superInStaticMembers1(target=es2021).js
+++ b/tests/baselines/reference/superInStaticMembers1(target=es2021).js
@@ -1,0 +1,1010 @@
+//// [tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts] ////
+
+//// [external.ts]
+export class Reflect {}
+export interface Foo {}
+export declare namespace Bar { type _ = unknown; }
+export const enum Baz {}
+export default class {};
+
+//// [locals.ts]
+export {};
+declare class B { static w(): number; }
+class C extends B {
+    static _ = [
+        (() => {
+            var Reflect; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var [Reflect] = [null]; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            class Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            function Reflect() {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            enum Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            const enum Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            type Reflect = unknown; // no collision
+            super.w();
+        })(),
+        (() => {
+            interface Reflect {}; // no collision
+            super.w();
+        })(),
+        (() => {
+            (class Reflect {}); // no collision
+            super.w();
+        })(),
+        (() => {
+            (function Reflect() {}); // no collision
+            super.w();
+        })(),
+    ];
+
+    static {
+        var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        var [Reflect] = [null]; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        var Reflect; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        class Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        function Reflect() {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        enum Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        const enum Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        type Reflect = unknown; // no collision
+        super.w();
+    }
+
+    static {
+        interface Reflect {} // no collision
+        super.w();
+    }
+
+    static {
+        (class Reflect {}) // no collision
+        super.w();
+    }
+
+    static {
+        (function Reflect() {}) // no collision
+        super.w();
+    }
+}
+
+//// [varInContainingScopeStaticField1.ts]
+export {};
+declare class B { static w(): number; }
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticField2.ts]
+export {};
+declare class B { static w(): number; }
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticField3.ts]
+export {};
+declare class B { static w(): number; }
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticBlock1.ts]
+export {};
+declare class B { static w(): number; }
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [varInContainingScopeStaticBlock2.ts]
+export {};
+declare class B { static w(): number; }
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [varInContainingScopeStaticBlock3.ts]
+export {};
+declare class B { static w(): number; }
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [classDeclInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+class Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [classDeclInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+class Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [funcDeclInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+function Reflect() {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [funcDeclInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+function Reflect() {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [valueNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+namespace Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [valueNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+namespace Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [enumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [enumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [constEnumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+const enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [constEnumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+const enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namespaceImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import * as Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namespaceImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import * as Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfInterfaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfInterfaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfConstEnumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfConstEnumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeOnlyNamedImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import type { Reflect } from "./external"; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeOnlyNamedImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import type { Reflect } from "./external"; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [defaultImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [defaultImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeOnlyDefaultImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import type Reflect from "./external"; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeOnlyDefaultImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import type Reflect from "./external"; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+type Reflect = unknown; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+type Reflect = unknown; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [interfaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+interface Reflect {}; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [interfaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+interface Reflect {}; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [uninstantiatedNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+declare namespace Reflect { type _ = unknown; }; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [uninstantiatedNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+declare namespace Reflect { type _ = unknown; }; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [classExprInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect {}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [classExprInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect {}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [inContainingClassExprStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect { // collision (es2015-es2021 only)
+    static {
+        class C extends B {
+            static _ = super.w();
+        }
+    }
+});
+
+//// [inContainingClassExprStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect { // collision (es2015-es2021 only)
+    static {
+        class C extends B {
+            static { super.w(); }
+        }
+    }
+});
+
+//// [funcExprInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() {}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [funcExprInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() {}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [inContainingFuncExprStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() { // collision (es2015-es2021 only)
+    class C extends B {
+        static _ = super.w();
+    }
+});
+
+//// [inContainingFuncExprStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() { // collision (es2015-es2021 only)
+    class C extends B {
+        static { super.w(); }
+    }
+});
+
+
+//// [external.js]
+export class Reflect {
+}
+export default class {
+}
+;
+//// [locals.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = [
+    (() => {
+        var Reflect; // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        var [Reflect] = [null]; // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        class Reflect {
+        } // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        function Reflect() { } // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        let Reflect;
+        (function (Reflect) {
+        })(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        ; // no collision
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        (class Reflect {
+        }); // no collision
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    (() => {
+        (function Reflect() { }); // no collision
+        Reflect.get(_b, "w", _a).call(_a);
+    })(),
+];
+(() => {
+    var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    var [Reflect] = [null]; // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    var Reflect; // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    class Reflect {
+    } // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    function Reflect() { } // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    let Reflect;
+    (function (Reflect) {
+    })(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    (class Reflect {
+    }); // no collision
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+(() => {
+    (function Reflect() { }); // no collision
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [varInContainingScopeStaticField1.js]
+var _a, _b;
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [varInContainingScopeStaticField2.js]
+var _a, _b;
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [varInContainingScopeStaticField3.js]
+var _a, _b;
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [varInContainingScopeStaticBlock1.js]
+var _a, _b;
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [varInContainingScopeStaticBlock2.js]
+var _a, _b;
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [varInContainingScopeStaticBlock3.js]
+var _a, _b;
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [classDeclInContainingScopeStaticField.js]
+var _a, _b;
+class Reflect {
+} // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [classDeclInContainingScopeStaticBlock.js]
+var _a, _b;
+class Reflect {
+} // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [funcDeclInContainingScopeStaticField.js]
+var _a, _b;
+function Reflect() { } // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [funcDeclInContainingScopeStaticBlock.js]
+var _a, _b;
+function Reflect() { } // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [valueNamespaceInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [valueNamespaceInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [enumInContainingScopeStaticField.js]
+var _a, _b;
+var Reflect;
+(function (Reflect) {
+})(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [enumInContainingScopeStaticBlock.js]
+var _a, _b;
+var Reflect;
+(function (Reflect) {
+})(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [constEnumInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [constEnumInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [namespaceImportInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [namespaceImportInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [namedImportInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [namedImportInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [namedImportOfInterfaceInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [namedImportOfInterfaceInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [namedImportOfConstEnumInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [namedImportOfConstEnumInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [typeOnlyNamedImportInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [typeOnlyNamedImportInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [defaultImportInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [defaultImportInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [typeOnlyDefaultImportInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [typeOnlyDefaultImportInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [typeInContainingScopeStaticField.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [typeInContainingScopeStaticBlock.js]
+var _a, _b;
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [interfaceInContainingScopeStaticField.js]
+var _a, _b;
+; // no collision
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [interfaceInContainingScopeStaticBlock.js]
+var _a, _b;
+; // no collision
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [uninstantiatedNamespaceInContainingScopeStaticField.js]
+var _a, _b;
+; // no collision
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [uninstantiatedNamespaceInContainingScopeStaticBlock.js]
+var _a, _b;
+; // no collision
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [classExprInContainingScopeStaticField.js]
+var _a, _b;
+(class Reflect {
+}); // no collision
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [classExprInContainingScopeStaticBlock.js]
+var _a, _b;
+(class Reflect {
+}); // no collision
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [inContainingClassExprStaticField.js]
+var _a;
+(_a = class Reflect {
+    },
+    (() => {
+        var _a, _b;
+        class C extends (_b = B) {
+        }
+        _a = C;
+        C._ = Reflect.get(_b, "w", _a).call(_a);
+    })(),
+    _a);
+export {};
+//// [inContainingClassExprStaticBlock.js]
+var _a;
+(_a = class Reflect {
+    },
+    (() => {
+        var _a, _b;
+        class C extends (_b = B) {
+        }
+        _a = C;
+        (() => {
+            Reflect.get(_b, "w", _a).call(_a);
+        })();
+    })(),
+    _a);
+export {};
+//// [funcExprInContainingScopeStaticField.js]
+var _a, _b;
+(function Reflect() { }); // no collision
+class C extends (_b = B) {
+}
+_a = C;
+C._ = Reflect.get(_b, "w", _a).call(_a);
+export {};
+//// [funcExprInContainingScopeStaticBlock.js]
+var _a, _b;
+(function Reflect() { }); // no collision
+class C extends (_b = B) {
+}
+_a = C;
+(() => {
+    Reflect.get(_b, "w", _a).call(_a);
+})();
+export {};
+//// [inContainingFuncExprStaticField.js]
+(function Reflect() {
+    var _a, _b;
+    class C extends (_b = B) {
+    }
+    _a = C;
+    C._ = Reflect.get(_b, "w", _a).call(_a);
+});
+export {};
+//// [inContainingFuncExprStaticBlock.js]
+(function Reflect() {
+    var _a, _b;
+    class C extends (_b = B) {
+    }
+    _a = C;
+    (() => {
+        Reflect.get(_b, "w", _a).call(_a);
+    })();
+});
+export {};

--- a/tests/baselines/reference/superInStaticMembers1(target=es5).js
+++ b/tests/baselines/reference/superInStaticMembers1(target=es5).js
@@ -1,0 +1,2063 @@
+//// [tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts] ////
+
+//// [external.ts]
+export class Reflect {}
+export interface Foo {}
+export declare namespace Bar { type _ = unknown; }
+export const enum Baz {}
+export default class {};
+
+//// [locals.ts]
+export {};
+declare class B { static w(): number; }
+class C extends B {
+    static _ = [
+        (() => {
+            var Reflect; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var [Reflect] = [null]; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            class Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            function Reflect() {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            enum Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            const enum Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            type Reflect = unknown; // no collision
+            super.w();
+        })(),
+        (() => {
+            interface Reflect {}; // no collision
+            super.w();
+        })(),
+        (() => {
+            (class Reflect {}); // no collision
+            super.w();
+        })(),
+        (() => {
+            (function Reflect() {}); // no collision
+            super.w();
+        })(),
+    ];
+
+    static {
+        var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        var [Reflect] = [null]; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        var Reflect; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        class Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        function Reflect() {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        enum Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        const enum Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        type Reflect = unknown; // no collision
+        super.w();
+    }
+
+    static {
+        interface Reflect {} // no collision
+        super.w();
+    }
+
+    static {
+        (class Reflect {}) // no collision
+        super.w();
+    }
+
+    static {
+        (function Reflect() {}) // no collision
+        super.w();
+    }
+}
+
+//// [varInContainingScopeStaticField1.ts]
+export {};
+declare class B { static w(): number; }
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticField2.ts]
+export {};
+declare class B { static w(): number; }
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticField3.ts]
+export {};
+declare class B { static w(): number; }
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticBlock1.ts]
+export {};
+declare class B { static w(): number; }
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [varInContainingScopeStaticBlock2.ts]
+export {};
+declare class B { static w(): number; }
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [varInContainingScopeStaticBlock3.ts]
+export {};
+declare class B { static w(): number; }
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [classDeclInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+class Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [classDeclInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+class Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [funcDeclInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+function Reflect() {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [funcDeclInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+function Reflect() {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [valueNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+namespace Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [valueNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+namespace Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [enumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [enumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [constEnumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+const enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [constEnumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+const enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namespaceImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import * as Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namespaceImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import * as Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfInterfaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfInterfaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfConstEnumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfConstEnumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeOnlyNamedImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import type { Reflect } from "./external"; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeOnlyNamedImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import type { Reflect } from "./external"; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [defaultImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [defaultImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeOnlyDefaultImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import type Reflect from "./external"; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeOnlyDefaultImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import type Reflect from "./external"; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+type Reflect = unknown; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+type Reflect = unknown; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [interfaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+interface Reflect {}; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [interfaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+interface Reflect {}; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [uninstantiatedNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+declare namespace Reflect { type _ = unknown; }; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [uninstantiatedNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+declare namespace Reflect { type _ = unknown; }; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [classExprInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect {}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [classExprInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect {}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [inContainingClassExprStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect { // collision (es2015-es2021 only)
+    static {
+        class C extends B {
+            static _ = super.w();
+        }
+    }
+});
+
+//// [inContainingClassExprStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect { // collision (es2015-es2021 only)
+    static {
+        class C extends B {
+            static { super.w(); }
+        }
+    }
+});
+
+//// [funcExprInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() {}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [funcExprInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() {}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [inContainingFuncExprStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() { // collision (es2015-es2021 only)
+    class C extends B {
+        static _ = super.w();
+    }
+});
+
+//// [inContainingFuncExprStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() { // collision (es2015-es2021 only)
+    class C extends B {
+        static { super.w(); }
+    }
+});
+
+
+//// [external.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Reflect = void 0;
+var Reflect = /** @class */ (function () {
+    function Reflect() {
+    }
+    return Reflect;
+}());
+exports.Reflect = Reflect;
+var default_1 = /** @class */ (function () {
+    function default_1() {
+    }
+    return default_1;
+}());
+exports.default = default_1;
+;
+//// [locals.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = [
+        (function () {
+            var Reflect; // collision (es2015-es2021 only)
+            _super.w.call(_a);
+        })(),
+        (function () {
+            var Reflect = { Reflect: null }.Reflect; // collision (es2015-es2021 only)
+            _super.w.call(_a);
+        })(),
+        (function () {
+            var Reflect = [null][0]; // collision (es2015-es2021 only)
+            _super.w.call(_a);
+        })(),
+        (function () {
+            var Reflect = /** @class */ (function () {
+                function Reflect() {
+                }
+                return Reflect;
+            }()); // collision (es2015-es2021 only)
+            _super.w.call(_a);
+        })(),
+        (function () {
+            function Reflect() { } // collision (es2015-es2021 only)
+            _super.w.call(_a);
+        })(),
+        (function () {
+            var Reflect;
+            (function (Reflect) {
+            })(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+            _super.w.call(_a);
+        })(),
+        (function () {
+            _super.w.call(_a);
+        })(),
+        (function () {
+            _super.w.call(_a);
+        })(),
+        (function () {
+            ; // no collision
+            _super.w.call(_a);
+        })(),
+        (function () {
+            (/** @class */ (function () {
+                function Reflect() {
+                }
+                return Reflect;
+            }())); // no collision
+            _super.w.call(_a);
+        })(),
+        (function () {
+            (function Reflect() { }); // no collision
+            _super.w.call(_a);
+        })(),
+    ];
+    (function () {
+        var Reflect = { Reflect: null }.Reflect; // collision (es2015-es2021 only)
+        _super.w.call(_a);
+    })();
+    (function () {
+        var Reflect = [null][0]; // collision (es2015-es2021 only)
+        _super.w.call(_a);
+    })();
+    (function () {
+        var Reflect; // collision (es2015-es2021 only)
+        _super.w.call(_a);
+    })();
+    (function () {
+        var Reflect = /** @class */ (function () {
+            function Reflect() {
+            }
+            return Reflect;
+        }()); // collision (es2015-es2021 only)
+        _super.w.call(_a);
+    })();
+    (function () {
+        function Reflect() { } // collision (es2015-es2021 only)
+        _super.w.call(_a);
+    })();
+    (function () {
+        var Reflect;
+        (function (Reflect) {
+        })(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+        _super.w.call(_a);
+    })();
+    (function () {
+        _super.w.call(_a);
+    })();
+    (function () {
+        _super.w.call(_a);
+    })();
+    (function () {
+        _super.w.call(_a);
+    })();
+    (function () {
+        (/** @class */ (function () {
+            function Reflect() {
+            }
+            return Reflect;
+        }())); // no collision
+        _super.w.call(_a);
+    })();
+    (function () {
+        (function Reflect() { }); // no collision
+        _super.w.call(_a);
+    })();
+    return C;
+}(B));
+//// [varInContainingScopeStaticField1.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var Reflect = null; // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [varInContainingScopeStaticField2.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var Reflect = { Reflect: null }.Reflect; // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [varInContainingScopeStaticField3.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var Reflect = [null][0]; // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [varInContainingScopeStaticBlock1.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var Reflect = null; // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [varInContainingScopeStaticBlock2.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var Reflect = { Reflect: null }.Reflect; // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [varInContainingScopeStaticBlock3.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var Reflect = [null][0]; // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [classDeclInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var Reflect = /** @class */ (function () {
+    function Reflect() {
+    }
+    return Reflect;
+}()); // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [classDeclInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var Reflect = /** @class */ (function () {
+    function Reflect() {
+    }
+    return Reflect;
+}()); // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [funcDeclInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+function Reflect() { } // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [funcDeclInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+function Reflect() { } // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [valueNamespaceInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [valueNamespaceInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [enumInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var Reflect;
+(function (Reflect) {
+})(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [enumInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var Reflect;
+(function (Reflect) {
+})(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [constEnumInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [constEnumInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [namespaceImportInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [namespaceImportInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [namedImportInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [namedImportInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [namedImportOfInterfaceInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [namedImportOfInterfaceInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [namedImportOfConstEnumInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [namedImportOfConstEnumInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [typeOnlyNamedImportInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [typeOnlyNamedImportInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [defaultImportInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [defaultImportInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [typeOnlyDefaultImportInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [typeOnlyDefaultImportInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [typeInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [typeInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [interfaceInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+; // no collision
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [interfaceInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+; // no collision
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [uninstantiatedNamespaceInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+; // no collision
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [uninstantiatedNamespaceInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+; // no collision
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [classExprInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+(/** @class */ (function () {
+    function Reflect() {
+    }
+    return Reflect;
+}())); // no collision
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [classExprInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+(/** @class */ (function () {
+    function Reflect() {
+    }
+    return Reflect;
+}())); // no collision
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [inContainingClassExprStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+(_a = /** @class */ (function () {
+        function Reflect() {
+        }
+        return Reflect;
+    }()),
+    (function () {
+        var C = /** @class */ (function (_super) {
+            __extends(C, _super);
+            function C() {
+                return _super !== null && _super.apply(this, arguments) || this;
+            }
+            var _a;
+            _a = C;
+            C._ = _super.w.call(_a);
+            return C;
+        }(B));
+    })(),
+    _a);
+//// [inContainingClassExprStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+(_a = /** @class */ (function () {
+        function Reflect() {
+        }
+        return Reflect;
+    }()),
+    (function () {
+        var _a;
+        var C = /** @class */ (function (_super) {
+            __extends(C, _super);
+            function C() {
+                return _super !== null && _super.apply(this, arguments) || this;
+            }
+            return C;
+        }(B));
+        _a = C;
+        (function () {
+            _super.w.call(_a);
+        })();
+    })(),
+    _a);
+//// [funcExprInContainingScopeStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+(function Reflect() { }); // no collision
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    var _a;
+    _a = C;
+    C._ = _super.w.call(_a);
+    return C;
+}(B));
+//// [funcExprInContainingScopeStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var _a;
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+(function Reflect() { }); // no collision
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(B));
+_a = C;
+(function () {
+    _super.w.call(_a);
+})();
+//// [inContainingFuncExprStaticField.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+(function Reflect() {
+    var C = /** @class */ (function (_super) {
+        __extends(C, _super);
+        function C() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        var _a;
+        _a = C;
+        C._ = _super.w.call(_a);
+        return C;
+    }(B));
+});
+//// [inContainingFuncExprStaticBlock.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+(function Reflect() {
+    var _this = this;
+    var _a;
+    var C = /** @class */ (function (_super) {
+        __extends(C, _super);
+        function C() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        return C;
+    }(B));
+    _a = C;
+    (function () {
+        _super.w.call(_a);
+    })();
+});

--- a/tests/baselines/reference/superInStaticMembers1(target=esnext).js
+++ b/tests/baselines/reference/superInStaticMembers1(target=esnext).js
@@ -1,0 +1,866 @@
+//// [tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts] ////
+
+//// [external.ts]
+export class Reflect {}
+export interface Foo {}
+export declare namespace Bar { type _ = unknown; }
+export const enum Baz {}
+export default class {};
+
+//// [locals.ts]
+export {};
+declare class B { static w(): number; }
+class C extends B {
+    static _ = [
+        (() => {
+            var Reflect; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var [Reflect] = [null]; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            class Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            function Reflect() {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            enum Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            const enum Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            type Reflect = unknown; // no collision
+            super.w();
+        })(),
+        (() => {
+            interface Reflect {}; // no collision
+            super.w();
+        })(),
+        (() => {
+            (class Reflect {}); // no collision
+            super.w();
+        })(),
+        (() => {
+            (function Reflect() {}); // no collision
+            super.w();
+        })(),
+    ];
+
+    static {
+        var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        var [Reflect] = [null]; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        var Reflect; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        class Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        function Reflect() {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        enum Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        const enum Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        type Reflect = unknown; // no collision
+        super.w();
+    }
+
+    static {
+        interface Reflect {} // no collision
+        super.w();
+    }
+
+    static {
+        (class Reflect {}) // no collision
+        super.w();
+    }
+
+    static {
+        (function Reflect() {}) // no collision
+        super.w();
+    }
+}
+
+//// [varInContainingScopeStaticField1.ts]
+export {};
+declare class B { static w(): number; }
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticField2.ts]
+export {};
+declare class B { static w(): number; }
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticField3.ts]
+export {};
+declare class B { static w(): number; }
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [varInContainingScopeStaticBlock1.ts]
+export {};
+declare class B { static w(): number; }
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [varInContainingScopeStaticBlock2.ts]
+export {};
+declare class B { static w(): number; }
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [varInContainingScopeStaticBlock3.ts]
+export {};
+declare class B { static w(): number; }
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [classDeclInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+class Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [classDeclInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+class Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [funcDeclInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+function Reflect() {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [funcDeclInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+function Reflect() {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [valueNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+namespace Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [valueNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+namespace Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [enumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [enumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [constEnumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+const enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [constEnumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+const enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namespaceImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import * as Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namespaceImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import * as Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfInterfaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfInterfaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [namedImportOfConstEnumInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [namedImportOfConstEnumInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeOnlyNamedImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import type { Reflect } from "./external"; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeOnlyNamedImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import type { Reflect } from "./external"; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [defaultImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+//// [defaultImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeOnlyDefaultImportInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+import type Reflect from "./external"; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeOnlyDefaultImportInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+import type Reflect from "./external"; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [typeInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+type Reflect = unknown; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [typeInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+type Reflect = unknown; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [interfaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+interface Reflect {}; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [interfaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+interface Reflect {}; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [uninstantiatedNamespaceInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+declare namespace Reflect { type _ = unknown; }; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [uninstantiatedNamespaceInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+declare namespace Reflect { type _ = unknown; }; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [classExprInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect {}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [classExprInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect {}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [inContainingClassExprStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect { // collision (es2015-es2021 only)
+    static {
+        class C extends B {
+            static _ = super.w();
+        }
+    }
+});
+
+//// [inContainingClassExprStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(class Reflect { // collision (es2015-es2021 only)
+    static {
+        class C extends B {
+            static { super.w(); }
+        }
+    }
+});
+
+//// [funcExprInContainingScopeStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() {}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+//// [funcExprInContainingScopeStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() {}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+//// [inContainingFuncExprStaticField.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() { // collision (es2015-es2021 only)
+    class C extends B {
+        static _ = super.w();
+    }
+});
+
+//// [inContainingFuncExprStaticBlock.ts]
+export {};
+declare class B { static w(): number; }
+(function Reflect() { // collision (es2015-es2021 only)
+    class C extends B {
+        static { super.w(); }
+    }
+});
+
+
+//// [external.js]
+export class Reflect {
+}
+export default class {
+}
+;
+//// [locals.js]
+class C extends B {
+    static _ = [
+        (() => {
+            var Reflect; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var [Reflect] = [null]; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            class Reflect {
+            } // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            function Reflect() { } // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            let Reflect;
+            (function (Reflect) {
+            })(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            super.w();
+        })(),
+        (() => {
+            super.w();
+        })(),
+        (() => {
+            ; // no collision
+            super.w();
+        })(),
+        (() => {
+            (class Reflect {
+            }); // no collision
+            super.w();
+        })(),
+        (() => {
+            (function Reflect() { }); // no collision
+            super.w();
+        })(),
+    ];
+    static {
+        var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+        super.w();
+    }
+    static {
+        var [Reflect] = [null]; // collision (es2015-es2021 only)
+        super.w();
+    }
+    static {
+        var Reflect; // collision (es2015-es2021 only)
+        super.w();
+    }
+    static {
+        class Reflect {
+        } // collision (es2015-es2021 only)
+        super.w();
+    }
+    static {
+        function Reflect() { } // collision (es2015-es2021 only)
+        super.w();
+    }
+    static {
+        let Reflect;
+        (function (Reflect) {
+        })(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+        super.w();
+    }
+    static {
+        super.w();
+    }
+    static {
+        super.w();
+    }
+    static {
+        super.w();
+    }
+    static {
+        (class Reflect {
+        }); // no collision
+        super.w();
+    }
+    static {
+        (function Reflect() { }); // no collision
+        super.w();
+    }
+}
+export {};
+//// [varInContainingScopeStaticField1.js]
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [varInContainingScopeStaticField2.js]
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [varInContainingScopeStaticField3.js]
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [varInContainingScopeStaticBlock1.js]
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [varInContainingScopeStaticBlock2.js]
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [varInContainingScopeStaticBlock3.js]
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [classDeclInContainingScopeStaticField.js]
+class Reflect {
+} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [classDeclInContainingScopeStaticBlock.js]
+class Reflect {
+} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [funcDeclInContainingScopeStaticField.js]
+function Reflect() { } // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [funcDeclInContainingScopeStaticBlock.js]
+function Reflect() { } // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [valueNamespaceInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [valueNamespaceInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [enumInContainingScopeStaticField.js]
+var Reflect;
+(function (Reflect) {
+})(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [enumInContainingScopeStaticBlock.js]
+var Reflect;
+(function (Reflect) {
+})(Reflect || (Reflect = {})); // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [constEnumInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [constEnumInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [namespaceImportInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [namespaceImportInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [namedImportInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [namedImportInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [namedImportOfInterfaceInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [namedImportOfInterfaceInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [namedImportOfConstEnumInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [namedImportOfConstEnumInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [typeOnlyNamedImportInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [typeOnlyNamedImportInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [defaultImportInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [defaultImportInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [typeOnlyDefaultImportInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [typeOnlyDefaultImportInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [typeInContainingScopeStaticField.js]
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [typeInContainingScopeStaticBlock.js]
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [interfaceInContainingScopeStaticField.js]
+; // no collision
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [interfaceInContainingScopeStaticBlock.js]
+; // no collision
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [uninstantiatedNamespaceInContainingScopeStaticField.js]
+; // no collision
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [uninstantiatedNamespaceInContainingScopeStaticBlock.js]
+; // no collision
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [classExprInContainingScopeStaticField.js]
+(class Reflect {
+}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [classExprInContainingScopeStaticBlock.js]
+(class Reflect {
+}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [inContainingClassExprStaticField.js]
+(class Reflect {
+    static {
+        class C extends B {
+            static _ = super.w();
+        }
+    }
+});
+export {};
+//// [inContainingClassExprStaticBlock.js]
+(class Reflect {
+    static {
+        class C extends B {
+            static { super.w(); }
+        }
+    }
+});
+export {};
+//// [funcExprInContainingScopeStaticField.js]
+(function Reflect() { }); // no collision
+class C extends B {
+    static _ = super.w();
+}
+export {};
+//// [funcExprInContainingScopeStaticBlock.js]
+(function Reflect() { }); // no collision
+class C extends B {
+    static { super.w(); }
+}
+export {};
+//// [inContainingFuncExprStaticField.js]
+(function Reflect() {
+    class C extends B {
+        static _ = super.w();
+    }
+});
+export {};
+//// [inContainingFuncExprStaticBlock.js]
+(function Reflect() {
+    class C extends B {
+        static { super.w(); }
+    }
+});
+export {};

--- a/tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts
+++ b/tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts
@@ -1,0 +1,492 @@
+// @target: es5, es2015, es2021, esnext
+// @noTypesAndSymbols: true
+
+// @filename: external.ts
+export class Reflect {}
+export interface Foo {}
+export declare namespace Bar { type _ = unknown; }
+export const enum Baz {}
+export default class {};
+
+// @filename: locals.ts
+export {};
+declare class B { static w(): number; }
+class C extends B {
+    static _ = [
+        (() => {
+            var Reflect; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            var [Reflect] = [null]; // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            class Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            function Reflect() {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            enum Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            const enum Reflect {} // collision (es2015-es2021 only)
+            super.w();
+        })(),
+        (() => {
+            type Reflect = unknown; // no collision
+            super.w();
+        })(),
+        (() => {
+            interface Reflect {}; // no collision
+            super.w();
+        })(),
+        (() => {
+            (class Reflect {}); // no collision
+            super.w();
+        })(),
+        (() => {
+            (function Reflect() {}); // no collision
+            super.w();
+        })(),
+    ];
+
+    static {
+        var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        var [Reflect] = [null]; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        var Reflect; // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        class Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        function Reflect() {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        enum Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        const enum Reflect {} // collision (es2015-es2021 only)
+        super.w();
+    }
+
+    static {
+        type Reflect = unknown; // no collision
+        super.w();
+    }
+
+    static {
+        interface Reflect {} // no collision
+        super.w();
+    }
+
+    static {
+        (class Reflect {}) // no collision
+        super.w();
+    }
+
+    static {
+        (function Reflect() {}) // no collision
+        super.w();
+    }
+}
+
+// @filename: varInContainingScopeStaticField1.ts
+export {};
+declare class B { static w(): number; }
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: varInContainingScopeStaticField2.ts
+export {};
+declare class B { static w(): number; }
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: varInContainingScopeStaticField3.ts
+export {};
+declare class B { static w(): number; }
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: varInContainingScopeStaticBlock1.ts
+export {};
+declare class B { static w(): number; }
+var Reflect = null; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: varInContainingScopeStaticBlock2.ts
+export {};
+declare class B { static w(): number; }
+var { Reflect } = { Reflect: null }; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: varInContainingScopeStaticBlock3.ts
+export {};
+declare class B { static w(): number; }
+var [Reflect] = [null]; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: classDeclInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+class Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: classDeclInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+class Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: funcDeclInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+function Reflect() {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: funcDeclInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+function Reflect() {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: valueNamespaceInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+namespace Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: valueNamespaceInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+namespace Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: enumInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: enumInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: constEnumInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+const enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: constEnumInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+const enum Reflect {} // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: namespaceImportInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+import * as Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: namespaceImportInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+import * as Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: namedImportInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+import { Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: namedImportInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+import { Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: namedImportOfInterfaceInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: namedImportOfInterfaceInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+import { Foo as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: namedImportOfUninstantiatedNamespaceInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: namedImportOfUninstantiatedNamespaceInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+import { Bar as Reflect } from "./external"; // collision (es2015-es2021 only, not a type-only import)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: namedImportOfConstEnumInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: namedImportOfConstEnumInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+import { Baz as Reflect } from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: typeOnlyNamedImportInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+import type { Reflect } from "./external"; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: typeOnlyNamedImportInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+import type { Reflect } from "./external"; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: defaultImportInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+import Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: defaultImportInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+import Reflect from "./external"; // collision (es2015-es2021 only)
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: typeOnlyDefaultImportInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+import type Reflect from "./external"; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: typeOnlyDefaultImportInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+import type Reflect from "./external"; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: typeInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+type Reflect = unknown; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: typeInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+type Reflect = unknown; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: interfaceInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+interface Reflect {}; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: interfaceInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+interface Reflect {}; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: uninstantiatedNamespaceInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+declare namespace Reflect { type _ = unknown; }; // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: uninstantiatedNamespaceInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+declare namespace Reflect { type _ = unknown; }; // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: classExprInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+(class Reflect {}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: classExprInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+(class Reflect {}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: inContainingClassExprStaticField.ts
+export {};
+declare class B { static w(): number; }
+(class Reflect { // collision (es2015-es2021 only)
+    static {
+        class C extends B {
+            static _ = super.w();
+        }
+    }
+});
+
+// @filename: inContainingClassExprStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+(class Reflect { // collision (es2015-es2021 only)
+    static {
+        class C extends B {
+            static { super.w(); }
+        }
+    }
+});
+
+// @filename: funcExprInContainingScopeStaticField.ts
+export {};
+declare class B { static w(): number; }
+(function Reflect() {}); // no collision
+class C extends B {
+    static _ = super.w();
+}
+
+// @filename: funcExprInContainingScopeStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+(function Reflect() {}); // no collision
+class C extends B {
+    static { super.w(); }
+}
+
+// @filename: inContainingFuncExprStaticField.ts
+export {};
+declare class B { static w(): number; }
+(function Reflect() { // collision (es2015-es2021 only)
+    class C extends B {
+        static _ = super.w();
+    }
+});
+
+// @filename: inContainingFuncExprStaticBlock.ts
+export {};
+declare class B { static w(): number; }
+(function Reflect() { // collision (es2015-es2021 only)
+    class C extends B {
+        static { super.w(); }
+    }
+});


### PR DESCRIPTION
This adds a missing collision check for the global `Reflect` object when encountering a `super` reference in a static initializer in ES2015-ES2021. 

The collision check isn't needed in <=ES5 for the following reasons:
- We don't support uncalled `SuperProperty` access in <=ES5
- We use `_super` in <= ES5
- `Reflect` isn't available in `ES5`, so we do not use it as part of the transformation for targets below ES2015.

This also updates `needCollisionCheckForIdentifier` to avoid false positives for type-only imports.