### PR TITLE
match TypedArray multiple-arguments constructor with MDN specifications

### DIFF
--- a/src/lib/es2020.bigint.d.ts
+++ b/src/lib/es2020.bigint.d.ts
@@ -371,7 +371,7 @@ interface BigInt64ArrayConstructor {
     readonly prototype: BigInt64Array;
     new(length?: number): BigInt64Array;
     new(array: Iterable<bigint>): BigInt64Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): BigInt64Array;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): BigInt64Array;
 
     /** The size in bytes of each element in the array. */
     readonly BYTES_PER_ELEMENT: number;
@@ -643,7 +643,7 @@ interface BigUint64ArrayConstructor {
     readonly prototype: BigUint64Array;
     new(length?: number): BigUint64Array;
     new(array: Iterable<bigint>): BigUint64Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): BigUint64Array;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): BigUint64Array;
 
     /** The size in bytes of each element in the array. */
     readonly BYTES_PER_ELEMENT: number;

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1980,7 +1980,7 @@ interface Int8ArrayConstructor {
     readonly prototype: Int8Array;
     new(length: number): Int8Array;
     new(array: ArrayLike<number> | ArrayBufferLike): Int8Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Int8Array;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Int8Array;
 
     /**
      * The size in bytes of each element in the array.
@@ -2263,7 +2263,7 @@ interface Uint8ArrayConstructor {
     readonly prototype: Uint8Array;
     new(length: number): Uint8Array;
     new(array: ArrayLike<number> | ArrayBufferLike): Uint8Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint8Array;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint8Array;
 
     /**
      * The size in bytes of each element in the array.
@@ -2545,7 +2545,7 @@ interface Uint8ClampedArrayConstructor {
     readonly prototype: Uint8ClampedArray;
     new(length: number): Uint8ClampedArray;
     new(array: ArrayLike<number> | ArrayBufferLike): Uint8ClampedArray;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint8ClampedArray;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint8ClampedArray;
 
     /**
      * The size in bytes of each element in the array.
@@ -2825,7 +2825,7 @@ interface Int16ArrayConstructor {
     readonly prototype: Int16Array;
     new(length: number): Int16Array;
     new(array: ArrayLike<number> | ArrayBufferLike): Int16Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Int16Array;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Int16Array;
 
     /**
      * The size in bytes of each element in the array.
@@ -3108,7 +3108,7 @@ interface Uint16ArrayConstructor {
     readonly prototype: Uint16Array;
     new(length: number): Uint16Array;
     new(array: ArrayLike<number> | ArrayBufferLike): Uint16Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint16Array;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint16Array;
 
     /**
      * The size in bytes of each element in the array.
@@ -3390,7 +3390,7 @@ interface Int32ArrayConstructor {
     readonly prototype: Int32Array;
     new(length: number): Int32Array;
     new(array: ArrayLike<number> | ArrayBufferLike): Int32Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Int32Array;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Int32Array;
 
     /**
      * The size in bytes of each element in the array.
@@ -3671,7 +3671,7 @@ interface Uint32ArrayConstructor {
     readonly prototype: Uint32Array;
     new(length: number): Uint32Array;
     new(array: ArrayLike<number> | ArrayBufferLike): Uint32Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint32Array;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint32Array;
 
     /**
      * The size in bytes of each element in the array.
@@ -3953,7 +3953,7 @@ interface Float32ArrayConstructor {
     readonly prototype: Float32Array;
     new(length: number): Float32Array;
     new(array: ArrayLike<number> | ArrayBufferLike): Float32Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Float32Array;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Float32Array;
 
     /**
      * The size in bytes of each element in the array.
@@ -4227,7 +4227,7 @@ interface Float64ArrayConstructor {
     readonly prototype: Float64Array;
     new(length: number): Float64Array;
     new(array: ArrayLike<number> | ArrayBufferLike): Float64Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Float64Array;
+    new(buffer: ArrayBuffer, byteOffset?: number, length?: number): Float64Array;
 
     /**
      * The size in bytes of each element in the array.


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/Uint8Array

The multiple-arguments constructor `(buffer, byteOffset, length)` accepts only an `ArrayBuffer` object as the first argument.
this can also be seen in the [ECMAScript specifications](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray) at 6.b.iii.

this PR matches the specification with the d.ts, without effecting the other constructor signatures.

Fixes #44191
