### PR TITLE
Fix JS auto import of CJS module with --module=es2015+ and allowSyntheticDefaultExports

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -670,14 +670,15 @@ namespace ts.codefix {
 
     function getExportEqualsImportKind(importingFile: SourceFile, compilerOptions: CompilerOptions): ImportKind {
         const allowSyntheticDefaults = getAllowSyntheticDefaultImports(compilerOptions);
-        // 1. 'import =' will not work in es2015+, so the decision is between a default
+        const isJS = isInJSFile(importingFile);
+        // 1. 'import =' will not work in es2015+ TS files, so the decision is between a default
         //    and a namespace import, based on allowSyntheticDefaultImports/esModuleInterop.
-        if (getEmitModuleKind(compilerOptions) >= ModuleKind.ES2015) {
+        if (!isJS && getEmitModuleKind(compilerOptions) >= ModuleKind.ES2015) {
             return allowSyntheticDefaults ? ImportKind.Default : ImportKind.Namespace;
         }
         // 2. 'import =' will not work in JavaScript, so the decision is between a default
         //    and const/require.
-        if (isInJSFile(importingFile)) {
+        if (isJS) {
             return isExternalModule(importingFile) ? ImportKind.Default : ImportKind.CommonJS;
         }
         // 3. At this point the most correct choice is probably 'import =', but people

--- a/tests/cases/fourslash/importNameCodeFix_commonjs_allowSynthetic.ts
+++ b/tests/cases/fourslash/importNameCodeFix_commonjs_allowSynthetic.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+// @module: esnext
+// @moduleResolution: node
+// @allowJs: true
+// @checkJs: true
+// @allowSyntheticDefaultImports: true
+
+// @Filename: /test_module.js
+//// const MY_EXPORTS = {}
+//// module.exports = MY_EXPORTS;
+
+// @Filename: /index.js
+//// const newVar = {
+////   any: MY_EXPORTS/**/,
+//// }
+
+goTo.marker("");
+verify.importFixAtPosition([`const MY_EXPORTS = require("./test_module");
+
+const newVar = {
+  any: MY_EXPORTS,
+}`]);


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #44825 
