### PR TITLE
fix(44868): Imported type incorrectly allowed to be used as a value when object shorthand is used

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7036,11 +7036,15 @@ namespace ts {
             || isPartOfTypeQuery(useSite)
             || isIdentifierInNonEmittingHeritageClause(useSite)
             || isPartOfPossiblyValidTypeOrAbstractComputedPropertyName(useSite)
-            || !isExpressionNode(useSite);
+            || !(isExpressionNode(useSite) || isShorthandPropertyNameUseSite(useSite));
     }
 
     export function typeOnlyDeclarationIsExport(typeOnlyDeclaration: Node) {
         return typeOnlyDeclaration.kind === SyntaxKind.ExportSpecifier;
+    }
+
+    function isShorthandPropertyNameUseSite(useSite: Node) {
+        return isIdentifier(useSite) && isShorthandPropertyAssignment(useSite.parent) && useSite.parent.name === useSite;
     }
 
     function isPartOfPossiblyValidTypeOrAbstractComputedPropertyName(node: Node) {

--- a/tests/baselines/reference/importClause_default.errors.txt
+++ b/tests/baselines/reference/importClause_default.errors.txt
@@ -1,14 +1,19 @@
 /b.ts(2,5): error TS1361: 'A' cannot be used as a value because it was imported using 'import type'.
+/b.ts(4,11): error TS1361: 'A' cannot be used as a value because it was imported using 'import type'.
 
 
 ==== /a.ts (0 errors) ====
     export default class A { a!: string }
     
-==== /b.ts (1 errors) ====
+==== /b.ts (2 errors) ====
     import type A from './a';
     new A();
         ~
 !!! error TS1361: 'A' cannot be used as a value because it was imported using 'import type'.
 !!! related TS1376 /b.ts:1:8: 'A' was imported here.
     let a: A = { a: '' };
+    let b = { A };
+              ~
+!!! error TS1361: 'A' cannot be used as a value because it was imported using 'import type'.
+!!! related TS1376 /b.ts:1:8: 'A' was imported here.
     

--- a/tests/baselines/reference/importClause_default.js
+++ b/tests/baselines/reference/importClause_default.js
@@ -7,6 +7,7 @@ export default class A { a!: string }
 import type A from './a';
 new A();
 let a: A = { a: '' };
+let b = { A };
 
 
 //// [a.js]
@@ -23,3 +24,4 @@ exports["default"] = A;
 exports.__esModule = true;
 new A();
 var a = { a: '' };
+var b = { A: A };

--- a/tests/baselines/reference/importClause_default.symbols
+++ b/tests/baselines/reference/importClause_default.symbols
@@ -15,3 +15,7 @@ let a: A = { a: '' };
 >A : Symbol(A, Decl(b.ts, 0, 6))
 >a : Symbol(a, Decl(b.ts, 2, 12))
 
+let b = { A };
+>b : Symbol(b, Decl(b.ts, 3, 3))
+>A : Symbol(A, Decl(b.ts, 3, 9))
+

--- a/tests/baselines/reference/importClause_default.types
+++ b/tests/baselines/reference/importClause_default.types
@@ -17,3 +17,8 @@ let a: A = { a: '' };
 >a : string
 >'' : ""
 
+let b = { A };
+>b : { A: typeof A; }
+>{ A } : { A: typeof A; }
+>A : typeof A
+

--- a/tests/baselines/reference/importClause_namedImports.errors.txt
+++ b/tests/baselines/reference/importClause_namedImports.errors.txt
@@ -1,4 +1,5 @@
 /d.ts(2,5): error TS1361: 'A' cannot be used as a value because it was imported using 'import type'.
+/d.ts(6,13): error TS1361: 'A' cannot be used as a value because it was imported using 'import type'.
 
 
 ==== /abc.ts (0 errors) ====
@@ -6,7 +7,7 @@
     export type B  = { b: string };
     export const C = "";
     
-==== /d.ts (1 errors) ====
+==== /d.ts (2 errors) ====
     import type { A, B, C } from './abc';
     new A();
         ~
@@ -15,4 +16,8 @@
     declare let a: A;
     declare let b: B;
     b.b;
+    const c = { A };
+                ~
+!!! error TS1361: 'A' cannot be used as a value because it was imported using 'import type'.
+!!! related TS1376 /d.ts:1:15: 'A' was imported here.
     

--- a/tests/baselines/reference/importClause_namedImports.js
+++ b/tests/baselines/reference/importClause_namedImports.js
@@ -11,6 +11,7 @@ new A();
 declare let a: A;
 declare let b: B;
 b.b;
+const c = { A };
 
 
 //// [abc.js]
@@ -29,3 +30,4 @@ exports.C = "";
 exports.__esModule = true;
 new A();
 b.b;
+var c = { A: A };

--- a/tests/baselines/reference/importClause_namedImports.symbols
+++ b/tests/baselines/reference/importClause_namedImports.symbols
@@ -31,3 +31,7 @@ b.b;
 >b : Symbol(b, Decl(d.ts, 3, 11))
 >b : Symbol(b, Decl(abc.ts, 1, 18))
 
+const c = { A };
+>c : Symbol(c, Decl(d.ts, 5, 5))
+>A : Symbol(A, Decl(d.ts, 5, 11))
+

--- a/tests/baselines/reference/importClause_namedImports.types
+++ b/tests/baselines/reference/importClause_namedImports.types
@@ -31,3 +31,8 @@ b.b;
 >b : B
 >b : string
 
+const c = { A };
+>c : { A: typeof A; }
+>{ A } : { A: typeof A; }
+>A : typeof A
+

--- a/tests/baselines/reference/importClause_namespaceImport.errors.txt
+++ b/tests/baselines/reference/importClause_namespaceImport.errors.txt
@@ -3,6 +3,7 @@
 /b.ts(4,14): error TS2694: Namespace '"/a"' has no exported member 'Value'.
 /b.ts(5,7): error TS2741: Property 'a' is missing in type '{}' but required in type 'A'.
 /b.ts(6,7): error TS2741: Property 'b' is missing in type '{}' but required in type 'B'.
+/b.ts(8,13): error TS1361: 'types' cannot be used as a value because it was imported using 'import type'.
 
 
 ==== /a.ts (0 errors) ====
@@ -11,7 +12,7 @@
     export type C<T> = T;
     export const Value = {};
     
-==== /b.ts (5 errors) ====
+==== /b.ts (6 errors) ====
     import type * as types from './a';
     types;
     ~~~~~
@@ -33,4 +34,8 @@
 !!! error TS2741: Property 'b' is missing in type '{}' but required in type 'B'.
 !!! related TS2728 /a.ts:2:18: 'b' is declared here.
     const c: types.C<string> = "";
+    const d = { types };
+                ~~~~~
+!!! error TS1361: 'types' cannot be used as a value because it was imported using 'import type'.
+!!! related TS1376 /b.ts:1:13: 'types' was imported here.
     

--- a/tests/baselines/reference/importClause_namespaceImport.js
+++ b/tests/baselines/reference/importClause_namespaceImport.js
@@ -14,6 +14,7 @@ let v: types.Value;
 const a: types.A = {};
 const b: types.B = {};
 const c: types.C<string> = "";
+const d = { types };
 
 
 //// [a.js]
@@ -42,3 +43,4 @@ var v;
 var a = {};
 var b = {};
 var c = "";
+var d = { types: types };

--- a/tests/baselines/reference/importClause_namespaceImport.symbols
+++ b/tests/baselines/reference/importClause_namespaceImport.symbols
@@ -46,3 +46,7 @@ const c: types.C<string> = "";
 >types : Symbol(types, Decl(b.ts, 0, 11))
 >C : Symbol(types.C, Decl(a.ts, 1, 29))
 
+const d = { types };
+>d : Symbol(d, Decl(b.ts, 7, 5))
+>types : Symbol(types, Decl(b.ts, 7, 11))
+

--- a/tests/baselines/reference/importClause_namespaceImport.types
+++ b/tests/baselines/reference/importClause_namespaceImport.types
@@ -45,3 +45,8 @@ const c: types.C<string> = "";
 >types : any
 >"" : ""
 
+const d = { types };
+>d : { types: typeof types; }
+>{ types } : { types: typeof types; }
+>types : typeof types
+

--- a/tests/cases/conformance/externalModules/typeOnly/importClause_default.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/importClause_default.ts
@@ -5,3 +5,4 @@ export default class A { a!: string }
 import type A from './a';
 new A();
 let a: A = { a: '' };
+let b = { A };

--- a/tests/cases/conformance/externalModules/typeOnly/importClause_namedImports.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/importClause_namedImports.ts
@@ -9,3 +9,4 @@ new A();
 declare let a: A;
 declare let b: B;
 b.b;
+const c = { A };

--- a/tests/cases/conformance/externalModules/typeOnly/importClause_namespaceImport.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/importClause_namespaceImport.ts
@@ -12,3 +12,4 @@ let v: types.Value;
 const a: types.A = {};
 const b: types.B = {};
 const c: types.C<string> = "";
+const d = { types };


### PR DESCRIPTION
Fixes #44868