### PR TITLE
Fix __spreadArray for non-concat-spreadables

### DIFF
--- a/src/compiler/factory/emitHelpers.ts
+++ b/src/compiler/factory/emitHelpers.ts
@@ -647,7 +647,7 @@ namespace ts {
                         ar[i] = from[i];
                     }
                 }
-                return to.concat(ar || from);
+                return to.concat(ar || Array.prototype.slice.call(from));
             };`
     };
 

--- a/tests/baselines/reference/argumentExpressionContextualTyping.js
+++ b/tests/baselines/reference/argumentExpressionContextualTyping.js
@@ -26,7 +26,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // In a typed function call, argument expressions are contextually typed by their corresponding parameter types.
 function foo(_a) {

--- a/tests/baselines/reference/arrayLiteralExpressionContextualTyping.js
+++ b/tests/baselines/reference/arrayLiteralExpressionContextualTyping.js
@@ -23,7 +23,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // In a contextually typed array literal expression containing no spread elements, an element expression at index N is contextually typed by
 //      the type of the property with the numeric name N in the contextual type, if any, or otherwise

--- a/tests/baselines/reference/arrayLiteralSpread.js
+++ b/tests/baselines/reference/arrayLiteralSpread.js
@@ -31,7 +31,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 function f0() {
     var a = [1, 2, 3];

--- a/tests/baselines/reference/arrayLiteralSpreadES5iterable.js
+++ b/tests/baselines/reference/arrayLiteralSpreadES5iterable.js
@@ -47,7 +47,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 function f0() {
     var a = [1, 2, 3];

--- a/tests/baselines/reference/arrayLiterals2ES5.js
+++ b/tests/baselines/reference/arrayLiterals2ES5.js
@@ -69,7 +69,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // SpreadElement:
 //      ...   AssignmentExpression

--- a/tests/baselines/reference/arrayLiterals3.js
+++ b/tests/baselines/reference/arrayLiterals3.js
@@ -47,7 +47,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // The resulting type an array literal expression is determined as follows:
 //     - If the array literal contains no spread elements and is contextually typed by a tuple-like type,

--- a/tests/baselines/reference/callChain.js
+++ b/tests/baselines/reference/callChain.js
@@ -50,7 +50,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o;
 o1 === null || o1 === void 0 ? void 0 : o1();

--- a/tests/baselines/reference/callOverload.js
+++ b/tests/baselines/reference/callOverload.js
@@ -19,7 +19,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var n;
 fn(1); // no error

--- a/tests/baselines/reference/callWithSpread.js
+++ b/tests/baselines/reference/callWithSpread.js
@@ -81,7 +81,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var _a, _b, _c, _d, _e, _f, _g;
 function foo(x, y) {

--- a/tests/baselines/reference/callWithSpread2.js
+++ b/tests/baselines/reference/callWithSpread2.js
@@ -45,7 +45,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // good
 all.apply(void 0, ns);

--- a/tests/baselines/reference/callWithSpread3.js
+++ b/tests/baselines/reference/callWithSpread3.js
@@ -44,7 +44,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // error
 fs2.apply(void 0, __spreadArray(['a'], s2, false)); // error on ...s2

--- a/tests/baselines/reference/callWithSpread5.js
+++ b/tests/baselines/reference/callWithSpread5.js
@@ -16,7 +16,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 fn.apply(void 0, __spreadArray(__spreadArray([], nnnu, false), [x], false));
 fn.apply(void 0, __spreadArray(__spreadArray([], nntnnnt, false), [x], false));

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.js
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.js
@@ -77,7 +77,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // In a destructuring assignment expression, the type of the expression on the right must be assignable to the assignment target on the left.
 // An expression of type S is considered assignable to an assignment target V if one of the following is true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.js
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.js
@@ -93,7 +93,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // In a destructuring assignment expression, the type of the expression on the right must be assignable to the assignment target on the left.
 // An expression of type S is considered assignable to an assignment target V if one of the following is true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.js
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.js
@@ -42,7 +42,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // V is an array assignment pattern, S is the type Any or an array-like type (section 3.3.2), and, for each assignment element E in V,
 //      S is the type Any, or

--- a/tests/baselines/reference/destructuringParameterDeclaration3ES5iterable.js
+++ b/tests/baselines/reference/destructuringParameterDeclaration3ES5iterable.js
@@ -71,7 +71,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 function a1() {
     var x = [];

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5.js
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5.js
@@ -49,7 +49,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // The type T associated with a destructuring variable declaration is determined as follows:
 //      If the declaration includes a type annotation, T is that type.

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.js
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.js
@@ -65,7 +65,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // The type T associated with a destructuring variable declaration is determined as follows:
 //      If the declaration includes a type annotation, T is that type.

--- a/tests/baselines/reference/excessiveStackDepthFlatArray.js
+++ b/tests/baselines/reference/excessiveStackDepthFlatArray.js
@@ -48,7 +48,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 configureStore({
     middleware: __spreadArray([], defaultMiddleware, true)

--- a/tests/baselines/reference/excessivelyLargeTupleSpread.js
+++ b/tests/baselines/reference/excessivelyLargeTupleSpread.js
@@ -48,7 +48,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var a0 = [0];
 var a1 = __spreadArray(__spreadArray([], a0, true), a0, true);

--- a/tests/baselines/reference/functionParameterArityMismatch.js
+++ b/tests/baselines/reference/functionParameterArityMismatch.js
@@ -24,7 +24,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 f1();
 f1(1, 2);

--- a/tests/baselines/reference/genericRestParameters1.js
+++ b/tests/baselines/reference/genericRestParameters1.js
@@ -174,7 +174,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 f1 = f2;
 f2 = f1;

--- a/tests/baselines/reference/genericRestParameters2.js
+++ b/tests/baselines/reference/genericRestParameters2.js
@@ -88,7 +88,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 f10(42, "hello");
 f10(42, "hello", true);

--- a/tests/baselines/reference/genericRestParameters3.js
+++ b/tests/baselines/reference/genericRestParameters3.js
@@ -75,7 +75,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 f1("foo", "abc");
 f1("foo", 10, true);

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -681,7 +681,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var Shape = /** @class */ (function () {
     function Shape() {

--- a/tests/baselines/reference/literalFreshnessPropagationOnNarrowing.js
+++ b/tests/baselines/reference/literalFreshnessPropagationOnNarrowing.js
@@ -69,7 +69,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 function f1() {
     var b = true;

--- a/tests/baselines/reference/newWithSpread.js
+++ b/tests/baselines/reference/newWithSpread.js
@@ -104,7 +104,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t;
 function f(x, y) {

--- a/tests/baselines/reference/newWithSpreadES5.js
+++ b/tests/baselines/reference/newWithSpreadES5.js
@@ -103,7 +103,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t;
 function f(x, y) {

--- a/tests/baselines/reference/noCrashOnNoLib.js
+++ b/tests/baselines/reference/noCrashOnNoLib.js
@@ -15,7 +15,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 exports.__esModule = true;
 exports.f = void 0;

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.js
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.js
@@ -80,7 +80,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 function fn(a, b, c, d, e, f, g) {
     var c_1, c_1_1;

--- a/tests/baselines/reference/readonlyRestParameters.js
+++ b/tests/baselines/reference/readonlyRestParameters.js
@@ -36,7 +36,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 function f0(a, b) {
     f0(a, b);

--- a/tests/baselines/reference/recursiveReverseMappedType.js
+++ b/tests/baselines/reference/recursiveReverseMappedType.js
@@ -24,7 +24,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 function join(l) {
     return __spreadArray(['marker'], l, true);

--- a/tests/baselines/reference/recursiveTypeReferences1.js
+++ b/tests/baselines/reference/recursiveTypeReferences1.js
@@ -139,7 +139,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var a0 = 1;
 var a1 = [1, [2, 3], [4, [5, [6, 7]]]];

--- a/tests/baselines/reference/restTuplesFromContextualTypes.js
+++ b/tests/baselines/reference/restTuplesFromContextualTypes.js
@@ -108,7 +108,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 (function (a, b, c) { }).apply(void 0, t1);
 (function () {

--- a/tests/baselines/reference/selfReferencingSpreadInLoop.js
+++ b/tests/baselines/reference/selfReferencingSpreadInLoop.js
@@ -13,7 +13,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var additional = [];
 for (var _i = 0, _a = [1, 2, 3]; _i < _a.length; _i++) {

--- a/tests/baselines/reference/spliceTuples.js
+++ b/tests/baselines/reference/spliceTuples.js
@@ -32,7 +32,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var k1;
 k1 = __spreadArray([1], sb, true);

--- a/tests/baselines/reference/spreadBooleanRespectsFreshness.js
+++ b/tests/baselines/reference/spreadBooleanRespectsFreshness.js
@@ -15,6 +15,6 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 foo1 = __spreadArray([], Array.isArray(foo2) ? foo2 : [foo2], true);

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
@@ -49,7 +49,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -145,7 +145,7 @@ sourceFile:../lib/file0.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -781,7 +781,7 @@ sourceFile:file4.ts
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/app/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":2229,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1370,"end":2229,"kind":"text"}]},{"pos":2229,"end":2826,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":894,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":896,"end":1396,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1398,"end":2257,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1398,"end":2257,"kind":"text"}]},{"pos":2257,"end":2854,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/app/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -805,7 +805,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-866):: typescript:spreadArray
+emitHelpers: (506-894):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -813,10 +813,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-emitHelpers: (868-1368):: typescript:rest
+emitHelpers: (896-1396):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -829,9 +829,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1370-2229):: ../lib/module.js texts:: 1
+prepend: (1398-2257):: ../lib/module.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1370-2229)
+text: (1398-2257)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -860,7 +860,7 @@ define("file2", ["require", "exports"], function (require, exports) {
 var globalConst = 10;
 
 ----------------------------------------------------------------------
-text: (2229-2826)
+text: (2257-2854)
 define("file3", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -927,32 +927,32 @@ declare const appfile4_ar: number[];
         },
         {
           "pos": 506,
-          "end": 866,
+          "end": 894,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 868,
-          "end": 1368,
+          "pos": 896,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1370,
-          "end": 2229,
+          "pos": 1398,
+          "end": 2257,
           "kind": "prepend",
           "data": "../lib/module.js",
           "texts": [
             {
-              "pos": 1370,
-              "end": 2229,
+              "pos": 1398,
+              "end": 2257,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2229,
-          "end": 2826,
+          "pos": 2257,
+          "end": 2854,
           "kind": "text"
         }
       ],
@@ -1018,7 +1018,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -1096,7 +1096,7 @@ sourceFile:file0.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -1460,7 +1460,7 @@ sourceFile:global.ts
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":2229,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":894,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":896,"end":1396,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1398,"end":2257,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/lib/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1484,7 +1484,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-866):: typescript:spreadArray
+emitHelpers: (506-894):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -1492,10 +1492,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-emitHelpers: (868-1368):: typescript:rest
+emitHelpers: (896-1396):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1508,7 +1508,7 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-text: (1370-2229)
+text: (1398-2257)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -1574,19 +1574,19 @@ declare const globalConst = 10;
         },
         {
           "pos": 506,
-          "end": 866,
+          "end": 894,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 868,
-          "end": 1368,
+          "pos": 896,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1370,
-          "end": 2229,
+          "pos": 1398,
+          "end": 2257,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
@@ -47,7 +47,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -140,7 +140,7 @@ sourceFile:../lib/file0.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -667,7 +667,7 @@ sourceFile:file4.ts
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/app/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":2115,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1370,"end":2115,"kind":"text"}]},{"pos":2115,"end":2712,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":894,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":896,"end":1396,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1398,"end":2143,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1398,"end":2143,"kind":"text"}]},{"pos":2143,"end":2740,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/app/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -691,7 +691,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-866):: typescript:spreadArray
+emitHelpers: (506-894):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -699,10 +699,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-emitHelpers: (868-1368):: typescript:rest
+emitHelpers: (896-1396):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -715,9 +715,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1370-2115):: ../lib/module.js texts:: 1
+prepend: (1398-2143):: ../lib/module.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1370-2115)
+text: (1398-2143)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -743,7 +743,7 @@ define("file2", ["require", "exports"], function (require, exports) {
 var globalConst = 10;
 
 ----------------------------------------------------------------------
-text: (2115-2712)
+text: (2143-2740)
 define("file3", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -810,32 +810,32 @@ declare const appfile4_ar: number[];
         },
         {
           "pos": 506,
-          "end": 866,
+          "end": 894,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 868,
-          "end": 1368,
+          "pos": 896,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1370,
-          "end": 2115,
+          "pos": 1398,
+          "end": 2143,
           "kind": "prepend",
           "data": "../lib/module.js",
           "texts": [
             {
-              "pos": 1370,
-              "end": 2115,
+              "pos": 1398,
+              "end": 2143,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2115,
-          "end": 2712,
+          "pos": 2143,
+          "end": 2740,
           "kind": "text"
         }
       ],
@@ -901,7 +901,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var myGlob = 20;
 function libfile0Spread() {
@@ -965,7 +965,7 @@ sourceFile:file0.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var myGlob = 20;
 1 >
@@ -1209,7 +1209,7 @@ sourceFile:global.ts
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1613,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":894,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":896,"end":1641,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/lib/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1233,7 +1233,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-866):: typescript:spreadArray
+emitHelpers: (506-894):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -1241,10 +1241,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-text: (868-1613)
+text: (896-1641)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -1307,13 +1307,13 @@ declare const globalConst = 10;
         },
         {
           "pos": 506,
-          "end": 866,
+          "end": 894,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 868,
-          "end": 1613,
+          "pos": 896,
+          "end": 1641,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/initial-build/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/initial-build/multiple-emitHelpers-in-all-projects.js
@@ -414,7 +414,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -509,7 +509,7 @@ sourceFile:../lib/file0.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -1118,7 +1118,7 @@ sourceFile:file4.ts
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/app/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":2200,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1370,"end":2200,"kind":"text"}]},{"pos":2200,"end":2797,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file3.ts","./file4.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":894,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":896,"end":1396,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1398,"end":2228,"kind":"prepend","data":"../lib/module.js","texts":[{"pos":1398,"end":2228,"kind":"text"}]},{"pos":2228,"end":2825,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"prepend","data":"../lib/module.d.ts","texts":[{"pos":0,"end":265,"kind":"text"}]},{"pos":265,"end":441,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/app/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1142,7 +1142,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-866):: typescript:spreadArray
+emitHelpers: (506-894):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -1150,10 +1150,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-emitHelpers: (868-1368):: typescript:rest
+emitHelpers: (896-1396):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1166,9 +1166,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1370-2200):: ../lib/module.js texts:: 1
+prepend: (1398-2228):: ../lib/module.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1370-2200)
+text: (1398-2228)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -1196,7 +1196,7 @@ define("file2", ["require", "exports"], function (require, exports) {
 var globalConst = 10;
 
 ----------------------------------------------------------------------
-text: (2200-2797)
+text: (2228-2825)
 define("file3", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -1263,32 +1263,32 @@ declare const appfile4_ar: number[];
         },
         {
           "pos": 506,
-          "end": 866,
+          "end": 894,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 868,
-          "end": 1368,
+          "pos": 896,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1370,
-          "end": 2200,
+          "pos": 1398,
+          "end": 2228,
           "kind": "prepend",
           "data": "../lib/module.js",
           "texts": [
             {
-              "pos": 1370,
-              "end": 2200,
+              "pos": 1398,
+              "end": 2228,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2200,
-          "end": 2797,
+          "pos": 2228,
+          "end": 2825,
           "kind": "text"
         }
       ],
@@ -1535,7 +1535,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -1612,7 +1612,7 @@ sourceFile:file0.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -1949,7 +1949,7 @@ sourceFile:global.ts
 >>>//# sourceMappingURL=module.js.map
 
 //// [/src/lib/module.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":2200,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"./","sourceFiles":["./file0.ts","./file1.ts","./file2.ts","./global.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":894,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":896,"end":1396,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1398,"end":2228,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray","typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":265,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/lib/module.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1973,7 +1973,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-866):: typescript:spreadArray
+emitHelpers: (506-894):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -1981,10 +1981,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-emitHelpers: (868-1368):: typescript:rest
+emitHelpers: (896-1396):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1997,7 +1997,7 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-text: (1370-2200)
+text: (1398-2228)
 var myGlob = 20;
 function libfile0Spread() {
     var b = [];
@@ -2062,19 +2062,19 @@ declare const globalConst = 10;
         },
         {
           "pos": 506,
-          "end": 866,
+          "end": 894,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 868,
-          "end": 1368,
+          "pos": 896,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1370,
-          "end": 2200,
+          "pos": 1398,
+          "end": 2228,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-all-projects.js
@@ -77,7 +77,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var s = "Hello, world";
 console.log(s);
@@ -147,7 +147,7 @@ sourceFile:../first_PART1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -528,7 +528,7 @@ sourceFile:../first_part3.ts
 >>>//# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1896,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1396,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1398,"end":1924,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/first/bin/first-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -565,7 +565,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1368):: typescript:spreadArray
+emitHelpers: (1008-1396):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -573,10 +573,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-text: (1370-1896)
+text: (1398-1924)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -640,13 +640,13 @@ declare const firstfirst_part3_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1368,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1370,
-          "end": 1896,
+          "pos": 1398,
+          "end": 1924,
           "kind": "text"
         }
       ],
@@ -707,7 +707,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var s = "Hello, world";
 console.log(s);
@@ -816,7 +816,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -1932,7 +1932,7 @@ sourceFile:../../third_part1.ts
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1896,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1896,"kind":"text"}]},{"pos":1896,"end":2590,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1896,"end":2590,"kind":"text"}]},{"pos":2590,"end":3025,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1396,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1398,"end":1924,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1398,"end":1924,"kind":"text"}]},{"pos":1924,"end":2618,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1924,"end":2618,"kind":"text"}]},{"pos":2618,"end":3053,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1969,7 +1969,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1368):: typescript:spreadArray
+emitHelpers: (1008-1396):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -1977,12 +1977,12 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-prepend: (1370-1896):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1398-1924):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1370-1896)
+text: (1398-1924)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -2003,9 +2003,9 @@ var firstfirst_part3_ar = [20, 30];
 firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 
 ----------------------------------------------------------------------
-prepend: (1896-2590):: ../../../2/second-output.js texts:: 1
+prepend: (1924-2618):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1896-2590)
+text: (1924-2618)
 var N;
 (function (N) {
     function f() {
@@ -2034,7 +2034,7 @@ var secondsecond_part2_ar = [20, 30];
 secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 
 ----------------------------------------------------------------------
-text: (2590-3025)
+text: (2618-3053)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -2115,39 +2115,39 @@ declare const thirdthird_part1_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1368,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1370,
-          "end": 1896,
+          "pos": 1398,
+          "end": 1924,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1370,
-              "end": 1896,
+              "pos": 1398,
+              "end": 1924,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1896,
-          "end": 2590,
+          "pos": 1924,
+          "end": 2618,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1896,
-              "end": 2590,
+              "pos": 1924,
+              "end": 2618,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2590,
-          "end": 3025,
+          "pos": 2618,
+          "end": 3053,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-different-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-declaration-doesnt-change/multiple-emitHelpers-in-different-projects.js
@@ -479,7 +479,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var s = "Hello, world";
 console.log(s);
@@ -569,7 +569,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -1350,7 +1350,7 @@ sourceFile:../../third_part1.ts
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1614,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1614,"kind":"text"}]},{"pos":1614,"end":2189,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1614,"end":2189,"kind":"text"}]},{"pos":2189,"end":2342,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1396,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1398,"end":1642,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1398,"end":1642,"kind":"text"}]},{"pos":1642,"end":2217,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1642,"end":2217,"kind":"text"}]},{"pos":2217,"end":2370,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1387,7 +1387,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1368):: typescript:spreadArray
+emitHelpers: (1008-1396):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -1395,12 +1395,12 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-prepend: (1370-1614):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1398-1642):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1370-1614)
+text: (1398-1642)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -1413,9 +1413,9 @@ function f() {
 }
 
 ----------------------------------------------------------------------
-prepend: (1614-2189):: ../../../2/second-output.js texts:: 1
+prepend: (1642-2217):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1614-2189)
+text: (1642-2217)
 var N;
 (function (N) {
     function f() {
@@ -1441,7 +1441,7 @@ var C = (function () {
 }());
 
 ----------------------------------------------------------------------
-text: (2189-2342)
+text: (2217-2370)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -1509,39 +1509,39 @@ declare function forthirdthird_part1Rest(): void;
         },
         {
           "pos": 1008,
-          "end": 1368,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1370,
-          "end": 1614,
+          "pos": 1398,
+          "end": 1642,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1370,
-              "end": 1614,
+              "pos": 1398,
+              "end": 1642,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1614,
-          "end": 2189,
+          "pos": 1642,
+          "end": 2217,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1614,
-              "end": 2189,
+              "pos": 1642,
+              "end": 2217,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2189,
-          "end": 2342,
+          "pos": 2217,
+          "end": 2370,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-all-projects.js
@@ -263,7 +263,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var s = "Hello, world";
 console.log(s);
@@ -319,7 +319,7 @@ sourceFile:../first_PART1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -590,7 +590,7 @@ sourceFile:../first_part3.ts
 >>>//# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1300,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":894,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":896,"end":1328,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/first/bin/first-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -614,7 +614,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-866):: typescript:spreadArray
+emitHelpers: (506-894):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -622,10 +622,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-text: (868-1300)
+text: (896-1328)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() { }
@@ -680,13 +680,13 @@ declare const firstfirst_part3_ar: number[];
         },
         {
           "pos": 506,
-          "end": 866,
+          "end": 894,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 868,
-          "end": 1300,
+          "pos": 896,
+          "end": 1328,
           "kind": "text"
         }
       ],
@@ -1188,7 +1188,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -1294,7 +1294,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -2311,7 +2311,7 @@ sourceFile:../../third_part1.ts
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":1802,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1802,"kind":"text"}]},{"pos":1802,"end":2496,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1802,"end":2496,"kind":"text"}]},{"pos":2496,"end":2931,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":894,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":896,"end":1396,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1398,"end":1830,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1398,"end":1830,"kind":"text"}]},{"pos":1830,"end":2524,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1830,"end":2524,"kind":"text"}]},{"pos":2524,"end":2959,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -2335,7 +2335,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-866):: typescript:spreadArray
+emitHelpers: (506-894):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -2343,10 +2343,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-emitHelpers: (868-1368):: typescript:rest
+emitHelpers: (896-1396):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -2359,9 +2359,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1370-1802):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1398-1830):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1370-1802)
+text: (1398-1830)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() { }
@@ -2379,9 +2379,9 @@ var firstfirst_part3_ar = [20, 30];
 firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 
 ----------------------------------------------------------------------
-prepend: (1802-2496):: ../../../2/second-output.js texts:: 1
+prepend: (1830-2524):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1802-2496)
+text: (1830-2524)
 var N;
 (function (N) {
     function f() {
@@ -2410,7 +2410,7 @@ var secondsecond_part2_ar = [20, 30];
 secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 
 ----------------------------------------------------------------------
-text: (2496-2931)
+text: (2524-2959)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -2485,45 +2485,45 @@ declare const thirdthird_part1_ar: number[];
         },
         {
           "pos": 506,
-          "end": 866,
+          "end": 894,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 868,
-          "end": 1368,
+          "pos": 896,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1370,
-          "end": 1802,
+          "pos": 1398,
+          "end": 1830,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1370,
-              "end": 1802,
+              "pos": 1398,
+              "end": 1830,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1802,
-          "end": 2496,
+          "pos": 1830,
+          "end": 2524,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1802,
-              "end": 2496,
+              "pos": 1830,
+              "end": 2524,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2496,
-          "end": 2931,
+          "pos": 2524,
+          "end": 2959,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-different-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/incremental-headers-change-without-dts-changes/multiple-emitHelpers-in-different-projects.js
@@ -784,7 +784,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
@@ -871,7 +871,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var __rest = (this && this.__rest) || function (s, e) {
 >>>    var t = {};
@@ -1553,7 +1553,7 @@ sourceFile:../../third_part1.ts
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1368,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1370,"end":1520,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1520,"kind":"text"}]},{"pos":1520,"end":2095,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1520,"end":2095,"kind":"text"}]},{"pos":2095,"end":2248,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":894,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":896,"end":1396,"kind":"emitHelpers","data":"typescript:rest"},{"pos":1398,"end":1548,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1398,"end":1548,"kind":"text"}]},{"pos":1548,"end":2123,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1548,"end":2123,"kind":"text"}]},{"pos":2123,"end":2276,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1577,7 +1577,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-866):: typescript:spreadArray
+emitHelpers: (506-894):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -1585,10 +1585,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-emitHelpers: (868-1368):: typescript:rest
+emitHelpers: (896-1396):: typescript:rest
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -1601,9 +1601,9 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 ----------------------------------------------------------------------
-prepend: (1370-1520):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1398-1548):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1370-1520)
+text: (1398-1548)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() { }
@@ -1613,9 +1613,9 @@ function f() {
 }
 
 ----------------------------------------------------------------------
-prepend: (1520-2095):: ../../../2/second-output.js texts:: 1
+prepend: (1548-2123):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1520-2095)
+text: (1548-2123)
 var N;
 (function (N) {
     function f() {
@@ -1641,7 +1641,7 @@ var C = (function () {
 }());
 
 ----------------------------------------------------------------------
-text: (2095-2248)
+text: (2123-2276)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -1703,45 +1703,45 @@ declare function forthirdthird_part1Rest(): void;
         },
         {
           "pos": 506,
-          "end": 866,
+          "end": 894,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 868,
-          "end": 1368,
+          "pos": 896,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:rest"
         },
         {
-          "pos": 1370,
-          "end": 1520,
+          "pos": 1398,
+          "end": 1548,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1370,
-              "end": 1520,
+              "pos": 1398,
+              "end": 1548,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1520,
-          "end": 2095,
+          "pos": 1548,
+          "end": 2123,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1520,
-              "end": 2095,
+              "pos": 1548,
+              "end": 2123,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2095,
-          "end": 2248,
+          "pos": 2123,
+          "end": 2276,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-all-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-all-projects.js
@@ -386,7 +386,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var N;
 (function (N) {
@@ -464,7 +464,7 @@ sourceFile:../second/second_part1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var N;
 1 >
@@ -929,7 +929,7 @@ sourceFile:../second/second_part2.ts
 >>>//# sourceMappingURL=second-output.js.map
 
 //// [/src/2/second-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":2064,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":267,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1396,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1398,"end":2092,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":267,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/2/second-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -966,7 +966,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1368):: typescript:spreadArray
+emitHelpers: (1008-1396):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -974,10 +974,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-text: (1370-2064)
+text: (1398-2092)
 var N;
 (function (N) {
     function f() {
@@ -1047,13 +1047,13 @@ declare const secondsecond_part2_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1368,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1370,
-          "end": 2064,
+          "pos": 1398,
+          "end": 2092,
           "kind": "text"
         }
       ],
@@ -1331,7 +1331,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var s = "Hello, world";
 console.log(s);
@@ -1400,7 +1400,7 @@ sourceFile:../first_PART1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -1754,7 +1754,7 @@ sourceFile:../first_part3.ts
 >>>//# sourceMappingURL=first-output.js.map
 
 //// [/src/first/bin/first-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1879,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"..","sourceFiles":["../first_PART1.ts","../first_part2.ts","../first_part3.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1396,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1398,"end":1907,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/first/bin/first-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -1791,7 +1791,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1368):: typescript:spreadArray
+emitHelpers: (1008-1396):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -1799,10 +1799,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-text: (1370-1879)
+text: (1398-1907)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -1865,13 +1865,13 @@ declare const firstfirst_part3_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1368,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1370,
-          "end": 1879,
+          "pos": 1398,
+          "end": 1907,
           "kind": "text"
         }
       ],
@@ -2415,7 +2415,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var s = "Hello, world";
 console.log(s);
@@ -2523,7 +2523,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -3612,7 +3612,7 @@ sourceFile:../../third_part1.ts
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1879,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1879,"kind":"text"}]},{"pos":1879,"end":2573,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1879,"end":2573,"kind":"text"}]},{"pos":2573,"end":3008,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1396,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1398,"end":1907,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1398,"end":1907,"kind":"text"}]},{"pos":1907,"end":2601,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1907,"end":2601,"kind":"text"}]},{"pos":2601,"end":3036,"kind":"text"}],"sources":{"helpers":["typescript:rest","typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":318,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":318,"kind":"text"}]},{"pos":318,"end":585,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":318,"end":585,"kind":"text"}]},{"pos":585,"end":765,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -3649,7 +3649,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1368):: typescript:spreadArray
+emitHelpers: (1008-1396):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -3657,12 +3657,12 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-prepend: (1370-1879):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1398-1907):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1370-1879)
+text: (1398-1907)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -3682,9 +3682,9 @@ var firstfirst_part3_ar = [20, 30];
 firstfirst_part3Spread.apply(void 0, __spreadArray([10], __read(firstfirst_part3_ar), false));
 
 ----------------------------------------------------------------------
-prepend: (1879-2573):: ../../../2/second-output.js texts:: 1
+prepend: (1907-2601):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1879-2573)
+text: (1907-2601)
 var N;
 (function (N) {
     function f() {
@@ -3713,7 +3713,7 @@ var secondsecond_part2_ar = [20, 30];
 secondsecond_part2Spread.apply(void 0, __spreadArray([10], __read(secondsecond_part2_ar), false));
 
 ----------------------------------------------------------------------
-text: (2573-3008)
+text: (2601-3036)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -3794,39 +3794,39 @@ declare const thirdthird_part1_ar: number[];
         },
         {
           "pos": 1008,
-          "end": 1368,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1370,
-          "end": 1879,
+          "pos": 1398,
+          "end": 1907,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1370,
-              "end": 1879,
+              "pos": 1398,
+              "end": 1907,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1879,
-          "end": 2573,
+          "pos": 1907,
+          "end": 2601,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1879,
-              "end": 2573,
+              "pos": 1907,
+              "end": 2601,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2573,
-          "end": 3008,
+          "pos": 2601,
+          "end": 3036,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-different-projects.js
+++ b/tests/baselines/reference/tsbuild/outfile-concat/initial-build/multiple-emitHelpers-in-different-projects.js
@@ -347,7 +347,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var N;
 (function (N) {
@@ -411,7 +411,7 @@ sourceFile:../second/second_part1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var N;
 1 >
@@ -775,7 +775,7 @@ sourceFile:../second/second_part2.ts
 >>>//# sourceMappingURL=second-output.js.map
 
 //// [/src/2/second-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":866,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":868,"end":1443,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":214,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../second","sourceFiles":["../second/second_part1.ts","../second/second_part2.ts"],"js":{"sections":[{"pos":0,"end":504,"kind":"emitHelpers","data":"typescript:read"},{"pos":506,"end":894,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":896,"end":1471,"kind":"text"}],"sources":{"helpers":["typescript:read","typescript:spreadArray"]}},"dts":{"sections":[{"pos":0,"end":214,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/2/second-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -799,7 +799,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (506-866):: typescript:spreadArray
+emitHelpers: (506-894):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -807,10 +807,10 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-text: (868-1443)
+text: (896-1471)
 var N;
 (function (N) {
     function f() {
@@ -870,13 +870,13 @@ declare class C {
         },
         {
           "pos": 506,
-          "end": 866,
+          "end": 894,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 868,
-          "end": 1443,
+          "pos": 896,
+          "end": 1471,
           "kind": "text"
         }
       ],
@@ -1830,7 +1830,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var s = "Hello, world";
 console.log(s);
@@ -1919,7 +1919,7 @@ sourceFile:../../../first/first_PART1.ts
 >>>            ar[i] = from[i];
 >>>        }
 >>>    }
->>>    return to.concat(ar || from);
+>>>    return to.concat(ar || Array.prototype.slice.call(from));
 >>>};
 >>>var s = "Hello, world";
 1 >
@@ -2673,7 +2673,7 @@ sourceFile:../../third_part1.ts
 >>>//# sourceMappingURL=third-output.js.map
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo]
-{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1368,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1370,"end":1597,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1370,"end":1597,"kind":"text"}]},{"pos":1597,"end":2172,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1597,"end":2172,"kind":"text"}]},{"pos":2172,"end":2325,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
+{"bundle":{"commonSourceDirectory":"../..","sourceFiles":["../../third_part1.ts"],"js":{"sections":[{"pos":0,"end":500,"kind":"emitHelpers","data":"typescript:rest"},{"pos":502,"end":1006,"kind":"emitHelpers","data":"typescript:read"},{"pos":1008,"end":1396,"kind":"emitHelpers","data":"typescript:spreadArray"},{"pos":1398,"end":1625,"kind":"prepend","data":"../../../first/bin/first-output.js","texts":[{"pos":1398,"end":1625,"kind":"text"}]},{"pos":1625,"end":2200,"kind":"prepend","data":"../../../2/second-output.js","texts":[{"pos":1625,"end":2200,"kind":"text"}]},{"pos":2200,"end":2353,"kind":"text"}],"sources":{"helpers":["typescript:rest"]}},"dts":{"sections":[{"pos":0,"end":208,"kind":"prepend","data":"../../../first/bin/first-output.d.ts","texts":[{"pos":0,"end":208,"kind":"text"}]},{"pos":208,"end":422,"kind":"prepend","data":"../../../2/second-output.d.ts","texts":[{"pos":208,"end":422,"kind":"text"}]},{"pos":422,"end":492,"kind":"text"}]}},"version":"FakeTSVersion"}
 
 //// [/src/third/thirdjs/output/third-output.tsbuildinfo.baseline.txt]
 ======================================================================
@@ -2710,7 +2710,7 @@ var __read = (this && this.__read) || function (o, n) {
     return ar;
 };
 ----------------------------------------------------------------------
-emitHelpers: (1008-1368):: typescript:spreadArray
+emitHelpers: (1008-1396):: typescript:spreadArray
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -2718,12 +2718,12 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 ----------------------------------------------------------------------
-prepend: (1370-1597):: ../../../first/bin/first-output.js texts:: 1
+prepend: (1398-1625):: ../../../first/bin/first-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1370-1597)
+text: (1398-1625)
 var s = "Hello, world";
 console.log(s);
 function forfirstfirst_PART1Rest() {
@@ -2735,9 +2735,9 @@ function f() {
 }
 
 ----------------------------------------------------------------------
-prepend: (1597-2172):: ../../../2/second-output.js texts:: 1
+prepend: (1625-2200):: ../../../2/second-output.js texts:: 1
 >>--------------------------------------------------------------------
-text: (1597-2172)
+text: (1625-2200)
 var N;
 (function (N) {
     function f() {
@@ -2763,7 +2763,7 @@ var C = (function () {
 }());
 
 ----------------------------------------------------------------------
-text: (2172-2325)
+text: (2200-2353)
 var c = new C();
 c.doSomething();
 function forthirdthird_part1Rest() {
@@ -2831,39 +2831,39 @@ declare function forthirdthird_part1Rest(): void;
         },
         {
           "pos": 1008,
-          "end": 1368,
+          "end": 1396,
           "kind": "emitHelpers",
           "data": "typescript:spreadArray"
         },
         {
-          "pos": 1370,
-          "end": 1597,
+          "pos": 1398,
+          "end": 1625,
           "kind": "prepend",
           "data": "../../../first/bin/first-output.js",
           "texts": [
             {
-              "pos": 1370,
-              "end": 1597,
+              "pos": 1398,
+              "end": 1625,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 1597,
-          "end": 2172,
+          "pos": 1625,
+          "end": 2200,
           "kind": "prepend",
           "data": "../../../2/second-output.js",
           "texts": [
             {
-              "pos": 1597,
-              "end": 2172,
+              "pos": 1625,
+              "end": 2200,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 2172,
-          "end": 2325,
+          "pos": 2200,
+          "end": 2353,
           "kind": "text"
         }
       ],

--- a/tests/baselines/reference/tsxEmit1.js
+++ b/tests/baselines/reference/tsxEmit1.js
@@ -48,7 +48,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var p;
 var selfClosed1 = <div />;

--- a/tests/baselines/reference/tsxReactEmit1.js
+++ b/tests/baselines/reference/tsxReactEmit1.js
@@ -49,7 +49,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var p;
 var selfClosed1 = React.createElement("div", null);

--- a/tests/baselines/reference/typedArrays-es5.js
+++ b/tests/baselines/reference/typedArrays-es5.js
@@ -40,7 +40,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 var float32Array = new Float32Array(1);
 __spreadArray([], float32Array, true);

--- a/tests/baselines/reference/variadicTuples1.js
+++ b/tests/baselines/reference/variadicTuples1.js
@@ -412,7 +412,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 // Variadics in array literals
 function tup2(t, u) {

--- a/tests/baselines/reference/variadicTuples2.js
+++ b/tests/baselines/reference/variadicTuples2.js
@@ -141,7 +141,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 tt1 = [5];
 tt1 = ['abc', 5];


### PR DESCRIPTION
The `__spreadArray` helper uses `Array.concat`, which doesn't work with DOM NodeList or HTMLCollection. This changes the `__spreadArray` helper to fall back to `Array.prototype.slice.call(from)` to ensure the elements of `from` are concatenated properly.

Fixes TypeScript side of https://github.com/microsoft/tslib/issues/153
