### PR TITLE
Fix getChildCount/At methods in EndOfFileTokens

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -259,11 +259,11 @@ namespace ts {
         }
 
         public getChildCount(): number {
-            return 0;
+            return this.getChildren().length;
         }
 
-        public getChildAt(): Node {
-            return undefined!;  // TODO: GH#18217
+        public getChildAt(index: number): Node {
+            return this.getChildren()[index];
         }
 
         public getChildren(): Node[] {

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -171,3 +171,14 @@ var x
     });
     assert.equal(5, kids.length);
 });
+
+describe("unittests:: Public APIs:: getChild* methods on EndOfFileToken with JSDoc", () => {
+    const content = `
+/** jsdoc comment attached to EndOfFileToken */
+`;
+    const sourceFile = ts.createSourceFile("/file.ts", content, ts.ScriptTarget.ESNext, /*setParentNodes*/ true);
+    const endOfFileToken = sourceFile.getChildren()[1];
+    assert.equal(endOfFileToken.getChildren().length, 1);
+    assert.equal(endOfFileToken.getChildCount(), 1);
+    assert.notEqual(endOfFileToken.getChildAt(0), /*expected*/ undefined);
+});


### PR DESCRIPTION
Before, they were hardcoded to return `0` and `undefined!`, respectively, but that is inaccurate for `EndOfFileToken`s with attached jsdoc.

Fixes #44990 
