### PR TITLE
Improve Node.cloneNode typing in lib.dom.d.ts

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -10492,7 +10492,7 @@ interface Node extends EventTarget {
     /**
      * Returns a copy of node. If deep is true, the copy also includes the node's descendants.
      */
-    cloneNode(deep?: boolean): Node;
+    cloneNode<T extends this>(deep?: boolean): T;
     /**
      * Returns a bitmask indicating the position of other relative to node.
      */


### PR DESCRIPTION
This is a small change to the types defined in lib.dom.d.ts which will allow for situations like this
```js
const list = document.createElement("ul");
const clonedList = list.cloneNode(true); // clonedList is now of type HTMLUListElement, not Node
```