### PR TITLE
Allow narrowing for any left-hand in operand

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -916,8 +916,8 @@ namespace ts {
             return isTypeOfExpression(expr1) && isNarrowableOperand(expr1.expression) && isStringLiteralLike(expr2);
         }
 
-        function isNarrowableInOperands(left: Expression, right: Expression) {
-            return isNarrowingExpression(right) && (isIdentifier(left) || isStringLiteralLike(left));
+        function isNarrowableInRightOperand(expr: Expression) {
+            return isNarrowingExpression(expr);
         }
 
         function isNarrowingBinaryExpression(expr: BinaryExpression) {
@@ -936,7 +936,7 @@ namespace ts {
                 case SyntaxKind.InstanceOfKeyword:
                     return isNarrowableOperand(expr.left);
                 case SyntaxKind.InKeyword:
-                    return isNarrowableInOperands(expr.left, expr.right);
+                    return isNarrowableInRightOperand(expr.right);
                 case SyntaxKind.CommaToken:
                     return isNarrowingExpression(expr.right);
             }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -916,10 +916,6 @@ namespace ts {
             return isTypeOfExpression(expr1) && isNarrowableOperand(expr1.expression) && isStringLiteralLike(expr2);
         }
 
-        function isNarrowableInRightOperand(expr: Expression) {
-            return isNarrowingExpression(expr);
-        }
-
         function isNarrowingBinaryExpression(expr: BinaryExpression) {
             switch (expr.operatorToken.kind) {
                 case SyntaxKind.EqualsToken:
@@ -936,7 +932,7 @@ namespace ts {
                 case SyntaxKind.InstanceOfKeyword:
                     return isNarrowableOperand(expr.left);
                 case SyntaxKind.InKeyword:
-                    return isNarrowableInRightOperand(expr.right);
+                    return isNarrowingExpression(expr.right);
                 case SyntaxKind.CommaToken:
                     return isNarrowingExpression(expr.right);
             }

--- a/tests/baselines/reference/controlFlowForInStatement2.js
+++ b/tests/baselines/reference/controlFlowForInStatement2.js
@@ -1,0 +1,37 @@
+//// [controlFlowForInStatement2.ts]
+const keywordA = 'a';
+const keywordB = 'b';
+
+type A = { [keywordA]: number };
+type B = { [keywordB]: string };
+
+declare const c: A | B;
+
+if ('a' in c) {
+    c; // narrowed to `A`
+}
+
+if (keywordA in c) {
+    c; // also narrowed to `A`
+}
+
+let stringB: string = 'b';
+
+if ((stringB as 'b') in c) {
+    c; // narrowed to `B`
+}
+
+
+//// [controlFlowForInStatement2.js]
+var keywordA = 'a';
+var keywordB = 'b';
+if ('a' in c) {
+    c; // narrowed to `A`
+}
+if (keywordA in c) {
+    c; // also narrowed to `A`
+}
+var stringB = 'b';
+if (stringB in c) {
+    c; // narrowed to `B`
+}

--- a/tests/baselines/reference/controlFlowForInStatement2.js
+++ b/tests/baselines/reference/controlFlowForInStatement2.js
@@ -21,6 +21,9 @@ if ((stringB as 'b') in c) {
     c; // narrowed to `B`
 }
 
+if ((stringB as ('a' | 'b')) in c) {
+    c; // not narrowed
+}
 
 //// [controlFlowForInStatement2.js]
 var keywordA = 'a';
@@ -34,4 +37,7 @@ if (keywordA in c) {
 var stringB = 'b';
 if (stringB in c) {
     c; // narrowed to `B`
+}
+if (stringB in c) {
+    c; // not narrowed
 }

--- a/tests/baselines/reference/controlFlowForInStatement2.symbols
+++ b/tests/baselines/reference/controlFlowForInStatement2.symbols
@@ -1,0 +1,48 @@
+=== tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts ===
+const keywordA = 'a';
+>keywordA : Symbol(keywordA, Decl(controlFlowForInStatement2.ts, 0, 5))
+
+const keywordB = 'b';
+>keywordB : Symbol(keywordB, Decl(controlFlowForInStatement2.ts, 1, 5))
+
+type A = { [keywordA]: number };
+>A : Symbol(A, Decl(controlFlowForInStatement2.ts, 1, 21))
+>[keywordA] : Symbol([keywordA], Decl(controlFlowForInStatement2.ts, 3, 10))
+>keywordA : Symbol(keywordA, Decl(controlFlowForInStatement2.ts, 0, 5))
+
+type B = { [keywordB]: string };
+>B : Symbol(B, Decl(controlFlowForInStatement2.ts, 3, 32))
+>[keywordB] : Symbol([keywordB], Decl(controlFlowForInStatement2.ts, 4, 10))
+>keywordB : Symbol(keywordB, Decl(controlFlowForInStatement2.ts, 1, 5))
+
+declare const c: A | B;
+>c : Symbol(c, Decl(controlFlowForInStatement2.ts, 6, 13))
+>A : Symbol(A, Decl(controlFlowForInStatement2.ts, 1, 21))
+>B : Symbol(B, Decl(controlFlowForInStatement2.ts, 3, 32))
+
+if ('a' in c) {
+>c : Symbol(c, Decl(controlFlowForInStatement2.ts, 6, 13))
+
+    c; // narrowed to `A`
+>c : Symbol(c, Decl(controlFlowForInStatement2.ts, 6, 13))
+}
+
+if (keywordA in c) {
+>keywordA : Symbol(keywordA, Decl(controlFlowForInStatement2.ts, 0, 5))
+>c : Symbol(c, Decl(controlFlowForInStatement2.ts, 6, 13))
+
+    c; // also narrowed to `A`
+>c : Symbol(c, Decl(controlFlowForInStatement2.ts, 6, 13))
+}
+
+let stringB: string = 'b';
+>stringB : Symbol(stringB, Decl(controlFlowForInStatement2.ts, 16, 3))
+
+if ((stringB as 'b') in c) {
+>stringB : Symbol(stringB, Decl(controlFlowForInStatement2.ts, 16, 3))
+>c : Symbol(c, Decl(controlFlowForInStatement2.ts, 6, 13))
+
+    c; // narrowed to `B`
+>c : Symbol(c, Decl(controlFlowForInStatement2.ts, 6, 13))
+}
+

--- a/tests/baselines/reference/controlFlowForInStatement2.symbols
+++ b/tests/baselines/reference/controlFlowForInStatement2.symbols
@@ -46,3 +46,10 @@ if ((stringB as 'b') in c) {
 >c : Symbol(c, Decl(controlFlowForInStatement2.ts, 6, 13))
 }
 
+if ((stringB as ('a' | 'b')) in c) {
+>stringB : Symbol(stringB, Decl(controlFlowForInStatement2.ts, 16, 3))
+>c : Symbol(c, Decl(controlFlowForInStatement2.ts, 6, 13))
+
+    c; // not narrowed
+>c : Symbol(c, Decl(controlFlowForInStatement2.ts, 6, 13))
+}

--- a/tests/baselines/reference/controlFlowForInStatement2.types
+++ b/tests/baselines/reference/controlFlowForInStatement2.types
@@ -1,0 +1,55 @@
+=== tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts ===
+const keywordA = 'a';
+>keywordA : "a"
+>'a' : "a"
+
+const keywordB = 'b';
+>keywordB : "b"
+>'b' : "b"
+
+type A = { [keywordA]: number };
+>A : A
+>[keywordA] : number
+>keywordA : "a"
+
+type B = { [keywordB]: string };
+>B : B
+>[keywordB] : string
+>keywordB : "b"
+
+declare const c: A | B;
+>c : A | B
+
+if ('a' in c) {
+>'a' in c : boolean
+>'a' : "a"
+>c : A | B
+
+    c; // narrowed to `A`
+>c : A
+}
+
+if (keywordA in c) {
+>keywordA in c : boolean
+>keywordA : "a"
+>c : A | B
+
+    c; // also narrowed to `A`
+>c : A
+}
+
+let stringB: string = 'b';
+>stringB : string
+>'b' : "b"
+
+if ((stringB as 'b') in c) {
+>(stringB as 'b') in c : boolean
+>(stringB as 'b') : "b"
+>stringB as 'b' : "b"
+>stringB : string
+>c : A | B
+
+    c; // narrowed to `B`
+>c : B
+}
+

--- a/tests/baselines/reference/controlFlowForInStatement2.types
+++ b/tests/baselines/reference/controlFlowForInStatement2.types
@@ -53,3 +53,13 @@ if ((stringB as 'b') in c) {
 >c : B
 }
 
+if ((stringB as ('a' | 'b')) in c) {
+>(stringB as ('a' | 'b')) in c : boolean
+>(stringB as ('a' | 'b')) : "a" | "b"
+>stringB as ('a' | 'b') : "a" | "b"
+>stringB : string
+>c : A | B
+
+    c; // not narrowed
+>c : A | B
+}

--- a/tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts
@@ -19,3 +19,7 @@ let stringB: string = 'b';
 if ((stringB as 'b') in c) {
     c; // narrowed to `B`
 }
+
+if ((stringB as ('a' | 'b')) in c) {
+    c; // not narrowed
+}

--- a/tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts
@@ -1,0 +1,21 @@
+const keywordA = 'a';
+const keywordB = 'b';
+
+type A = { [keywordA]: number };
+type B = { [keywordB]: string };
+
+declare const c: A | B;
+
+if ('a' in c) {
+    c; // narrowed to `A`
+}
+
+if (keywordA in c) {
+    c; // also narrowed to `A`
+}
+
+let stringB: string = 'b';
+
+if ((stringB as 'b') in c) {
+    c; // narrowed to `B`
+}


### PR DESCRIPTION
Extends a more restrictive fix already in place for #42639.

Previously, narrowing of an `in` expression happens if the expression satisfy two constraints:
* In the binder: `isNarrowableInOperands` is a syntactic constraint that allows narrowing of an expression if the right `in` operand is a narrowing expression, and the left `in` operand is a string literal (e.g. `if ('prop' in c) { ... }`).
* In the checker: `narrowBinaryExpression` only calls `narrowByInKeyword` if the left `in` operand's type is a string literal type.

An already merged PR (#44893) relaxed the binder constraint to allow narrowing in cases the left `in` operand is an identifier, to address scenarios such as:
```ts
type A = { a: number };
type B = { b: string };
declare c: A | B;

if ("a" in c) {
    c; // c has type `A` here
}

const a = "a";
if (a in c) {
    c; // c should also have type `A` here; previously it had type `A | B`
}
```

This PR further relaxes the constraint in the binder for narrowing `in` expressions, by no longer placing any syntactic constraint on the left `in` operand expression. This means that an `in` expression is considered narrowable by the binder if the right expression is narrowing:

```ts
type A = { a: number };
type B = { b: string };
declare c: A | B;

if ("a" in c) {
    c; // c has type `A` here
}

const a = "a";
if (a in c) {
    c; // c has type `A` here
}

let stringA: string = "a";
if ((stringA as "a") in c) {
    c; // c now has type `A` here too
}

if ((stringA as ("a" | "b")) in c) {
    c; // c has type `A | B`; not narrowed because the left expression has type `"a" | "b"`, i.e. not a string literal type
}
```

Concerns:
From what I can tell, a possible concern would be performance, since this PR makes it so the checker attempts to narrow more types of `in` expressions, but the impact may be negligible.
A caveat here (brought up by @andrewbranch) regarding perf tests is that, since the checker currently doesn't narrow those kinds of expressions, real world code is unlikely to have those kinds of expressions.



