### PR TITLE
Increase type instantiation depth limit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16227,26 +16227,19 @@ namespace ts {
                 let result = root.instantiations!.get(id);
                 if (!result) {
                     const newMapper = createTypeMapper(root.outerTypeParameters, typeArguments);
-                    result = instantiateConditionalType(root, newMapper, aliasSymbol, aliasTypeArguments);
+                    const checkType = root.checkType;
+                    const distributionType = root.isDistributive ? getMappedType(checkType, newMapper) : undefined;
+                    // Distributive conditional types are distributed over union types. For example, when the
+                    // distributive conditional type T extends U ? X : Y is instantiated with A | B for T, the
+                    // result is (A extends U ? X : Y) | (B extends U ? X : Y).
+                    result = distributionType && checkType !== distributionType && distributionType.flags & (TypeFlags.Union | TypeFlags.Never) ?
+                        mapTypeWithAlias(distributionType, t => getConditionalType(root, prependTypeMapping(checkType, t, newMapper)), aliasSymbol, aliasTypeArguments) :
+                        getConditionalType(root, newMapper, aliasSymbol, aliasTypeArguments);
                     root.instantiations!.set(id, result);
                 }
                 return result;
             }
             return type;
-        }
-
-        function instantiateConditionalType(root: ConditionalRoot, mapper: TypeMapper, aliasSymbol?: Symbol, aliasTypeArguments?: readonly Type[]): Type {
-            // Check if we have a conditional type where the check type is a naked type parameter. If so,
-            // the conditional type is distributive over union types and when T is instantiated to a union
-            // type A | B, we produce (A extends U ? X : Y) | (B extends U ? X : Y).
-            if (root.isDistributive) {
-                const checkType = root.checkType as TypeParameter;
-                const instantiatedType = getMappedType(checkType, mapper);
-                if (checkType !== instantiatedType && instantiatedType.flags & (TypeFlags.Union | TypeFlags.Never)) {
-                    return mapTypeWithAlias(instantiatedType, t => getConditionalType(root, prependTypeMapping(checkType, t, mapper)), aliasSymbol, aliasTypeArguments);
-                }
-            }
-            return getConditionalType(root, mapper, aliasSymbol, aliasTypeArguments);
         }
 
         function instantiateType(type: Type, mapper: TypeMapper | undefined): Type;
@@ -16259,10 +16252,10 @@ namespace ts {
             if (!couldContainTypeVariables(type)) {
                 return type;
             }
-            if (instantiationDepth === 50 || instantiationCount >= 5000000) {
-                // We have reached 50 recursive type instantiations and there is a very high likelyhood we're dealing
-                // with a combination of infinite generic types that perpetually generate new type identities. We stop
-                // the recursion here by yielding the error type.
+            if (instantiationDepth === 500 || instantiationCount >= 5000000) {
+                // We have reached 500 recursive type instantiations, or 5M type instantiations caused by the same statement
+                // or expression. There is a very high likelyhood we're dealing with a combination of infinite generic types
+                // that perpetually generate new type identities, so we stop the recursion here by yielding the error type.
                 tracing?.instant(tracing.Phase.CheckTypes, "instantiateType_DepthLimit", { typeId: type.id, instantiationDepth, instantiationCount });
                 error(currentNode, Diagnostics.Type_instantiation_is_excessively_deep_and_possibly_infinite);
                 return errorType;

--- a/tests/baselines/reference/recursiveConditionalTypes.errors.txt
+++ b/tests/baselines/reference/recursiveConditionalTypes.errors.txt
@@ -6,7 +6,6 @@ tests/cases/compiler/recursiveConditionalTypes.ts(21,5): error TS2322: Type 'T' 
 tests/cases/compiler/recursiveConditionalTypes.ts(22,5): error TS2322: Type 'Awaited<T>' is not assignable to type 'T'.
   'T' could be instantiated with an arbitrary type which could be unrelated to 'Awaited<T>'.
 tests/cases/compiler/recursiveConditionalTypes.ts(35,11): error TS2589: Type instantiation is excessively deep and possibly infinite.
-tests/cases/compiler/recursiveConditionalTypes.ts(46,12): error TS2589: Type instantiation is excessively deep and possibly infinite.
 tests/cases/compiler/recursiveConditionalTypes.ts(49,5): error TS2322: Type 'TupleOf<number, M>' is not assignable to type 'TupleOf<number, N>'.
   Type 'number extends M ? number[] : _TupleOf<number, M, []>' is not assignable to type 'TupleOf<number, N>'.
     Type 'number[] | _TupleOf<number, M, []>' is not assignable to type 'TupleOf<number, N>'.
@@ -25,7 +24,7 @@ tests/cases/compiler/recursiveConditionalTypes.ts(116,9): error TS2345: Argument
               Type 'string' is not assignable to type 'number'.
 
 
-==== tests/cases/compiler/recursiveConditionalTypes.ts (9 errors) ====
+==== tests/cases/compiler/recursiveConditionalTypes.ts (8 errors) ====
     // Awaiting promises
     
     type Awaited<T> =
@@ -85,8 +84,6 @@ tests/cases/compiler/recursiveConditionalTypes.ts(116,9): error TS2345: Argument
     type TT2 = TupleOf<number, number>;
     type TT3 = TupleOf<number, any>;
     type TT4 = TupleOf<number, 100>;  // Depth error
-               ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2589: Type instantiation is excessively deep and possibly infinite.
     
     function f22<N extends number, M extends N>(tn: TupleOf<number, N>, tm: TupleOf<number, M>) {
         tn = tm;

--- a/tests/baselines/reference/recursiveConditionalTypes.errors.txt
+++ b/tests/baselines/reference/recursiveConditionalTypes.errors.txt
@@ -6,15 +6,16 @@ tests/cases/compiler/recursiveConditionalTypes.ts(21,5): error TS2322: Type 'T' 
 tests/cases/compiler/recursiveConditionalTypes.ts(22,5): error TS2322: Type 'Awaited<T>' is not assignable to type 'T'.
   'T' could be instantiated with an arbitrary type which could be unrelated to 'Awaited<T>'.
 tests/cases/compiler/recursiveConditionalTypes.ts(35,11): error TS2589: Type instantiation is excessively deep and possibly infinite.
-tests/cases/compiler/recursiveConditionalTypes.ts(49,5): error TS2322: Type 'TupleOf<number, M>' is not assignable to type 'TupleOf<number, N>'.
+tests/cases/compiler/recursiveConditionalTypes.ts(47,12): error TS2589: Type instantiation is excessively deep and possibly infinite.
+tests/cases/compiler/recursiveConditionalTypes.ts(50,5): error TS2322: Type 'TupleOf<number, M>' is not assignable to type 'TupleOf<number, N>'.
   Type 'number extends M ? number[] : _TupleOf<number, M, []>' is not assignable to type 'TupleOf<number, N>'.
     Type 'number[] | _TupleOf<number, M, []>' is not assignable to type 'TupleOf<number, N>'.
       Type 'number[]' is not assignable to type 'TupleOf<number, N>'.
-tests/cases/compiler/recursiveConditionalTypes.ts(50,5): error TS2322: Type 'TupleOf<number, N>' is not assignable to type 'TupleOf<number, M>'.
+tests/cases/compiler/recursiveConditionalTypes.ts(51,5): error TS2322: Type 'TupleOf<number, N>' is not assignable to type 'TupleOf<number, M>'.
   Type 'number extends N ? number[] : _TupleOf<number, N, []>' is not assignable to type 'TupleOf<number, M>'.
     Type 'number[] | _TupleOf<number, N, []>' is not assignable to type 'TupleOf<number, M>'.
       Type 'number[]' is not assignable to type 'TupleOf<number, M>'.
-tests/cases/compiler/recursiveConditionalTypes.ts(116,9): error TS2345: Argument of type 'Grow2<[], T>' is not assignable to parameter of type 'Grow1<[], T>'.
+tests/cases/compiler/recursiveConditionalTypes.ts(117,9): error TS2345: Argument of type 'Grow2<[], T>' is not assignable to parameter of type 'Grow1<[], T>'.
   Type '[] | Grow2<[string], T>' is not assignable to type 'Grow1<[], T>'.
     Type '[]' is not assignable to type 'Grow1<[], T>'.
       Type 'Grow2<[string], T>' is not assignable to type 'Grow1<[number], T>'.
@@ -24,7 +25,7 @@ tests/cases/compiler/recursiveConditionalTypes.ts(116,9): error TS2345: Argument
               Type 'string' is not assignable to type 'number'.
 
 
-==== tests/cases/compiler/recursiveConditionalTypes.ts (8 errors) ====
+==== tests/cases/compiler/recursiveConditionalTypes.ts (9 errors) ====
     // Awaiting promises
     
     type Awaited<T> =
@@ -83,7 +84,10 @@ tests/cases/compiler/recursiveConditionalTypes.ts(116,9): error TS2345: Argument
     type TT1 = TupleOf<number, 0 | 2 | 4>;
     type TT2 = TupleOf<number, number>;
     type TT3 = TupleOf<number, any>;
-    type TT4 = TupleOf<number, 100>;  // Depth error
+    type TT4 = TupleOf<number, 100>;
+    type TT5 = TupleOf<number, 1000>;  // Depth error
+               ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2589: Type instantiation is excessively deep and possibly infinite.
     
     function f22<N extends number, M extends N>(tn: TupleOf<number, N>, tm: TupleOf<number, M>) {
         tn = tm;

--- a/tests/baselines/reference/recursiveConditionalTypes.js
+++ b/tests/baselines/reference/recursiveConditionalTypes.js
@@ -44,7 +44,8 @@ type TT0 = TupleOf<string, 4>;
 type TT1 = TupleOf<number, 0 | 2 | 4>;
 type TT2 = TupleOf<number, number>;
 type TT3 = TupleOf<number, any>;
-type TT4 = TupleOf<number, 100>;  // Depth error
+type TT4 = TupleOf<number, 100>;
+type TT5 = TupleOf<number, 1000>;  // Depth error
 
 function f22<N extends number, M extends N>(tn: TupleOf<number, N>, tm: TupleOf<number, M>) {
     tn = tm;
@@ -194,6 +195,7 @@ declare type TT1 = TupleOf<number, 0 | 2 | 4>;
 declare type TT2 = TupleOf<number, number>;
 declare type TT3 = TupleOf<number, any>;
 declare type TT4 = TupleOf<number, 100>;
+declare type TT5 = TupleOf<number, 1000>;
 declare function f22<N extends number, M extends N>(tn: TupleOf<number, N>, tm: TupleOf<number, M>): void;
 declare function f23<T>(t: TupleOf<T, 3>): T;
 interface Box<T> {

--- a/tests/baselines/reference/recursiveConditionalTypes.symbols
+++ b/tests/baselines/reference/recursiveConditionalTypes.symbols
@@ -179,351 +179,355 @@ type TT3 = TupleOf<number, any>;
 >TT3 : Symbol(TT3, Decl(recursiveConditionalTypes.ts, 43, 35))
 >TupleOf : Symbol(TupleOf, Decl(recursiveConditionalTypes.ts, 34, 16))
 
-type TT4 = TupleOf<number, 100>;  // Depth error
+type TT4 = TupleOf<number, 100>;
 >TT4 : Symbol(TT4, Decl(recursiveConditionalTypes.ts, 44, 32))
 >TupleOf : Symbol(TupleOf, Decl(recursiveConditionalTypes.ts, 34, 16))
 
+type TT5 = TupleOf<number, 1000>;  // Depth error
+>TT5 : Symbol(TT5, Decl(recursiveConditionalTypes.ts, 45, 32))
+>TupleOf : Symbol(TupleOf, Decl(recursiveConditionalTypes.ts, 34, 16))
+
 function f22<N extends number, M extends N>(tn: TupleOf<number, N>, tm: TupleOf<number, M>) {
->f22 : Symbol(f22, Decl(recursiveConditionalTypes.ts, 45, 32))
->N : Symbol(N, Decl(recursiveConditionalTypes.ts, 47, 13))
->M : Symbol(M, Decl(recursiveConditionalTypes.ts, 47, 30))
->N : Symbol(N, Decl(recursiveConditionalTypes.ts, 47, 13))
->tn : Symbol(tn, Decl(recursiveConditionalTypes.ts, 47, 44))
+>f22 : Symbol(f22, Decl(recursiveConditionalTypes.ts, 46, 33))
+>N : Symbol(N, Decl(recursiveConditionalTypes.ts, 48, 13))
+>M : Symbol(M, Decl(recursiveConditionalTypes.ts, 48, 30))
+>N : Symbol(N, Decl(recursiveConditionalTypes.ts, 48, 13))
+>tn : Symbol(tn, Decl(recursiveConditionalTypes.ts, 48, 44))
 >TupleOf : Symbol(TupleOf, Decl(recursiveConditionalTypes.ts, 34, 16))
->N : Symbol(N, Decl(recursiveConditionalTypes.ts, 47, 13))
->tm : Symbol(tm, Decl(recursiveConditionalTypes.ts, 47, 67))
+>N : Symbol(N, Decl(recursiveConditionalTypes.ts, 48, 13))
+>tm : Symbol(tm, Decl(recursiveConditionalTypes.ts, 48, 67))
 >TupleOf : Symbol(TupleOf, Decl(recursiveConditionalTypes.ts, 34, 16))
->M : Symbol(M, Decl(recursiveConditionalTypes.ts, 47, 30))
+>M : Symbol(M, Decl(recursiveConditionalTypes.ts, 48, 30))
 
     tn = tm;
->tn : Symbol(tn, Decl(recursiveConditionalTypes.ts, 47, 44))
->tm : Symbol(tm, Decl(recursiveConditionalTypes.ts, 47, 67))
+>tn : Symbol(tn, Decl(recursiveConditionalTypes.ts, 48, 44))
+>tm : Symbol(tm, Decl(recursiveConditionalTypes.ts, 48, 67))
 
     tm = tn;
->tm : Symbol(tm, Decl(recursiveConditionalTypes.ts, 47, 67))
->tn : Symbol(tn, Decl(recursiveConditionalTypes.ts, 47, 44))
+>tm : Symbol(tm, Decl(recursiveConditionalTypes.ts, 48, 67))
+>tn : Symbol(tn, Decl(recursiveConditionalTypes.ts, 48, 44))
 }
 
 declare function f23<T>(t: TupleOf<T, 3>): T;
->f23 : Symbol(f23, Decl(recursiveConditionalTypes.ts, 50, 1))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 52, 21))
->t : Symbol(t, Decl(recursiveConditionalTypes.ts, 52, 24))
+>f23 : Symbol(f23, Decl(recursiveConditionalTypes.ts, 51, 1))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 53, 21))
+>t : Symbol(t, Decl(recursiveConditionalTypes.ts, 53, 24))
 >TupleOf : Symbol(TupleOf, Decl(recursiveConditionalTypes.ts, 34, 16))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 52, 21))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 52, 21))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 53, 21))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 53, 21))
 
 f23(['a', 'b', 'c']);  // string
->f23 : Symbol(f23, Decl(recursiveConditionalTypes.ts, 50, 1))
+>f23 : Symbol(f23, Decl(recursiveConditionalTypes.ts, 51, 1))
 
 // Inference to recursive type
 
 interface Box<T> { value: T };
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 58, 14))
->value : Symbol(Box.value, Decl(recursiveConditionalTypes.ts, 58, 18))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 58, 14))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 59, 14))
+>value : Symbol(Box.value, Decl(recursiveConditionalTypes.ts, 59, 18))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 59, 14))
 
 type RecBox<T> = T | Box<RecBox<T>>;
->RecBox : Symbol(RecBox, Decl(recursiveConditionalTypes.ts, 58, 30))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 59, 12))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 59, 12))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->RecBox : Symbol(RecBox, Decl(recursiveConditionalTypes.ts, 58, 30))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 59, 12))
+>RecBox : Symbol(RecBox, Decl(recursiveConditionalTypes.ts, 59, 30))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 60, 12))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 60, 12))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>RecBox : Symbol(RecBox, Decl(recursiveConditionalTypes.ts, 59, 30))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 60, 12))
 
 type InfBox<T> = Box<InfBox<T>>;
->InfBox : Symbol(InfBox, Decl(recursiveConditionalTypes.ts, 59, 36))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 60, 12))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->InfBox : Symbol(InfBox, Decl(recursiveConditionalTypes.ts, 59, 36))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 60, 12))
+>InfBox : Symbol(InfBox, Decl(recursiveConditionalTypes.ts, 60, 36))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 61, 12))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>InfBox : Symbol(InfBox, Decl(recursiveConditionalTypes.ts, 60, 36))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 61, 12))
 
 declare function unbox<T>(box: RecBox<T>): T
->unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 60, 32))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 62, 23))
->box : Symbol(box, Decl(recursiveConditionalTypes.ts, 62, 26))
->RecBox : Symbol(RecBox, Decl(recursiveConditionalTypes.ts, 58, 30))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 62, 23))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 62, 23))
+>unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 61, 32))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 63, 23))
+>box : Symbol(box, Decl(recursiveConditionalTypes.ts, 63, 26))
+>RecBox : Symbol(RecBox, Decl(recursiveConditionalTypes.ts, 59, 30))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 63, 23))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 63, 23))
 
 type T1 = Box<string>;
->T1 : Symbol(T1, Decl(recursiveConditionalTypes.ts, 62, 44))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
+>T1 : Symbol(T1, Decl(recursiveConditionalTypes.ts, 63, 44))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
 
 type T2 = Box<T1>;
->T2 : Symbol(T2, Decl(recursiveConditionalTypes.ts, 64, 22))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->T1 : Symbol(T1, Decl(recursiveConditionalTypes.ts, 62, 44))
+>T2 : Symbol(T2, Decl(recursiveConditionalTypes.ts, 65, 22))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>T1 : Symbol(T1, Decl(recursiveConditionalTypes.ts, 63, 44))
 
 type T3 = Box<T2>;
->T3 : Symbol(T3, Decl(recursiveConditionalTypes.ts, 65, 18))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->T2 : Symbol(T2, Decl(recursiveConditionalTypes.ts, 64, 22))
+>T3 : Symbol(T3, Decl(recursiveConditionalTypes.ts, 66, 18))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>T2 : Symbol(T2, Decl(recursiveConditionalTypes.ts, 65, 22))
 
 type T4 = Box<T3>;
->T4 : Symbol(T4, Decl(recursiveConditionalTypes.ts, 66, 18))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->T3 : Symbol(T3, Decl(recursiveConditionalTypes.ts, 65, 18))
+>T4 : Symbol(T4, Decl(recursiveConditionalTypes.ts, 67, 18))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>T3 : Symbol(T3, Decl(recursiveConditionalTypes.ts, 66, 18))
 
 type T5 = Box<T4>;
->T5 : Symbol(T5, Decl(recursiveConditionalTypes.ts, 67, 18))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->T4 : Symbol(T4, Decl(recursiveConditionalTypes.ts, 66, 18))
+>T5 : Symbol(T5, Decl(recursiveConditionalTypes.ts, 68, 18))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>T4 : Symbol(T4, Decl(recursiveConditionalTypes.ts, 67, 18))
 
 type T6 = Box<T5>;
->T6 : Symbol(T6, Decl(recursiveConditionalTypes.ts, 68, 18))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->T5 : Symbol(T5, Decl(recursiveConditionalTypes.ts, 67, 18))
+>T6 : Symbol(T6, Decl(recursiveConditionalTypes.ts, 69, 18))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>T5 : Symbol(T5, Decl(recursiveConditionalTypes.ts, 68, 18))
 
 declare let b1: Box<Box<Box<Box<Box<Box<string>>>>>>;
->b1 : Symbol(b1, Decl(recursiveConditionalTypes.ts, 71, 11))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
->Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 54, 21))
+>b1 : Symbol(b1, Decl(recursiveConditionalTypes.ts, 72, 11))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
+>Box : Symbol(Box, Decl(recursiveConditionalTypes.ts, 55, 21))
 
 declare let b2: T6;
->b2 : Symbol(b2, Decl(recursiveConditionalTypes.ts, 72, 11))
->T6 : Symbol(T6, Decl(recursiveConditionalTypes.ts, 68, 18))
+>b2 : Symbol(b2, Decl(recursiveConditionalTypes.ts, 73, 11))
+>T6 : Symbol(T6, Decl(recursiveConditionalTypes.ts, 69, 18))
 
 declare let b3: InfBox<string>;
->b3 : Symbol(b3, Decl(recursiveConditionalTypes.ts, 73, 11))
->InfBox : Symbol(InfBox, Decl(recursiveConditionalTypes.ts, 59, 36))
+>b3 : Symbol(b3, Decl(recursiveConditionalTypes.ts, 74, 11))
+>InfBox : Symbol(InfBox, Decl(recursiveConditionalTypes.ts, 60, 36))
 
 declare let b4: { value: { value: { value: typeof b4 }}};
->b4 : Symbol(b4, Decl(recursiveConditionalTypes.ts, 74, 11))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 74, 17))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 74, 26))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 74, 35))
->b4 : Symbol(b4, Decl(recursiveConditionalTypes.ts, 74, 11))
+>b4 : Symbol(b4, Decl(recursiveConditionalTypes.ts, 75, 11))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 75, 17))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 75, 26))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 75, 35))
+>b4 : Symbol(b4, Decl(recursiveConditionalTypes.ts, 75, 11))
 
 unbox(b1);  // string
->unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 60, 32))
->b1 : Symbol(b1, Decl(recursiveConditionalTypes.ts, 71, 11))
+>unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 61, 32))
+>b1 : Symbol(b1, Decl(recursiveConditionalTypes.ts, 72, 11))
 
 unbox(b2);  // string
->unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 60, 32))
->b2 : Symbol(b2, Decl(recursiveConditionalTypes.ts, 72, 11))
+>unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 61, 32))
+>b2 : Symbol(b2, Decl(recursiveConditionalTypes.ts, 73, 11))
 
 unbox(b3);  // InfBox<string>
->unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 60, 32))
->b3 : Symbol(b3, Decl(recursiveConditionalTypes.ts, 73, 11))
+>unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 61, 32))
+>b3 : Symbol(b3, Decl(recursiveConditionalTypes.ts, 74, 11))
 
 unbox({ value: { value: { value: { value: { value: { value: 5 }}}}}});  // number
->unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 60, 32))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 79, 7))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 79, 16))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 79, 25))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 79, 34))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 79, 43))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 79, 52))
+>unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 61, 32))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 80, 7))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 80, 16))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 80, 25))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 80, 34))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 80, 43))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 80, 52))
 
 unbox(b4);  // { value: { value: typeof b4 }}
->unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 60, 32))
->b4 : Symbol(b4, Decl(recursiveConditionalTypes.ts, 74, 11))
+>unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 61, 32))
+>b4 : Symbol(b4, Decl(recursiveConditionalTypes.ts, 75, 11))
 
 unbox({ value: { value: { get value() { return this; } }}});  // { readonly value: ... }
->unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 60, 32))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 81, 7))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 81, 16))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 81, 25))
+>unbox : Symbol(unbox, Decl(recursiveConditionalTypes.ts, 61, 32))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 82, 7))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 82, 16))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 82, 25))
 
 // Inference from nested instantiations of same generic types
 
 type Box1<T> = { value: T };
->Box1 : Symbol(Box1, Decl(recursiveConditionalTypes.ts, 81, 60))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 85, 10))
->value : Symbol(value, Decl(recursiveConditionalTypes.ts, 85, 16))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 85, 10))
-
-type Box2<T> = { value: T };
->Box2 : Symbol(Box2, Decl(recursiveConditionalTypes.ts, 85, 28))
+>Box1 : Symbol(Box1, Decl(recursiveConditionalTypes.ts, 82, 60))
 >T : Symbol(T, Decl(recursiveConditionalTypes.ts, 86, 10))
 >value : Symbol(value, Decl(recursiveConditionalTypes.ts, 86, 16))
 >T : Symbol(T, Decl(recursiveConditionalTypes.ts, 86, 10))
 
+type Box2<T> = { value: T };
+>Box2 : Symbol(Box2, Decl(recursiveConditionalTypes.ts, 86, 28))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 87, 10))
+>value : Symbol(value, Decl(recursiveConditionalTypes.ts, 87, 16))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 87, 10))
+
 declare function foo<T>(x: Box1<Box1<T>>): T;
->foo : Symbol(foo, Decl(recursiveConditionalTypes.ts, 86, 28))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 88, 21))
->x : Symbol(x, Decl(recursiveConditionalTypes.ts, 88, 24))
->Box1 : Symbol(Box1, Decl(recursiveConditionalTypes.ts, 81, 60))
->Box1 : Symbol(Box1, Decl(recursiveConditionalTypes.ts, 81, 60))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 88, 21))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 88, 21))
+>foo : Symbol(foo, Decl(recursiveConditionalTypes.ts, 87, 28))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 89, 21))
+>x : Symbol(x, Decl(recursiveConditionalTypes.ts, 89, 24))
+>Box1 : Symbol(Box1, Decl(recursiveConditionalTypes.ts, 82, 60))
+>Box1 : Symbol(Box1, Decl(recursiveConditionalTypes.ts, 82, 60))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 89, 21))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 89, 21))
 
 declare let z: Box2<Box2<string>>;
->z : Symbol(z, Decl(recursiveConditionalTypes.ts, 90, 11))
->Box2 : Symbol(Box2, Decl(recursiveConditionalTypes.ts, 85, 28))
->Box2 : Symbol(Box2, Decl(recursiveConditionalTypes.ts, 85, 28))
+>z : Symbol(z, Decl(recursiveConditionalTypes.ts, 91, 11))
+>Box2 : Symbol(Box2, Decl(recursiveConditionalTypes.ts, 86, 28))
+>Box2 : Symbol(Box2, Decl(recursiveConditionalTypes.ts, 86, 28))
 
 foo(z);  // unknown, but ideally would be string (requires unique recursion ID for each type reference)
->foo : Symbol(foo, Decl(recursiveConditionalTypes.ts, 86, 28))
->z : Symbol(z, Decl(recursiveConditionalTypes.ts, 90, 11))
+>foo : Symbol(foo, Decl(recursiveConditionalTypes.ts, 87, 28))
+>z : Symbol(z, Decl(recursiveConditionalTypes.ts, 91, 11))
 
 // Intersect tuple element types
 
 type Intersect<U extends any[], R = unknown> = U extends [infer H, ...infer T] ? Intersect<T, R & H> : R;
->Intersect : Symbol(Intersect, Decl(recursiveConditionalTypes.ts, 92, 7))
->U : Symbol(U, Decl(recursiveConditionalTypes.ts, 96, 15))
->R : Symbol(R, Decl(recursiveConditionalTypes.ts, 96, 31))
->U : Symbol(U, Decl(recursiveConditionalTypes.ts, 96, 15))
->H : Symbol(H, Decl(recursiveConditionalTypes.ts, 96, 63))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 96, 75))
->Intersect : Symbol(Intersect, Decl(recursiveConditionalTypes.ts, 92, 7))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 96, 75))
->R : Symbol(R, Decl(recursiveConditionalTypes.ts, 96, 31))
->H : Symbol(H, Decl(recursiveConditionalTypes.ts, 96, 63))
->R : Symbol(R, Decl(recursiveConditionalTypes.ts, 96, 31))
+>Intersect : Symbol(Intersect, Decl(recursiveConditionalTypes.ts, 93, 7))
+>U : Symbol(U, Decl(recursiveConditionalTypes.ts, 97, 15))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 97, 31))
+>U : Symbol(U, Decl(recursiveConditionalTypes.ts, 97, 15))
+>H : Symbol(H, Decl(recursiveConditionalTypes.ts, 97, 63))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 97, 75))
+>Intersect : Symbol(Intersect, Decl(recursiveConditionalTypes.ts, 93, 7))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 97, 75))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 97, 31))
+>H : Symbol(H, Decl(recursiveConditionalTypes.ts, 97, 63))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 97, 31))
 
 type QQ = Intersect<[string[], number[], 7]>;
->QQ : Symbol(QQ, Decl(recursiveConditionalTypes.ts, 96, 105))
->Intersect : Symbol(Intersect, Decl(recursiveConditionalTypes.ts, 92, 7))
+>QQ : Symbol(QQ, Decl(recursiveConditionalTypes.ts, 97, 105))
+>Intersect : Symbol(Intersect, Decl(recursiveConditionalTypes.ts, 93, 7))
 
 // Infer between structurally identical recursive conditional types
 
 type Unpack1<T> = T extends (infer U)[] ? Unpack1<U> : T;
->Unpack1 : Symbol(Unpack1, Decl(recursiveConditionalTypes.ts, 98, 45))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 102, 13))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 102, 13))
->U : Symbol(U, Decl(recursiveConditionalTypes.ts, 102, 34))
->Unpack1 : Symbol(Unpack1, Decl(recursiveConditionalTypes.ts, 98, 45))
->U : Symbol(U, Decl(recursiveConditionalTypes.ts, 102, 34))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 102, 13))
+>Unpack1 : Symbol(Unpack1, Decl(recursiveConditionalTypes.ts, 99, 45))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 103, 13))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 103, 13))
+>U : Symbol(U, Decl(recursiveConditionalTypes.ts, 103, 34))
+>Unpack1 : Symbol(Unpack1, Decl(recursiveConditionalTypes.ts, 99, 45))
+>U : Symbol(U, Decl(recursiveConditionalTypes.ts, 103, 34))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 103, 13))
 
 type Unpack2<T> = T extends (infer U)[] ? Unpack2<U> : T;
->Unpack2 : Symbol(Unpack2, Decl(recursiveConditionalTypes.ts, 102, 57))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 103, 13))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 103, 13))
->U : Symbol(U, Decl(recursiveConditionalTypes.ts, 103, 34))
->Unpack2 : Symbol(Unpack2, Decl(recursiveConditionalTypes.ts, 102, 57))
->U : Symbol(U, Decl(recursiveConditionalTypes.ts, 103, 34))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 103, 13))
+>Unpack2 : Symbol(Unpack2, Decl(recursiveConditionalTypes.ts, 103, 57))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 104, 13))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 104, 13))
+>U : Symbol(U, Decl(recursiveConditionalTypes.ts, 104, 34))
+>Unpack2 : Symbol(Unpack2, Decl(recursiveConditionalTypes.ts, 103, 57))
+>U : Symbol(U, Decl(recursiveConditionalTypes.ts, 104, 34))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 104, 13))
 
 function f20<T, U extends T>(x: Unpack1<T>, y: Unpack2<T>) {
->f20 : Symbol(f20, Decl(recursiveConditionalTypes.ts, 103, 57))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 105, 13))
->U : Symbol(U, Decl(recursiveConditionalTypes.ts, 105, 15))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 105, 13))
->x : Symbol(x, Decl(recursiveConditionalTypes.ts, 105, 29))
->Unpack1 : Symbol(Unpack1, Decl(recursiveConditionalTypes.ts, 98, 45))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 105, 13))
->y : Symbol(y, Decl(recursiveConditionalTypes.ts, 105, 43))
->Unpack2 : Symbol(Unpack2, Decl(recursiveConditionalTypes.ts, 102, 57))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 105, 13))
+>f20 : Symbol(f20, Decl(recursiveConditionalTypes.ts, 104, 57))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 106, 13))
+>U : Symbol(U, Decl(recursiveConditionalTypes.ts, 106, 15))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 106, 13))
+>x : Symbol(x, Decl(recursiveConditionalTypes.ts, 106, 29))
+>Unpack1 : Symbol(Unpack1, Decl(recursiveConditionalTypes.ts, 99, 45))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 106, 13))
+>y : Symbol(y, Decl(recursiveConditionalTypes.ts, 106, 43))
+>Unpack2 : Symbol(Unpack2, Decl(recursiveConditionalTypes.ts, 103, 57))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 106, 13))
 
     x = y;
->x : Symbol(x, Decl(recursiveConditionalTypes.ts, 105, 29))
->y : Symbol(y, Decl(recursiveConditionalTypes.ts, 105, 43))
+>x : Symbol(x, Decl(recursiveConditionalTypes.ts, 106, 29))
+>y : Symbol(y, Decl(recursiveConditionalTypes.ts, 106, 43))
 
     y = x;
->y : Symbol(y, Decl(recursiveConditionalTypes.ts, 105, 43))
->x : Symbol(x, Decl(recursiveConditionalTypes.ts, 105, 29))
+>y : Symbol(y, Decl(recursiveConditionalTypes.ts, 106, 43))
+>x : Symbol(x, Decl(recursiveConditionalTypes.ts, 106, 29))
 
     f20(y, x);
->f20 : Symbol(f20, Decl(recursiveConditionalTypes.ts, 103, 57))
->y : Symbol(y, Decl(recursiveConditionalTypes.ts, 105, 43))
->x : Symbol(x, Decl(recursiveConditionalTypes.ts, 105, 29))
+>f20 : Symbol(f20, Decl(recursiveConditionalTypes.ts, 104, 57))
+>y : Symbol(y, Decl(recursiveConditionalTypes.ts, 106, 43))
+>x : Symbol(x, Decl(recursiveConditionalTypes.ts, 106, 29))
 }
 
 type Grow1<T extends unknown[], N extends number> = T['length'] extends N ? T : Grow1<[number, ...T], N>;
->Grow1 : Symbol(Grow1, Decl(recursiveConditionalTypes.ts, 109, 1))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 111, 11))
->N : Symbol(N, Decl(recursiveConditionalTypes.ts, 111, 31))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 111, 11))
->N : Symbol(N, Decl(recursiveConditionalTypes.ts, 111, 31))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 111, 11))
->Grow1 : Symbol(Grow1, Decl(recursiveConditionalTypes.ts, 109, 1))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 111, 11))
->N : Symbol(N, Decl(recursiveConditionalTypes.ts, 111, 31))
+>Grow1 : Symbol(Grow1, Decl(recursiveConditionalTypes.ts, 110, 1))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 112, 11))
+>N : Symbol(N, Decl(recursiveConditionalTypes.ts, 112, 31))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 112, 11))
+>N : Symbol(N, Decl(recursiveConditionalTypes.ts, 112, 31))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 112, 11))
+>Grow1 : Symbol(Grow1, Decl(recursiveConditionalTypes.ts, 110, 1))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 112, 11))
+>N : Symbol(N, Decl(recursiveConditionalTypes.ts, 112, 31))
 
 type Grow2<T extends unknown[], N extends number> = T['length'] extends N ? T : Grow2<[string, ...T], N>;
->Grow2 : Symbol(Grow2, Decl(recursiveConditionalTypes.ts, 111, 105))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 112, 11))
->N : Symbol(N, Decl(recursiveConditionalTypes.ts, 112, 31))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 112, 11))
->N : Symbol(N, Decl(recursiveConditionalTypes.ts, 112, 31))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 112, 11))
->Grow2 : Symbol(Grow2, Decl(recursiveConditionalTypes.ts, 111, 105))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 112, 11))
->N : Symbol(N, Decl(recursiveConditionalTypes.ts, 112, 31))
+>Grow2 : Symbol(Grow2, Decl(recursiveConditionalTypes.ts, 112, 105))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 113, 11))
+>N : Symbol(N, Decl(recursiveConditionalTypes.ts, 113, 31))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 113, 11))
+>N : Symbol(N, Decl(recursiveConditionalTypes.ts, 113, 31))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 113, 11))
+>Grow2 : Symbol(Grow2, Decl(recursiveConditionalTypes.ts, 112, 105))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 113, 11))
+>N : Symbol(N, Decl(recursiveConditionalTypes.ts, 113, 31))
 
 function f21<T extends number>(x: Grow1<[], T>, y: Grow2<[], T>) {
->f21 : Symbol(f21, Decl(recursiveConditionalTypes.ts, 112, 105))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 114, 13))
->x : Symbol(x, Decl(recursiveConditionalTypes.ts, 114, 31))
->Grow1 : Symbol(Grow1, Decl(recursiveConditionalTypes.ts, 109, 1))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 114, 13))
->y : Symbol(y, Decl(recursiveConditionalTypes.ts, 114, 47))
->Grow2 : Symbol(Grow2, Decl(recursiveConditionalTypes.ts, 111, 105))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 114, 13))
+>f21 : Symbol(f21, Decl(recursiveConditionalTypes.ts, 113, 105))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 115, 13))
+>x : Symbol(x, Decl(recursiveConditionalTypes.ts, 115, 31))
+>Grow1 : Symbol(Grow1, Decl(recursiveConditionalTypes.ts, 110, 1))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 115, 13))
+>y : Symbol(y, Decl(recursiveConditionalTypes.ts, 115, 47))
+>Grow2 : Symbol(Grow2, Decl(recursiveConditionalTypes.ts, 112, 105))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 115, 13))
 
     f21(y, x);  // Error
->f21 : Symbol(f21, Decl(recursiveConditionalTypes.ts, 112, 105))
->y : Symbol(y, Decl(recursiveConditionalTypes.ts, 114, 47))
->x : Symbol(x, Decl(recursiveConditionalTypes.ts, 114, 31))
+>f21 : Symbol(f21, Decl(recursiveConditionalTypes.ts, 113, 105))
+>y : Symbol(y, Decl(recursiveConditionalTypes.ts, 115, 47))
+>x : Symbol(x, Decl(recursiveConditionalTypes.ts, 115, 31))
 }
 
 // Repros from #41756
 
 type ParseSuccess<R extends string> = { rest: R };
->ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
->R : Symbol(R, Decl(recursiveConditionalTypes.ts, 120, 18))
->rest : Symbol(rest, Decl(recursiveConditionalTypes.ts, 120, 39))
->R : Symbol(R, Decl(recursiveConditionalTypes.ts, 120, 18))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 117, 1))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 121, 18))
+>rest : Symbol(rest, Decl(recursiveConditionalTypes.ts, 121, 39))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 121, 18))
 
 type ParseManyWhitespace<S extends string> =
->ParseManyWhitespace : Symbol(ParseManyWhitespace, Decl(recursiveConditionalTypes.ts, 120, 50))
->S : Symbol(S, Decl(recursiveConditionalTypes.ts, 122, 25))
+>ParseManyWhitespace : Symbol(ParseManyWhitespace, Decl(recursiveConditionalTypes.ts, 121, 50))
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 123, 25))
 
     S extends ` ${infer R0}` ?
->S : Symbol(S, Decl(recursiveConditionalTypes.ts, 122, 25))
->R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 123, 23))
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 123, 25))
+>R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 124, 23))
 
         ParseManyWhitespace<R0> extends ParseSuccess<infer R1> ? ParseSuccess<R1> : null :
->ParseManyWhitespace : Symbol(ParseManyWhitespace, Decl(recursiveConditionalTypes.ts, 120, 50))
->R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 123, 23))
->ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
->R1 : Symbol(R1, Decl(recursiveConditionalTypes.ts, 124, 58))
->ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
->R1 : Symbol(R1, Decl(recursiveConditionalTypes.ts, 124, 58))
+>ParseManyWhitespace : Symbol(ParseManyWhitespace, Decl(recursiveConditionalTypes.ts, 121, 50))
+>R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 124, 23))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 117, 1))
+>R1 : Symbol(R1, Decl(recursiveConditionalTypes.ts, 125, 58))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 117, 1))
+>R1 : Symbol(R1, Decl(recursiveConditionalTypes.ts, 125, 58))
 
         ParseSuccess<S>;
->ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
->S : Symbol(S, Decl(recursiveConditionalTypes.ts, 122, 25))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 117, 1))
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 123, 25))
 
 type TP1 = ParseManyWhitespace<" foo">;
->TP1 : Symbol(TP1, Decl(recursiveConditionalTypes.ts, 125, 24))
->ParseManyWhitespace : Symbol(ParseManyWhitespace, Decl(recursiveConditionalTypes.ts, 120, 50))
+>TP1 : Symbol(TP1, Decl(recursiveConditionalTypes.ts, 126, 24))
+>ParseManyWhitespace : Symbol(ParseManyWhitespace, Decl(recursiveConditionalTypes.ts, 121, 50))
 
 type ParseManyWhitespace2<S extends string> =
->ParseManyWhitespace2 : Symbol(ParseManyWhitespace2, Decl(recursiveConditionalTypes.ts, 127, 39))
->S : Symbol(S, Decl(recursiveConditionalTypes.ts, 129, 26))
+>ParseManyWhitespace2 : Symbol(ParseManyWhitespace2, Decl(recursiveConditionalTypes.ts, 128, 39))
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 130, 26))
 
     S extends ` ${infer R0}` ?
->S : Symbol(S, Decl(recursiveConditionalTypes.ts, 129, 26))
->R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 130, 23))
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 130, 26))
+>R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 131, 23))
 
         Helper<ParseManyWhitespace2<R0>> :
->Helper : Symbol(Helper, Decl(recursiveConditionalTypes.ts, 132, 24))
->ParseManyWhitespace2 : Symbol(ParseManyWhitespace2, Decl(recursiveConditionalTypes.ts, 127, 39))
->R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 130, 23))
+>Helper : Symbol(Helper, Decl(recursiveConditionalTypes.ts, 133, 24))
+>ParseManyWhitespace2 : Symbol(ParseManyWhitespace2, Decl(recursiveConditionalTypes.ts, 128, 39))
+>R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 131, 23))
 
         ParseSuccess<S>;
->ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
->S : Symbol(S, Decl(recursiveConditionalTypes.ts, 129, 26))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 117, 1))
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 130, 26))
 
 type Helper<T> = T extends ParseSuccess<infer R> ? ParseSuccess<R> : null
->Helper : Symbol(Helper, Decl(recursiveConditionalTypes.ts, 132, 24))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 134, 12))
->T : Symbol(T, Decl(recursiveConditionalTypes.ts, 134, 12))
->ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
->R : Symbol(R, Decl(recursiveConditionalTypes.ts, 134, 45))
->ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
->R : Symbol(R, Decl(recursiveConditionalTypes.ts, 134, 45))
+>Helper : Symbol(Helper, Decl(recursiveConditionalTypes.ts, 133, 24))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 135, 12))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 135, 12))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 117, 1))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 135, 45))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 117, 1))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 135, 45))
 
 type TP2 = ParseManyWhitespace2<" foo">;
->TP2 : Symbol(TP2, Decl(recursiveConditionalTypes.ts, 134, 73))
->ParseManyWhitespace2 : Symbol(ParseManyWhitespace2, Decl(recursiveConditionalTypes.ts, 127, 39))
+>TP2 : Symbol(TP2, Decl(recursiveConditionalTypes.ts, 135, 73))
+>ParseManyWhitespace2 : Symbol(ParseManyWhitespace2, Decl(recursiveConditionalTypes.ts, 128, 39))
 

--- a/tests/baselines/reference/recursiveConditionalTypes.types
+++ b/tests/baselines/reference/recursiveConditionalTypes.types
@@ -104,8 +104,11 @@ type TT2 = TupleOf<number, number>;
 type TT3 = TupleOf<number, any>;
 >TT3 : number[]
 
-type TT4 = TupleOf<number, 100>;  // Depth error
+type TT4 = TupleOf<number, 100>;
 >TT4 : [number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number]
+
+type TT5 = TupleOf<number, 1000>;  // Depth error
+>TT5 : any
 
 function f22<N extends number, M extends N>(tn: TupleOf<number, N>, tm: TupleOf<number, M>) {
 >f22 : <N extends number, M extends N>(tn: TupleOf<number, N>, tm: TupleOf<number, M>) => void

--- a/tests/baselines/reference/recursiveConditionalTypes.types
+++ b/tests/baselines/reference/recursiveConditionalTypes.types
@@ -105,7 +105,7 @@ type TT3 = TupleOf<number, any>;
 >TT3 : number[]
 
 type TT4 = TupleOf<number, 100>;  // Depth error
->TT4 : any
+>TT4 : [number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number]
 
 function f22<N extends number, M extends N>(tn: TupleOf<number, N>, tm: TupleOf<number, M>) {
 >f22 : <N extends number, M extends N>(tn: TupleOf<number, N>, tm: TupleOf<number, M>) => void

--- a/tests/cases/compiler/recursiveConditionalTypes.ts
+++ b/tests/cases/compiler/recursiveConditionalTypes.ts
@@ -47,7 +47,8 @@ type TT0 = TupleOf<string, 4>;
 type TT1 = TupleOf<number, 0 | 2 | 4>;
 type TT2 = TupleOf<number, number>;
 type TT3 = TupleOf<number, any>;
-type TT4 = TupleOf<number, 100>;  // Depth error
+type TT4 = TupleOf<number, 100>;
+type TT5 = TupleOf<number, 1000>;  // Depth error
 
 function f22<N extends number, M extends N>(tn: TupleOf<number, N>, tm: TupleOf<number, M>) {
     tn = tm;


### PR DESCRIPTION
This PR increases the type instantiation depth limit from 50 to 500. Resolution of recursive types (such as conditional types and indexed access types) can cause deeply nested invocations in the type instantiation logic of the compiler, which may ultimately cause stack overflows during compilation. For this reason we limit nested invocations of the `instantiateType` function, reporting a "Type instantiation is excessively deep and possibly infinite" error when the limit is reached. The current limit of 50 is generally reasonable, but in some scenarios involving tuple types and template literal types it is quickly reached. For example, the type

```ts
type GetChars<S> = S extends `${infer Char}${infer Rest}` ? Char | GetChars<Rest> : never;
```

extracts a union of the single characters in a literal string and reaches the instantiation depth limit after just 24 characters (each level of recursion involves two invocations of `instantiateType`). Likewise, utility types to manipulate tuple types often suffer from the same restrictions. It is sometimes possible to "batch process" multiple constituents at once, as in

```ts
type GetChars<S> =
    S extends `${infer C1}${infer C2}${infer C3}${infer C4}${infer Rest}` ? C1 | C2 | C3 | C4 | GetChars<Rest> :
    S extends `${infer C1}${infer Rest}` ? C1 | GetChars<Rest> : never;
```

but this is cumbersome and often too complex.

Since the instantiation depth limit is a reasonable approximation of call stack depth in the compiler, if we assume each recursive `instantiateType` call involves 5 stack frames and each stack frame consumes 100 bytes, then 500 levels of recursion roughly corresponds to 250K bytes, which is 25-50% of the default stack size in Node.js. That seems appropriate.

It's been suggested we make the depth limit configurable through a compiler option. I remain opposed to that as it is ultimately an implementation detail of the compiler that very well could change.