### PR TITLE
Negative cases of getNarrowedType that match the exact type should be filtered out, even when generic

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24004,6 +24004,9 @@ namespace ts {
                         if (!isRelated(t, candidate)) {
                             return true;
                         }
+                        if (candidate === t) {
+                            return false;
+                        }
                         const constraint = getBaseConstraintOfType(t);
                         if (constraint && constraint !== t) {
                             return !isRelated(constraint, candidate);

--- a/tests/baselines/reference/genericCapturingFunctionNarrowing.js
+++ b/tests/baselines/reference/genericCapturingFunctionNarrowing.js
@@ -1,0 +1,28 @@
+//// [genericCapturingFunctionNarrowing.ts]
+function needsToNarrowTheType<First extends { foo: string }, Second extends { bar: string }>(thing: First | Second) {
+    if (hasAFoo(thing)) {
+        console.log(thing.foo);
+    }
+    else {
+        // I would expect this to work because the type should be narrowed in this branch to `Second`
+        console.log(thing.bar); // Error: Property 'bar' does not exist on type 'First | Second'.
+    }
+
+    function hasAFoo(value: First | Second): value is First {
+        return "foo" in value;
+    }
+}
+
+//// [genericCapturingFunctionNarrowing.js]
+function needsToNarrowTheType(thing) {
+    if (hasAFoo(thing)) {
+        console.log(thing.foo);
+    }
+    else {
+        // I would expect this to work because the type should be narrowed in this branch to `Second`
+        console.log(thing.bar); // Error: Property 'bar' does not exist on type 'First | Second'.
+    }
+    function hasAFoo(value) {
+        return "foo" in value;
+    }
+}

--- a/tests/baselines/reference/genericCapturingFunctionNarrowing.symbols
+++ b/tests/baselines/reference/genericCapturingFunctionNarrowing.symbols
@@ -1,0 +1,46 @@
+=== tests/cases/compiler/genericCapturingFunctionNarrowing.ts ===
+function needsToNarrowTheType<First extends { foo: string }, Second extends { bar: string }>(thing: First | Second) {
+>needsToNarrowTheType : Symbol(needsToNarrowTheType, Decl(genericCapturingFunctionNarrowing.ts, 0, 0))
+>First : Symbol(First, Decl(genericCapturingFunctionNarrowing.ts, 0, 30))
+>foo : Symbol(foo, Decl(genericCapturingFunctionNarrowing.ts, 0, 45))
+>Second : Symbol(Second, Decl(genericCapturingFunctionNarrowing.ts, 0, 60))
+>bar : Symbol(bar, Decl(genericCapturingFunctionNarrowing.ts, 0, 77))
+>thing : Symbol(thing, Decl(genericCapturingFunctionNarrowing.ts, 0, 93))
+>First : Symbol(First, Decl(genericCapturingFunctionNarrowing.ts, 0, 30))
+>Second : Symbol(Second, Decl(genericCapturingFunctionNarrowing.ts, 0, 60))
+
+    if (hasAFoo(thing)) {
+>hasAFoo : Symbol(hasAFoo, Decl(genericCapturingFunctionNarrowing.ts, 7, 5))
+>thing : Symbol(thing, Decl(genericCapturingFunctionNarrowing.ts, 0, 93))
+
+        console.log(thing.foo);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>thing.foo : Symbol(foo, Decl(genericCapturingFunctionNarrowing.ts, 0, 45))
+>thing : Symbol(thing, Decl(genericCapturingFunctionNarrowing.ts, 0, 93))
+>foo : Symbol(foo, Decl(genericCapturingFunctionNarrowing.ts, 0, 45))
+    }
+    else {
+        // I would expect this to work because the type should be narrowed in this branch to `Second`
+        console.log(thing.bar); // Error: Property 'bar' does not exist on type 'First | Second'.
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>thing.bar : Symbol(bar, Decl(genericCapturingFunctionNarrowing.ts, 0, 77))
+>thing : Symbol(thing, Decl(genericCapturingFunctionNarrowing.ts, 0, 93))
+>bar : Symbol(bar, Decl(genericCapturingFunctionNarrowing.ts, 0, 77))
+    }
+
+    function hasAFoo(value: First | Second): value is First {
+>hasAFoo : Symbol(hasAFoo, Decl(genericCapturingFunctionNarrowing.ts, 7, 5))
+>value : Symbol(value, Decl(genericCapturingFunctionNarrowing.ts, 9, 21))
+>First : Symbol(First, Decl(genericCapturingFunctionNarrowing.ts, 0, 30))
+>Second : Symbol(Second, Decl(genericCapturingFunctionNarrowing.ts, 0, 60))
+>value : Symbol(value, Decl(genericCapturingFunctionNarrowing.ts, 9, 21))
+>First : Symbol(First, Decl(genericCapturingFunctionNarrowing.ts, 0, 30))
+
+        return "foo" in value;
+>value : Symbol(value, Decl(genericCapturingFunctionNarrowing.ts, 9, 21))
+    }
+}

--- a/tests/baselines/reference/genericCapturingFunctionNarrowing.types
+++ b/tests/baselines/reference/genericCapturingFunctionNarrowing.types
@@ -1,0 +1,43 @@
+=== tests/cases/compiler/genericCapturingFunctionNarrowing.ts ===
+function needsToNarrowTheType<First extends { foo: string }, Second extends { bar: string }>(thing: First | Second) {
+>needsToNarrowTheType : <First extends { foo: string; }, Second extends { bar: string; }>(thing: First | Second) => void
+>foo : string
+>bar : string
+>thing : First | Second
+
+    if (hasAFoo(thing)) {
+>hasAFoo(thing) : boolean
+>hasAFoo : (value: First | Second) => value is First
+>thing : First | Second
+
+        console.log(thing.foo);
+>console.log(thing.foo) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>thing.foo : string
+>thing : First
+>foo : string
+    }
+    else {
+        // I would expect this to work because the type should be narrowed in this branch to `Second`
+        console.log(thing.bar); // Error: Property 'bar' does not exist on type 'First | Second'.
+>console.log(thing.bar) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>thing.bar : string
+>thing : Second
+>bar : string
+    }
+
+    function hasAFoo(value: First | Second): value is First {
+>hasAFoo : (value: First | Second) => value is First
+>value : First | Second
+
+        return "foo" in value;
+>"foo" in value : boolean
+>"foo" : "foo"
+>value : First | Second
+    }
+}

--- a/tests/baselines/reference/quickinfoTypeAtReturnPositionsInaccurate.errors.txt
+++ b/tests/baselines/reference/quickinfoTypeAtReturnPositionsInaccurate.errors.txt
@@ -1,11 +1,8 @@
 tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts(33,15): error TS2339: Property 'numExclusive' does not exist on type 'NumClass<number> | StrClass<string>'.
   Property 'numExclusive' does not exist on type 'StrClass<string>'.
-tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts(101,11): error TS2322: Type 'Program | T' is not assignable to type 'Program'.
-  Type 'T' is not assignable to type 'Program'.
-    Property 'state' is missing in type 'BuilderProgram' but required in type 'Program'.
 
 
-==== tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts (2 errors) ====
+==== tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts (1 errors) ====
     class NumClass<T extends number> {
         private value!: T;
         public get(): T {
@@ -110,9 +107,4 @@ tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts(101,11): error 
     declare function isBuilderProgram<T extends BuilderProgram>(program: Program | T): program is T;
     export function listFiles<T extends BuilderProgram>(program: Program | T) {
         const x: Program = isBuilderProgram(program) ? program.getProgram() : program;
-              ~
-!!! error TS2322: Type 'Program | T' is not assignable to type 'Program'.
-!!! error TS2322:   Type 'T' is not assignable to type 'Program'.
-!!! error TS2322:     Property 'state' is missing in type 'BuilderProgram' but required in type 'Program'.
-!!! related TS2728 tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts:97:5: 'state' is declared here.
     }

--- a/tests/baselines/reference/quickinfoTypeAtReturnPositionsInaccurate.types
+++ b/tests/baselines/reference/quickinfoTypeAtReturnPositionsInaccurate.types
@@ -226,7 +226,7 @@ export function listFiles<T extends BuilderProgram>(program: Program | T) {
 
     const x: Program = isBuilderProgram(program) ? program.getProgram() : program;
 >x : Program
->isBuilderProgram(program) ? program.getProgram() : program : Program | T
+>isBuilderProgram(program) ? program.getProgram() : program : Program
 >isBuilderProgram(program) : boolean
 >isBuilderProgram : <T extends BuilderProgram>(program: Program | T) => program is T
 >program : Program | T
@@ -234,5 +234,5 @@ export function listFiles<T extends BuilderProgram>(program: Program | T) {
 >program.getProgram : () => Program
 >program : T
 >getProgram : () => Program
->program : Program | T
+>program : Program
 }

--- a/tests/cases/compiler/genericCapturingFunctionNarrowing.ts
+++ b/tests/cases/compiler/genericCapturingFunctionNarrowing.ts
@@ -1,0 +1,13 @@
+function needsToNarrowTheType<First extends { foo: string }, Second extends { bar: string }>(thing: First | Second) {
+    if (hasAFoo(thing)) {
+        console.log(thing.foo);
+    }
+    else {
+        // I would expect this to work because the type should be narrowed in this branch to `Second`
+        console.log(thing.bar); // Error: Property 'bar' does not exist on type 'First | Second'.
+    }
+
+    function hasAFoo(value: First | Second): value is First {
+        return "foo" in value;
+    }
+}


### PR DESCRIPTION
Fixes #44404

The reported regression is caused by the changes in #43763 - in breaking apart constraints in negative cases, we made it so `First` (a generic) could never remove `First` (itself), since `First` is constrained to `{foo: string}` (yet obviously isn't related to the generic subtype in question). With this change to that, we do not perform the constraint check if the candidate exactly matches - this is easily foiled (by subtypes and intersections).

See, the thing is - after some investigation, I've decided this is a kind of hacky fix layered on a hacky fix.
#43763 is ultimately doing the best it can to work around the fact that the subtype comparison result for `Slice[A][B]` and `Extract<Slice[A][B]. whatever>` is _wrong_ - a root cause bug which #41821 fixes. I think, rather than this, we should be looking to pull in #41821 and completely revert the non-test changes in #43763 (since I can confirm the issue is also fixed by #41821). _That_ combined change can be found [here](https://github.com/microsoft/TypeScript/compare/main...weswigham:generic-cfa-more-fixes?expand=1), if we think we'd like to do that, instead (the relevant diff has been merged into #41821).