### PR TITLE
Change PerformanceObserver to be compatible with new Node types

### DIFF
--- a/src/compiler/performanceCore.ts
+++ b/src/compiler/performanceCore.ts
@@ -32,7 +32,7 @@ namespace ts {
 
     export interface PerformanceObserver {
         disconnect(): void;
-        observe(options: { entryTypes: readonly string[] }): void;
+        observe(options: { entryTypes: readonly ("mark" | "measure")[] }): void;
     }
 
     export type PerformanceObserverConstructor = new (callback: (list: PerformanceObserverEntryList, observer: PerformanceObserver) => void) => PerformanceObserver;

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -256,7 +256,7 @@ namespace ts.server {
         /* eslint-enable no-restricted-globals */
 
         if (typeof global !== "undefined" && global.gc) {
-            sys.gc = () => global.gc();
+            sys.gc = () => global.gc!();
         }
 
         sys.require = (initialDir: string, moduleName: string): RequireResult => {


### PR DESCRIPTION
Our CI build is failing due to a conflict introduced by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53669. This is impacting our nightly build publish as well.

This PR changes `ts.PerformanceObserver.observe` to resolve the conflict.