### PR TITLE
Don’t try to create auto import provider when host program doesn’t exist

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1902,6 +1902,11 @@ namespace ts.server {
                 return ts.emptyArray;
             }
 
+            const program = hostProject.getCurrentProgram();
+            if (!program) {
+                return ts.emptyArray;
+            }
+
             let dependencyNames: Set<string> | undefined;
             let rootNames: string[] | undefined;
             const rootFileName = combinePaths(hostProject.currentDirectory, inferredTypesContainingFile);
@@ -1918,7 +1923,6 @@ namespace ts.server {
                     compilerOptions,
                     moduleResolutionHost));
 
-                const program = hostProject.getCurrentProgram()!;
                 const symlinkCache = hostProject.getSymlinkCache();
                 for (const resolution of resolutions) {
                     if (!resolution.resolvedTypeReferenceDirective?.resolvedFileName) continue;

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1070,7 +1070,7 @@ namespace ts.server {
                 this.lastCachedUnresolvedImportsList = undefined;
             }
 
-            const isFirstLoad = this.projectProgramVersion === 0;
+            const isFirstLoad = this.projectProgramVersion === 0 && hasNewProgram;
             if (hasNewProgram) {
                 this.projectProgramVersion++;
             }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1070,7 +1070,7 @@ namespace ts.server {
                 this.lastCachedUnresolvedImportsList = undefined;
             }
 
-            const isFirstLoad = this.projectProgramVersion === 0 && hasNewProgram;
+            const isFirstProgramLoad = this.projectProgramVersion === 0 && hasNewProgram;
             if (hasNewProgram) {
                 this.projectProgramVersion++;
             }
@@ -1078,7 +1078,7 @@ namespace ts.server {
                 if (!this.autoImportProviderHost) this.autoImportProviderHost = undefined;
                 this.autoImportProviderHost?.markAsDirty();
             }
-            if (isFirstLoad) {
+            if (isFirstProgramLoad) {
                 // Preload auto import provider so it's not created during completions request
                 this.getPackageJsonAutoImportProvider();
             }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #44849

Looking at the error stack and the code path leading to the crash, I’m not sure how to produce this, but one user claimed that they had some reason to believe it was triggered by an unofficial Vue extension, and indeed both VS Code reports list that extension, but I couldn’t trigger it myself. At any rate, the auto import provider can be loaded lazily, and if someone somehow requests it before having a program, there’s no reason to crash; we can just return undefined.
