### PR TITLE
Fix auto import crashes caused by unrelocatable symbols

### DIFF
--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -329,7 +329,7 @@ namespace ts {
             const defaultInfo = getDefaultLikeExportInfo(moduleSymbol, checker, compilerOptions);
             // Note: I think we shouldn't actually see resolved module symbols here, but weird merges
             // can cause it to happen: see 'completionsImport_mergedReExport.ts'
-            if (defaultInfo && !checker.isUndefinedSymbol(defaultInfo.symbol) && defaultInfo.symbol.name[0] !== `"`) {
+            if (defaultInfo && !checker.isUndefinedSymbol(defaultInfo.symbol) && !isExternalModuleSymbol(defaultInfo.symbol)) {
                 cache.add(
                     importingFile.path,
                     defaultInfo.symbol,
@@ -341,7 +341,7 @@ namespace ts {
                     checker);
             }
             for (const exported of checker.getExportsAndPropertiesOfModule(moduleSymbol)) {
-                if (exported !== defaultInfo?.symbol && !isKnownSymbol(exported) && exported.name[0] !== `"` && addToSeen(seenExports, exported)) {
+                if (exported !== defaultInfo?.symbol && !isKnownSymbol(exported) && !isExternalModuleSymbol(exported) && addToSeen(seenExports, exported)) {
                     cache.add(
                         importingFile.path,
                         exported,

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -327,7 +327,9 @@ namespace ts {
             const seenExports = new Map<Symbol, true>();
             const checker = program.getTypeChecker();
             const defaultInfo = getDefaultLikeExportInfo(moduleSymbol, checker, compilerOptions);
-            if (defaultInfo && !checker.isUndefinedSymbol(defaultInfo.symbol)) {
+            // Note: I think we shouldn't actually see resolved module symbols here, but weird merges
+            // can cause it to happen: see 'completionsImport_mergedReExport.ts'
+            if (defaultInfo && !checker.isUndefinedSymbol(defaultInfo.symbol) && defaultInfo.symbol.name[0] !== `"`) {
                 cache.add(
                     importingFile.path,
                     defaultInfo.symbol,
@@ -339,7 +341,7 @@ namespace ts {
                     checker);
             }
             for (const exported of checker.getExportsAndPropertiesOfModule(moduleSymbol)) {
-                if (exported !== defaultInfo?.symbol && addToSeen(seenExports, exported)) {
+                if (exported !== defaultInfo?.symbol && !isKnownSymbol(exported) && exported.name[0] !== `"` && addToSeen(seenExports, exported)) {
                     cache.add(
                         importingFile.path,
                         exported,

--- a/tests/cases/fourslash/server/completionsImport_computedSymbolName.ts
+++ b/tests/cases/fourslash/server/completionsImport_computedSymbolName.ts
@@ -39,6 +39,7 @@ verify.completions({
 
 edit.insert("N");
 
+// Should not crash
 verify.completions({
   marker: "",
   preferences: {

--- a/tests/cases/fourslash/server/completionsImport_computedSymbolName.ts
+++ b/tests/cases/fourslash/server/completionsImport_computedSymbolName.ts
@@ -1,0 +1,47 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "commonjs" } }
+
+// @Filename: /node_modules/@types/ts-node/index.d.ts
+//// export {};
+//// declare const REGISTER_INSTANCE: unique symbol;
+//// declare global {
+////     namespace NodeJS {
+////       interface Process {
+////           [REGISTER_INSTANCE]?: Service;
+////       }
+////   }
+//// }
+
+// @Filename: /node_modules/@types/node/index.d.ts
+//// declare module "process" {
+////     global {
+////         var process: NodeJS.Process;
+////         namespace NodeJS {
+////             interface Process {
+////                 argv: string[];
+////             }
+////         }
+////     }
+////     export = process;
+//// }
+
+// @Filename: /index.ts
+//// I/**/
+
+verify.completions({
+  marker: "",
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});
+
+edit.insert("N");
+
+verify.completions({
+  marker: "",
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});

--- a/tests/cases/fourslash/server/completionsImport_mergedReExport.ts
+++ b/tests/cases/fourslash/server/completionsImport_mergedReExport.ts
@@ -1,0 +1,55 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "commonjs" } }
+
+// @Filename: /package.json
+//// { "dependencies": { "@jest/types": "*", "ts-jest": "*" } }
+
+// @Filename: /node_modules/@jest/types/index.d.ts
+//// import type * as Config from "./Config";
+//// export type { Config };
+
+// @Filename: /node_modules/@jest/types/Config.d.ts
+//// export interface ConfigGlobals {
+////     [K: string]: unknown;
+//// }
+
+// @Filename: /node_modules/ts-jest/index.d.ts
+//// export {};
+//// declare module "@jest/types" {
+////     namespace Config {
+////         interface ConfigGlobals {
+////             'ts-jest': any;
+////         }
+////     }
+//// }
+
+// @Filename: /index.ts
+//// C/**/
+
+verify.completions({
+  marker: "",
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});
+
+edit.insert("o");
+
+// Should not crash
+verify.completions({
+  marker: "",
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});
+
+// Because of the way `Config` is merged, we are actually not including it
+// in completions here, though it would be better if we could. The `exports`
+// of "@jest/types/index" would contain an alias symbol named `Config` without
+// the merge from ts-jest, but with the merge, the `exports` contains the merge
+// of `namespace Config` and the "@jest/types/Config" module symbol. This is
+// unexpected (to me) and difficult to work with, and might be wrong? My
+// expectation would have been to preserve the export alias symbol, but let it
+// *resolve* to the merge of the SourceFile and the namespace declaration.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #45030

Fixes two separate crashes—one was a simple overlooked case for skipping symbol property names, but the other was caused by a weird symbol merge that I think might be wrong/undesirable—I was expecting to see an alias in the `exports` of a module symbol, but instead got a merged resolved module symbol—see the comment below the second fourslash test.
