### PR TITLE
Visit children of jsdoc type aliases in the binder

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1666,13 +1666,13 @@ namespace ts {
         }
 
         function bindJSDocTypeAlias(node: JSDocTypedefTag | JSDocCallbackTag | JSDocEnumTag) {
-            setParent(node.tagName, node);
+            bind(node.tagName);
             if (node.kind !== SyntaxKind.JSDocEnumTag && node.fullName) {
                 setParent(node.fullName, node);
                 setParentRecursive(node.fullName, /*incremental*/ false);
             }
             if (typeof node.comment !== "string") {
-                setEachParent(node.comment, node);
+                bindEach(node.comment);
             }
         }
 

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1668,6 +1668,7 @@ namespace ts {
         function bindJSDocTypeAlias(node: JSDocTypedefTag | JSDocCallbackTag | JSDocEnumTag) {
             bind(node.tagName);
             if (node.kind !== SyntaxKind.JSDocEnumTag && node.fullName) {
+                // don't bind the type name yet; that's delayed until delayedBindJSDocTypedefTag
                 setParent(node.fullName, node);
                 setParentRecursive(node.fullName, /*incremental*/ false);
             }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1666,6 +1666,7 @@ namespace ts {
         }
 
         function bindJSDocTypeAlias(node: JSDocTypedefTag | JSDocCallbackTag | JSDocEnumTag) {
+            bindEachChild(node);
             setParent(node.tagName, node);
             if (node.kind !== SyntaxKind.JSDocEnumTag && node.fullName) {
                 setParent(node.fullName, node);

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1666,11 +1666,13 @@ namespace ts {
         }
 
         function bindJSDocTypeAlias(node: JSDocTypedefTag | JSDocCallbackTag | JSDocEnumTag) {
-            bindEachChild(node);
             setParent(node.tagName, node);
             if (node.kind !== SyntaxKind.JSDocEnumTag && node.fullName) {
                 setParent(node.fullName, node);
                 setParentRecursive(node.fullName, /*incremental*/ false);
+            }
+            if (typeof node.comment !== "string") {
+                setEachParent(node.comment, node);
             }
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -530,8 +530,8 @@ namespace ts {
                             visitNode(cbNode, (node as JSDocTypedefTag).fullName) ||
                             (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocComment> | undefined))
                         : visitNode(cbNode, (node as JSDocTypedefTag).fullName) ||
-                            visitNode(cbNode, (node as JSDocTypedefTag).typeExpression)) ||
-                            (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocComment> | undefined));
+                            visitNode(cbNode, (node as JSDocTypedefTag).typeExpression) ||
+                            (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocComment> | undefined)));
             case SyntaxKind.JSDocCallbackTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     visitNode(cbNode, (node as JSDocCallbackTag).fullName) ||

--- a/tests/baselines/reference/quickInfoLink2.baseline
+++ b/tests/baselines/reference/quickInfoLink2.baseline
@@ -1,0 +1,105 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoLink2.js",
+      "position": 39,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "type",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 16,
+        "length": 23
+      },
+      "displayParts": [
+        {
+          "text": "type",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "AdditionalWallabyConfig",
+          "kind": "aliasName"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=",
+          "kind": "operator"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "{",
+          "kind": "punctuation"
+        },
+        {
+          "text": "\n",
+          "kind": "lineBreak"
+        },
+        {
+          "text": "    ",
+          "kind": "space"
+        },
+        {
+          "text": "autoDetect",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "boolean",
+          "kind": "keyword"
+        },
+        {
+          "text": ";",
+          "kind": "punctuation"
+        },
+        {
+          "text": "\n",
+          "kind": "lineBreak"
+        },
+        {
+          "text": "}",
+          "kind": "punctuation"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "Additional valid Wallaby config properties\nthat aren't defined in ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "IWallabyConfig ",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": ".",
+          "kind": "text"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/quickInfoLink2.ts
+++ b/tests/cases/fourslash/quickInfoLink2.ts
@@ -1,0 +1,12 @@
+///<reference path="fourslash.ts" />
+
+// @checkJs: true
+// @Filename: quickInfoLink2.js
+//// /**
+////  * @typedef AdditionalWallabyConfig/**/ Additional valid Wallaby config properties
+////  * that aren't defined in {@link IWallabyConfig}.
+////  * @property {boolean} autoDetect
+////  */
+
+verify.noErrors()
+verify.baselineQuickInfo();


### PR DESCRIPTION
This sets up parent pointers and matches bindJSDocClassTag just below.

Fixes #45254 and almost certainly #45248, though I haven't figured out to repro the second case.
