### PR TITLE
`convertStringOrTemplateLiteral.ts`: Re-fix `escapeStringForTemplate`

### DIFF
--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -147,14 +147,13 @@ namespace ts.refactor.convertStringOrTemplateLiteral {
         }
     };
 
-    function escapeStringForTemplate(s: string) {
+    function escapeRawStringForTemplate(s: string) {
         // Escaping for $s in strings that are to be used in template strings
-        // Naive implementation: replace \x by itself and otherwise $ by \$.
+        // Naive implementation: replace \x by itself and otherwise $ and ` by \$ and \`.
         // But to complicate it a bit, this should work for raw strings too.
-        // And another bit: escape the $ in the replacement for JS's .replace().
-        return s.replace(/\\.|\$/g, m => m === "$" ? "\\\$" : m);
+        return s.replace(/\\.|[$`]/g, m => m[0] === "\\" ? m : "\\" + m);
         // Finally, a less-backslash-happy version can work too, doing only ${ instead of all $s:
-        //     s.replace(/\\.|\${/g, m => m === "${" ? "\\\${" : m);
+        //     s.replace(/\\.|\${|`/g, m => m[0] === "\\" ? m : "\\" + m);
         // but `\$${foo}` is likely more clear than the more-confusing-but-still-working `$${foo}`.
     }
 
@@ -170,8 +169,8 @@ namespace ts.refactor.convertStringOrTemplateLiteral {
         while (index < nodes.length) {
             const node = nodes[index];
             if (isStringLiteralLike(node)) { // includes isNoSubstitutionTemplateLiteral(node)
-                text += escapeStringForTemplate(node.text);
-                rawText += escapeStringForTemplate(getTextOfNode(node).slice(1, -1));
+                text += node.text;
+                rawText += escapeRawStringForTemplate(getTextOfNode(node).slice(1, -1));
                 indexes.push(index);
                 index++;
             }

--- a/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_escapeSequences.ts
+++ b/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_escapeSequences.ts
@@ -94,3 +94,15 @@ edit.applyRefactor({
     // newContent is: let s = `\u0041\u0061${text}\0\u0000`;
     newContent: 'let s = `\\u0041\\u0061${text}\\0\\u0000`;'
 });
+
+// @Filename: /i.ts
+////let s = /*i1*/'$`' + text + "`\\"/*i2*/;
+
+goTo.select("i1", "i2");
+edit.applyRefactor({
+    refactorName: "Convert to template string",
+    actionName: "Convert to template string",
+    actionDescription: ts.Diagnostics.Convert_to_template_string.message,
+    // newContent is: let s = `\$\`${text}\`\\`;
+    newContent: 'let s = `\\$\\`${text}\\`\\\\`;'
+});


### PR DESCRIPTION
Make it backslash-escape backticks too.  While I was there, remove the
use of this function for the text (which was the earlier confused
version that used only `text`), and rename it as
`escapeRawStringForTemplate` to clarify.

Added a test to the preivious pile of tests.

Fixes #45278 (and the original microsoft/tsserverfuzzer#334).
