### PR TITLE
fix Performance types to match the latest @types/node changes

### DIFF
--- a/src/compiler/performanceCore.ts
+++ b/src/compiler/performanceCore.ts
@@ -3,6 +3,8 @@ namespace ts {
     // The following definitions provide the minimum compatible support for the Web Performance User Timings API
     // between browsers and NodeJS:
 
+    export type EntryType = "node" | "mark" | "measure" | "gc" | "function" | "http2" | "http";
+
     export interface PerformanceHooks {
         /** Indicates whether we should write native performance events */
         shouldWriteNativeEvents: boolean;
@@ -19,20 +21,20 @@ namespace ts {
 
     export interface PerformanceEntry {
         name: string;
-        entryType: string;
+        entryType: EntryType;
         startTime: number;
         duration: number;
     }
 
     export interface PerformanceObserverEntryList {
         getEntries(): PerformanceEntryList;
-        getEntriesByName(name: string, type?: string): PerformanceEntryList;
-        getEntriesByType(type: string): PerformanceEntryList;
+        getEntriesByName(name: string, type?: EntryType): PerformanceEntryList;
+        getEntriesByType(type: EntryType): PerformanceEntryList;
     }
 
     export interface PerformanceObserver {
         disconnect(): void;
-        observe(options: { entryTypes: readonly string[] }): void;
+        observe(options: { entryTypes: readonly EntryType[] } | { type: EntryType }): void;
     }
 
     export type PerformanceObserverConstructor = new (callback: (list: PerformanceObserverEntryList, observer: PerformanceObserver) => void) => PerformanceObserver;

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -255,8 +255,8 @@ namespace ts.server {
         sys.clearImmediate = clearImmediate;
         /* eslint-enable no-restricted-globals */
 
-        if (typeof global !== "undefined" && global.gc) {
-            sys.gc = () => global.gc();
+        if (typeof global !== "undefined" && typeof global.gc === "function") {
+            sys.gc = global.gc;
         }
 
         sys.require = (initialDir: string, moduleName: string): RequireResult => {


### PR DESCRIPTION
In the latest version of `@types/node` [was added](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/88febcff5089238f997826d21cea65d81737d9f5/types/node/perf_hooks.d.ts#L4) more specific `EntryType` instead of `string` that breaks the `performanceCore` definition.
