### PR TITLE
fix(45102): Refactor to convert to/from arrow function does not consider 'arguments'

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -555,6 +555,7 @@ namespace ts {
                 getResolvedSignatureWorker(node, candidatesOutArray, argumentCount, CheckMode.IsForSignatureHelp),
             getExpandedParameters,
             hasEffectiveRestParameter,
+            containsArgumentsReference,
             getConstantValue: nodeIn => {
                 const node = getParseTreeNode(nodeIn, canHaveConstantValue);
                 return node ? getConstantValue(node) : undefined;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4205,6 +4205,8 @@ namespace ts {
         /* @internal */ getResolvedSignatureForSignatureHelp(node: CallLikeExpression, candidatesOutArray?: Signature[], argumentCount?: number): Signature | undefined;
         /* @internal */ getExpandedParameters(sig: Signature): readonly (readonly Symbol[])[];
         /* @internal */ hasEffectiveRestParameter(sig: Signature): boolean;
+        /* @internal */ containsArgumentsReference(declaration: SignatureDeclaration): boolean;
+
         getSignatureFromDeclaration(declaration: SignatureDeclaration): Signature | undefined;
         isImplementationOfOverload(node: SignatureDeclaration): boolean | undefined;
         isUndefinedSymbol(symbol: Symbol): boolean;

--- a/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
+++ b/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
@@ -141,7 +141,7 @@ namespace ts.refactor.convertArrowFunctionOrFunctionExpression {
         const token = getTokenAtPosition(file, startPosition);
         const typeChecker = program.getTypeChecker();
         const func = tryGetFunctionFromVariableDeclaration(file, typeChecker, token.parent);
-        if (func && !containingThis(func.body)) {
+        if (func && !containingThis(func.body) && !typeChecker.containsArgumentsReference(func)) {
             return { selectedVariableDeclaration: true, func };
         }
 
@@ -150,7 +150,8 @@ namespace ts.refactor.convertArrowFunctionOrFunctionExpression {
             maybeFunc &&
             (isFunctionExpression(maybeFunc) || isArrowFunction(maybeFunc)) &&
             !rangeContainsRange(maybeFunc.body, token) &&
-            !containingThis(maybeFunc.body)
+            !containingThis(maybeFunc.body) &&
+            !typeChecker.containsArgumentsReference(maybeFunc)
         ) {
             if (isFunctionExpression(maybeFunc) && isFunctionReferencedInFile(file, typeChecker, maybeFunc)) return undefined;
             return { selectedVariableDeclaration: false, func: maybeFunc };

--- a/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_Availability_Anon_arguments.ts
+++ b/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_Availability_Anon_arguments.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+////function foo() {
+////    return /*a*/(/*b*/) => arguments;
+////}
+
+goTo.select("a", "b");
+verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to named function");
+verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to anonymous function");
+verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to arrow function");

--- a/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_Availability_Arrow_arguments.ts
+++ b/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_Availability_Arrow_arguments.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+////function foo() {
+////    return /*a*/f/*b*/unction () { arguments }
+////}
+
+goTo.select("a", "b");
+verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to named function");
+verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to anonymous function");
+verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to arrow function");


### PR DESCRIPTION
Fixes #45102