### PR TITLE
Fix and validate post-increment/decrement in module emit

### DIFF
--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -2724,6 +2724,14 @@ namespace ts {
             node.operator = operator;
             node.operand = parenthesizerRules().parenthesizeOperandOfPrefixUnary(operand);
             node.transformFlags |= propagateChildFlags(node.operand);
+            // Only set this flag for non-generated identifiers and non-"local" names. See the
+            // comment in `visitPreOrPostfixUnaryExpression` in module.ts
+            if ((operator === SyntaxKind.PlusPlusToken || operator === SyntaxKind.MinusMinusToken) &&
+                isIdentifier(node.operand) &&
+                !isGeneratedIdentifier(node.operand) &&
+                !isLocalName(node.operand)) {
+                node.transformFlags |= TransformFlags.ContainsUpdateExpressionForIdentifier;
+            }
             return node;
         }
 
@@ -2739,7 +2747,14 @@ namespace ts {
             const node = createBaseExpression<PostfixUnaryExpression>(SyntaxKind.PostfixUnaryExpression);
             node.operator = operator;
             node.operand = parenthesizerRules().parenthesizeOperandOfPostfixUnary(operand);
-            node.transformFlags = propagateChildFlags(node.operand);
+            node.transformFlags |= propagateChildFlags(node.operand);
+            // Only set this flag for non-generated identifiers and non-"local" names. See the
+            // comment in `visitPreOrPostfixUnaryExpression` in module.ts
+            if (isIdentifier(node.operand) &&
+                !isGeneratedIdentifier(node.operand) &&
+                !isLocalName(node.operand)) {
+                node.transformFlags |= TransformFlags.ContainsUpdateExpressionForIdentifier;
+            }
             return node;
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6635,6 +6635,7 @@ namespace ts {
         ContainsClassFields = 1 << 23,
         ContainsPossibleTopLevelAwait = 1 << 24,
         ContainsLexicalSuper = 1 << 25,
+        ContainsUpdateExpressionForIdentifier = 1 << 26,
         // Please leave this as 1 << 29.
         // It is the maximum bit we can set before we outgrow the size of a v8 small integer (SMI) on an x86 system.
         // It is a good reminder of how much room we have left

--- a/src/harness/evaluatorImpl.ts
+++ b/src/harness/evaluatorImpl.ts
@@ -36,98 +36,424 @@ namespace evaluator {
 
         const output = result.getOutput(source.main, "js")!;
         assert.isDefined(output);
-
         globals = { Symbol: FakeSymbol, ...globals };
-        return createLoader(fs, globals)(output.file);
-    }
-
-    function createLoader(fs: vfs.FileSystem, globals: Record<string, any>) {
-        interface Module {
-            exports: any;
-        }
-
-        const moduleCache = new ts.Map<string, Module>();
-        return load;
-
-        function evaluate(text: string, file: string, module: Module) {
-            const globalNames: string[] = [];
-            const globalArgs: any[] = [];
-            for (const name in globals) {
-                if (ts.hasProperty(globals, name)) {
-                    globalNames.push(name);
-                    globalArgs.push(globals[name]);
-                }
-            }
-            const base = vpath.dirname(file);
-            const localRequire = (id: string) => requireModule(id, base);
-            const evaluateText = `(function (module, exports, require, __dirname, __filename, ${globalNames.join(", ")}) { ${text} })`;
-            // eslint-disable-next-line no-eval
-            const evaluateThunk = (void 0, eval)(evaluateText) as (module: any, exports: any, require: (id: string) => any, dirname: string, filename: string, ...globalArgs: any[]) => void;
-            evaluateThunk.call(globals, module, module.exports, localRequire, vpath.dirname(file), file, FakeSymbol, ...globalArgs);
-        }
-
-        function loadModule(file: string): Module {
-            if (!ts.isExternalModuleNameRelative(file)) throw new Error(`Module '${file}' could not be found.`);
-            let module = moduleCache.get(file);
-            if (module) return module;
-            moduleCache.set(file, module = { exports: {} });
-            try {
-                const sourceText = fs.readFileSync(file, "utf8");
-                evaluate(sourceText, file, module);
-                return module;
-            }
-            catch (e) {
-                moduleCache.delete(file);
-                throw e;
-            }
-        }
-
-        function isFile(file: string) {
-            return fs.existsSync(file) && fs.statSync(file).isFile();
-        }
-
-        function loadAsFile(file: string): Module | undefined {
-            if (isFile(file)) return loadModule(file);
-            if (isFile(file + ".js")) return loadModule(file + ".js");
-            return undefined;
-        }
-
-        function loadIndex(dir: string): Module | undefined {
-            const indexFile = vpath.resolve(dir, "index.js");
-            if (isFile(indexFile)) return loadModule(indexFile);
-            return undefined;
-        }
-
-        function loadAsDirectory(dir: string): Module | undefined {
-            const packageFile = vpath.resolve(dir, "package.json");
-            if (isFile(packageFile)) {
-                const text = fs.readFileSync(packageFile, "utf8");
-                const json = JSON.parse(text);
-                if (json.main) {
-                    const main = vpath.resolve(dir, json.main);
-                    const result = loadAsFile(main) || loadIndex(main);
-                    if (result === undefined) throw new Error("Module not found");
-                }
-            }
-            return loadIndex(dir);
-        }
-
-        function requireModule(id: string, base: string) {
-            if (!ts.isExternalModuleNameRelative(id)) throw new Error(`Module '${id}' could not be found.`);
-            const file = vpath.resolve(base, id);
-            const module = loadAsFile(file) || loadAsDirectory(file);
-            if (!module) throw new Error(`Module '${id}' could not be found.`);
-            return module.exports;
-        }
-
-        function load(file: string) {
-            return requireModule(file, fs.cwd());
-        }
+        const loader = getLoader(compilerOptions, fs, globals);
+        return loader.import(output.file);
     }
 
     export function evaluateJavaScript(sourceText: string, globals?: Record<string, any>, sourceFile = sourceFileJs) {
         globals = { Symbol: FakeSymbol, ...globals };
         const fs = new vfs.FileSystem(/*ignoreCase*/ false, { files: { [sourceFile]: sourceText } });
-        return createLoader(fs, globals)(sourceFile);
+        return new CommonJsLoader(fs, globals).import(sourceFile);
+    }
+
+    function getLoader(compilerOptions: ts.CompilerOptions, fs: vfs.FileSystem, globals: Record<string, any>): Loader<unknown> {
+        const moduleKind = ts.getEmitModuleKind(compilerOptions);
+        switch (moduleKind) {
+            case ts.ModuleKind.UMD:
+            case ts.ModuleKind.CommonJS:
+                return new CommonJsLoader(fs, globals);
+            case ts.ModuleKind.System:
+                return new SystemLoader(fs, globals);
+            case ts.ModuleKind.AMD:
+            case ts.ModuleKind.None:
+            default:
+                throw new Error(`ModuleKind '${ts.ModuleKind[moduleKind]}' not supported by evaluator.`);
+        }
+    }
+
+    abstract class Loader<TModule> {
+        protected readonly fs: vfs.FileSystem;
+        protected readonly globals: Record<string, any>;
+
+        private moduleCache = new ts.Map<string, TModule>();
+
+        constructor(fs: vfs.FileSystem, globals: Record<string, any>) {
+            this.fs = fs;
+            this.globals = globals;
+        }
+
+        protected isFile(file: string) {
+            return this.fs.existsSync(file) && this.fs.statSync(file).isFile();
+        }
+
+        protected abstract evaluate(text: string, file: string, module: TModule): void;
+        protected abstract createModule(file: string): TModule;
+        protected abstract getExports(module: TModule): any;
+
+        protected load(file: string): TModule {
+            if (!ts.isExternalModuleNameRelative(file)) throw new Error(`Module '${file}' could not be found.`);
+            let module = this.moduleCache.get(file);
+            if (module) return module;
+            this.moduleCache.set(file, module = this.createModule(file));
+            try {
+                const sourceText = this.fs.readFileSync(file, "utf8");
+                this.evaluate(sourceText, file, module);
+                return module;
+            }
+            catch (e) {
+                this.moduleCache.delete(file);
+                throw e;
+            }
+        }
+
+        protected resolve(id: string, base: string) {
+            return vpath.resolve(base, id);
+        }
+
+        import(id: string, base = this.fs.cwd()) {
+            if (!ts.isExternalModuleNameRelative(id)) throw new Error(`Module '${id}' could not be found.`);
+            const file = this.resolve(id, base);
+            const module = this.load(file);
+            if (!module) throw new Error(`Module '${id}' could not be found.`);
+            return this.getExports(module);
+        }
+    }
+
+    interface CommonJSModule {
+        exports: any;
+    }
+
+    class CommonJsLoader extends Loader<CommonJSModule> {
+        private resolveAsFile(file: string) {
+            if (this.isFile(file)) return file;
+            if (this.isFile(file + ".js")) return file + ".js";
+            return undefined;
+        }
+
+        private resolveIndex(dir: string) {
+            const indexFile = vpath.resolve(dir, "index.js");
+            if (this.isFile(indexFile)) return indexFile;
+            return undefined;
+        }
+
+        private resolveAsDirectory(dir: string) {
+            const packageFile = vpath.resolve(dir, "package.json");
+            if (this.isFile(packageFile)) {
+                const text = this.fs.readFileSync(packageFile, "utf8");
+                const json = JSON.parse(text);
+                if (json.main) {
+                    const main = vpath.resolve(dir, json.main);
+                    const result = this.resolveAsFile(main) || this.resolveIndex(main);
+                    if (result === undefined) throw new Error("Module not found");
+                }
+            }
+            return this.resolveIndex(dir);
+        }
+
+        protected resolve(id: string, base: string) {
+            const file = vpath.resolve(base, id);
+            const resolved = this.resolveAsFile(file) || this.resolveAsDirectory(file);
+            if (!resolved) throw new Error(`Module '${id}' could not be found.`);
+            return resolved;
+        }
+
+        protected createModule(): CommonJSModule {
+            return { exports: {} };
+        }
+
+        protected getExports(module: CommonJSModule) {
+            return module.exports;
+        }
+
+        protected evaluate(text: string, file: string, module: CommonJSModule): void {
+            const globalNames: string[] = [];
+            const globalArgs: any[] = [];
+            for (const name in this.globals) {
+                if (ts.hasProperty(this.globals, name)) {
+                    globalNames.push(name);
+                    globalArgs.push(this.globals[name]);
+                }
+            }
+            const base = vpath.dirname(file);
+            const localRequire = (id: string) => this.import(id, base);
+            const evaluateText = `(function (module, exports, require, __dirname, __filename, ${globalNames.join(", ")}) { ${text} })`;
+            // eslint-disable-next-line no-eval
+            const evaluateThunk = (void 0, eval)(evaluateText) as (module: any, exports: any, require: (id: string) => any, dirname: string, filename: string, ...globalArgs: any[]) => void;
+            evaluateThunk.call(this.globals, module, module.exports, localRequire, vpath.dirname(file), file, ...globalArgs);
+        }
+    }
+
+    interface SystemModule {
+        file: string;
+        exports: any;
+        hasExports: boolean;
+        state: SystemModuleState;
+        dependencies: SystemModule[];
+        dependers: SystemModule[];
+        setters: SystemModuleDependencySetter[];
+        requestedDependencies?: string[];
+        declaration?: SystemModuleDeclaration;
+        hasError?: boolean;
+        error?: any;
+    }
+
+    const enum SystemModuleState {
+        // Instantiation phases:
+        Uninstantiated,
+        Instantiated,
+
+        // Linker phases:
+        AddingDependencies,
+        AllDependenciesAdded,
+        AllDependenciesInstantiated,
+        WiringSetters,
+        Linked,
+
+        // Evaluation phases:
+        Evaluating,
+        Ready,
+    }
+
+    interface SystemModuleExporter {
+        <T>(name: string, value: T): T;
+        <T extends object>(values: T): T;
+    }
+
+    interface SystemModuleContext {
+        import: (id: string) => Promise<any>;
+        meta: any;
+    }
+
+    type SystemModuleRegisterCallback = (exporter: SystemModuleExporter, context: SystemModuleContext) => SystemModuleDeclaration;
+    type SystemModuleDependencySetter = (dependency: any) => void;
+
+    interface SystemModuleDeclaration {
+        setters: SystemModuleDependencySetter[];
+        execute: () => void;
+    }
+
+    interface SystemGlobal {
+        register(dependencies: string[], declare: SystemModuleRegisterCallback): void;
+    }
+
+    class SystemLoader extends Loader<SystemModule> {
+        protected createModule(file: string): SystemModule {
+            return {
+                file,
+                // eslint-disable-next-line no-null/no-null
+                exports: Object.create(/*o*/ null),
+                dependencies: [],
+                dependers: [],
+                setters: [],
+                hasExports: false,
+                state: SystemModuleState.Uninstantiated
+            };
+        }
+
+        protected getExports(module: SystemModule) {
+            if (module.state < SystemModuleState.Ready) {
+                this.resetDependers(module, []);
+                this.evaluateModule(module, []);
+                if (module.state < SystemModuleState.Ready) {
+                    const error = new Error("Module graph could not be loaded");
+                    this.handleError(module, error);
+                    throw error;
+                }
+            }
+            if (module.hasError) {
+                throw module.error;
+            }
+            return module.exports;
+        }
+
+        private handleError(module: SystemModule, error: any) {
+            if (!module.hasError) {
+                module.hasError = true;
+                module.error = error;
+                module.state = SystemModuleState.Ready;
+            }
+        }
+
+        protected evaluate(text: string, _file: string, module: SystemModule): void {
+            const globalNames: string[] = [];
+            const globalArgs: any[] = [];
+            for (const name in this.globals) {
+                if (ts.hasProperty(this.globals, name)) {
+                    globalNames.push(name);
+                    globalArgs.push(this.globals[name]);
+                }
+            }
+            const localSystem: SystemGlobal = {
+                register: (dependencies, declare) => this.instantiateModule(module, dependencies, declare)
+            };
+            const evaluateText = `(function (System, ${globalNames.join(", ")}) { ${text} })`;
+            try {
+                // eslint-disable-next-line no-eval
+                const evaluateThunk = (void 0, eval)(evaluateText) as (System: any, ...globalArgs: any[]) => void;
+                evaluateThunk.call(this.globals, localSystem, ...globalArgs);
+            }
+            catch (e) {
+                this.handleError(module, e);
+                throw e;
+            }
+        }
+
+        private instantiateModule(module: SystemModule, dependencies: string[], registration?: SystemModuleRegisterCallback) {
+            function exporter<T>(name: string, value: T): T;
+            function exporter<T>(value: T): T;
+            function exporter<T>(...args: [string, T] | [T]) {
+                module.hasExports = true;
+                const name = args.length === 1 ? undefined : args[0];
+                const value = args.length === 1 ? args[0] : args[1];
+                if (name !== undefined) {
+                    module.exports[name] = value;
+                }
+                else {
+                    for (const name in value) {
+                        module.exports[name] = value[name];
+                    }
+                }
+                for (const setter of module.setters) {
+                    setter(module.exports);
+                }
+                return value;
+            }
+
+            const context: SystemModuleContext = {
+                import: (_id) => { throw new Error("Dynamic import not implemented."); },
+                meta: {
+                    url: ts.isUrl(module.file) ? module.file : `file:///${ts.normalizeSlashes(module.file).replace(/^\//, "").split("/").map(encodeURIComponent).join("/")}`
+                }
+            };
+
+            module.requestedDependencies = dependencies;
+
+            try {
+                module.declaration = registration?.(exporter, context);
+                module.state = SystemModuleState.Instantiated;
+
+                for (const depender of module.dependers) {
+                    this.linkModule(depender);
+                }
+
+                this.linkModule(module);
+            }
+            catch (e) {
+                this.handleError(module, e);
+                throw e;
+            }
+        }
+
+        private linkModule(module: SystemModule) {
+            try {
+                for (;;) {
+                    switch (module.state) {
+                        case SystemModuleState.Uninstantiated: {
+                            throw new Error("Module not yet instantiated");
+                        }
+                        case SystemModuleState.Instantiated: {
+                            // Module has been instantiated, start requesting dependencies.
+                            // Set state so that re-entry while adding dependencies does nothing.
+                            module.state = SystemModuleState.AddingDependencies;
+                            const base = vpath.dirname(module.file);
+                            const dependencies = module.requestedDependencies || [];
+
+                            for (const dependencyId of dependencies) {
+                                const dependency = this.load(this.resolve(dependencyId, base));
+                                module.dependencies.push(dependency);
+                                dependency.dependers.push(module);
+                            }
+
+                            // All dependencies have been added, switch state
+                            // to check whether all dependencies are instantiated
+                            module.state = SystemModuleState.AllDependenciesAdded;
+                            continue;
+                        }
+                        case SystemModuleState.AddingDependencies: {
+                            // in the middle of adding dependencies for this module, do nothing
+                            return;
+                        }
+                        case SystemModuleState.AllDependenciesAdded: {
+                            // all dependencies have been added, advance state if all dependencies are instantiated.
+                            for (const dependency of module.dependencies) {
+                                if (dependency.state === SystemModuleState.Uninstantiated) {
+                                    return;
+                                }
+                            }
+
+                            // indicate all dependencies are instantiated for this module.
+                            module.state = SystemModuleState.AllDependenciesInstantiated;
+
+                            // trigger links for dependers of this module.
+                            for (const depender of module.dependers) {
+                                this.linkModule(depender);
+                            }
+                            continue;
+                        }
+                        case SystemModuleState.AllDependenciesInstantiated: {
+                            // all dependencies have been instantiated, start wiring setters
+                            module.state = SystemModuleState.WiringSetters;
+                            for (let i = 0; i < module.dependencies.length; i++) {
+                                const dependency = module.dependencies[i];
+                                const setter = module.declaration?.setters[i];
+                                if (setter) {
+                                    dependency.setters.push(setter);
+                                    if (dependency.hasExports || dependency.state === SystemModuleState.Ready) {
+                                        // wire hoisted exports or ready dependencies.
+                                        setter(dependency.exports);
+                                    }
+                                }
+                            }
+
+                            module.state = SystemModuleState.Linked;
+
+                            // ensure graph is fully linked
+                            for (const depender of module.dependers) {
+                                this.linkModule(depender);
+                            }
+                            continue;
+                        }
+
+                        case SystemModuleState.WiringSetters: // in the middle of wiring setters for this module, nothing to do
+                        case SystemModuleState.Linked: // module has already been linked, nothing to do
+                        case SystemModuleState.Evaluating: // module is currently evaluating, nothing to do
+                        case SystemModuleState.Ready: // module is done evaluating, nothing to do
+                            return;
+                    }
+                }
+            }
+            catch (e) {
+                this.handleError(module, e);
+                throw e;
+            }
+        }
+
+        private resetDependers(module: SystemModule, stack: SystemModule[]) {
+            if (stack.lastIndexOf(module) !== -1) {
+                return;
+            }
+
+            stack.push(module);
+            module.dependers.length = 0;
+            for (const dependency of module.dependencies) {
+                this.resetDependers(dependency, stack);
+            }
+            stack.pop();
+        }
+
+        private evaluateModule(module: SystemModule, stack: SystemModule[]) {
+            if (module.state < SystemModuleState.Linked) throw new Error("Invalid state for evaluation.");
+            if (module.state !== SystemModuleState.Linked) return;
+
+            if (stack.lastIndexOf(module) !== -1) {
+                // we are already evaluating this module
+                return;
+            }
+
+            stack.push(module);
+            module.state = SystemModuleState.Evaluating;
+            try {
+                for (const dependency of module.dependencies) {
+                    this.evaluateModule(dependency, stack);
+                }
+                module.declaration?.execute?.();
+                module.state = SystemModuleState.Ready;
+            }
+            catch (e) {
+                this.handleError(module, e);
+                throw e;
+            }
+        }
     }
 }

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -99,6 +99,7 @@
         "unittests/evaluation/optionalCall.ts",
         "unittests/evaluation/objectRest.ts",
         "unittests/evaluation/superInStaticInitializer.ts",
+        "unittests/evaluation/updateExpressionInModule.ts",
         "unittests/services/cancellableLanguageServiceOperations.ts",
         "unittests/services/colorization.ts",
         "unittests/services/convertToAsyncFunction.ts",

--- a/src/testRunner/unittests/evaluation/updateExpressionInModule.ts
+++ b/src/testRunner/unittests/evaluation/updateExpressionInModule.ts
@@ -1,0 +1,125 @@
+describe("unittests:: evaluation:: updateExpressionInModule", () => {
+    // only run BigInt tests if BigInt is supported in the host environment
+    const itIfBigInt = typeof BigInt === "function" ? it : it.skip;
+
+    it("pre-increment in commonjs using Number", () => {
+        const result = evaluator.evaluateTypeScript({
+            files: {
+                "/.src/main.ts": `
+                let a = 1;
+                export { a };
+                export const b = ++a;
+                `
+            },
+            rootFiles: ["/.src/main.ts"],
+            main: "/.src/main.ts"
+        }, { module: ts.ModuleKind.CommonJS });
+        assert.equal(result.a, 2);
+        assert.equal(result.b, 2);
+    });
+    it("pre-increment in System using Number", () => {
+        const result = evaluator.evaluateTypeScript({
+            files: {
+                "/.src/main.ts": `
+                let a = 1;
+                export { a };
+                export const b = ++a;
+                `
+            },
+            rootFiles: ["/.src/main.ts"],
+            main: "/.src/main.ts"
+        }, { module: ts.ModuleKind.System });
+        assert.equal(result.a, 2);
+        assert.equal(result.b, 2);
+    });
+    itIfBigInt("pre-increment in commonjs using BigInt", () => {
+        const result = evaluator.evaluateTypeScript({
+            files: {
+                "/.src/main.ts": `
+                let a = BigInt(1);
+                export { a };
+                export const b = ++a;
+                `
+            },
+            rootFiles: ["/.src/main.ts"],
+            main: "/.src/main.ts"
+        }, { module: ts.ModuleKind.CommonJS }, { BigInt });
+        assert.equal(result.a, BigInt(2));
+        assert.equal(result.b, BigInt(2));
+    });
+    itIfBigInt("pre-increment in System using BigInt", () => {
+        const result = evaluator.evaluateTypeScript({
+            files: {
+                "/.src/main.ts": `
+                let a = BigInt(1);
+                export { a };
+                export const b = ++a;
+                `
+            },
+            rootFiles: ["/.src/main.ts"],
+            main: "/.src/main.ts"
+        }, { module: ts.ModuleKind.System }, { BigInt });
+        assert.equal(result.a, BigInt(2));
+        assert.equal(result.b, BigInt(2));
+    });
+    it("post-increment in commonjs using Number", () => {
+        const result = evaluator.evaluateTypeScript({
+            files: {
+                "/.src/main.ts": `
+                let a = 1;
+                export { a };
+                export const b = a++;
+                `
+            },
+            rootFiles: ["/.src/main.ts"],
+            main: "/.src/main.ts"
+        }, { module: ts.ModuleKind.CommonJS });
+        assert.equal(result.a, 2);
+        assert.equal(result.b, 1);
+    });
+    it("post-increment in System using Number", () => {
+        const result = evaluator.evaluateTypeScript({
+            files: {
+                "/.src/main.ts": `
+                let a = 1;
+                export { a };
+                export const b = a++;
+                `
+            },
+            rootFiles: ["/.src/main.ts"],
+            main: "/.src/main.ts"
+        }, { module: ts.ModuleKind.System });
+        assert.equal(result.a, 2);
+        assert.equal(result.b, 1);
+    });
+    itIfBigInt("post-increment in commonjs using BigInt", () => {
+        const result = evaluator.evaluateTypeScript({
+            files: {
+                "/.src/main.ts": `
+                let a = BigInt(1);
+                export { a };
+                export const b = a++;
+                `
+            },
+            rootFiles: ["/.src/main.ts"],
+            main: "/.src/main.ts"
+        }, { module: ts.ModuleKind.CommonJS }, { BigInt });
+        assert.equal(result.a, BigInt(2));
+        assert.equal(result.b, BigInt(1));
+    });
+    itIfBigInt("post-increment in System using BigInt", () => {
+        const result = evaluator.evaluateTypeScript({
+            files: {
+                "/.src/main.ts": `
+                let a = BigInt(1);
+                export { a };
+                export const b = a++;
+                `
+            },
+            rootFiles: ["/.src/main.ts"],
+            main: "/.src/main.ts"
+        }, { module: ts.ModuleKind.System }, { BigInt });
+        assert.equal(result.a, BigInt(2));
+        assert.equal(result.b, BigInt(1));
+    });
+});

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
@@ -9,7 +9,7 @@ var buzz = 10;
 buzz += 3;
 
 var bizz = 8;
-bizz++; // compiles to exports.bizz = bizz += 1
+bizz++; // compiles to exports.bizz = (bizz++, bizz)
 bizz--; // similarly
 ++bizz; // compiles to exports.bizz = ++bizz
 
@@ -32,6 +32,6 @@ exports.buzz = buzz;
 exports.buzz = buzz += 3;
 var bizz = 8;
 exports.bizz = bizz;
-(exports.bizz = ++bizz) - 1; // compiles to exports.bizz = bizz += 1
-(exports.bizz = --bizz) + 1; // similarly
+exports.bizz = (bizz++, bizz); // compiles to exports.bizz = (bizz++, bizz)
+exports.bizz = (bizz--, bizz); // similarly
 exports.bizz = ++bizz; // compiles to exports.bizz = ++bizz

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.symbols
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.symbols
@@ -20,7 +20,7 @@ buzz += 3;
 var bizz = 8;
 >bizz : Symbol(bizz, Decl(server.ts, 9, 3))
 
-bizz++; // compiles to exports.bizz = bizz += 1
+bizz++; // compiles to exports.bizz = (bizz++, bizz)
 >bizz : Symbol(bizz, Decl(server.ts, 9, 3))
 
 bizz--; // similarly

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.types
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.types
@@ -30,7 +30,7 @@ var bizz = 8;
 >bizz : number
 >8 : 8
 
-bizz++; // compiles to exports.bizz = bizz += 1
+bizz++; // compiles to exports.bizz = (bizz++, bizz)
 >bizz++ : number
 >bizz : number
 

--- a/tests/baselines/reference/moduleExportsUnaryExpression.js
+++ b/tests/baselines/reference/moduleExportsUnaryExpression.js
@@ -18,21 +18,22 @@ export { x };
 
 //// [moduleExportsUnaryExpression.js]
 "use strict";
+var _a, _b, _c, _d;
 exports.__esModule = true;
 exports.x = exports.foo = void 0;
 var x = 1;
 exports.x = x;
 function foo(y) {
-    if (y <= (exports.x = ++x) - 1)
-        return y <= (exports.x = ++x) - 1;
-    if (y <= (exports.x = --x) + 1)
-        return y <= (exports.x = --x) + 1;
+    if (y <= (exports.x = (_a = x++, x), _a))
+        return y <= (exports.x = (_b = x++, x), _b);
+    if (y <= (exports.x = (_c = x--, x), _c))
+        return y <= (exports.x = (_d = x--, x), _d);
     if (y <= (exports.x = ++x))
         return y <= (exports.x = ++x);
     if (y <= (exports.x = --x))
         return y <= (exports.x = --x);
-    (exports.x = ++x) - 1;
-    (exports.x = --x) + 1;
+    exports.x = (x++, x);
+    exports.x = (x--, x);
     exports.x = ++x;
     exports.x = --x;
 }

--- a/tests/baselines/reference/systemModule8.js
+++ b/tests/baselines/reference/systemModule8.js
@@ -41,8 +41,8 @@ System.register([], function (exports_1, context_1) {
         setters: [],
         execute: function () {
             exports_1("x", x = 1);
-            exports_1("x", ++x) - 1;
-            exports_1("x", --x) + 1;
+            exports_1("x", (x++, x));
+            exports_1("x", (x--, x));
             exports_1("x", ++x);
             exports_1("x", --x);
             exports_1("x", x += 1);
@@ -55,8 +55,8 @@ System.register([], function (exports_1, context_1) {
             x - 1;
             x & 1;
             x | 1;
-            for (exports_1("x", x = 5);; exports_1("x", ++x) - 1) { }
-            for (exports_1("x", x = 8);; exports_1("x", --x) + 1) { }
+            for (exports_1("x", x = 5);; exports_1("x", (x++, x))) { }
+            for (exports_1("x", x = 8);; exports_1("x", (x--, x))) { }
             for (exports_1("x", x = 15);; exports_1("x", ++x)) { }
             for (exports_1("x", x = 18);; exports_1("x", --x)) { }
             for (var x_1 = 50;;) { }

--- a/tests/cases/compiler/es6ExportClauseWithAssignmentInEs5.ts
+++ b/tests/cases/compiler/es6ExportClauseWithAssignmentInEs5.ts
@@ -12,7 +12,7 @@ var buzz = 10;
 buzz += 3;
 
 var bizz = 8;
-bizz++; // compiles to exports.bizz = bizz += 1
+bizz++; // compiles to exports.bizz = (bizz++, bizz)
 bizz--; // similarly
 ++bizz; // compiles to exports.bizz = ++bizz
 


### PR DESCRIPTION
This changes the emit for post-increment/decrement in our module emit for CommonJS, AMD, UMD, and System. This aligns with another recent change that fixed pre-/post-increment/decrement for private fields, and also ensures that pre-/post-increment/decrement work with `BigInt` values (our previous emit did not).

This also adds evaluation tests for pre-/post-increment/decrement in CommonJS and System (which required adding a mini System loader to the evaluator test framework). AMD and UMD are not included in the evaluation tests because that emit is covered by the CommonJS case.

Fixes #33044
