### PR TITLE
Watch mode watches for changes in package.json files used in resolution

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -494,6 +494,7 @@ namespace ts {
     export interface PackageJsonInfoCache {
         /*@internal*/ getPackageJsonInfo(packageJsonPath: string): PackageJsonInfo | boolean | undefined;
         /*@internal*/ setPackageJsonInfo(packageJsonPath: string, info: PackageJsonInfo | boolean): void;
+        /*@internal*/ entries(): [Path, PackageJsonInfo | boolean][];
         clear(): void;
     }
 
@@ -559,7 +560,7 @@ namespace ts {
 
     function createPackageJsonInfoCache(currentDirectory: string, getCanonicalFileName: (s: string) => string): PackageJsonInfoCache {
         let cache: ESMap<Path, PackageJsonInfo | boolean> | undefined;
-        return { getPackageJsonInfo, setPackageJsonInfo, clear };
+        return { getPackageJsonInfo, setPackageJsonInfo, clear, entries };
         function getPackageJsonInfo(packageJsonPath: string) {
             return cache?.get(toPath(packageJsonPath, currentDirectory, getCanonicalFileName));
         }
@@ -568,6 +569,10 @@ namespace ts {
         }
         function clear() {
             cache = undefined;
+        }
+        function entries() {
+            const iter = cache?.entries();
+            return iter ? arrayFrom(iter) : [];
         }
     }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1054,6 +1054,7 @@ namespace ts {
             getSourceFileByPath,
             getSourceFiles: () => files,
             getMissingFilePaths: () => missingFilePaths!, // TODO: GH#18217
+            getModuleResolutionCache: () => moduleResolutionCache,
             getFilesByNameMap: () => filesByName,
             getCompilerOptions: () => options,
             getSyntacticDiagnostics,

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -25,6 +25,8 @@ namespace ts {
         updateTypeRootsWatch(): void;
         closeTypeRootsWatch(): void;
 
+        getModuleResolutionCache(): ModuleResolutionCache;
+
         clear(): void;
     }
 
@@ -203,6 +205,7 @@ namespace ts {
         const typeRootsWatches = new Map<string, FileWatcher>();
 
         return {
+            getModuleResolutionCache: () => moduleResolutionCache,
             startRecordingFilesWithChangedResolutions,
             finishRecordingFilesWithChangedResolutions,
             // perDirectoryResolvedModuleNames and perDirectoryResolvedTypeReferenceDirectives could be non empty if there was exception during program update

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -257,6 +257,8 @@ namespace ts {
         readonly allWatchedInputFiles: ESMap<ResolvedConfigFilePath, ESMap<Path, FileWatcher>>;
         readonly allWatchedConfigFiles: ESMap<ResolvedConfigFilePath, FileWatcher>;
         readonly allWatchedExtendedConfigFiles: ESMap<Path, SharedExtendedConfigFileWatcher<ResolvedConfigFilePath>>;
+        readonly allWatchedPackageJsonFiles: ESMap<ResolvedConfigFilePath, ESMap<Path, FileWatcher>>;
+        readonly lastCachedPackageJsonLookups: ESMap<ResolvedConfigFilePath, readonly (readonly [Path, object | boolean])[] | undefined>;
 
         timerToBuildInvalidatedProject: any;
         reportFileChangeDetected: boolean;
@@ -336,6 +338,8 @@ namespace ts {
             allWatchedInputFiles: new Map(),
             allWatchedConfigFiles: new Map(),
             allWatchedExtendedConfigFiles: new Map(),
+            allWatchedPackageJsonFiles: new Map(),
+            lastCachedPackageJsonLookups: new Map(),
 
             timerToBuildInvalidatedProject: undefined,
             reportFileChangeDetected: false,
@@ -495,6 +499,12 @@ namespace ts {
 
             mutateMapSkippingNewValues(
                 state.allWatchedInputFiles,
+                currentProjects,
+                { onDeleteValue: existingMap => existingMap.forEach(closeFileWatcher) }
+            );
+
+            mutateMapSkippingNewValues(
+                state.allWatchedPackageJsonFiles,
                 currentProjects,
                 { onDeleteValue: existingMap => existingMap.forEach(closeFileWatcher) }
             );
@@ -861,6 +871,11 @@ namespace ts {
                 getConfigFileParsingDiagnostics(config),
                 config.projectReferences
             );
+            state.lastCachedPackageJsonLookups.set(projectPath, state.moduleResolutionCache && map(
+                state.moduleResolutionCache.getPackageJsonInfoCache().entries(),
+                ([path, data]) => ([state.host.realpath ? state.host.realpath(path) as Path : path, data] as const)
+            ));
+
             if (state.watch) {
                 state.builderPrograms.set(projectPath, program);
             }
@@ -1192,12 +1207,14 @@ namespace ts {
                 watchExtendedConfigFiles(state, projectPath, config);
                 watchWildCardDirectories(state, project, projectPath, config);
                 watchInputFiles(state, project, projectPath, config);
+                watchPackageJsonFiles(state, project, projectPath, config);
             }
             else if (reloadLevel === ConfigFileProgramReloadLevel.Partial) {
                 // Update file names
                 config.fileNames = getFileNamesFromConfigSpecs(config.options.configFile!.configFileSpecs!, getDirectoryPath(project), config.options, state.parseConfigFileHost);
                 updateErrorForNoInputFiles(config.fileNames, project, config.options.configFile!.configFileSpecs!, config.errors, canJsonReportNoInputFiles(config.raw));
                 watchInputFiles(state, project, projectPath, config);
+                watchPackageJsonFiles(state, project, projectPath, config);
             }
 
             const status = getUpToDateStatus(state, config, projectPath);
@@ -1490,6 +1507,13 @@ namespace ts {
             // Check extended config time
             const extendedConfigStatus = forEach(project.options.configFile!.extendedSourceFiles || emptyArray, configFile => checkConfigFileUpToDateStatus(state, configFile, oldestOutputFileTime, oldestOutputFileName));
             if (extendedConfigStatus) return extendedConfigStatus;
+
+            // Check package file time
+            const dependentPackageFileStatus = forEach(
+                state.lastCachedPackageJsonLookups.get(resolvedPath) || emptyArray,
+                ([path]) => checkConfigFileUpToDateStatus(state, path, oldestOutputFileTime, oldestOutputFileName)
+            );
+            if (dependentPackageFileStatus) return dependentPackageFileStatus;
         }
 
         if (!force && !state.buildInfoChecked.has(resolvedPath)) {
@@ -1862,6 +1886,25 @@ namespace ts {
         );
     }
 
+    function watchPackageJsonFiles(state: SolutionBuilderState, resolved: ResolvedConfigFileName, resolvedPath: ResolvedConfigFilePath, parsed: ParsedCommandLine) {
+        if (!state.watch || !state.lastCachedPackageJsonLookups) return;
+        mutateMap(
+            getOrCreateValueMapFromConfigFileMap(state.allWatchedPackageJsonFiles, resolvedPath),
+            new Map(state.lastCachedPackageJsonLookups.get(resolvedPath)),
+            {
+                createNewValue: (path, _input) => state.watchFile(
+                    path,
+                    () => invalidateProjectAndScheduleBuilds(state, resolvedPath, ConfigFileProgramReloadLevel.Full),
+                    PollingInterval.High,
+                    parsed?.watchOptions,
+                    WatchType.PackageJson,
+                    resolved
+                ),
+                onDeleteValue: closeFileWatcher,
+            }
+        );
+    }
+
     function startWatching(state: SolutionBuilderState, buildOrder: AnyBuildOrder) {
         if (!state.watchAllProjectsPending) return;
         state.watchAllProjectsPending = false;
@@ -1877,6 +1920,9 @@ namespace ts {
 
                 // Watch input files
                 watchInputFiles(state, resolved, resolvedPath, cfg);
+
+                // Watch package json files
+                watchPackageJsonFiles(state, resolved, resolvedPath, cfg);
             }
         }
     }
@@ -1886,6 +1932,7 @@ namespace ts {
         clearMap(state.allWatchedExtendedConfigFiles, closeFileWatcherOf);
         clearMap(state.allWatchedWildcardDirectories, watchedWildcardDirectories => clearMap(watchedWildcardDirectories, closeFileWatcherOf));
         clearMap(state.allWatchedInputFiles, watchedWildcardDirectories => clearMap(watchedWildcardDirectories, closeFileWatcher));
+        clearMap(state.allWatchedPackageJsonFiles, watchedPacageJsonFiles => clearMap(watchedPacageJsonFiles, closeFileWatcher));
     }
 
     /**

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -873,7 +873,7 @@ namespace ts {
             );
             state.lastCachedPackageJsonLookups.set(projectPath, state.moduleResolutionCache && map(
                 state.moduleResolutionCache.getPackageJsonInfoCache().entries(),
-                ([path, data]) => ([state.host.realpath ? state.host.realpath(path) as Path : path, data] as const)
+                ([path, data]) => ([state.host.realpath ? toPath(state, state.host.realpath(path)) : path, data] as const)
             ));
 
             if (state.watch) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3895,6 +3895,8 @@ namespace ts {
         /* @internal */
         getMissingFilePaths(): readonly Path[];
         /* @internal */
+        getModuleResolutionCache(): ModuleResolutionCache | undefined;
+        /* @internal */
         getFilesByNameMap(): ESMap<string, SourceFile | false | undefined>;
 
         /**

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -418,6 +418,7 @@ namespace ts {
         ConfigFileOfReferencedProject: "Config file of referened project",
         ExtendedConfigOfReferencedProject: "Extended config file of referenced project",
         WildcardDirectoryOfReferencedProject: "Wild card directory of referenced project",
+        PackageJson: "package.json file",
     };
 
     export interface WatchTypeRegistry {
@@ -431,6 +432,7 @@ namespace ts {
         ConfigFileOfReferencedProject: "Config file of referened project",
         ExtendedConfigOfReferencedProject: "Extended config file of referenced project",
         WildcardDirectoryOfReferencedProject: "Wild card directory of referenced project",
+        PackageJson: "package.json file",
     }
 
     interface WatchFactory<X, Y = undefined> extends ts.WatchFactory<X, Y> {

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -265,12 +265,14 @@ namespace ts {
         let builderProgram: T;
         let reloadLevel: ConfigFileProgramReloadLevel;                      // level to indicate if the program needs to be reloaded from config file/just filenames etc
         let missingFilesMap: ESMap<Path, FileWatcher>;                       // Map of file watchers for the missing files
+        let packageJsonMap: ESMap<Path, FileWatcher>;                       // map of watchers for package json files used in module resolution
         let watchedWildcardDirectories: ESMap<string, WildcardDirectoryWatcher>; // map of watchers for the wild card directories in the config file
         let timerToUpdateProgram: any;                                      // timer callback to recompile the program
         let timerToInvalidateFailedLookupResolutions: any;                  // timer callback to invalidate resolutions for changes in failed lookup locations
         let parsedConfigs: ESMap<Path, ParsedConfig> | undefined;           // Parsed commandline and watching cached for referenced projects
         let sharedExtendedConfigFileWatchers: ESMap<Path, SharedExtendedConfigFileWatcher<Path>>; // Map of file watchers for extended files, shared between different referenced projects
         let extendedConfigCache = host.extendedConfigCache;                 // Cache for extended config evaluation
+        let changesAffectResolution = false;                                // Flag for indicating non-config changes affect module resolution
 
         const sourceFilesCache = new Map<string, HostFileInfo>();           // Cache that stores the source file and version info
         let missingFilePathsRequestedForRelease: Path[] | undefined;        // These paths are held temporarily so that we can remove the entry from source file cache if the file is not tracked by missing files
@@ -419,13 +421,13 @@ namespace ts {
             const program = getCurrentBuilderProgram();
             if (hasChangedCompilerOptions) {
                 newLine = updateNewLine();
-                if (program && changesAffectModuleResolution(program.getCompilerOptions(), compilerOptions)) {
+                if (program && (changesAffectResolution || changesAffectModuleResolution(program.getCompilerOptions(), compilerOptions))) {
                     resolutionCache.clear();
                 }
             }
 
             // All resolutions are invalid if user provided resolutions
-            const hasInvalidatedResolution = resolutionCache.createHasInvalidatedResolution(userProvidedResolution);
+            const hasInvalidatedResolution = resolutionCache.createHasInvalidatedResolution(userProvidedResolution || changesAffectResolution);
             if (isProgramUptoDate(getCurrentProgram(), rootFileNames, compilerOptions, getSourceVersion, fileExists, hasInvalidatedResolution, hasChangedAutomaticTypeDirectiveNames, getParsedCommandLine, projectReferences)) {
                 if (hasChangedConfigFileParsingErrors) {
                     builderProgram = createProgram(/*rootNames*/ undefined, /*options*/ undefined, compilerHost, builderProgram, configFileParsingDiagnostics, projectReferences);
@@ -435,6 +437,8 @@ namespace ts {
             else {
                 createNewProgram(hasInvalidatedResolution);
             }
+
+            changesAffectResolution = false; // reset for next sync
 
             if (host.afterProgramCreate && program !== builderProgram) {
                 host.afterProgramCreate(builderProgram);
@@ -457,10 +461,13 @@ namespace ts {
             compilerHost.hasInvalidatedResolution = hasInvalidatedResolution;
             compilerHost.hasChangedAutomaticTypeDirectiveNames = hasChangedAutomaticTypeDirectiveNames;
             builderProgram = createProgram(rootFileNames, compilerOptions, compilerHost, builderProgram, configFileParsingDiagnostics, projectReferences);
+            // map package json cache entries to their realpaths so we don't try to watch across symlinks
+            const packageCacheEntries = map(resolutionCache.getModuleResolutionCache().getPackageJsonInfoCache().entries(), ([path, data]) => ([compilerHost.realpath ? compilerHost.realpath(path) as Path : path, data] as const));
             resolutionCache.finishCachingPerDirectoryResolution();
 
             // Update watches
             updateMissingFilePathsWatch(builderProgram.getProgram(), missingFilesMap || (missingFilesMap = new Map()), watchMissingFilePath);
+            updatePackageJsonWatch(packageCacheEntries, packageJsonMap || (packageJsonMap = new Map()), watchPackageJsonLookupPath);
             if (needsUpdateInTypeRootWatch) {
                 resolutionCache.updateTypeRootsWatch();
             }
@@ -821,6 +828,24 @@ namespace ts {
             return parsedConfigs?.has(missingFilePath) ?
                 noopFileWatcher :
                 watchFilePath(missingFilePath, missingFilePath, onMissingFileChange, PollingInterval.Medium, watchOptions, WatchType.MissingFile);
+        }
+
+        function watchPackageJsonLookupPath(packageJsonPath: Path) {
+            // If the package.json is pulled into the compilation itself (eg, via json imports), don't add a second watcher here
+            return sourceFilesCache.has(packageJsonPath) ?
+                noopFileWatcher :
+                watchFilePath(packageJsonPath, packageJsonPath, onPackageJsonChange, PollingInterval.High, watchOptions, WatchType.PackageJson);
+        }
+
+        function onPackageJsonChange(fileName: string, eventKind: FileWatcherEventKind, path: Path) {
+            updateCachedSystemWithFile(fileName, path, eventKind);
+
+            // package.json changes invalidate module resolution and can change the set of loaded files
+            // so if we witness a change to one, we have to do a full reload
+            reloadLevel = ConfigFileProgramReloadLevel.Full;
+            changesAffectResolution = true;
+            // Update the program
+            scheduleProgramUpdate();
         }
 
         function onMissingFileChange(fileName: string, eventKind: FileWatcherEventKind, missingFilePath: Path) {

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -462,7 +462,7 @@ namespace ts {
             compilerHost.hasChangedAutomaticTypeDirectiveNames = hasChangedAutomaticTypeDirectiveNames;
             builderProgram = createProgram(rootFileNames, compilerOptions, compilerHost, builderProgram, configFileParsingDiagnostics, projectReferences);
             // map package json cache entries to their realpaths so we don't try to watch across symlinks
-            const packageCacheEntries = map(resolutionCache.getModuleResolutionCache().getPackageJsonInfoCache().entries(), ([path, data]) => ([compilerHost.realpath ? compilerHost.realpath(path) as Path : path, data] as const));
+            const packageCacheEntries = map(resolutionCache.getModuleResolutionCache().getPackageJsonInfoCache().entries(), ([path, data]) => ([compilerHost.realpath ? toPath(compilerHost.realpath(path)) : path, data] as const));
             resolutionCache.finishCachingPerDirectoryResolution();
 
             // Update watches

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -356,6 +356,25 @@ namespace ts {
     }
 
     /**
+     * Updates watchers based on the package json files used in module resolution
+     */
+    export function updatePackageJsonWatch(
+        lookups: readonly (readonly [Path, object | boolean])[],
+        packageJsonWatches: ESMap<Path, FileWatcher>,
+        createPackageJsonWatch: (packageJsonPath: Path, data: object | boolean) => FileWatcher,
+    ) {
+        const newMap = new Map(lookups);
+        mutateMap(
+            packageJsonWatches,
+            newMap,
+            {
+                createNewValue: createPackageJsonWatch,
+                onDeleteValue: closeFileWatcher
+            }
+        );
+    }
+
+    /**
      * Updates the existing missing file watches with the new set of missing files after new program is created
      */
     export function updateMissingFilePathsWatch(

--- a/src/testRunner/unittests/tsbuild/moduleResolution.ts
+++ b/src/testRunner/unittests/tsbuild/moduleResolution.ts
@@ -85,5 +85,151 @@ namespace ts.tscWatch {
             }),
             commandLineArgs: ["-b", "/src/packages/pkg1.tsconfig.json", "/src/packages/pkg2.tsconfig.json", "--verbose", "--traceResolution"],
         });
+
+        verifyTscWatch({
+            scenario: "moduleResolution",
+            subScenario: `watches for changes to package-json main fields`,
+            sys: () => createWatchedSystem([
+                {
+                    path: `${projectRoot}/packages/pkg1/package.json`,
+                    content: JSON.stringify({
+                        name: "pkg1",
+                        version: "1.0.0",
+                        main: "build/index.js",
+                    })
+                },
+                {
+                    path: `${projectRoot}/packages/pkg1/index.ts`,
+                    content: Utils.dedent`
+                    import type { TheNum } from 'pkg2'
+                    export const theNum: TheNum = 42;`
+                },
+                {
+                    path: `${projectRoot}/packages/pkg1/tsconfig.json`,
+                    content: JSON.stringify({
+                        compilerOptions: {
+                            outDir: "build",
+                        },
+                    })
+                },
+                {
+                    path: `${projectRoot}/packages/pkg2/build/const.d.ts`,
+                    content: `export type TheNum = 42;`
+                },
+                {
+                    path: `${projectRoot}/packages/pkg2/build/index.d.ts`,
+                    content: `export type { TheNum } from './const.js';`
+                },
+                {
+                    path: `${projectRoot}/packages/pkg2/build/other.d.ts`,
+                    content: `export type TheStr = string;`
+                },
+                {
+                    path: `${projectRoot}/packages/pkg2/package.json`,
+                    content: JSON.stringify({
+                        name: "pkg2",
+                        version: "1.0.0",
+                        main: "build/index.js",
+                    })
+                },
+                {
+                    path: `${projectRoot}/node_modules/pkg2`,
+                    symLink: `${projectRoot}/packages/pkg2`,
+                },
+                libFile
+            ], { currentDirectory: projectRoot }),
+            commandLineArgs: ["--project", "./packages/pkg1/tsconfig.json", "-w", "--traceResolution"],
+            changes: [
+                {
+                    caption: "reports import errors after change to package file",
+                    change: sys => replaceFileText(sys, `${projectRoot}/packages/pkg2/package.json`, `index.js`, `other.js`),
+                    timeouts: runQueuedTimeoutCallbacks,
+                },
+                {
+                    caption: "removes those errors when a package file is changed back",
+                    change: sys => replaceFileText(sys, `${projectRoot}/packages/pkg2/package.json`, `other.js`, `index.js`),
+                    timeouts: runQueuedTimeoutCallbacks,
+                },
+            ]
+        });
+
+
+        verifyTscWatch({
+            scenario: "moduleResolution",
+            subScenario: `build mode watches for changes to package-json main fields`,
+            sys: () => createWatchedSystem([
+                {
+                    path: `${projectRoot}/packages/pkg1/package.json`,
+                    content: JSON.stringify({
+                        name: "pkg1",
+                        version: "1.0.0",
+                        main: "build/index.js",
+                    })
+                },
+                {
+                    path: `${projectRoot}/packages/pkg1/index.ts`,
+                    content: Utils.dedent`
+                    import type { TheNum } from 'pkg2'
+                    export const theNum: TheNum = 42;`
+                },
+                {
+                    path: `${projectRoot}/packages/pkg1/tsconfig.json`,
+                    content: JSON.stringify({
+                        compilerOptions: {
+                            outDir: "build",
+                        },
+                        references: [{ path: "../pkg2" }]
+                    })
+                },
+                {
+                    path: `${projectRoot}/packages/pkg2/tsconfig.json`,
+                    content: JSON.stringify({
+                        compilerOptions: {
+                            composite: true,
+                            outDir: "build",
+                            baseUrl: ".",
+                        }
+                    })
+                },
+                {
+                    path: `${projectRoot}/packages/pkg2/const.ts`,
+                    content: `export type TheNum = 42;`
+                },
+                {
+                    path: `${projectRoot}/packages/pkg2/index.ts`,
+                    content: `export type { TheNum } from './const.js';`
+                },
+                {
+                    path: `${projectRoot}/packages/pkg2/other.ts`,
+                    content: `export type TheStr = string;`
+                },
+                {
+                    path: `${projectRoot}/packages/pkg2/package.json`,
+                    content: JSON.stringify({
+                        name: "pkg2",
+                        version: "1.0.0",
+                        main: "build/index.js",
+                    })
+                },
+                {
+                    path: `${projectRoot}/node_modules/pkg2`,
+                    symLink: `${projectRoot}/packages/pkg2`,
+                },
+                libFile
+            ], { currentDirectory: projectRoot }),
+            commandLineArgs: ["-b", "packages/pkg1", "--verbose", "-w", "--traceResolution"],
+            changes: [
+                {
+                    caption: "reports import errors after change to package file",
+                    change: sys => replaceFileText(sys, `${projectRoot}/packages/pkg2/package.json`, `index.js`, `other.js`),
+                    timeouts: runQueuedTimeoutCallbacks,
+                },
+                {
+                    caption: "removes those errors when a package file is changed back",
+                    change: sys => replaceFileText(sys, `${projectRoot}/packages/pkg2/package.json`, `other.js`, `index.js`),
+                    timeouts: runQueuedTimeoutCallbacks,
+                },
+            ]
+        });
     });
 }

--- a/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-bad-reference.js
+++ b/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-bad-reference.js
@@ -252,6 +252,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/demo/tsconfig-base.json","pollingInterval":250}
 /user/username/projects/demo/core/utilities.ts:
   {"fileName":"/user/username/projects/demo/core/utilities.ts","pollingInterval":250}
+/user/username/projects/demo/animals/package.json:
+  {"fileName":"/user/username/projects/demo/animals/package.json","pollingInterval":250}
 /user/username/projects/demo/animals/tsconfig.json:
   {"fileName":"/user/username/projects/demo/animals/tsconfig.json","pollingInterval":250}
 /user/username/projects/demo/animals/animal.ts:
@@ -520,6 +522,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/demo/tsconfig-base.json","pollingInterval":250}
 /user/username/projects/demo/core/utilities.ts:
   {"fileName":"/user/username/projects/demo/core/utilities.ts","pollingInterval":250}
+/user/username/projects/demo/animals/package.json:
+  {"fileName":"/user/username/projects/demo/animals/package.json","pollingInterval":250}
 /user/username/projects/demo/animals/tsconfig.json:
   {"fileName":"/user/username/projects/demo/animals/tsconfig.json","pollingInterval":250}
 /user/username/projects/demo/animals/animal.ts:

--- a/tests/baselines/reference/tsbuild/watchMode/moduleResolution/build-mode-watches-for-changes-to-package-json-main-fields.js
+++ b/tests/baselines/reference/tsbuild/watchMode/moduleResolution/build-mode-watches-for-changes-to-package-json-main-fields.js
@@ -1,0 +1,466 @@
+Input::
+//// [/user/username/projects/myproject/packages/pkg1/package.json]
+{"name":"pkg1","version":"1.0.0","main":"build/index.js"}
+
+//// [/user/username/projects/myproject/packages/pkg1/index.ts]
+import type { TheNum } from 'pkg2'
+export const theNum: TheNum = 42;
+
+//// [/user/username/projects/myproject/packages/pkg1/tsconfig.json]
+{"compilerOptions":{"outDir":"build"},"references":[{"path":"../pkg2"}]}
+
+//// [/user/username/projects/myproject/packages/pkg2/tsconfig.json]
+{"compilerOptions":{"composite":true,"outDir":"build","baseUrl":"."}}
+
+//// [/user/username/projects/myproject/packages/pkg2/const.ts]
+export type TheNum = 42;
+
+//// [/user/username/projects/myproject/packages/pkg2/index.ts]
+export type { TheNum } from './const.js';
+
+//// [/user/username/projects/myproject/packages/pkg2/other.ts]
+export type TheStr = string;
+
+//// [/user/username/projects/myproject/packages/pkg2/package.json]
+{"name":"pkg2","version":"1.0.0","main":"build/index.js"}
+
+//// [/user/username/projects/myproject/node_modules/pkg2] symlink(/user/username/projects/myproject/packages/pkg2)
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+
+/a/lib/tsc.js -b packages/pkg1 --verbose -w --traceResolution
+Output::
+>> Screen clear
+[[90m12:00:43 AM[0m] Starting compilation in watch mode...
+
+[[90m12:00:44 AM[0m] Projects in this build: 
+    * packages/pkg2/tsconfig.json
+    * packages/pkg1/tsconfig.json
+
+[[90m12:00:45 AM[0m] Project 'packages/pkg2/tsconfig.json' is out of date because output file 'packages/pkg2/build/const.js' does not exist
+
+[[90m12:00:46 AM[0m] Building project '/user/username/projects/myproject/packages/pkg2/tsconfig.json'...
+
+======== Resolving module './const.js' from '/user/username/projects/myproject/packages/pkg2/index.ts'. ========
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/packages/pkg2/const.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/packages/pkg2/const.js.ts' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/const.js.tsx' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/const.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/packages/pkg2/const.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/packages/pkg2/const.ts' exist - use it as a name resolution result.
+======== Module name './const.js' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/const.ts'. ========
+[[90m12:01:06 AM[0m] Project 'packages/pkg1/tsconfig.json' is out of date because output file 'packages/pkg1/build/index.js' does not exist
+
+[[90m12:01:07 AM[0m] Building project '/user/username/projects/myproject/packages/pkg1/tsconfig.json'...
+
+======== Resolving module 'pkg2' from '/user/username/projects/myproject/packages/pkg1/index.ts'. ========
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module 'pkg2' from 'node_modules' folder, target file type 'TypeScript'.
+Directory '/user/username/projects/myproject/packages/pkg1/node_modules' does not exist, skipping all lookups in it.
+Directory '/user/username/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Found 'package.json' at '/user/username/projects/myproject/node_modules/pkg2/package.json'.
+'package.json' does not have a 'typesVersions' field.
+File '/user/username/projects/myproject/node_modules/pkg2.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.d.ts' does not exist.
+'package.json' does not have a 'typings' field.
+'package.json' does not have a 'types' field.
+'package.json' has 'main' field 'build/index.js' that references '/user/username/projects/myproject/node_modules/pkg2/build/index.js'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js' exist - use it as a name resolution result.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js' has an unsupported extension, so skipping it.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/node_modules/pkg2/build/index.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/node_modules/pkg2/build/index.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.d.ts' exist - use it as a name resolution result.
+Resolving real path for '/user/username/projects/myproject/node_modules/pkg2/build/index.d.ts', result '/user/username/projects/myproject/packages/pkg2/build/index.d.ts'.
+======== Module name 'pkg2' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/build/index.d.ts' with Package ID 'pkg2/build/index.d.ts@1.0.0'. ========
+======== Resolving module './const.js' from '/user/username/projects/myproject/packages/pkg2/build/index.d.ts'. ========
+Using compiler options of project reference redirect '/user/username/projects/myproject/packages/pkg2/tsconfig.json'.
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/packages/pkg2/build/const.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.ts' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.tsx' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/packages/pkg2/build/const.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/packages/pkg2/build/const.ts' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.tsx' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.d.ts' exist - use it as a name resolution result.
+======== Module name './const.js' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/build/const.d.ts'. ========
+[[90m12:01:13 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/packages/pkg2/const.ts","/user/username/projects/myproject/packages/pkg2/index.ts","/user/username/projects/myproject/packages/pkg2/other.ts"]
+Program options: {"composite":true,"outDir":"/user/username/projects/myproject/packages/pkg2/build","baseUrl":"/user/username/projects/myproject/packages/pkg2","watch":true,"traceResolution":true,"configFilePath":"/user/username/projects/myproject/packages/pkg2/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/packages/pkg2/const.ts
+/user/username/projects/myproject/packages/pkg2/index.ts
+/user/username/projects/myproject/packages/pkg2/other.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/packages/pkg2/const.ts
+/user/username/projects/myproject/packages/pkg2/index.ts
+/user/username/projects/myproject/packages/pkg2/other.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/user/username/projects/myproject/packages/pkg2/const.ts (used version)
+/user/username/projects/myproject/packages/pkg2/index.ts (used version)
+/user/username/projects/myproject/packages/pkg2/other.ts (used version)
+
+Program root files: ["/user/username/projects/myproject/packages/pkg1/index.ts"]
+Program options: {"outDir":"/user/username/projects/myproject/packages/pkg1/build","watch":true,"traceResolution":true,"configFilePath":"/user/username/projects/myproject/packages/pkg1/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts (used version)
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts (used version)
+/user/username/projects/myproject/packages/pkg1/index.ts (used version)
+
+WatchedFiles::
+/user/username/projects/myproject/packages/pkg2/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/const.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/const.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/index.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/index.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/other.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/other.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg1/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg1/index.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/index.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/package.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/package.json","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/packages/pkg2:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg2","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg1:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/packages/pkg2/build/const.js]
+"use strict";
+exports.__esModule = true;
+
+
+//// [/user/username/projects/myproject/packages/pkg2/build/const.d.ts]
+export declare type TheNum = 42;
+
+
+//// [/user/username/projects/myproject/packages/pkg2/build/index.js]
+"use strict";
+exports.__esModule = true;
+
+
+//// [/user/username/projects/myproject/packages/pkg2/build/index.d.ts]
+export type { TheNum } from './const.js';
+
+
+//// [/user/username/projects/myproject/packages/pkg2/build/other.js]
+"use strict";
+exports.__esModule = true;
+
+
+//// [/user/username/projects/myproject/packages/pkg2/build/other.d.ts]
+export declare type TheStr = string;
+
+
+//// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../../../../../../a/lib/lib.d.ts","../const.ts","../index.ts","../other.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true},"-11202312776-export type TheNum = 42;","-11225381282-export type { TheNum } from './const.js';","-4609154030-export type TheStr = string;"],"options":{"composite":true,"outDir":"./"},"fileIdsList":[[2]],"referencedMap":[[3,1]],"exportedModulesMap":[[3,1]],"semanticDiagnosticsPerFile":[1,2,3,4]},"version":"FakeTSVersion"}
+
+//// [/user/username/projects/myproject/packages/pkg2/build/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../../../../../a/lib/lib.d.ts",
+      "../const.ts",
+      "../index.ts",
+      "../other.ts"
+    ],
+    "fileNamesList": [
+      [
+        "../const.ts"
+      ]
+    ],
+    "fileInfos": {
+      "../../../../../../../a/lib/lib.d.ts": {
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "signature": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "affectsGlobalScope": true
+      },
+      "../const.ts": {
+        "version": "-11202312776-export type TheNum = 42;",
+        "signature": "-11202312776-export type TheNum = 42;"
+      },
+      "../index.ts": {
+        "version": "-11225381282-export type { TheNum } from './const.js';",
+        "signature": "-11225381282-export type { TheNum } from './const.js';"
+      },
+      "../other.ts": {
+        "version": "-4609154030-export type TheStr = string;",
+        "signature": "-4609154030-export type TheStr = string;"
+      }
+    },
+    "options": {
+      "composite": true,
+      "outDir": "./"
+    },
+    "referencedMap": {
+      "../index.ts": [
+        "../const.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "../index.ts": [
+        "../const.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../../../../../../a/lib/lib.d.ts",
+      "../const.ts",
+      "../index.ts",
+      "../other.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 841
+}
+
+//// [/user/username/projects/myproject/packages/pkg1/build/index.js]
+"use strict";
+exports.__esModule = true;
+exports.theNum = void 0;
+exports.theNum = 42;
+
+
+
+Change:: reports import errors after change to package file
+
+Input::
+//// [/user/username/projects/myproject/packages/pkg2/package.json]
+{"name":"pkg2","version":"1.0.0","main":"build/other.js"}
+
+
+Output::
+>> Screen clear
+[[90m12:01:17 AM[0m] File change detected. Starting incremental compilation...
+
+[[90m12:01:18 AM[0m] Project 'packages/pkg1/tsconfig.json' is out of date because oldest output 'packages/pkg1/build/index.js' is older than newest input 'packages/pkg2'
+
+[[90m12:01:19 AM[0m] Building project '/user/username/projects/myproject/packages/pkg1/tsconfig.json'...
+
+======== Resolving module 'pkg2' from '/user/username/projects/myproject/packages/pkg1/index.ts'. ========
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module 'pkg2' from 'node_modules' folder, target file type 'TypeScript'.
+Directory '/user/username/projects/myproject/packages/pkg1/node_modules' does not exist, skipping all lookups in it.
+Directory '/user/username/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Found 'package.json' at '/user/username/projects/myproject/node_modules/pkg2/package.json'.
+'package.json' does not have a 'typesVersions' field.
+File '/user/username/projects/myproject/node_modules/pkg2.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.d.ts' does not exist.
+'package.json' does not have a 'typings' field.
+'package.json' does not have a 'types' field.
+'package.json' has 'main' field 'build/other.js' that references '/user/username/projects/myproject/node_modules/pkg2/build/other.js'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.js' exist - use it as a name resolution result.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.js' has an unsupported extension, so skipping it.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/node_modules/pkg2/build/other.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.js.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.js.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/node_modules/pkg2/build/other.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.d.ts' exist - use it as a name resolution result.
+Resolving real path for '/user/username/projects/myproject/node_modules/pkg2/build/other.d.ts', result '/user/username/projects/myproject/packages/pkg2/build/other.d.ts'.
+======== Module name 'pkg2' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/build/other.d.ts' with Package ID 'pkg2/build/other.d.ts@1.0.0'. ========
+[96mpackages/pkg1/index.ts[0m:[93m1[0m:[93m15[0m - [91merror[0m[90m TS2305: [0mModule '"pkg2"' has no exported member 'TheNum'.
+
+[7m1[0m import type { TheNum } from 'pkg2'
+[7m [0m [91m              ~~~~~~[0m
+
+[[90m12:01:20 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/packages/pkg1/index.ts"]
+Program options: {"outDir":"/user/username/projects/myproject/packages/pkg1/build","watch":true,"traceResolution":true,"configFilePath":"/user/username/projects/myproject/packages/pkg1/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/packages/pkg2/build/other.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/packages/pkg2/build/other.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Shape signatures in builder refreshed for::
+/user/username/projects/myproject/packages/pkg2/build/other.d.ts (used version)
+/user/username/projects/myproject/packages/pkg1/index.ts (computed .d.ts)
+
+WatchedFiles::
+/user/username/projects/myproject/packages/pkg2/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/const.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/const.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/index.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/index.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/other.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/other.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg1/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg1/index.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/index.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/package.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/package.json","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/packages/pkg2:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg2","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg1:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+
+Change:: removes those errors when a package file is changed back
+
+Input::
+//// [/user/username/projects/myproject/packages/pkg2/package.json]
+{"name":"pkg2","version":"1.0.0","main":"build/index.js"}
+
+
+Output::
+>> Screen clear
+[[90m12:01:24 AM[0m] File change detected. Starting incremental compilation...
+
+[[90m12:01:25 AM[0m] Project 'packages/pkg1/tsconfig.json' is out of date because oldest output 'packages/pkg1/build/index.js' is older than newest input 'packages/pkg2'
+
+[[90m12:01:26 AM[0m] Building project '/user/username/projects/myproject/packages/pkg1/tsconfig.json'...
+
+======== Resolving module 'pkg2' from '/user/username/projects/myproject/packages/pkg1/index.ts'. ========
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module 'pkg2' from 'node_modules' folder, target file type 'TypeScript'.
+Directory '/user/username/projects/myproject/packages/pkg1/node_modules' does not exist, skipping all lookups in it.
+Directory '/user/username/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Found 'package.json' at '/user/username/projects/myproject/node_modules/pkg2/package.json'.
+'package.json' does not have a 'typesVersions' field.
+File '/user/username/projects/myproject/node_modules/pkg2.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.d.ts' does not exist.
+'package.json' does not have a 'typings' field.
+'package.json' does not have a 'types' field.
+'package.json' has 'main' field 'build/index.js' that references '/user/username/projects/myproject/node_modules/pkg2/build/index.js'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js' exist - use it as a name resolution result.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js' has an unsupported extension, so skipping it.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/node_modules/pkg2/build/index.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/node_modules/pkg2/build/index.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.d.ts' exist - use it as a name resolution result.
+Resolving real path for '/user/username/projects/myproject/node_modules/pkg2/build/index.d.ts', result '/user/username/projects/myproject/packages/pkg2/build/index.d.ts'.
+======== Module name 'pkg2' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/build/index.d.ts' with Package ID 'pkg2/build/index.d.ts@1.0.0'. ========
+======== Resolving module './const.js' from '/user/username/projects/myproject/packages/pkg2/build/index.d.ts'. ========
+Using compiler options of project reference redirect '/user/username/projects/myproject/packages/pkg2/tsconfig.json'.
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/packages/pkg2/build/const.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.ts' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.tsx' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/packages/pkg2/build/const.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/packages/pkg2/build/const.ts' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.tsx' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.d.ts' exist - use it as a name resolution result.
+======== Module name './const.js' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/build/const.d.ts'. ========
+[[90m12:01:30 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/packages/pkg1/index.ts"]
+Program options: {"outDir":"/user/username/projects/myproject/packages/pkg1/build","watch":true,"traceResolution":true,"configFilePath":"/user/username/projects/myproject/packages/pkg1/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Shape signatures in builder refreshed for::
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts (used version)
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts (used version)
+/user/username/projects/myproject/packages/pkg1/index.ts (computed .d.ts)
+
+WatchedFiles::
+/user/username/projects/myproject/packages/pkg2/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/const.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/const.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/index.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/index.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/other.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/other.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg1/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg1/index.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/index.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/package.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/package.json","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/packages/pkg2:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg2","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg1:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/packages/pkg1/build/index.js] file written with same contents

--- a/tests/baselines/reference/tsbuild/watchMode/moduleResolutionCache/handles-the-cache-correctly-when-two-projects-use-different-module-resolution-settings.js
+++ b/tests/baselines/reference/tsbuild/watchMode/moduleResolutionCache/handles-the-cache-correctly-when-two-projects-use-different-module-resolution-settings.js
@@ -112,6 +112,15 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/project1/tsconfig.json","pollingInterval":250}
 /user/username/projects/myproject/project1/index.ts:
   {"fileName":"/user/username/projects/myproject/project1/index.ts","pollingInterval":250}
+/user/username/projects/myproject/project1/node_modules/file/package.json:
+  {"fileName":"/user/username/projects/myproject/project1/node_modules/file/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/myproject/project1/node_modules/file/package.json","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/foo/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/foo/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/foo/package.json","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/bar/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/bar/package.json","pollingInterval":250}
 /user/username/projects/myproject/project2/tsconfig.json:
   {"fileName":"/user/username/projects/myproject/project2/tsconfig.json","pollingInterval":250}
 /user/username/projects/myproject/project2/index.ts:
@@ -310,6 +319,15 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/project1/tsconfig.json","pollingInterval":250}
 /user/username/projects/myproject/project1/index.ts:
   {"fileName":"/user/username/projects/myproject/project1/index.ts","pollingInterval":250}
+/user/username/projects/myproject/project1/node_modules/file/package.json:
+  {"fileName":"/user/username/projects/myproject/project1/node_modules/file/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/myproject/project1/node_modules/file/package.json","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/foo/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/foo/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/foo/package.json","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/bar/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/bar/package.json","pollingInterval":250}
 /user/username/projects/myproject/project2/tsconfig.json:
   {"fileName":"/user/username/projects/myproject/project2/tsconfig.json","pollingInterval":250}
 /user/username/projects/myproject/project2/index.ts:

--- a/tests/baselines/reference/tsbuild/watchMode/reexport/Reports-errors-correctly.js
+++ b/tests/baselines/reference/tsbuild/watchMode/reexport/Reports-errors-correctly.js
@@ -136,6 +136,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/reexport/src/main/tsconfig.json","pollingInterval":250}
 /user/username/projects/reexport/src/main/index.ts:
   {"fileName":"/user/username/projects/reexport/src/main/index.ts","pollingInterval":250}
+/user/username/projects/reexport/src/pure/package.json:
+  {"fileName":"/user/username/projects/reexport/src/pure/package.json","pollingInterval":250}
 /user/username/projects/reexport/src/tsconfig.json:
   {"fileName":"/user/username/projects/reexport/src/tsconfig.json","pollingInterval":250}
 
@@ -329,6 +331,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/reexport/src/main/tsconfig.json","pollingInterval":250}
 /user/username/projects/reexport/src/main/index.ts:
   {"fileName":"/user/username/projects/reexport/src/main/index.ts","pollingInterval":250}
+/user/username/projects/reexport/src/pure/package.json:
+  {"fileName":"/user/username/projects/reexport/src/pure/package.json","pollingInterval":250}
 /user/username/projects/reexport/src/tsconfig.json:
   {"fileName":"/user/username/projects/reexport/src/tsconfig.json","pollingInterval":250}
 
@@ -484,6 +488,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/reexport/src/main/tsconfig.json","pollingInterval":250}
 /user/username/projects/reexport/src/main/index.ts:
   {"fileName":"/user/username/projects/reexport/src/main/index.ts","pollingInterval":250}
+/user/username/projects/reexport/src/pure/package.json:
+  {"fileName":"/user/username/projects/reexport/src/pure/package.json","pollingInterval":250}
 /user/username/projects/reexport/src/tsconfig.json:
   {"fileName":"/user/username/projects/reexport/src/tsconfig.json","pollingInterval":250}
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/jsxImportSource-option-changed.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/jsxImportSource-option-changed.js
@@ -86,6 +86,10 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/index.tsx","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/react/jsx-runtime/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/react/Jsx-runtime/package.json","pollingInterval":250}
+/user/username/projects/myproject/node_modules/react/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/react/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/jsxImportSource-option-changed.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/jsxImportSource-option-changed.js
@@ -87,7 +87,7 @@ WatchedFiles::
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/myproject/node_modules/react/jsx-runtime/package.json:
-  {"fileName":"/user/username/projects/myproject/node_modules/react/Jsx-runtime/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/myproject/node_modules/react/jsx-runtime/package.json","pollingInterval":250}
 /user/username/projects/myproject/node_modules/react/package.json:
   {"fileName":"/user/username/projects/myproject/node_modules/react/package.json","pollingInterval":250}
 

--- a/tests/baselines/reference/tscWatch/incremental/importHelpers-backing-types-removed-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/importHelpers-backing-types-removed-watch.js
@@ -63,6 +63,8 @@ WatchedFiles::
   {"fileName":"/users/username/projects/project/node_modules/tslib/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/users/username/projects/project/node_modules/tslib/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/tslib/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -120,6 +122,9 @@ Shape signatures in builder refreshed for::
 /users/username/projects/project/index.tsx (used version)
 
 WatchedFiles::
+/users/username/projects/project/node_modules/tslib/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/tslib/package.json","pollingInterval":250}
+  {"fileName":"/users/username/projects/project/node_modules/tslib/package.json","pollingInterval":250}
 /users/username/projects/project/tsconfig.json:
   {"fileName":"/users/username/projects/project/tsconfig.json","pollingInterval":250}
 /users/username/projects/project/index.tsx:

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-added-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-added-watch.js
@@ -183,6 +183,10 @@ WatchedFiles::
   {"fileName":"/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/users/username/projects/project/node_modules/react/jsx-runtime/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/react/jsx-runtime/package.json","pollingInterval":250}
+/users/username/projects/project/node_modules/react/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/react/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-removed-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-removed-watch.js
@@ -74,6 +74,10 @@ WatchedFiles::
   {"fileName":"/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/users/username/projects/project/node_modules/react/jsx-runtime/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/react/jsx-runtime/package.json","pollingInterval":250}
+/users/username/projects/project/node_modules/react/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/react/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -186,6 +190,12 @@ Shape signatures in builder refreshed for::
 /users/username/projects/project/index.tsx (computed .d.ts)
 
 WatchedFiles::
+/users/username/projects/project/node_modules/react/jsx-runtime/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/react/jsx-runtime/package.json","pollingInterval":250}
+  {"fileName":"/users/username/projects/project/node_modules/react/jsx-runtime/package.json","pollingInterval":250}
+/users/username/projects/project/node_modules/react/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/react/package.json","pollingInterval":250}
+  {"fileName":"/users/username/projects/project/node_modules/react/package.json","pollingInterval":250}
 /users/username/projects/project/tsconfig.json:
   {"fileName":"/users/username/projects/project/tsconfig.json","pollingInterval":250}
 /users/username/projects/project/index.tsx:

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
@@ -97,6 +97,10 @@ WatchedFiles::
   {"fileName":"/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/users/username/projects/project/node_modules/react/jsx-runtime/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/react/jsx-runtime/package.json","pollingInterval":250}
+/users/username/projects/project/node_modules/react/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/react/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -221,6 +225,10 @@ Shape signatures in builder refreshed for::
 /users/username/projects/project/index.tsx (computed .d.ts)
 
 WatchedFiles::
+/users/username/projects/project/node_modules/react/jsx-runtime/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/react/jsx-runtime/package.json","pollingInterval":250}
+/users/username/projects/project/node_modules/react/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/react/package.json","pollingInterval":250}
 /users/username/projects/project/tsconfig.json:
   {"fileName":"/users/username/projects/project/tsconfig.json","pollingInterval":250}
 /users/username/projects/project/index.tsx:
@@ -229,6 +237,10 @@ WatchedFiles::
   {"fileName":"/users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/users/username/projects/project/node_modules/preact/jsx-runtime/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/preact/jsx-runtime/package.json","pollingInterval":250}
+/users/username/projects/project/node_modules/preact/package.json:
+  {"fileName":"/users/username/projects/project/node_modules/preact/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/moduleResolution/watches-for-changes-to-package-json-main-fields.js
+++ b/tests/baselines/reference/tscWatch/moduleResolution/watches-for-changes-to-package-json-main-fields.js
@@ -1,0 +1,347 @@
+Input::
+//// [/user/username/projects/myproject/packages/pkg1/package.json]
+{"name":"pkg1","version":"1.0.0","main":"build/index.js"}
+
+//// [/user/username/projects/myproject/packages/pkg1/index.ts]
+import type { TheNum } from 'pkg2'
+export const theNum: TheNum = 42;
+
+//// [/user/username/projects/myproject/packages/pkg1/tsconfig.json]
+{"compilerOptions":{"outDir":"build"}}
+
+//// [/user/username/projects/myproject/packages/pkg2/build/const.d.ts]
+export type TheNum = 42;
+
+//// [/user/username/projects/myproject/packages/pkg2/build/index.d.ts]
+export type { TheNum } from './const.js';
+
+//// [/user/username/projects/myproject/packages/pkg2/build/other.d.ts]
+export type TheStr = string;
+
+//// [/user/username/projects/myproject/packages/pkg2/package.json]
+{"name":"pkg2","version":"1.0.0","main":"build/index.js"}
+
+//// [/user/username/projects/myproject/node_modules/pkg2] symlink(/user/username/projects/myproject/packages/pkg2)
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+
+/a/lib/tsc.js --project ./packages/pkg1/tsconfig.json -w --traceResolution
+Output::
+>> Screen clear
+[[90m12:00:43 AM[0m] Starting compilation in watch mode...
+
+======== Resolving module 'pkg2' from '/user/username/projects/myproject/packages/pkg1/index.ts'. ========
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module 'pkg2' from 'node_modules' folder, target file type 'TypeScript'.
+Directory '/user/username/projects/myproject/packages/pkg1/node_modules' does not exist, skipping all lookups in it.
+Directory '/user/username/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Found 'package.json' at '/user/username/projects/myproject/node_modules/pkg2/package.json'.
+'package.json' does not have a 'typesVersions' field.
+File '/user/username/projects/myproject/node_modules/pkg2.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.d.ts' does not exist.
+'package.json' does not have a 'typings' field.
+'package.json' does not have a 'types' field.
+'package.json' has 'main' field 'build/index.js' that references '/user/username/projects/myproject/node_modules/pkg2/build/index.js'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js' does not exist.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/node_modules/pkg2/build/index.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/node_modules/pkg2/build/index.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.d.ts' exist - use it as a name resolution result.
+Resolving real path for '/user/username/projects/myproject/node_modules/pkg2/build/index.d.ts', result '/user/username/projects/myproject/packages/pkg2/build/index.d.ts'.
+======== Module name 'pkg2' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/build/index.d.ts' with Package ID 'pkg2/build/index.d.ts@1.0.0'. ========
+======== Resolving module './const.js' from '/user/username/projects/myproject/packages/pkg2/build/index.d.ts'. ========
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/packages/pkg2/build/const.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.ts' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.tsx' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/packages/pkg2/build/const.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/packages/pkg2/build/const.ts' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.tsx' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.d.ts' exist - use it as a name resolution result.
+======== Module name './const.js' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/build/const.d.ts'. ========
+[[90m12:00:49 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/packages/pkg1/index.ts"]
+Program options: {"outDir":"/user/username/projects/myproject/packages/pkg1/build","project":"/user/username/projects/myproject/packages/pkg1/tsconfig.json","watch":true,"traceResolution":true,"configFilePath":"/user/username/projects/myproject/packages/pkg1/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts (used version)
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts (used version)
+/user/username/projects/myproject/packages/pkg1/index.ts (used version)
+
+WatchedFiles::
+/user/username/projects/myproject/packages/pkg1/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg1/index.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/index.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/build/index.d.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/build/const.d.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/package.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/package.json","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/packages/pkg2:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg2","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg1/node_modules:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/node_modules:
+  {"directoryName":"/user/username/projects/myproject/packages/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules:
+  {"directoryName":"/user/username/projects/myproject/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg1/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/packages/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg1:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/packages/pkg1/build/index.js]
+"use strict";
+exports.__esModule = true;
+exports.theNum = void 0;
+exports.theNum = 42;
+
+
+
+Change:: reports import errors after change to package file
+
+Input::
+//// [/user/username/projects/myproject/packages/pkg2/package.json]
+{"name":"pkg2","version":"1.0.0","main":"build/other.js"}
+
+
+Output::
+>> Screen clear
+[[90m12:00:53 AM[0m] File change detected. Starting incremental compilation...
+
+======== Resolving module 'pkg2' from '/user/username/projects/myproject/packages/pkg1/index.ts'. ========
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module 'pkg2' from 'node_modules' folder, target file type 'TypeScript'.
+Directory '/user/username/projects/myproject/packages/pkg1/node_modules' does not exist, skipping all lookups in it.
+Directory '/user/username/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Found 'package.json' at '/user/username/projects/myproject/node_modules/pkg2/package.json'.
+'package.json' does not have a 'typesVersions' field.
+File '/user/username/projects/myproject/node_modules/pkg2.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.d.ts' does not exist.
+'package.json' does not have a 'typings' field.
+'package.json' does not have a 'types' field.
+'package.json' has 'main' field 'build/other.js' that references '/user/username/projects/myproject/node_modules/pkg2/build/other.js'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.js' does not exist.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/node_modules/pkg2/build/other.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.js.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.js.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/node_modules/pkg2/build/other.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/other.d.ts' exist - use it as a name resolution result.
+Resolving real path for '/user/username/projects/myproject/node_modules/pkg2/build/other.d.ts', result '/user/username/projects/myproject/packages/pkg2/build/other.d.ts'.
+======== Module name 'pkg2' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/build/other.d.ts' with Package ID 'pkg2/build/other.d.ts@1.0.0'. ========
+[96mpackages/pkg1/index.ts[0m:[93m1[0m:[93m15[0m - [91merror[0m[90m TS2305: [0mModule '"pkg2"' has no exported member 'TheNum'.
+
+[7m1[0m import type { TheNum } from 'pkg2'
+[7m [0m [91m              ~~~~~~[0m
+
+[[90m12:00:57 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/packages/pkg1/index.ts"]
+Program options: {"outDir":"/user/username/projects/myproject/packages/pkg1/build","project":"/user/username/projects/myproject/packages/pkg1/tsconfig.json","watch":true,"traceResolution":true,"configFilePath":"/user/username/projects/myproject/packages/pkg1/tsconfig.json"}
+Program structureReused: SafeModules
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/packages/pkg2/build/other.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/packages/pkg2/build/other.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Shape signatures in builder refreshed for::
+/user/username/projects/myproject/packages/pkg2/build/other.d.ts (used version)
+/user/username/projects/myproject/packages/pkg1/index.ts (computed .d.ts)
+
+WatchedFiles::
+/user/username/projects/myproject/packages/pkg1/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg1/index.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/index.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/package.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/package.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/build/other.d.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/build/other.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/packages/pkg1:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg1/node_modules:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/node_modules:
+  {"directoryName":"/user/username/projects/myproject/packages/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules:
+  {"directoryName":"/user/username/projects/myproject/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg1/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/packages/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/packages/pkg1/build/index.js] file written with same contents
+
+Change:: removes those errors when a package file is changed back
+
+Input::
+//// [/user/username/projects/myproject/packages/pkg2/package.json]
+{"name":"pkg2","version":"1.0.0","main":"build/index.js"}
+
+
+Output::
+>> Screen clear
+[[90m12:01:01 AM[0m] File change detected. Starting incremental compilation...
+
+======== Resolving module 'pkg2' from '/user/username/projects/myproject/packages/pkg1/index.ts'. ========
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module 'pkg2' from 'node_modules' folder, target file type 'TypeScript'.
+Directory '/user/username/projects/myproject/packages/pkg1/node_modules' does not exist, skipping all lookups in it.
+Directory '/user/username/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Found 'package.json' at '/user/username/projects/myproject/node_modules/pkg2/package.json'.
+'package.json' does not have a 'typesVersions' field.
+File '/user/username/projects/myproject/node_modules/pkg2.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2.d.ts' does not exist.
+'package.json' does not have a 'typings' field.
+'package.json' does not have a 'types' field.
+'package.json' has 'main' field 'build/index.js' that references '/user/username/projects/myproject/node_modules/pkg2/build/index.js'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js' does not exist.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/node_modules/pkg2/build/index.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/node_modules/pkg2/build/index.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.ts' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.tsx' does not exist.
+File '/user/username/projects/myproject/node_modules/pkg2/build/index.d.ts' exist - use it as a name resolution result.
+Resolving real path for '/user/username/projects/myproject/node_modules/pkg2/build/index.d.ts', result '/user/username/projects/myproject/packages/pkg2/build/index.d.ts'.
+======== Module name 'pkg2' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/build/index.d.ts' with Package ID 'pkg2/build/index.d.ts@1.0.0'. ========
+======== Resolving module './const.js' from '/user/username/projects/myproject/packages/pkg2/build/index.d.ts'. ========
+Module resolution kind is not specified, using 'NodeJs'.
+Loading module as file / folder, candidate module location '/user/username/projects/myproject/packages/pkg2/build/const.js', target file type 'TypeScript'.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.ts' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.tsx' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.js.d.ts' does not exist.
+File name '/user/username/projects/myproject/packages/pkg2/build/const.js' has a '.js' extension - stripping it.
+File '/user/username/projects/myproject/packages/pkg2/build/const.ts' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.tsx' does not exist.
+File '/user/username/projects/myproject/packages/pkg2/build/const.d.ts' exist - use it as a name resolution result.
+======== Module name './const.js' was successfully resolved to '/user/username/projects/myproject/packages/pkg2/build/const.d.ts'. ========
+[[90m12:01:05 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/packages/pkg1/index.ts"]
+Program options: {"outDir":"/user/username/projects/myproject/packages/pkg1/build","project":"/user/username/projects/myproject/packages/pkg1/tsconfig.json","watch":true,"traceResolution":true,"configFilePath":"/user/username/projects/myproject/packages/pkg1/tsconfig.json"}
+Program structureReused: SafeModules
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts
+/user/username/projects/myproject/packages/pkg1/index.ts
+
+Shape signatures in builder refreshed for::
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts (used version)
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts (used version)
+/user/username/projects/myproject/packages/pkg1/index.ts (computed .d.ts)
+
+WatchedFiles::
+/user/username/projects/myproject/packages/pkg1/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg1/index.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg1/index.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/package.json:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/package.json","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/build/index.d.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/build/index.d.ts","pollingInterval":250}
+/user/username/projects/myproject/packages/pkg2/build/const.d.ts:
+  {"fileName":"/user/username/projects/myproject/packages/pkg2/build/const.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/packages/pkg1:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg2:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg2","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg1/node_modules:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/node_modules:
+  {"directoryName":"/user/username/projects/myproject/packages/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules:
+  {"directoryName":"/user/username/projects/myproject/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/pkg1/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/packages/pkg1/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/packages/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/packages/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/packages/pkg1/build/index.js] file written with same contents

--- a/tests/baselines/reference/tscWatch/programUpdates/should-properly-handle-module-resolution-changes-in-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-properly-handle-module-resolution-changes-in-config-file.js
@@ -66,6 +66,8 @@ WatchedFiles::
   {"fileName":"/a/b/node_modules/module1.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/a/b/node_modules/module1/package.json:
+  {"fileName":"/a/b/node_modules/module1/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/programUpdates/types-should-load-from-config-file-path-if-config-exists.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/types-should-load-from-config-file-path-if-config-exists.js
@@ -58,6 +58,10 @@ WatchedFiles::
   {"fileName":"/a/b/node_modules/@types/node/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/a/b/node_modules/node/package.json:
+  {"fileName":"/a/b/node_modules/node/package.json","pollingInterval":250}
+/a/b/node_modules/@types/node/package.json:
+  {"fileName":"/a/b/node_modules/@types/node/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders-with-no-files-clause.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders-with-no-files-clause.js
@@ -155,6 +155,10 @@ WatchedFiles::
   {"fileName":"/user/username/projects/transitiveReferences/refs/a.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/transitivereferences/b/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+/user/username/projects/transitivereferences/a/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:
@@ -370,6 +374,10 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/nrefs/a.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/nrefs/a.d.ts","pollingInterval":250}
+/user/username/projects/transitivereferences/b/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+/user/username/projects/transitivereferences/a/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:
@@ -463,6 +471,10 @@ WatchedFiles::
   {"fileName":"/user/username/projects/transitiveReferences/a/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/transitivereferences/b/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+/user/username/projects/transitivereferences/a/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
 /user/username/projects/transitivereferences/refs/a.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/refs/a.d.ts","pollingInterval":250}
 
@@ -827,6 +839,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/transitiveReferences/b/index.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/a/index.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/a/index.d.ts","pollingInterval":250}
+/user/username/projects/transitivereferences/a/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders-with-no-files-clause.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders-with-no-files-clause.js
@@ -156,9 +156,9 @@ WatchedFiles::
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/b/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/b/package.json","pollingInterval":250}
 /user/username/projects/transitivereferences/a/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:
@@ -375,9 +375,9 @@ WatchedFiles::
 /user/username/projects/transitivereferences/nrefs/a.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/nrefs/a.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/b/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/b/package.json","pollingInterval":250}
 /user/username/projects/transitivereferences/a/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:
@@ -472,9 +472,9 @@ WatchedFiles::
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/b/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/b/package.json","pollingInterval":250}
 /user/username/projects/transitivereferences/a/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/a/package.json","pollingInterval":250}
 /user/username/projects/transitivereferences/refs/a.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/refs/a.d.ts","pollingInterval":250}
 
@@ -840,7 +840,7 @@ WatchedFiles::
 /user/username/projects/transitivereferences/a/index.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/a/index.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/a/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders.js
@@ -155,6 +155,10 @@ WatchedFiles::
   {"fileName":"/user/username/projects/transitiveReferences/refs/a.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/transitivereferences/b/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+/user/username/projects/transitivereferences/a/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:
@@ -362,6 +366,10 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/nrefs/a.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/nrefs/a.d.ts","pollingInterval":250}
+/user/username/projects/transitivereferences/b/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+/user/username/projects/transitivereferences/a/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:
@@ -451,6 +459,10 @@ WatchedFiles::
   {"fileName":"/user/username/projects/transitiveReferences/a/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/transitivereferences/b/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+/user/username/projects/transitivereferences/a/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
 /user/username/projects/transitivereferences/refs/a.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/refs/a.d.ts","pollingInterval":250}
 
@@ -799,6 +811,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/transitiveReferences/b/index.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/a/index.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/a/index.d.ts","pollingInterval":250}
+/user/username/projects/transitivereferences/a/package.json:
+  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders.js
@@ -156,9 +156,9 @@ WatchedFiles::
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/b/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/b/package.json","pollingInterval":250}
 /user/username/projects/transitivereferences/a/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:
@@ -367,9 +367,9 @@ WatchedFiles::
 /user/username/projects/transitivereferences/nrefs/a.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/nrefs/a.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/b/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/b/package.json","pollingInterval":250}
 /user/username/projects/transitivereferences/a/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:
@@ -460,9 +460,9 @@ WatchedFiles::
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/b/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/b/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/b/package.json","pollingInterval":250}
 /user/username/projects/transitivereferences/a/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/a/package.json","pollingInterval":250}
 /user/username/projects/transitivereferences/refs/a.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/refs/a.d.ts","pollingInterval":250}
 
@@ -812,7 +812,7 @@ WatchedFiles::
 /user/username/projects/transitivereferences/a/index.d.ts:
   {"fileName":"/user/username/projects/transitiveReferences/a/index.d.ts","pollingInterval":250}
 /user/username/projects/transitivereferences/a/package.json:
-  {"fileName":"/user/username/projects/transitiveReferences/a/package.json","pollingInterval":250}
+  {"fileName":"/user/username/projects/transitivereferences/a/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/transitivereferences:

--- a/tests/baselines/reference/tscWatch/resolutionCache/ignores-changes-in-node_modules-that-start-with-dot/watch-with-configFile.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/ignores-changes-in-node_modules-that-start-with-dot/watch-with-configFile.js
@@ -58,6 +58,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/somemodule/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/somemodule/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/somemodule/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -95,6 +97,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/somemodule/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/somemodule/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/somemodule/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/ignores-changes-in-node_modules-that-start-with-dot/watch-without-configFile.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/ignores-changes-in-node_modules-that-start-with-dot/watch-without-configFile.js
@@ -56,6 +56,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/somemodule/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/somemodule/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/somemodule/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -87,6 +89,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/somemodule/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/somemodule/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/somemodule/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/when-types-in-compiler-option-are-global-and-installed-at-later-point.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/when-types-in-compiler-option-are-global-and-installed-at-later-point.js
@@ -120,6 +120,8 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/myproject/node_modules/@myapp/ts-types/types/somefile.define.d.ts:
   {"fileName":"/user/username/projects/myproject/node_modules/@myapp/ts-types/types/somefile.define.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@myapp/ts-types/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@myapp/ts-types/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -148,6 +150,8 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/myproject/node_modules/@myapp/ts-types/types/somefile.define.d.ts:
   {"fileName":"/user/username/projects/myproject/node_modules/@myapp/ts-types/types/somefile.define.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@myapp/ts-types/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@myapp/ts-types/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/with-modules-linked-to-sibling-folder.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/with-modules-linked-to-sibling-folder.js
@@ -70,6 +70,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/linked-package/dist/other.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/linked-package/package.json:
+  {"fileName":"/user/username/projects/myproject/linked-package/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
@@ -55,6 +55,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 undefined Source file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/package.json 2000 undefined package.json file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
 [[90m12:00:40 AM[0m] Found 0 errors. Watching for file changes.
@@ -105,6 +106,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/@types/node/globals.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -223,6 +226,7 @@ FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/index.d.ts 250 undefined Source file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/package.json 2000 undefined package.json file
 [96mworker.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS2580: [0mCannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
 
 [7m1[0m process.on("uncaughtException");
@@ -314,6 +318,7 @@ CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/mocha/package.json 2000 undefined package.json file
 [96mworker.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS2580: [0mCannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
 
 [7m1[0m process.on("uncaughtException");
@@ -346,6 +351,8 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts:
   {"fileName":"/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/mocha/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/mocha/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -382,6 +389,9 @@ Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/mocha/package.json 2000 undefined package.json file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/package.json 2000 undefined package.json file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/node/package.json 2000 undefined package.json file
 [91merror[0m[90m TS2688: [0mCannot find type definition file for 'node'.
   The file is in the program because:
     Entry point for implicit type library 'node'
@@ -411,6 +421,10 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts:
   {"fileName":"/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/package.json","pollingInterval":250}
+/user/username/projects/myproject/node_modules/node/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/node/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -478,6 +492,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/globals.d.ts 250 undefined Source file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/node/package.json 2000 undefined package.json file
 [[90m12:01:19 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -520,6 +535,8 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts:
   {"fileName":"/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/package.json","pollingInterval":250}
 /user/username/projects/myproject/node_modules/@types/node/index.d.ts:
   {"fileName":"/user/username/projects/myproject/node_modules/@types/node/index.d.ts","pollingInterval":250}
 /user/username/projects/myproject/node_modules/@types/node/base.d.ts:

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
@@ -117,6 +117,12 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /a/b/node_modules/@types/node/index.d.ts:
   {"fileName":"/a/b/node_modules/@types/node/index.d.ts","pollingInterval":250}
+/a/b/node_modules/fs/package.json:
+  {"fileName":"/a/b/node_modules/fs/package.json","pollingInterval":250}
+/a/b/node_modules/@types/fs/package.json:
+  {"fileName":"/a/b/node_modules/@types/fs/package.json","pollingInterval":250}
+/a/b/node_modules/@types/node/package.json:
+  {"fileName":"/a/b/node_modules/@types/node/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-renaming-node_modules-folder-that-already-contains-@types-folder.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-renaming-node_modules-folder-that-already-contains-@types-folder.js
@@ -109,6 +109,10 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/myproject/node_modules/@types/qqq/index.d.ts:
   {"fileName":"/user/username/projects/myproject/node_modules/@types/qqq/index.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/qqq/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/qqq/package.json","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/qqq/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/qqq/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-reusing-program-with-files-from-external-library.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-reusing-program-with-files-from-external-library.js
@@ -69,7 +69,7 @@ WatchedFiles::
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /a/b/projects/myproject/node_modules/module1/package.json:
-  {"fileName":"/a/b/projects/myProject/node_modules/module1/package.json","pollingInterval":250}
+  {"fileName":"/a/b/projects/myproject/node_modules/module1/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-reusing-program-with-files-from-external-library.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-reusing-program-with-files-from-external-library.js
@@ -68,6 +68,8 @@ WatchedFiles::
   {"fileName":"/a/b/projects/myProject/src/file2.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/a/b/projects/myproject/node_modules/module1/package.json:
+  {"fileName":"/a/b/projects/myProject/node_modules/module1/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/when-there-are-symlinks-to-folders-in-recursive-folders.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/when-there-are-symlinks-to-folders-in-recursive-folders.js
@@ -59,6 +59,7 @@ DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/src 1 undefi
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/src 1 undefined Failed Lookup Locations
 DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/node_modules 1 undefined Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /home/user/projects/myproject/node_modules/reala/package.json 2000 undefined package.json file
 DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/node_modules/@types 1 undefined Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/node_modules/@types 1 undefined Type roots
 [[90m12:00:48 AM[0m] Found 0 errors. Watching for file changes.
@@ -94,6 +95,8 @@ WatchedFiles::
   {"fileName":"/home/user/projects/myproject/node_modules/reala/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/home/user/projects/myproject/node_modules/reala/package.json:
+  {"fileName":"/home/user/projects/myproject/node_modules/reala/package.json","pollingInterval":250}
 
 FsWatches::
 /home/user/projects/myproject/src:

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory-with-outDir-and-declaration-enabled.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory-with-outDir-and-declaration-enabled.js
@@ -58,6 +58,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/file2/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/file2/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/file2/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/src:
@@ -102,6 +104,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/file2/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/file2/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/file2/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/src:
@@ -140,6 +144,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/file2/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/file2/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/file2/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/src:

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory.js
@@ -58,6 +58,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/file2/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/file2/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/file2/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/src:
@@ -96,6 +98,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/file2/index.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/file2/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/file2/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/src:
@@ -409,6 +413,8 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/myproject/node_modules/file2/index.d.ts:
   {"fileName":"/user/username/projects/myproject/node_modules/file2/index.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/file2/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/file2/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/src:

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-excludeDirectories-option-extendedDiagnostics.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-excludeDirectories-option-extendedDiagnostics.js
@@ -48,6 +48,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 {"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Source file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 {"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 {"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/bar/package.json 2000 {"excludeDirectories":["/user/username/projects/myproject/node_modules"]} package.json file
 ExcludeWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Type roots
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/main.js :: WatchInfo: /user/username/projects/myproject/src 1 {"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/main.js :: WatchInfo: /user/username/projects/myproject/src 1 {"excludeDirectories":["/user/username/projects/myproject/node_modules"]} Failed Lookup Locations
@@ -89,6 +90,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/bar/foo.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/bar/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -126,6 +129,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/bar/foo.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/bar/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-excludeDirectories-option-with-recursive-directory-watching-extendedDiagnostics.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-excludeDirectories-option-with-recursive-directory-watching-extendedDiagnostics.js
@@ -49,6 +49,7 @@ FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 {"excludeDirectories":["/user/username/projects/myproject/**/temp"]} Source file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 {"excludeDirectories":["/user/username/projects/myproject/**/temp"]} Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 {"excludeDirectories":["/user/username/projects/myproject/**/temp"]} Failed Lookup Locations
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/bar/package.json 2000 {"excludeDirectories":["/user/username/projects/myproject/**/temp"]} package.json file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeDirectories":["/user/username/projects/myproject/**/temp"]} Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeDirectories":["/user/username/projects/myproject/**/temp"]} Type roots
 [[90m12:00:40 AM[0m] Found 0 errors. Watching for file changes.
@@ -89,6 +90,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/bar/foo.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/bar/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/node_modules:
@@ -140,6 +143,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/bar/foo.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/bar/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/node_modules:
@@ -178,6 +183,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/bar/foo.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/bar/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/node_modules:

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-excludeDirectories-option-with-recursive-directory-watching.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-excludeDirectories-option-with-recursive-directory-watching.js
@@ -72,6 +72,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/bar/foo.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/bar/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/node_modules:
@@ -114,6 +116,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/bar/foo.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/bar/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/node_modules:
@@ -152,6 +156,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/bar/foo.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/bar/package.json","pollingInterval":250}
 
 FsWatches::
 /user/username/projects/myproject/node_modules:

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-excludeDirectories-option.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-excludeDirectories-option.js
@@ -72,6 +72,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/bar/foo.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/bar/package.json","pollingInterval":250}
 
 FsWatches::
 
@@ -109,6 +111,8 @@ WatchedFiles::
   {"fileName":"/user/username/projects/myproject/node_modules/bar/foo.d.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/bar/package.json:
+  {"fileName":"/user/username/projects/myproject/node_modules/bar/package.json","pollingInterval":250}
 
 FsWatches::
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-excludeFiles-option-extendedDiagnostics.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-excludeFiles-option-extendedDiagnostics.js
@@ -49,6 +49,7 @@ ExcludeWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modul
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 {"excludeFiles":["/user/username/projects/myproject/node_modules/*"]} Source file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 {"excludeFiles":["/user/username/projects/myproject/node_modules/*"]} Failed Lookup Locations
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/src 1 {"excludeFiles":["/user/username/projects/myproject/node_modules/*"]} Failed Lookup Locations
+ExcludeWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/bar/package.json 2000 {"excludeFiles":["/user/username/projects/myproject/node_modules/*"]} package.json file
 DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/node_modules/*"]} Type roots
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 {"excludeFiles":["/user/username/projects/myproject/node_modules/*"]} Type roots
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/src/main.js :: WatchInfo: /user/username/projects/myproject/src 1 {"excludeFiles":["/user/username/projects/myproject/node_modules/*"]} Failed Lookup Locations


### PR DESCRIPTION
This fixes an issue I noticed while writing tests for cts/mts (and `type: module`) support - when a `package.json` changed, we weren't noticing it in watch mode (and consequently weren't invaliding resolutions and rechecking programs) - the fix is somewhat substantial, so is now a separate PR, this. (In build mode, this fix is wholly non-incremental - we'll only pick up changes to package files after we've done a build involving them once, since we pull the data from the resolution cache - we could probably fix this by serializing the list of used package file resolutions for a file/project into the build info, but that seems involved).

cc @andrewbranch since you said including package json files in the normal watched file set may affect/help package autoimports.
