### PR TITLE
Check for watched directories before clearing map

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2288,8 +2288,10 @@ namespace ts.server {
             // If any of the project is still watching wild cards dont close the watcher
             if (forEachEntry(configFileExistenceInfo.config.projects, identity)) return;
 
-            clearMap(configFileExistenceInfo.config.watchedDirectories!, closeFileWatcherOf);
-            configFileExistenceInfo.config.watchedDirectories = undefined;
+            if (configFileExistenceInfo.config.watchedDirectories) {
+                clearMap(configFileExistenceInfo.config.watchedDirectories, closeFileWatcherOf);
+                configFileExistenceInfo.config.watchedDirectories = undefined;
+            }
             configFileExistenceInfo.config.watchedDirectoriesStale = undefined;
         }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Without any info about a repro of this crash, I’m not sure how to come up with a test for this. However, as @DanielRosenwasser pointed out, the PR where this code was added (#42929) uses defensive checks against `config.watchedDirectories` being undefined elsewhere, so perhaps this was just an oversight.

Fixes #44372
