### PR TITLE
fix(45294): Parameter inlay hints don't show for interpolated string when set to literals

### DIFF
--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -210,11 +210,13 @@ namespace ts.InlayHints {
                 }
                 case SyntaxKind.TrueKeyword:
                 case SyntaxKind.FalseKeyword:
-                case SyntaxKind.ArrowFunction:
                 case SyntaxKind.FunctionExpression:
+                case SyntaxKind.ArrowFunction:
                 case SyntaxKind.ObjectLiteralExpression:
                 case SyntaxKind.ArrayLiteralExpression:
                 case SyntaxKind.NullKeyword:
+                case SyntaxKind.NoSubstitutionTemplateLiteral:
+                case SyntaxKind.TemplateExpression:
                     return true;
                 case SyntaxKind.Identifier: {
                     const name = (node as Identifier).escapedText;

--- a/tests/cases/fourslash/inlayHintsShouldWork62.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork62.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+////function trace(message: string) {}
+////trace(/*a*/`${1}`);
+////trace(/*b*/``);
+
+const [a, b] = test.markers();
+verify.getInlayHints([
+    {
+        text: 'message:',
+        position: a.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: 'message:',
+        position: b.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    }
+], undefined, {
+    includeInlayParameterNameHints: "literals"
+});


### PR DESCRIPTION
Fixes #45294