### PR TITLE
fix(44902): TS Server crashed when extending a mixin class and use the override keyword (after 4.4.0) 

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27857,7 +27857,7 @@ namespace ts {
         }
 
         function getSuggestedSymbolForNonexistentClassMember(name: string, baseType: Type): Symbol | undefined {
-            return getSpellingSuggestionForName(name, arrayFrom(getMembersOfSymbol(baseType.symbol).values()), SymbolFlags.ClassMember);
+            return getSpellingSuggestionForName(name, getPropertiesOfType(baseType), SymbolFlags.ClassMember);
         }
 
         function getSuggestedSymbolForNonexistentProperty(name: Identifier | PrivateIdentifier | string, containingType: Type): Symbol | undefined {

--- a/tests/baselines/reference/override19.errors.txt
+++ b/tests/baselines/reference/override19.errors.txt
@@ -1,0 +1,27 @@
+tests/cases/conformance/override/override19.ts(12,13): error TS4113: This member cannot have an 'override' modifier because it is not declared in the base class 'A & { context: Context; }'.
+tests/cases/conformance/override/override19.ts(16,14): error TS4117: This member cannot have an 'override' modifier because it is not declared in the base class 'A & { context: Context; }'. Did you mean 'doSomething'?
+
+
+==== tests/cases/conformance/override/override19.ts (2 errors) ====
+    type Foo = abstract new(...args: any) => any;
+    declare function CreateMixin<C extends Foo, T extends Foo>(Context: C, Base: T): T & {
+       new (...args: any[]): { context: InstanceType<C> }
+    }
+    class Context {}
+    
+    class A {
+        doSomething() {}
+    }
+    
+    class B extends CreateMixin(Context, A) {
+       override foo() {} // Remove override
+                ~~~
+!!! error TS4113: This member cannot have an 'override' modifier because it is not declared in the base class 'A & { context: Context; }'.
+    }
+    
+    class C extends CreateMixin(Context, A) {
+        override doSomethang() {} // Suggestion 'doSomething'
+                 ~~~~~~~~~~~
+!!! error TS4117: This member cannot have an 'override' modifier because it is not declared in the base class 'A & { context: Context; }'. Did you mean 'doSomething'?
+    }
+    

--- a/tests/baselines/reference/override19.js
+++ b/tests/baselines/reference/override19.js
@@ -1,0 +1,32 @@
+//// [override19.ts]
+type Foo = abstract new(...args: any) => any;
+declare function CreateMixin<C extends Foo, T extends Foo>(Context: C, Base: T): T & {
+   new (...args: any[]): { context: InstanceType<C> }
+}
+class Context {}
+
+class A {
+    doSomething() {}
+}
+
+class B extends CreateMixin(Context, A) {
+   override foo() {} // Remove override
+}
+
+class C extends CreateMixin(Context, A) {
+    override doSomethang() {} // Suggestion 'doSomething'
+}
+
+
+//// [override19.js]
+class Context {
+}
+class A {
+    doSomething() { }
+}
+class B extends CreateMixin(Context, A) {
+    foo() { } // Remove override
+}
+class C extends CreateMixin(Context, A) {
+    doSomethang() { } // Suggestion 'doSomething'
+}

--- a/tests/baselines/reference/override19.symbols
+++ b/tests/baselines/reference/override19.symbols
@@ -1,0 +1,53 @@
+=== tests/cases/conformance/override/override19.ts ===
+type Foo = abstract new(...args: any) => any;
+>Foo : Symbol(Foo, Decl(override19.ts, 0, 0))
+>args : Symbol(args, Decl(override19.ts, 0, 24))
+
+declare function CreateMixin<C extends Foo, T extends Foo>(Context: C, Base: T): T & {
+>CreateMixin : Symbol(CreateMixin, Decl(override19.ts, 0, 45))
+>C : Symbol(C, Decl(override19.ts, 1, 29))
+>Foo : Symbol(Foo, Decl(override19.ts, 0, 0))
+>T : Symbol(T, Decl(override19.ts, 1, 43))
+>Foo : Symbol(Foo, Decl(override19.ts, 0, 0))
+>Context : Symbol(Context, Decl(override19.ts, 1, 59))
+>C : Symbol(C, Decl(override19.ts, 1, 29))
+>Base : Symbol(Base, Decl(override19.ts, 1, 70))
+>T : Symbol(T, Decl(override19.ts, 1, 43))
+>T : Symbol(T, Decl(override19.ts, 1, 43))
+
+   new (...args: any[]): { context: InstanceType<C> }
+>args : Symbol(args, Decl(override19.ts, 2, 8))
+>context : Symbol(context, Decl(override19.ts, 2, 26))
+>InstanceType : Symbol(InstanceType, Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(override19.ts, 1, 29))
+}
+class Context {}
+>Context : Symbol(Context, Decl(override19.ts, 3, 1))
+
+class A {
+>A : Symbol(A, Decl(override19.ts, 4, 16))
+
+    doSomething() {}
+>doSomething : Symbol(A.doSomething, Decl(override19.ts, 6, 9))
+}
+
+class B extends CreateMixin(Context, A) {
+>B : Symbol(B, Decl(override19.ts, 8, 1))
+>CreateMixin : Symbol(CreateMixin, Decl(override19.ts, 0, 45))
+>Context : Symbol(Context, Decl(override19.ts, 3, 1))
+>A : Symbol(A, Decl(override19.ts, 4, 16))
+
+   override foo() {} // Remove override
+>foo : Symbol(B.foo, Decl(override19.ts, 10, 41))
+}
+
+class C extends CreateMixin(Context, A) {
+>C : Symbol(C, Decl(override19.ts, 12, 1))
+>CreateMixin : Symbol(CreateMixin, Decl(override19.ts, 0, 45))
+>Context : Symbol(Context, Decl(override19.ts, 3, 1))
+>A : Symbol(A, Decl(override19.ts, 4, 16))
+
+    override doSomethang() {} // Suggestion 'doSomething'
+>doSomethang : Symbol(C.doSomethang, Decl(override19.ts, 14, 41))
+}
+

--- a/tests/baselines/reference/override19.types
+++ b/tests/baselines/reference/override19.types
@@ -1,0 +1,46 @@
+=== tests/cases/conformance/override/override19.ts ===
+type Foo = abstract new(...args: any) => any;
+>Foo : Foo
+>args : any
+
+declare function CreateMixin<C extends Foo, T extends Foo>(Context: C, Base: T): T & {
+>CreateMixin : <C extends Foo, T extends Foo>(Context: C, Base: T) => T & (new (...args: any[]) => {    context: InstanceType<C>;})
+>Context : C
+>Base : T
+
+   new (...args: any[]): { context: InstanceType<C> }
+>args : any[]
+>context : InstanceType<C>
+}
+class Context {}
+>Context : Context
+
+class A {
+>A : A
+
+    doSomething() {}
+>doSomething : () => void
+}
+
+class B extends CreateMixin(Context, A) {
+>B : B
+>CreateMixin(Context, A) : A & { context: Context; }
+>CreateMixin : <C extends Foo, T extends Foo>(Context: C, Base: T) => T & (new (...args: any[]) => { context: InstanceType<C>; })
+>Context : typeof Context
+>A : typeof A
+
+   override foo() {} // Remove override
+>foo : () => void
+}
+
+class C extends CreateMixin(Context, A) {
+>C : C
+>CreateMixin(Context, A) : A & { context: Context; }
+>CreateMixin : <C extends Foo, T extends Foo>(Context: C, Base: T) => T & (new (...args: any[]) => { context: InstanceType<C>; })
+>Context : typeof Context
+>A : typeof A
+
+    override doSomethang() {} // Suggestion 'doSomething'
+>doSomethang : () => void
+}
+

--- a/tests/cases/conformance/override/override19.ts
+++ b/tests/cases/conformance/override/override19.ts
@@ -1,0 +1,20 @@
+// @target: esnext
+// @noImplicitOverride: true
+
+type Foo = abstract new(...args: any) => any;
+declare function CreateMixin<C extends Foo, T extends Foo>(Context: C, Base: T): T & {
+   new (...args: any[]): { context: InstanceType<C> }
+}
+class Context {}
+
+class A {
+    doSomething() {}
+}
+
+class B extends CreateMixin(Context, A) {
+   override foo() {} // Remove override
+}
+
+class C extends CreateMixin(Context, A) {
+    override doSomethang() {} // Suggestion 'doSomething'
+}

--- a/tests/cases/fourslash/codeFixSpelling13.ts
+++ b/tests/cases/fourslash/codeFixSpelling13.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitOverride: true
+
+////type Foo = abstract new(...args: any) => any;
+////declare function CreateMixin<C extends Foo, T extends Foo>(Context: C, Base: T): T & {
+////    new (...args: any[]): { context: InstanceType<C> }
+////}
+////class Context {}
+////class A {
+////    foo() {}
+////}
+////class B extends CreateMixin(Context, A) {
+////    [|override doSomethang() {}|]
+////}
+
+verify.codeFix({
+    index: 0,
+    description: [ts.Diagnostics.Remove_override_modifier.message],
+    newRangeContent: "doSomethang() {}"
+});

--- a/tests/cases/fourslash/codeFixSpelling14.ts
+++ b/tests/cases/fourslash/codeFixSpelling14.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitOverride: true
+
+////type Foo = abstract new(...args: any) => any;
+////declare function CreateMixin<C extends Foo, T extends Foo>(Context: C, Base: T): T & {
+////    new (...args: any[]): { context: InstanceType<C> }
+////}
+////class Context {}
+////class A {
+////    doSomething() {}
+////}
+////class B extends CreateMixin(Context, A) {
+////    override [|doSomethang|]() {}
+////}
+
+verify.codeFix({
+    index: 0,
+    description: [ts.Diagnostics.Change_spelling_to_0.message, "doSomething"],
+    newRangeContent: "doSomething"
+});


### PR DESCRIPTION
Fixes #44902 