### PR TITLE
Improve error message TS1210

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2294,7 +2294,7 @@ namespace ts {
             // Provide specialized messages to help the user understand why we think they're in
             // strict mode.
             if (getContainingClass(node)) {
-                return Diagnostics.Invalid_use_of_0_Class_definitions_are_automatically_in_strict_mode;
+                return Diagnostics.Code_contained_in_a_class_is_evaluated_in_JavaScript_s_strict_mode_which_does_not_allow_this_use_of_0_For_more_information_see_https_Colon_Slash_Slashdeveloper_mozilla_org_Slashen_US_Slashdocs_SlashWeb_SlashJavaScript_SlashReference_SlashStrict_mode;
             }
 
             if (file.externalModuleIndicator) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -663,7 +663,7 @@
         "category": "Error",
         "code": 1208
     },
-    "Invalid use of '{0}'. Class definitions are automatically in strict mode.": {
+    "Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of '{0}'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.": {
         "category": "Error",
         "code": 1210
     },

--- a/tests/baselines/reference/classStaticBlock6.errors.txt
+++ b/tests/baselines/reference/classStaticBlock6.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/classes/classStaticBlock/classStaticBlock6.ts(8,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/conformance/classes/classStaticBlock/classStaticBlock6.ts(9,13): error TS1210: Invalid use of 'eval'. Class definitions are automatically in strict mode.
+tests/cases/conformance/classes/classStaticBlock/classStaticBlock6.ts(8,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/conformance/classes/classStaticBlock/classStaticBlock6.ts(9,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'eval'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/conformance/classes/classStaticBlock/classStaticBlock6.ts(13,9): error TS18037: Await expression cannot be used inside a class static block.
 tests/cases/conformance/classes/classStaticBlock/classStaticBlock6.ts(13,14): error TS1109: Expression expected.
 tests/cases/conformance/classes/classStaticBlock/classStaticBlock6.ts(17,9): error TS2662: Cannot find name 'arguments'. Did you mean the static member 'C.arguments'?
@@ -25,10 +25,10 @@ tests/cases/conformance/classes/classStaticBlock/classStaticBlock6.ts(55,13): er
             let await = 1;
             let arguments = 1;
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             let eval = 1;
                 ~~~~
-!!! error TS1210: Invalid use of 'eval'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'eval'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     
         static {

--- a/tests/baselines/reference/collisionArgumentsClassConstructor.errors.txt
+++ b/tests/baselines/reference/collisionArgumentsClassConstructor.errors.txt
@@ -1,32 +1,32 @@
 tests/cases/compiler/collisionArgumentsClassConstructor.ts(3,28): error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(3,31): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(4,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(8,17): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(3,31): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(4,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(8,17): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/compiler/collisionArgumentsClassConstructor.ts(8,17): error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(9,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(13,17): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(14,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(20,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(25,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(9,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(13,17): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(14,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(20,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(25,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/compiler/collisionArgumentsClassConstructor.ts(30,17): error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(30,24): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(31,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(35,24): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(36,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(51,31): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(52,31): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(30,24): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(31,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(35,24): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(36,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(51,31): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(52,31): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/compiler/collisionArgumentsClassConstructor.ts(53,25): error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(53,28): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(54,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(59,17): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(60,17): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(61,17): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(53,28): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(54,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(59,17): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(60,17): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(61,17): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/compiler/collisionArgumentsClassConstructor.ts(61,17): error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(62,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(67,17): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(68,17): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(69,17): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassConstructor.ts(70,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(62,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(67,17): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(68,17): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(69,17): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassConstructor.ts(70,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 
 
 ==== tests/cases/compiler/collisionArgumentsClassConstructor.ts (29 errors) ====
@@ -36,30 +36,30 @@ tests/cases/compiler/collisionArgumentsClassConstructor.ts(70,13): error TS1210:
                                ~~~~~~~~~~~~
 !!! error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
                                   ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var arguments: any[]; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     class c12 {
         constructor(arguments: number, ...rest) { // error
                     ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
                     ~~~~~~~~~~~~~~~~~
 !!! error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
             var arguments = 10; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     class c1NoError {
         constructor(arguments: number) { // no error
                     ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var arguments = 10; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     
@@ -67,14 +67,14 @@ tests/cases/compiler/collisionArgumentsClassConstructor.ts(70,13): error TS1210:
         constructor(...restParameters) {
             var arguments = 10; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     class c2NoError {
         constructor() {
             var arguments = 10; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     
@@ -83,19 +83,19 @@ tests/cases/compiler/collisionArgumentsClassConstructor.ts(70,13): error TS1210:
                     ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
                            ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var arguments = 10; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     class c3NoError {
         constructor(public arguments: number) { // no error
                            ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var arguments = 10; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     
@@ -112,52 +112,52 @@ tests/cases/compiler/collisionArgumentsClassConstructor.ts(70,13): error TS1210:
     class c5 {
         constructor(i: number, ...arguments); // no codegen no error
                                   ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         constructor(i: string, ...arguments); // no codegen no error
                                   ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         constructor(i: any, ...arguments) { // error
                             ~~~~~~~~~~~~
 !!! error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
                                ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var arguments: any[]; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     
     class c52 {
         constructor(arguments: number, ...rest); // no codegen no error
                     ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         constructor(arguments: string, ...rest); // no codegen no error
                     ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         constructor(arguments: any, ...rest) { // error
                     ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
                     ~~~~~~~~~~~~~~
 !!! error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
             var arguments: any; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     
     class c5NoError {
         constructor(arguments: number); // no error
                     ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         constructor(arguments: string); // no error
                     ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         constructor(arguments: any) { // no error
                     ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var arguments: any; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     

--- a/tests/baselines/reference/collisionArgumentsClassMethod.errors.txt
+++ b/tests/baselines/reference/collisionArgumentsClassMethod.errors.txt
@@ -1,27 +1,27 @@
 tests/cases/compiler/collisionArgumentsClassMethod.ts(2,27): error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(2,30): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(3,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(5,17): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(2,30): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(3,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(5,17): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/compiler/collisionArgumentsClassMethod.ts(5,17): error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(6,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(8,23): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(9,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(11,29): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(12,29): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(6,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(8,23): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(9,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(11,29): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(12,29): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/compiler/collisionArgumentsClassMethod.ts(13,23): error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(13,26): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(14,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(16,16): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(17,16): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(18,16): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(13,26): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(14,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(16,16): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(17,16): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(18,16): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/compiler/collisionArgumentsClassMethod.ts(18,16): error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(19,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(21,22): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(22,22): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(23,22): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(24,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(43,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/compiler/collisionArgumentsClassMethod.ts(46,13): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(19,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(21,22): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(22,22): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(23,22): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(24,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(43,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/compiler/collisionArgumentsClassMethod.ts(46,13): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 
 
 ==== tests/cases/compiler/collisionArgumentsClassMethod.ts (24 errors) ====
@@ -30,69 +30,69 @@ tests/cases/compiler/collisionArgumentsClassMethod.ts(46,13): error TS1210: Inva
                               ~~~~~~~~~~~~
 !!! error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
                                  ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var arguments: any[]; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
         public foo1(arguments: number, ...rest) { //arguments is error
                     ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
                     ~~~~~~~~~~~~~~~~~
 !!! error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
             var arguments = 10; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
         public fooNoError(arguments: number) { // no error
                           ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var arguments = 10; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
         public f4(i: number, ...arguments); // no codegen no error
                                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         public f4(i: string, ...arguments); // no codegen no error
                                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         public f4(i: any, ...arguments) { // error
                           ~~~~~~~~~~~~
 !!! error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
                              ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var arguments: any[]; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
         public f41(arguments: number, ...rest); // no codegen no error
                    ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         public f41(arguments: string, ...rest); // no codegen no error
                    ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         public f41(arguments: any, ...rest) { // error
                    ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
                    ~~~~~~~~~~~~~~
 !!! error TS2396: Duplicate identifier 'arguments'. Compiler uses 'arguments' to initialize rest parameters.
             var arguments: any; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
         public f4NoError(arguments: number); // no error
                          ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         public f4NoError(arguments: string); // no error
                          ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         public f4NoError(arguments: any) { // no error
                          ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var arguments: any; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }
     
@@ -113,11 +113,11 @@ tests/cases/compiler/collisionArgumentsClassMethod.ts(46,13): error TS1210: Inva
         public foo(...restParameters) {
             var arguments = 10; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
         public fooNoError() {
             var arguments = 10; // no error
                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
     }

--- a/tests/baselines/reference/emitArrowFunctionWhenUsingArguments12.errors.txt
+++ b/tests/baselines/reference/emitArrowFunctionWhenUsingArguments12.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments12.ts(2,7): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments12.ts(2,7): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments12.ts(3,23): error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.
 
 
@@ -6,7 +6,7 @@ tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments12.
     class C {
         f(arguments) {
           ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var a = () => arguments;
                           ~~~~~~~~~
 !!! error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.

--- a/tests/baselines/reference/emitArrowFunctionWhenUsingArguments12_ES6.errors.txt
+++ b/tests/baselines/reference/emitArrowFunctionWhenUsingArguments12_ES6.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments12_ES6.ts(2,7): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments12_ES6.ts(2,7): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 
 
 ==== tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments12_ES6.ts (1 errors) ====
     class C {
         f(arguments) {
           ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             var a = () => arguments;
         }
     }

--- a/tests/baselines/reference/jsFileCompilationBindStrictModeErrors.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationBindStrictModeErrors.errors.txt
@@ -7,7 +7,7 @@ tests/cases/compiler/a.js(10,10): error TS1100: Invalid use of 'eval' in strict 
 tests/cases/compiler/a.js(12,10): error TS1100: Invalid use of 'arguments' in strict mode.
 tests/cases/compiler/a.js(15,1): error TS1101: 'with' statements are not allowed in strict mode.
 tests/cases/compiler/a.js(15,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
-tests/cases/compiler/b.js(3,7): error TS1210: Invalid use of 'eval'. Class definitions are automatically in strict mode.
+tests/cases/compiler/b.js(3,7): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'eval'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/compiler/b.js(6,13): error TS1213: Identifier expected. 'let' is a reserved word in strict mode. Class definitions are automatically in strict mode.
 tests/cases/compiler/c.js(1,12): error TS1214: Identifier expected. 'let' is a reserved word in strict mode. Modules are automatically in strict mode.
 tests/cases/compiler/c.js(2,5): error TS1215: Invalid use of 'eval'. Modules are automatically in strict mode.
@@ -57,7 +57,7 @@ tests/cases/compiler/d.js(2,11): error TS1005: ',' expected.
     class c {
         a(eval) { //error
           ~~~~
-!!! error TS1210: Invalid use of 'eval'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'eval'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         }
         method() {
             var let = 10; // error

--- a/tests/baselines/reference/parseClassDeclarationInStrictModeByDefaultInES6.errors.txt
+++ b/tests/baselines/reference/parseClassDeclarationInStrictModeByDefaultInES6.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/es6/classDeclaration/parseClassDeclarationInStrictModeByDefaultInES6.ts(4,16): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
-tests/cases/conformance/es6/classDeclaration/parseClassDeclarationInStrictModeByDefaultInES6.ts(5,17): error TS1210: Invalid use of 'eval'. Class definitions are automatically in strict mode.
-tests/cases/conformance/es6/classDeclaration/parseClassDeclarationInStrictModeByDefaultInES6.ts(6,9): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/conformance/es6/classDeclaration/parseClassDeclarationInStrictModeByDefaultInES6.ts(4,16): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/conformance/es6/classDeclaration/parseClassDeclarationInStrictModeByDefaultInES6.ts(5,17): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'eval'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
+tests/cases/conformance/es6/classDeclaration/parseClassDeclarationInStrictModeByDefaultInES6.ts(6,9): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/conformance/es6/classDeclaration/parseClassDeclarationInStrictModeByDefaultInES6.ts(6,9): error TS2322: Type 'string' is not assignable to type 'IArguments'.
 
 
@@ -10,13 +10,13 @@ tests/cases/conformance/es6/classDeclaration/parseClassDeclarationInStrictModeBy
         public implements() { }
         public foo(arguments: any) { }
                    ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
         private bar(eval:any) {
                     ~~~~
-!!! error TS1210: Invalid use of 'eval'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'eval'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             arguments = "hello";
             ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
             ~~~~~~~~~
 !!! error TS2322: Type 'string' is not assignable to type 'IArguments'.
         }

--- a/tests/baselines/reference/parserRealSource11.errors.txt
+++ b/tests/baselines/reference/parserRealSource11.errors.txt
@@ -113,7 +113,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(504,58): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(506,22): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(507,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(518,32): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(520,29): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(520,29): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(525,27): error TS2304: Cannot find name 'Signature'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(527,36): error TS2304: Cannot find name 'TypeFlow'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(528,34): error TS2304: Cannot find name 'NodeType'.
@@ -241,7 +241,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(959,27): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(961,25): error TS2304: Cannot find name 'IHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(963,27): error TS2304: Cannot find name 'Signature'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(981,27): error TS2304: Cannot find name 'Type'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(985,29): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(985,29): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1004,44): error TS2304: Cannot find name 'hasFlag'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1004,67): error TS2304: Cannot find name 'FncFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1005,57): error TS2304: Cannot find name 'FncFlags'.
@@ -1263,7 +1263,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                          public target: AST,
                          public arguments: ASTList) {
                                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
                 super(nodeType);
                 this.minChar = this.target.minChar;
             }
@@ -1984,7 +1984,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
             constructor (public name: Identifier, public bod: ASTList, public isConstructor: boolean,
                          public arguments: ASTList, public vars: ASTList, public scopes: ASTList, public statics: ASTList,
                                 ~~~~~~~~~
-!!! error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
+!!! error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
                 nodeType: number) {
     
                 super(nodeType);


### PR DESCRIPTION
Changes error message `TS1210` from:
```
Invalid use of '{0}'. Class definitions are automatically in strict mode.
```
to
```
Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of '{0}'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
```
as [suggested](https://github.com/microsoft/TypeScript/issues/44765#issuecomment-870842520).

Fixes #44765
