### PR TITLE
Update tsc-instrumented for project build

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -510,7 +510,7 @@ task("baseline-accept").description = "Makes the most recent test results the ne
 task("baseline-accept-rwc", () => baselineAccept(localRwcBaseline, refRwcBaseline));
 task("baseline-accept-rwc").description = "Makes the most recent rwc test results the new baseline, overwriting the old baseline";
 
-const buildLoggedIO = () => buildProject("src/loggedIO");
+const buildLoggedIO = () => buildProject("src/loggedIO/tsconfig-tsc-instrumented.json");
 const cleanLoggedIO = () => del("built/local/loggedIO.js");
 cleanTasks.push(cleanLoggedIO);
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -510,21 +510,15 @@ task("baseline-accept").description = "Makes the most recent test results the ne
 task("baseline-accept-rwc", () => baselineAccept(localRwcBaseline, refRwcBaseline));
 task("baseline-accept-rwc").description = "Makes the most recent rwc test results the new baseline, overwriting the old baseline";
 
-const buildLoggedIO = async () => {
-    mkdirp.sync("built/local/temp");
-    await exec(process.execPath, ["lib/tsc", "--types", "--target", "es5", "--lib", "es5", "--outdir", "built/local/temp", "src/harness/loggedIO.ts"]);
-    fs.renameSync("built/local/temp/harness/loggedIO.js", "built/local/loggedIO.js");
-    await del("built/local/temp");
-};
-
-const cleanLoggedIO = () => del("built/local/temp/loggedIO.js");
+const buildLoggedIO = () => buildProject("src/loggedIO");
+const cleanLoggedIO = () => del("built/local/loggedIO.js");
 cleanTasks.push(cleanLoggedIO);
 
 const buildInstrumenter = () => buildProject("src/instrumenter");
 const cleanInstrumenter = () => cleanProject("src/instrumenter");
 cleanTasks.push(cleanInstrumenter);
 
-const tscInstrumented = () => exec(process.execPath, ["built/local/instrumenter.js", "record", cmdLineOptions.tests || "iocapture", "built/local"]);
+const tscInstrumented = () => exec(process.execPath, ["built/local/instrumenter.js", "record", cmdLineOptions.tests || "iocapture", "built/local/tsc.js"]);
 task("tsc-instrumented", series(lkgPreBuild, parallel(localize, buildTsc, buildServer, buildServices, buildLssl, buildLoggedIO, buildInstrumenter), tscInstrumented));
 task("tsc-instrumented").description = "Builds an instrumented tsc.js";
 task("tsc-instrumented").flags = {

--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -38,7 +38,6 @@
         "virtualFileSystemWithWatch.ts",
         "fourslashImpl.ts",
         "fourslashInterfaceImpl.ts",
-        "typeWriter.ts",
-        "loggedIO.ts"
+        "typeWriter.ts"
     ]
 }

--- a/src/instrumenter/instrumenter.ts
+++ b/src/instrumenter/instrumenter.ts
@@ -15,36 +15,18 @@ ts.sys.startReplay("${ logFilename }");`);
 
 function instrument(tscPath: string, prepareCode: string, cleanupCode = "") {
     const bak = `${tscPath}.bak`;
-    fs.exists(bak, (backupExists: boolean) => {
-        let filename = tscPath;
-        if (backupExists) {
-            filename = bak;
-        }
-
-        fs.readFile(filename, "utf-8", (err: any, tscContent: string) => {
-            if (err) throw err;
-
-            fs.writeFile(bak, tscContent, (err: any) => {
-                if (err) throw err;
-
-                fs.readFile(path.resolve(path.dirname(tscPath) + "/loggedIO.js"), "utf-8", (err: any, loggerContent: string) => {
-                    if (err) throw err;
-
-                    const invocationLine = "ts.executeCommandLine(ts.sys.args);";
-                    const index1 = tscContent.indexOf(invocationLine);
-                    if (index1 < 0) {
-                        throw new Error(`Could not find ${invocationLine}`);
-                    }
-
-                    const index2 = index1 + invocationLine.length;
-                    const newContent = tscContent.substr(0, index1) + loggerContent + prepareCode + invocationLine + cleanupCode + tscContent.substr(index2) + "\r\n";
-                    fs.writeFile(tscPath, newContent, err => {
-                        if (err) throw err;
-                    });
-                });
-            });
-        });
-    });
+    const filename = fs.existsSync(bak) ? bak : tscPath;
+    const tscContent = fs.readFileSync(filename, "utf-8");
+    fs.writeFileSync(bak, tscContent);
+    const loggerContent = fs.readFileSync(path.resolve(path.dirname(tscPath) + "/loggedIO.js"), "utf-8")
+    const invocationLine = "ts.executeCommandLine(ts.sys, ts.noop, ts.sys.args);";
+    const index1 = tscContent.indexOf(invocationLine);
+    if (index1 < 0) {
+        throw new Error(`Could not find ${invocationLine}`);
+    }
+    const index2 = index1 + invocationLine.length;
+    const newContent = tscContent.substr(0, index1) + loggerContent + prepareCode + invocationLine + cleanupCode + tscContent.substr(index2) + "\r\n";
+    fs.writeFileSync(tscPath, newContent)
 }
 
 const isJson = (arg: string) => arg.indexOf(".json") > 0;
@@ -59,5 +41,3 @@ else if (process.argv.some(isJson)) {
     const filename = process.argv.filter(isJson)[0];
     instrumentForReplay(filename, tscPath);
 }
-
-

--- a/src/instrumenter/instrumenter.ts
+++ b/src/instrumenter/instrumenter.ts
@@ -18,7 +18,7 @@ function instrument(tscPath: string, prepareCode: string, cleanupCode = "") {
     const filename = fs.existsSync(bak) ? bak : tscPath;
     const tscContent = fs.readFileSync(filename, "utf-8");
     fs.writeFileSync(bak, tscContent);
-    const loggerContent = fs.readFileSync(path.resolve(path.dirname(tscPath) + "/loggedIO.js"), "utf-8")
+    const loggerContent = fs.readFileSync(path.resolve(path.dirname(tscPath) + "/loggedIO.js"), "utf-8");
     const invocationLine = "ts.executeCommandLine(ts.sys, ts.noop, ts.sys.args);";
     const index1 = tscContent.indexOf(invocationLine);
     if (index1 < 0) {
@@ -26,7 +26,7 @@ function instrument(tscPath: string, prepareCode: string, cleanupCode = "") {
     }
     const index2 = index1 + invocationLine.length;
     const newContent = tscContent.substr(0, index1) + loggerContent + prepareCode + invocationLine + cleanupCode + tscContent.substr(index2) + "\r\n";
-    fs.writeFileSync(tscPath, newContent)
+    fs.writeFileSync(tscPath, newContent);
 }
 
 const isJson = (arg: string) => arg.indexOf(".json") > 0;

--- a/src/loggedIO/loggedIO.ts
+++ b/src/loggedIO/loggedIO.ts
@@ -205,9 +205,7 @@ namespace Playback {
         return log;
     }
 
-    function initWrapper(wrapper: PlaybackSystem, underlying: ts.System): void;
-    function initWrapper(wrapper: PlaybackIO, underlying: Harness.IO): void;
-    function initWrapper(wrapper: PlaybackSystem | PlaybackIO, underlying: ts.System | Harness.IO): void {
+    export function initWrapper(...[wrapper, underlying]: [PlaybackSystem, ts.System] | [PlaybackIO, Harness.IO]): void {
         ts.forEach(Object.keys(underlying), prop => {
             (wrapper as any)[prop] = (underlying as any)[prop];
         });

--- a/src/loggedIO/tsconfig-tsc-instrumented.json
+++ b/src/loggedIO/tsconfig-tsc-instrumented.json
@@ -1,0 +1,25 @@
+{
+    "extends": "../tsconfig-base",
+    "compilerOptions": {
+        "outFile": "../../built/local/loggedIO.js",
+        "types": [
+            "node", "mocha", "chai"
+        ],
+        "lib": [
+            "es6",
+            "scripthost"
+        ]
+    },
+    "references": [
+        { "path": "../compiler", "prepend": true },
+        { "path": "../services", "prepend": true },
+        { "path": "../jsTyping", "prepend": true },
+        { "path": "../server", "prepend": true },
+        { "path": "../typingsInstallerCore", "prepend": true },
+        { "path": "../harness", "prepend": true },
+    ],
+
+    "files": [
+        "loggedIO.ts"
+    ]
+}

--- a/src/loggedIO/tsconfig.json
+++ b/src/loggedIO/tsconfig.json
@@ -10,12 +10,12 @@
         ]
     },
     "references": [
-        { "path": "../compiler", "prepend": true },
-        { "path": "../services", "prepend": true },
-        { "path": "../jsTyping", "prepend": true },
-        { "path": "../server", "prepend": true },
-        { "path": "../typingsInstallerCore", "prepend": true },
-        { "path": "../harness", "prepend": true },
+        { "path": "../compiler" },
+        { "path": "../services" },
+        { "path": "../jsTyping" },
+        { "path": "../server" },
+        { "path": "../typingsInstallerCore" },
+        { "path": "../harness" },
     ],
 
     "files": [

--- a/src/loggedIO/tsconfig.json
+++ b/src/loggedIO/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "extends": "../tsconfig-base",
+    "compilerOptions": {
+        "outFile": "../../built/local/loggedIO.js",
+        "types": [
+        ],
+        "lib": [
+            "es6",
+            "scripthost"
+        ]
+    },
+    "references": [
+        { "path": "../compiler", "prepend": true },
+        { "path": "../services", "prepend": true },
+        { "path": "../jsTyping", "prepend": true },
+        { "path": "../server", "prepend": true },
+        { "path": "../typingsInstallerCore", "prepend": true },
+        { "path": "../harness", "prepend": true },
+    ],
+
+    "files": [
+        "loggedIO.ts"
+    ]
+}

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -23,7 +23,8 @@
         { "path": "../server", "prepend": true },
         { "path": "../webServer", "prepend": true },
         { "path": "../typingsInstallerCore", "prepend": true },
-        { "path": "../harness", "prepend": true }
+        { "path": "../harness", "prepend": true },
+        { "path": "../loggedIO", "prepend": true }
     ],
 
     "files": [


### PR DESCRIPTION
loggedIO has a weird build that never got updated for the project build system. This PR just adds a project for it in a straightforward way. It might be less efficient than the old way, but that's not a big concern for recording RWC test cases.

However, I may have done things wrong. If anybody knows tsc-instrumented, please comment.