### PR TITLE
Detect preference for `node:`-prefixed node core modules

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -886,6 +886,7 @@ namespace ts {
         let sourceFileToPackageName = new Map<Path, string>();
         // Key is a file name. Value is the (non-empty, or undefined) list of files that redirect to it.
         let redirectTargetsMap = createMultiMap<Path, string>();
+        let usesUriStyleNodeCoreModules = false;
 
         /**
          * map with
@@ -1087,6 +1088,7 @@ namespace ts {
             getLibFileFromReference,
             sourceFileToPackageName,
             redirectTargetsMap,
+            usesUriStyleNodeCoreModules,
             isEmittedFile,
             getConfigFileParsingDiagnostics,
             getResolvedModuleWithFailedLookupLocationsFromCache,
@@ -1635,6 +1637,7 @@ namespace ts {
 
             sourceFileToPackageName = oldProgram.sourceFileToPackageName;
             redirectTargetsMap = oldProgram.redirectTargetsMap;
+            usesUriStyleNodeCoreModules = oldProgram.usesUriStyleNodeCoreModules;
 
             return StructureIsReused.Completely;
         }
@@ -2327,6 +2330,9 @@ namespace ts {
                     // only through top - level external module names. Relative external module names are not permitted.
                     if (moduleNameExpr && isStringLiteral(moduleNameExpr) && moduleNameExpr.text && (!inAmbientModule || !isExternalModuleNameRelative(moduleNameExpr.text))) {
                         imports = append(imports, moduleNameExpr);
+                        if (!usesUriStyleNodeCoreModules && currentNodeModulesDepth === 0 && !file.isDeclarationFile) {
+                            usesUriStyleNodeCoreModules = startsWith(moduleNameExpr.text, "node:");
+                        }
                     }
                 }
                 else if (isModuleDeclaration(node)) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3964,6 +3964,8 @@ namespace ts {
         /* @internal */ sourceFileToPackageName: ESMap<Path, string>;
         /** Set of all source files that some other source file redirects to. */
         /* @internal */ redirectTargetsMap: MultiMap<Path, string>;
+        /** Whether any (non-external, non-declaration) source files use `node:`-prefixed module specifiers. */
+        /* @internal */ readonly usesUriStyleNodeCoreModules: boolean;
         /** Is the file emitted file */
         /* @internal */ isEmittedFile(file: string): boolean;
         /* @internal */ getFileIncludeReasons(): MultiMap<Path, FileIncludeReason>;

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1409,7 +1409,7 @@ namespace FourSlashInterface {
             "await",
         ].map(keywordEntry);
 
-        export const undefinedVarEntry: ExpectedCompletionEntry = {
+        export const undefinedVarEntry: ExpectedCompletionEntryObject = {
             name: "undefined",
             kind: "var",
             sortText: SortText.GlobalsOrKeywords
@@ -1568,11 +1568,14 @@ namespace FourSlashInterface {
         ];
 
         export function globalsPlus(plus: readonly ExpectedCompletionEntry[]): readonly ExpectedCompletionEntry[] {
+            const firstEntry = plus[0];
+            const afterUndefined = typeof firstEntry !== "string" && firstEntry.sortText! > undefinedVarEntry.sortText!;
             return [
                 globalThisEntry,
                 ...globalsVars,
-                ...plus,
+                ...afterUndefined ? ts.emptyArray : plus,
                 undefinedVarEntry,
+                ...afterUndefined ? plus : ts.emptyArray,
                 ...globalKeywords];
         }
 

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -29,8 +29,9 @@ namespace ts.JsTyping {
         return availableVersion.compareTo(cachedTyping.version) <= 0;
     }
 
-    export const nodeCoreModuleList: readonly string[] = [
+    const unprefixedNodeCoreModuleList = [
         "assert",
+        "assert/strict",
         "async_hooks",
         "buffer",
         "child_process",
@@ -39,14 +40,18 @@ namespace ts.JsTyping {
         "constants",
         "crypto",
         "dgram",
+        "diagnostics_channel",
         "dns",
+        "dns/promises",
         "domain",
         "events",
         "fs",
+        "fs/promises",
         "http",
         "https",
         "http2",
         "inspector",
+        "module",
         "net",
         "os",
         "path",
@@ -57,16 +62,26 @@ namespace ts.JsTyping {
         "readline",
         "repl",
         "stream",
+        "stream/promises",
         "string_decoder",
         "timers",
+        "timers/promises",
         "tls",
+        "trace_events",
         "tty",
         "url",
         "util",
+        "util/types",
         "v8",
         "vm",
+        "wasi",
+        "worker_threads",
         "zlib"
     ];
+
+    export const prefixedNodeCoreModuleList = unprefixedNodeCoreModuleList.map(name => `node:${name}`);
+
+    export const nodeCoreModuleList: readonly string[] = [...unprefixedNodeCoreModuleList, ...prefixedNodeCoreModuleList];
 
     export const nodeCoreModules = new Set(nodeCoreModuleList);
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1959,6 +1959,10 @@ namespace ts.Completions {
             function isImportableExportInfo(info: SymbolExportInfo) {
                 const moduleFile = tryCast(info.moduleSymbol.valueDeclaration, isSourceFile);
                 if (!moduleFile) {
+                    const moduleName = stripQuotes(info.moduleSymbol.name);
+                    if (JsTyping.nodeCoreModules.has(moduleName) && startsWith(moduleName, "node:") !== shouldUseUriStyleNodeCoreModules(sourceFile, program)) {
+                        return false;
+                    }
                     return packageJsonFilter
                         ? packageJsonFilter.allowsImportingAmbientModule(info.moduleSymbol, getModuleSpecifierResolutionHost(info.isFromPackageJson))
                         : true;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3171,5 +3171,14 @@ namespace ts {
         return !!(getCombinedNodeFlagsAlwaysIncludeJSDoc(decl) & ModifierFlags.Deprecated);
     }
 
+    export function shouldUseUriStyleNodeCoreModules(file: SourceFile, program: Program): boolean {
+        const decisionFromFile = firstDefined(file.imports, node => {
+            if (JsTyping.nodeCoreModules.has(node.text)) {
+                return startsWith(node.text, "node:");
+            }
+        });
+        return decisionFromFile ?? program.usesUriStyleNodeCoreModules;
+    }
+
     // #endregion
 }

--- a/tests/cases/fourslash/completionsImport_uriStyleNodeCoreModules1.ts
+++ b/tests/cases/fourslash/completionsImport_uriStyleNodeCoreModules1.ts
@@ -1,0 +1,30 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+
+// @Filename: /node_modules/@types/node/index.d.ts
+//// declare module "fs" { function writeFile(): void }
+//// declare module "fs/promises" { function writeFile(): Promise<void> }
+//// declare module "node:fs" { export * from "fs"; }
+//// declare module "node:fs/promises" { export * from "fs/promises"; }
+
+// @Filename: /index.ts
+//// write/**/
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "writeFile",
+    source: "fs",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }, {
+    name: "writeFile",
+    source: "fs/promises",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});

--- a/tests/cases/fourslash/completionsImport_uriStyleNodeCoreModules2.ts
+++ b/tests/cases/fourslash/completionsImport_uriStyleNodeCoreModules2.ts
@@ -1,0 +1,33 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+
+// @Filename: /node_modules/@types/node/index.d.ts
+//// declare module "fs" { function writeFile(): void }
+//// declare module "fs/promises" { function writeFile(): Promise<void> }
+//// declare module "node:fs" { export * from "fs"; }
+//// declare module "node:fs/promises" { export * from "fs/promises"; }
+
+// @Filename: /other.ts
+//// import "node:fs/promises";
+
+// @Filename: /index.ts
+//// write/**/
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "writeFile",
+    source: "node:fs",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }, {
+    name: "writeFile",
+    source: "node:fs/promises",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});

--- a/tests/cases/fourslash/completionsImport_uriStyleNodeCoreModules3.ts
+++ b/tests/cases/fourslash/completionsImport_uriStyleNodeCoreModules3.ts
@@ -1,0 +1,108 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+
+// @Filename: /node_modules/@types/node/index.d.ts
+//// declare module "path" { function join(...segments: readonly string[]): string; }
+//// declare module "node:path" { export * from "path"; }
+//// declare module "fs" { function writeFile(): void }
+//// declare module "fs/promises" { function writeFile(): Promise<void> }
+//// declare module "node:fs" { export * from "fs"; }
+//// declare module "node:fs/promises" { export * from "fs/promises"; }
+
+// @Filename: /other.ts
+//// import "node:fs/promises";
+
+// @Filename: /noPrefix.ts
+//// import "path";
+//// write/*noPrefix*/
+
+// @Filename: /prefix.ts
+//// import "node:path";
+//// write/*prefix*/
+
+// @Filename: /mixed1.ts
+//// import "path";
+//// import "node:path";
+//// write/*mixed1*/
+
+// @Filename: /mixed2.ts
+//// import "node:path";
+//// import "path";
+//// write/*mixed2*/
+
+verify.completions({
+  marker: "noPrefix",
+  exact: completion.globalsPlus([{
+    name: "writeFile",
+    source: "fs",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }, {
+    name: "writeFile",
+    source: "fs/promises",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});
+
+verify.completions({
+  marker: "prefix",
+  exact: completion.globalsPlus([{
+    name: "writeFile",
+    source: "node:fs",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }, {
+    name: "writeFile",
+    source: "node:fs/promises",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});
+
+// We're doing as little work as possible to decide which module specifiers
+// to use, so we just take the *first* recognized node core module in the file
+// and copy its style.
+
+verify.completions({
+  marker: "mixed1",
+  exact: completion.globalsPlus([{
+    name: "writeFile",
+    source: "fs",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }, {
+    name: "writeFile",
+    source: "fs/promises",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});
+
+verify.completions({
+  marker: "mixed2",
+  exact: completion.globalsPlus([{
+    name: "writeFile",
+    source: "node:fs",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }, {
+    name: "writeFile",
+    source: "node:fs/promises",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});

--- a/tests/cases/fourslash/importNameCodeFix_uriStyleNodeCoreModules1.ts
+++ b/tests/cases/fourslash/importNameCodeFix_uriStyleNodeCoreModules1.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+
+// @Filename: /node_modules/@types/node/index.d.ts
+//// declare module "fs" { function writeFile(): void }
+//// declare module "fs/promises" { function writeFile(): Promise<void> }
+//// declare module "node:fs" { export * from "fs"; }
+//// declare module "node:fs/promises" { export * from "fs/promises"; }
+
+// @Filename: /index.ts
+//// writeFile/**/
+
+verify.importFixModuleSpecifiers("", ["fs", "fs/promises", "node:fs", "node:fs/promises"]);

--- a/tests/cases/fourslash/importNameCodeFix_uriStyleNodeCoreModules2.ts
+++ b/tests/cases/fourslash/importNameCodeFix_uriStyleNodeCoreModules2.ts
@@ -1,0 +1,29 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+
+// @Filename: /node_modules/@types/node/index.d.ts
+//// declare module "fs" { function writeFile(): void }
+//// declare module "fs/promises" { function writeFile(): Promise<void> }
+//// declare module "node:fs" { export * from "fs"; }
+//// declare module "node:fs/promises" { export * from "fs/promises"; }
+
+// @Filename: /other.ts
+//// import "node:fs/promises";
+
+// @Filename: /index.ts
+//// writeFile/**/
+
+verify.importFixModuleSpecifiers("", ["node:fs", "node:fs/promises", "fs", "fs/promises"]);
+
+goTo.file("/other.ts");
+edit.replaceLine(0, "\n");
+
+goTo.file("/index.ts");
+verify.importFixModuleSpecifiers("", ["fs", "fs/promises", "node:fs", "node:fs/promises"]);
+
+goTo.file("/other.ts");
+edit.replaceLine(0, `import "node:fs/promises";\n`);
+
+goTo.file("/index.ts");
+verify.importFixModuleSpecifiers("", ["node:fs", "node:fs/promises", "fs", "fs/promises"]);

--- a/tests/cases/fourslash/importNameCodeFix_uriStyleNodeCoreModules3.ts
+++ b/tests/cases/fourslash/importNameCodeFix_uriStyleNodeCoreModules3.ts
@@ -1,0 +1,42 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+
+// @Filename: /node_modules/@types/node/index.d.ts
+//// declare module "path" { function join(...segments: readonly string[]): string; }
+//// declare module "node:path" { export * from "path"; }
+//// declare module "fs" { function writeFile(): void }
+//// declare module "fs/promises" { function writeFile(): Promise<void> }
+//// declare module "node:fs" { export * from "fs"; }
+//// declare module "node:fs/promises" { export * from "fs/promises"; }
+
+// @Filename: /other.ts
+//// import "node:fs/promises";
+
+// @Filename: /noPrefix.ts
+//// import "path";
+//// writeFile/*noPrefix*/
+
+// @Filename: /prefix.ts
+//// import "node:path";
+//// writeFile/*prefix*/
+
+// @Filename: /mixed1.ts
+//// import "path";
+//// import "node:path";
+//// writeFile/*mixed1*/
+
+// @Filename: /mixed2.ts
+//// import "node:path";
+//// import "path";
+//// writeFile/*mixed2*/
+
+verify.importFixModuleSpecifiers("noPrefix", ["fs", "fs/promises", "node:fs", "node:fs/promises"]);
+verify.importFixModuleSpecifiers("prefix", ["node:fs", "node:fs/promises", "fs", "fs/promises"]);
+
+// We're doing as little work as possible to decide which module specifiers
+// to use, so we just take the *first* recognized node core module in the file
+// and copy its style.
+
+verify.importFixModuleSpecifiers("mixed1", ["fs", "fs/promises", "node:fs", "node:fs/promises"]);
+verify.importFixModuleSpecifiers("mixed2", ["node:fs", "node:fs/promises", "fs", "fs/promises"]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #43842

1. It was actually really easy and cheap to detect the presence of `node:` module specifiers as we build the program, so this _does_ use other files as a backup heuristic, despite my hesitance about that in the design meeting. It currently prefers the `node:` versions if it sees any imports/re-exports of that flavor in non-node_modules, non-declaration files. It would be trivial to change that to a more conservative strategy of preferring the `node:` flavor if it finds some `node:`-prefixed imports/re-exports **and no unprefixed ones**, if we’re more comfortable with that.
2. The _first_ recognized node core module import in a file sets the preferred style for that file. Other files are only considered for files that have no node core module imports yet.
3. For **completions**, only the preferred style  is shown. For **codefixes**, both styles are shown, but the preferred style is sorted higher. (There is a precedent for codefixes offering a more granular and complete set of modules to import from.)
