### PR TITLE
Fix class name reference in class expr

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24354,7 +24354,7 @@ namespace ts {
                     let container = getThisContainer(node, /*includeArrowFunctions*/ false);
                     while (container.kind !== SyntaxKind.SourceFile) {
                         if (container.parent === declaration) {
-                            if (container.kind === SyntaxKind.PropertyDeclaration && isStatic(container)) {
+                            if (isPropertyDeclaration(container) && isStatic(container) || isClassStaticBlockDeclaration(container)) {
                                 getNodeLinks(declaration).flags |= NodeCheckFlags.ClassWithConstructorReference;
                                 getNodeLinks(node).flags |= NodeCheckFlags.ConstructorReferenceInClass;
                             }

--- a/tests/baselines/reference/classStaticBlock27.js
+++ b/tests/baselines/reference/classStaticBlock27.js
@@ -1,0 +1,41 @@
+//// [classStaticBlock27.ts]
+// https://github.com/microsoft/TypeScript/issues/44872
+
+void class Foo {
+    static prop = 1
+    static {
+        console.log(Foo.prop);
+        Foo.prop++;
+    }
+    static {
+        console.log(Foo.prop);
+        Foo.prop++;
+    }
+    static {
+        console.log(Foo.prop);
+        Foo.prop++;
+    }
+}
+
+//// [classStaticBlock27.js]
+// https://github.com/microsoft/TypeScript/issues/44872
+var _a;
+void (_a = /** @class */ (function () {
+        function Foo() {
+        }
+        return Foo;
+    }()),
+    _a.prop = 1,
+    (function () {
+        console.log(_a.prop);
+        _a.prop++;
+    })(),
+    (function () {
+        console.log(_a.prop);
+        _a.prop++;
+    })(),
+    (function () {
+        console.log(_a.prop);
+        _a.prop++;
+    })(),
+    _a);

--- a/tests/baselines/reference/classStaticBlock27.symbols
+++ b/tests/baselines/reference/classStaticBlock27.symbols
@@ -1,0 +1,52 @@
+=== tests/cases/conformance/classes/classStaticBlock/classStaticBlock27.ts ===
+// https://github.com/microsoft/TypeScript/issues/44872
+
+void class Foo {
+>Foo : Symbol(Foo, Decl(classStaticBlock27.ts, 2, 4))
+
+    static prop = 1
+>prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+
+    static {
+        console.log(Foo.prop);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>Foo.prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+>Foo : Symbol(Foo, Decl(classStaticBlock27.ts, 2, 4))
+>prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+
+        Foo.prop++;
+>Foo.prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+>Foo : Symbol(Foo, Decl(classStaticBlock27.ts, 2, 4))
+>prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+    }
+    static {
+        console.log(Foo.prop);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>Foo.prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+>Foo : Symbol(Foo, Decl(classStaticBlock27.ts, 2, 4))
+>prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+
+        Foo.prop++;
+>Foo.prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+>Foo : Symbol(Foo, Decl(classStaticBlock27.ts, 2, 4))
+>prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+    }
+    static {
+        console.log(Foo.prop);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>Foo.prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+>Foo : Symbol(Foo, Decl(classStaticBlock27.ts, 2, 4))
+>prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+
+        Foo.prop++;
+>Foo.prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+>Foo : Symbol(Foo, Decl(classStaticBlock27.ts, 2, 4))
+>prop : Symbol(Foo.prop, Decl(classStaticBlock27.ts, 2, 16))
+    }
+}

--- a/tests/baselines/reference/classStaticBlock27.types
+++ b/tests/baselines/reference/classStaticBlock27.types
@@ -1,0 +1,61 @@
+=== tests/cases/conformance/classes/classStaticBlock/classStaticBlock27.ts ===
+// https://github.com/microsoft/TypeScript/issues/44872
+
+void class Foo {
+>void class Foo {    static prop = 1    static {        console.log(Foo.prop);        Foo.prop++;    }    static {        console.log(Foo.prop);        Foo.prop++;    }    static {        console.log(Foo.prop);        Foo.prop++;    }} : undefined
+>class Foo {    static prop = 1    static {        console.log(Foo.prop);        Foo.prop++;    }    static {        console.log(Foo.prop);        Foo.prop++;    }    static {        console.log(Foo.prop);        Foo.prop++;    }} : typeof Foo
+>Foo : typeof Foo
+
+    static prop = 1
+>prop : number
+>1 : 1
+
+    static {
+        console.log(Foo.prop);
+>console.log(Foo.prop) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>Foo.prop : number
+>Foo : typeof Foo
+>prop : number
+
+        Foo.prop++;
+>Foo.prop++ : number
+>Foo.prop : number
+>Foo : typeof Foo
+>prop : number
+    }
+    static {
+        console.log(Foo.prop);
+>console.log(Foo.prop) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>Foo.prop : number
+>Foo : typeof Foo
+>prop : number
+
+        Foo.prop++;
+>Foo.prop++ : number
+>Foo.prop : number
+>Foo : typeof Foo
+>prop : number
+    }
+    static {
+        console.log(Foo.prop);
+>console.log(Foo.prop) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>Foo.prop : number
+>Foo : typeof Foo
+>prop : number
+
+        Foo.prop++;
+>Foo.prop++ : number
+>Foo.prop : number
+>Foo : typeof Foo
+>prop : number
+    }
+}

--- a/tests/cases/conformance/classes/classStaticBlock/classStaticBlock27.ts
+++ b/tests/cases/conformance/classes/classStaticBlock/classStaticBlock27.ts
@@ -1,0 +1,17 @@
+// https://github.com/microsoft/TypeScript/issues/44872
+
+void class Foo {
+    static prop = 1
+    static {
+        console.log(Foo.prop);
+        Foo.prop++;
+    }
+    static {
+        console.log(Foo.prop);
+        Foo.prop++;
+    }
+    static {
+        console.log(Foo.prop);
+        Foo.prop++;
+    }
+}


### PR DESCRIPTION
Fixes the class name reference in a static block in a class expression. 

Fixes #44872
