### PR TITLE
Filter auto imports by symbol flags before resolving module specifiers

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1932,7 +1932,7 @@ namespace ts.Completions {
                     exportInfo.forEach(sourceFile.path, (info, symbolName, isFromAmbientModule) => {
                         if (!detailsEntryId && isStringANonContextualKeyword(symbolName)) return;
                         // `targetFlags` should be the same for each `info`
-                        if (!isTypeOnlyLocation && !(info[0].targetFlags & SymbolFlags.Value)) return;
+                        if (!isTypeOnlyLocation && !importCompletionNode && !(info[0].targetFlags & SymbolFlags.Value)) return;
                         if (isTypeOnlyLocation && !(info[0].targetFlags & (SymbolFlags.Module | SymbolFlags.Type))) return;
                         const isCompletionDetailsMatch = detailsEntryId && some(info, i => detailsEntryId.source === stripQuotes(i.moduleSymbol.name));
                         if (isCompletionDetailsMatch || !detailsEntryId && charactersFuzzyMatchInString(symbolName, lowerCaseTokenText)) {

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -20,8 +20,7 @@ namespace ts {
         /** Set if `moduleSymbol` is an external module, not an ambient module */
         moduleFileName: string | undefined;
         exportKind: ExportKind;
-        /** If true, can't use an es6 import from a js file. */
-        isTypeOnly: boolean;
+        targetFlags: SymbolFlags;
         /** True if export was only found via the package.json AutoImportProvider (for telemetry). */
         isFromPackageJson: boolean;
     }
@@ -38,7 +37,7 @@ namespace ts {
         readonly moduleSymbol: Symbol | undefined;
         moduleFileName: string | undefined;
         exportKind: ExportKind;
-        isTypeOnly: boolean;
+        targetFlags: SymbolFlags;
         isFromPackageJson: boolean;
     }
 
@@ -92,7 +91,7 @@ namespace ts {
                     moduleFile,
                     moduleFileName: moduleFile?.fileName,
                     exportKind,
-                    isTypeOnly: !(skipAlias(symbol, checker).flags & SymbolFlags.Value),
+                    targetFlags: skipAlias(symbol, checker).flags,
                     isFromPackageJson,
                     symbol: storedSymbol,
                     moduleSymbol: storedModuleSymbol,
@@ -143,7 +142,7 @@ namespace ts {
 
         function rehydrateCachedInfo(info: CachedSymbolExportInfo): SymbolExportInfo {
             if (info.symbol && info.moduleSymbol) return info as SymbolExportInfo;
-            const { id, exportKind, isTypeOnly, isFromPackageJson, moduleFileName } = info;
+            const { id, exportKind, targetFlags, isFromPackageJson, moduleFileName } = info;
             const [cachedSymbol, cachedModuleSymbol] = symbols.get(id) || emptyArray;
             if (cachedSymbol && cachedModuleSymbol) {
                 return {
@@ -151,7 +150,7 @@ namespace ts {
                     moduleSymbol: cachedModuleSymbol,
                     moduleFileName,
                     exportKind,
-                    isTypeOnly,
+                    targetFlags,
                     isFromPackageJson,
                 };
             }
@@ -173,7 +172,7 @@ namespace ts {
                 moduleSymbol,
                 moduleFileName,
                 exportKind,
-                isTypeOnly,
+                targetFlags,
                 isFromPackageJson,
             };
         }

--- a/tests/cases/fourslash/importStatementCompletions1.ts
+++ b/tests/cases/fourslash/importStatementCompletions1.ts
@@ -2,6 +2,7 @@
 
 // @Filename: /mod.ts
 //// export const foo = 0;
+//// export type Foo = number;
 
 // @Filename: /index0.ts
 //// [|import f/*0*/|]
@@ -29,6 +30,13 @@
       name: "foo",
       source: "./mod",
       insertText: `import { foo$1 } from "./mod";`,
+      isSnippet: true,
+      replacementSpan: test.ranges()[marker],
+      sourceDisplay: "./mod",
+    }, {
+      name: "Foo",
+      source: "./mod",
+      insertText: `import { Foo$1 } from "./mod";`,
       isSnippet: true,
       replacementSpan: test.ranges()[marker],
       sourceDisplay: "./mod",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

This made value-space auto imports 1.3x faster uncached and 2.7x faster cached for me. The tradeoff is that there’s less already-cached work the first time you request completions in a type-space location (or vice versa, if you happened to request completions in a type location first). This seems like a good trade to me, since the most expensive completions request is always going to be the first one you make with a totally cold cache; it makes sense to me to defer some of that work to a later request where _some_ things have already been cached.
