### PR TITLE
Fix completions in return when in function with contextual 'this'

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1602,6 +1602,12 @@ namespace ts.Completions {
             }
 
             if (!isTypeLocation) {
+                // GH#39946. Pulling on the type of a node inside of a function with a contextual `this` parameter can result in a circularity
+                // if the `node` is part of the exprssion of a `yield` or `return`. This circularity doesn't exist at compile time because
+                // we will check (and cache) the type of `this` *before* checking the type of the node.
+                const container = getThisContainer(node, /*includeArrowFunctions*/ false);
+                if (!isSourceFile(container) && container.parent) typeChecker.getTypeAtLocation(container);
+
                 let type = typeChecker.getTypeAtLocation(node).getNonOptionalType();
                 let insertQuestionDot = false;
                 if (type.isNullableType()) {

--- a/tests/cases/fourslash/completionListInReturnWithContextualThis.ts
+++ b/tests/cases/fourslash/completionListInReturnWithContextualThis.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+////interface Ctx {
+////    foo(): {
+////        x: number
+////    };
+////}
+////
+////declare function wrap(cb: (this: Ctx) => any): void;
+////
+////wrap(function () {
+////    const xs = this.foo();
+////    return xs./*inReturn*/
+////});
+////
+////wrap(function () {
+////    const xs = this.foo();
+////    const y = xs./*involvedInReturn*/
+////    return y;
+////});
+
+verify.completions(
+    {
+        marker: "inReturn",
+        exact: ["x"],
+    },
+    {
+        marker: "involvedInReturn",
+        exact: ["x"],
+    },
+);


### PR DESCRIPTION
This change forces the containing function to be type-checked when requesting completions so that contextual `this` parameters in the containing function are already checked (and cached). Prior to this change, pulling on a type while requesting completions could result in a circularity that doesn't exist at compile time.

Fixes #39946
