### PR TITLE
Avoid no-op export map updates

### DIFF
--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -499,7 +499,7 @@ namespace ts {
                 if (state.previousCache) {
                     if (state.previousCache.id === cacheId && state.previousCache.version === cacheVersion) {
                         // If this is the same cache at the same version as last time this BuilderState
-                        // was updated, there's not need to update again
+                        // was updated, there's no need to update again
                         return;
                     }
                     state.previousCache.id = cacheId;


### PR DESCRIPTION
This is a follow-up to #44402.  Internal teams with large projects have seen significant perf wins from that change (~20% reduction in build time) but I've stumbled onto some pathological cases where the change actually increases build time by ~50%.

The builder maintains two copies of the exported modules map - changes are accumulated in a copy so that they can be discarded if something invalidated the update.  When the build _does_ complete successfully, one `ManyToManyPathMap` is updated from another, which requires traversing both.  In local measurements, each such update was taking 2-4 seconds (this is very project-specific) and there were 2000 in the course of building a single project.  However, it turned out that the copy was never actually modified after its initialization, so all subsequent updates of the "real" map were no-ops.  This change introduces a cheap way to determine that the cache hasn't changed.

I think we could probably use a more sophisticated method to handle these updates (e.g. accumulating only a delta), but I deliberately made the change very simple because we're so late in the 4.4 cycle.