### PR TITLE
fix(45182): Incorrect "Property is used before its initialization" error with body-less arrow functions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27782,6 +27782,7 @@ namespace ts {
                     case SyntaxKind.ExpressionWithTypeArguments:
                     case SyntaxKind.HeritageClause:
                         return false;
+                    case SyntaxKind.ArrowFunction:
                     case SyntaxKind.ExpressionStatement:
                         return isBlock(node.parent) && isClassStaticBlockDeclaration(node.parent.parent) ? true : "quit";
                     default:

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.errors.txt
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.errors.txt
@@ -62,4 +62,13 @@ tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterProper
         }
         constructor(public p1: number) {}
     }
+    class H {
+        constructor(public p1: C) {}
+    
+        public p2 = () => {
+            return this.p1.foo;
+        }
+    
+        public p3 = () => this.p1.foo;
+    }
     

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.js
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.js
@@ -40,6 +40,15 @@ class G {
     }
     constructor(public p1: number) {}
 }
+class H {
+    constructor(public p1: C) {}
+
+    public p2 = () => {
+        return this.p1.foo;
+    }
+
+    public p3 = () => this.p1.foo;
+}
 
 
 //// [assignParameterPropertyToPropertyDeclarationESNext.js]
@@ -89,4 +98,14 @@ class G {
     constructor(p1) {
         this.p1 = p1;
     }
+}
+class H {
+    p1;
+    constructor(p1) {
+        this.p1 = p1;
+    }
+    p2 = () => {
+        return this.p1.foo;
+    };
+    p3 = () => this.p1.foo;
 }

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.symbols
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.symbols
@@ -136,4 +136,30 @@ class G {
     constructor(public p1: number) {}
 >p1 : Symbol(G.p1, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 39, 16))
 }
+class H {
+>H : Symbol(H, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 40, 1))
+
+    constructor(public p1: C) {}
+>p1 : Symbol(H.p1, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 42, 16))
+>C : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
+
+    public p2 = () => {
+>p2 : Symbol(H.p2, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 42, 32))
+
+        return this.p1.foo;
+>this.p1.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 10, 16))
+>this.p1 : Symbol(H.p1, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 42, 16))
+>this : Symbol(H, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 40, 1))
+>p1 : Symbol(H.p1, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 42, 16))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 10, 16))
+    }
+
+    public p3 = () => this.p1.foo;
+>p3 : Symbol(H.p3, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 46, 5))
+>this.p1.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 10, 16))
+>this.p1 : Symbol(H.p1, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 42, 16))
+>this : Symbol(H, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 40, 1))
+>p1 : Symbol(H.p1, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 42, 16))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 10, 16))
+}
 

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.types
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.types
@@ -145,4 +145,31 @@ class G {
     constructor(public p1: number) {}
 >p1 : number
 }
+class H {
+>H : H
+
+    constructor(public p1: C) {}
+>p1 : C
+
+    public p2 = () => {
+>p2 : () => string
+>() => {        return this.p1.foo;    } : () => string
+
+        return this.p1.foo;
+>this.p1.foo : string
+>this.p1 : C
+>this : this
+>p1 : C
+>foo : string
+    }
+
+    public p3 = () => this.p1.foo;
+>p3 : () => string
+>() => this.p1.foo : () => string
+>this.p1.foo : string
+>this.p1 : C
+>this : this
+>p1 : C
+>foo : string
+}
 

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts
@@ -41,3 +41,12 @@ class G {
     }
     constructor(public p1: number) {}
 }
+class H {
+    constructor(public p1: C) {}
+
+    public p2 = () => {
+        return this.p1.foo;
+    }
+
+    public p3 = () => this.p1.foo;
+}


### PR DESCRIPTION
Fixes #45182