### PR TITLE
Reuse checker's property accessibility check for completions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -736,8 +736,10 @@ namespace ts {
 
             getLocalTypeParametersOfClassOrInterfaceOrTypeAlias,
             isDeclarationVisible,
-            isPropertyAccessible: (node, isSuper, writing, type, prop) => {
-                return checkPropertyAccessibilityAtNode(node, isSuper, writing, type, prop).result === TypeChecks.Ok;
+            isPropertyAccessible: (nodeIn, isSuper, writing, type, prop) => {
+                const node = getParseTreeNode(nodeIn);
+                return node ?
+                    checkPropertyAccessibilityAtNode(node, isSuper, writing, type, prop).result === TypeChecks.Ok : false;
             }
         };
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -263,30 +263,6 @@ namespace ts {
         Uncapitalize: IntrinsicTypeKind.Uncapitalize
     }));
 
-    enum TypeChecks {
-        Ok,
-        HasDiagnostic
-    }
-
-    interface CheckerResultOk {
-        result: TypeChecks.Ok
-    }
-
-    interface CheckerResultHasDiagnostic {
-        result: TypeChecks.HasDiagnostic,
-        message: DiagnosticMessage;
-        args:
-            | never[]
-            | [string | number]
-            | [string | number, string | number]
-            | [string | number, string | number, string | number]
-            | [string | number, string | number, string | number, string | number];
-    }
-
-    type CheckerResult =
-        | CheckerResultOk
-        | CheckerResultHasDiagnostic;
-
     function SymbolLinks(this: SymbolLinks) {
     }
 
@@ -736,9 +712,7 @@ namespace ts {
 
             getLocalTypeParametersOfClassOrInterfaceOrTypeAlias,
             isDeclarationVisible,
-            isPropertyAccessible: (node, isSuper, writing, type, prop) => {
-                return checkPropertyAccessibilityAtNode(node, isSuper, writing, type, prop).result === TypeChecks.Ok;
-            }
+            isPropertyAccessible,
         };
 
         function getResolvedSignatureWorker(nodeIn: CallLikeExpression, candidatesOutArray: Signature[] | undefined, argumentCount: number | undefined, checkMode: CheckMode): Signature | undefined {
@@ -27293,35 +27267,28 @@ namespace ts {
             node: PropertyAccessExpression | QualifiedName | PropertyAccessExpression | VariableDeclaration | ParameterDeclaration | ImportTypeNode | PropertyAssignment | ShorthandPropertyAssignment | BindingElement,
             isSuper: boolean, writing: boolean, type: Type, prop: Symbol, reportError = true): boolean {
 
-            const errorNode = node.kind === SyntaxKind.QualifiedName ? node.right :
+            const errorNode = !reportError ? undefined : node.kind === SyntaxKind.QualifiedName ? node.right :
                 node.kind === SyntaxKind.ImportType ? node :
                 node.kind === SyntaxKind.BindingElement && node.propertyName ? node.propertyName : node.name;
 
-            const typeChecks = checkPropertyAccessibilityAtNode(node, isSuper, writing, type, prop);
-            switch (typeChecks.result) {
-                case (TypeChecks.Ok):
-                    return true;
-                case (TypeChecks.HasDiagnostic):
-                    if (reportError) {
-                        error(errorNode, typeChecks.message, ...typeChecks.args);
-                    }
-                    return false;
-            }
+            return checkPropertyAccessibilityAtLocation(node, isSuper, writing, type, prop, errorNode);
         }
 
-        // Possible concerns:
-        // (1) I'm not sure if this function has the right behavior if `node` is allowed to be any node,
-        // although we only use `node` for its location in the parse tree.
-        // (2) Does it even make sense to check for property accessibility at a certain arbitrary node?
-        // Maybe this function should be called "checkPropertyVisibilityAtNode" or something else.
-        function checkPropertyAccessibilityAtNode(node: Node,
+        /**
+         * Check whether the requested property can be accessed at the requested location.
+         * Returns true if node is a valid property access, and false otherwise.
+         * @param location The location node where we want to check if the property is accessible.
+         * @param isSuper True if the access is from `super.`.
+         * @param writing True if this is a write property access, false if it is a read property access.
+         * @param type The type of the object whose property is being accessed. (Not the type of the property.)
+         * @param prop The symbol for the property being accessed.
+         * @param errorNode The node where we should report an invalid property access error, or undefined if we should not report errors.
+         */
+        function checkPropertyAccessibilityAtLocation(location: Node,
             isSuper: boolean, writing: boolean,
-            type: Type, prop: Symbol): CheckerResult {
-            const flags = getDeclarationModifierFlagsFromSymbol(prop, writing);
+            type: Type, prop: Symbol, errorNode?: Node): boolean {
 
-            const checkerOk: CheckerResultOk = {
-                result: TypeChecks.Ok
-            };
+            const flags = getDeclarationModifierFlagsFromSymbol(prop, writing);
 
             if (isSuper) {
                 // TS 1.0 spec (April 2014): 4.8.2
@@ -27333,11 +27300,10 @@ namespace ts {
                 //   a super property access is permitted and must specify a public static member function of the base class.
                 if (languageVersion < ScriptTarget.ES2015) {
                     if (symbolHasNonMethodDeclaration(prop)) {
-                        return {
-                            result: TypeChecks.HasDiagnostic,
-                            message: Diagnostics.Only_public_and_protected_methods_of_the_base_class_are_accessible_via_the_super_keyword,
-                            args: emptyArray
-                        };
+                        if (errorNode) {
+                            error(errorNode, Diagnostics.Only_public_and_protected_methods_of_the_base_class_are_accessible_via_the_super_keyword);
+                        }
+                        return false;
                     }
                 }
                 if (flags & ModifierFlags.Abstract) {
@@ -27345,30 +27311,34 @@ namespace ts {
                     // This error could mask a private property access error. But, a member
                     // cannot simultaneously be private and abstract, so this will trigger an
                     // additional error elsewhere.
-                    return {
-                        result: TypeChecks.HasDiagnostic,
-                        message: Diagnostics.Abstract_method_0_in_class_1_cannot_be_accessed_via_super_expression,
-                        args: [symbolToString(prop), typeToString(getDeclaringClass(prop)!)]
-                    };
+                    if (errorNode) {
+                        error(errorNode,
+                            Diagnostics.Abstract_method_0_in_class_1_cannot_be_accessed_via_super_expression,
+                            symbolToString(prop),
+                            typeToString(getDeclaringClass(prop)!));
+                    }
+                    return false;
                 }
             }
 
             // Referencing abstract properties within their own constructors is not allowed
             if ((flags & ModifierFlags.Abstract) && symbolHasNonMethodDeclaration(prop) &&
-                (isThisProperty(node) || isThisInitializedObjectBindingExpression(node) || isObjectBindingPattern(node.parent) && isThisInitializedDeclaration(node.parent.parent))) {
+                (isThisProperty(location) || isThisInitializedObjectBindingExpression(location) || isObjectBindingPattern(location.parent) && isThisInitializedDeclaration(location.parent.parent))) {
                 const declaringClassDeclaration = getClassLikeDeclarationOfSymbol(getParentOfSymbol(prop)!);
-                if (declaringClassDeclaration && isNodeUsedDuringClassInitialization(node)) {
-                    return {
-                        result: TypeChecks.HasDiagnostic,
-                        message: Diagnostics.Abstract_property_0_in_class_1_cannot_be_accessed_in_the_constructor,
-                        args: [symbolToString(prop), getTextOfIdentifierOrLiteral(declaringClassDeclaration.name!)]
-                    };
+                if (declaringClassDeclaration && isNodeUsedDuringClassInitialization(location)) {
+                    if (errorNode) {
+                        error(errorNode,
+                            Diagnostics.Abstract_property_0_in_class_1_cannot_be_accessed_in_the_constructor,
+                            symbolToString(prop),
+                            getTextOfIdentifierOrLiteral(declaringClassDeclaration.name!));
+                    }
+                    return false;
                 }
             }
 
             // Public properties are otherwise accessible.
             if (!(flags & ModifierFlags.NonPublicAccessibilityModifier)) {
-                return checkerOk;
+                return true;
             }
 
             // Property is known to be private or protected at this point
@@ -27376,26 +27346,28 @@ namespace ts {
             // Private property is accessible if the property is within the declaring class
             if (flags & ModifierFlags.Private) {
                 const declaringClassDeclaration = getClassLikeDeclarationOfSymbol(getParentOfSymbol(prop)!)!;
-                if (!isNodeWithinClass(node, declaringClassDeclaration)) {
-                    return {
-                        result: TypeChecks.HasDiagnostic,
-                        message: Diagnostics.Property_0_is_private_and_only_accessible_within_class_1,
-                        args: [symbolToString(prop), typeToString(getDeclaringClass(prop)!)]
-                    };
+                if (!isNodeWithinClass(location, declaringClassDeclaration)) {
+                    if (errorNode) {
+                        error(errorNode,
+                            Diagnostics.Property_0_is_private_and_only_accessible_within_class_1,
+                            symbolToString(prop),
+                            typeToString(getDeclaringClass(prop)!));
+                    }
+                    return false;
                 }
-                return checkerOk;
+                return true;
             }
 
             // Property is known to be protected at this point
 
             // All protected properties of a supertype are accessible in a super access
             if (isSuper) {
-                return checkerOk;
+                return true;
             }
 
             // Find the first enclosing class that has the declaring classes of the protected constituents
             // of the property as base classes
-            let enclosingClass = forEachEnclosingClass(node, enclosingDeclaration => {
+            let enclosingClass = forEachEnclosingClass(location, enclosingDeclaration => {
                 const enclosingClass = getDeclaredTypeOfSymbol(getSymbolOfNode(enclosingDeclaration)!) as InterfaceType;
                 return isClassDerivedFromDeclaringClasses(enclosingClass, prop, writing) ? enclosingClass : undefined;
             });
@@ -27404,12 +27376,14 @@ namespace ts {
                 // allow PropertyAccessibility if context is in function with this parameter
                 // static member access is disallow
                 let thisParameter: ParameterDeclaration | undefined;
-                if (flags & ModifierFlags.Static || !(thisParameter = getThisParameterFromNodeContext(node)) || !thisParameter.type) {
-                    return {
-                        result: TypeChecks.HasDiagnostic,
-                        message: Diagnostics.Property_0_is_protected_and_only_accessible_within_class_1_and_its_subclasses,
-                        args: [symbolToString(prop), typeToString(getDeclaringClass(prop) || type)]
-                    };
+                if (flags & ModifierFlags.Static || !(thisParameter = getThisParameterFromNodeContext(location)) || !thisParameter.type) {
+                    if (errorNode) {
+                        error(errorNode,
+                            Diagnostics.Property_0_is_protected_and_only_accessible_within_class_1_and_its_subclasses,
+                            symbolToString(prop),
+                            typeToString(getDeclaringClass(prop) || type));
+                    }
+                    return false;
                 }
 
                 const thisType = getTypeFromTypeNode(thisParameter.type);
@@ -27417,20 +27391,21 @@ namespace ts {
             }
             // No further restrictions for static properties
             if (flags & ModifierFlags.Static) {
-                return checkerOk;
+                return true;
             }
             if (type.flags & TypeFlags.TypeParameter) {
                 // get the original type -- represented as the type constraint of the 'this' type
                 type = (type as TypeParameter).isThisType ? getConstraintOfTypeParameter(type as TypeParameter)! : getBaseConstraintOfType(type as TypeParameter)!; // TODO: GH#18217 Use a different variable that's allowed to be undefined
             }
             if (!type || !hasBaseType(type, enclosingClass)) {
-                return {
-                    result: TypeChecks.HasDiagnostic,
-                    message: Diagnostics.Property_0_is_protected_and_only_accessible_through_an_instance_of_class_1_This_is_an_instance_of_class_2,
-                    args: [symbolToString(prop), typeToString(enclosingClass), typeToString(type)]
-                };
+                if (errorNode) {
+                    error(errorNode,
+                        Diagnostics.Property_0_is_protected_and_only_accessible_through_an_instance_of_class_1_This_is_an_instance_of_class_2,
+                        symbolToString(prop), typeToString(enclosingClass), typeToString(type));
+                }
+                return false;
             }
-            return checkerOk;
+            return true;
         }
 
         function getThisParameterFromNodeContext(node: Node) {
@@ -28150,8 +28125,22 @@ namespace ts {
             }
         }
 
+        /**
+         * Checks if an existing property access is valid for completions purposes.
+         * @param node a property access-like node where we want to check if we can access a property.
+         * This node does not need to be an access of the property we are checking.
+         * e.g. in completions, this node will often be an incomplete property access node, as in `foo.`.
+         * Besides providing a location (i.e. scope) used to check property accessibility, we use this node for
+         * computing whether this is a `super` property access.
+         * @param type the type whose property we are checking
+         * @param property the accessed property's symbol
+         */
         function isValidPropertyAccessForCompletions(node: PropertyAccessExpression | ImportTypeNode | QualifiedName, type: Type, property: Symbol): boolean {
-            return isValidPropertyAccessWithType(node, node.kind === SyntaxKind.PropertyAccessExpression && node.expression.kind === SyntaxKind.SuperKeyword, property.escapedName, type);
+            return isPropertyAccessible(node,
+                node.kind === SyntaxKind.PropertyAccessExpression && node.expression.kind === SyntaxKind.SuperKeyword,
+                /* isWrite */ false,
+                type,
+                property);
             // Previously we validated the 'this' type of methods but this adversely affected performance. See #31377 for more context.
         }
 
@@ -28161,19 +28150,45 @@ namespace ts {
             propertyName: __String,
             type: Type): boolean {
 
+            // Short-circuiting for improved performance.
             if (type === errorType || isTypeAny(type)) {
                 return true;
             }
+
             const prop = getPropertyOfType(type, propertyName);
-            if (prop) {
-                if (prop.valueDeclaration && isPrivateIdentifierClassElementDeclaration(prop.valueDeclaration)) {
-                    const declClass = getContainingClass(prop.valueDeclaration);
-                    return !isOptionalChain(node) && !!findAncestor(node, parent => parent === declClass);
-                }
-                return checkPropertyAccessibility(node, isSuper, /*writing*/ false, type, prop, /* reportError */ false);
+            return !!prop && isPropertyAccessible(node, isSuper, /* isWrite */ false, type, prop);
+        }
+
+        /**
+         * Checks if a property can be accessed in a location.
+         * The location is given by the `node` parameter.
+         * The node does not need to be a property access.
+         * @param node location where to check property accessibility
+         * @param isSuper whether to consider this a `super` property access, e.g. `super.foo`.
+         * @param isWrite whether this is a write access, e.g. `++foo.x`.
+         * @param type type where the property comes from.
+         * @param property property symbol.
+         */
+        function isPropertyAccessible(
+            node: Node,
+            isSuper: boolean,
+            isWrite: boolean,
+            type: Type,
+            property: Symbol): boolean {
+
+            // Short-circuiting for improved performance.
+            if (type === errorType || isTypeAny(type)) {
+                return true;
             }
-            // In js files properties of unions are allowed in completion
-            return isInJSFile(node) && (type.flags & TypeFlags.Union) !== 0 && (type as UnionType).types.some(elementType => isValidPropertyAccessWithType(node, isSuper, propertyName, elementType));
+
+            // A #private property access in an optional chain is an error dealt with by the parser.
+             // The checker does not check for it, so we need to do our own check here.
+             if (property.valueDeclaration && isPrivateIdentifierClassElementDeclaration(property.valueDeclaration)) {
+                const declClass = getContainingClass(property.valueDeclaration);
+                return !isOptionalChain(node) && !!findAncestor(node, parent => parent === declClass);
+            }
+
+            return checkPropertyAccessibilityAtLocation(node, isSuper, isWrite, type, property);
         }
 
         /**

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28157,8 +28157,8 @@ namespace ts {
          * e.g. in completions, this node will often be an incomplete property access node, as in `foo.`.
          * Besides providing a location (i.e. scope) used to check property accessibility, we use this node for
          * computing whether this is a `super` property access.
-         * @param type the type whose property we are checking
-         * @param property the accessed property's symbol
+         * @param type the type whose property we are checking.
+         * @param property the accessed property's symbol.
          */
         function isValidPropertyAccessForCompletions(node: PropertyAccessExpression | ImportTypeNode | QualifiedName, type: Type, property: Symbol): boolean {
             return isPropertyAccessible(node,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -736,10 +736,8 @@ namespace ts {
 
             getLocalTypeParametersOfClassOrInterfaceOrTypeAlias,
             isDeclarationVisible,
-            isPropertyAccessible: (nodeIn, isSuper, writing, type, prop) => {
-                const node = getParseTreeNode(nodeIn);
-                return node ?
-                    checkPropertyAccessibilityAtNode(node, isSuper, writing, type, prop).result === TypeChecks.Ok : false;
+            isPropertyAccessible: (node, isSuper, writing, type, prop) => {
+                return checkPropertyAccessibilityAtNode(node, isSuper, writing, type, prop).result === TypeChecks.Ok;
             }
         };
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11802,7 +11802,7 @@ namespace ts {
             return getReducedType(getApparentType(getReducedType(type)));
         }
 
-        function createUnionOrIntersectionProperty(containingType: UnionOrIntersectionType, name: __String, skipObjectFunctionPropertyAugment?: boolean): Symbol | undefined { // candidate
+        function createUnionOrIntersectionProperty(containingType: UnionOrIntersectionType, name: __String, skipObjectFunctionPropertyAugment?: boolean): Symbol | undefined {
             let singleProp: Symbol | undefined;
             let propSet: ESMap<SymbolId, Symbol> | undefined;
             let indexTypes: Type[] | undefined;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27292,7 +27292,8 @@ namespace ts {
             node: PropertyAccessExpression | QualifiedName | PropertyAccessExpression | VariableDeclaration | ParameterDeclaration | ImportTypeNode | PropertyAssignment | ShorthandPropertyAssignment | BindingElement,
             isSuper: boolean, writing: boolean, type: Type, prop: Symbol, reportError = true): boolean {
 
-            const errorNode = !reportError ? undefined : node.kind === SyntaxKind.QualifiedName ? node.right :
+            const errorNode = !reportError ? undefined :
+                node.kind === SyntaxKind.QualifiedName ? node.right :
                 node.kind === SyntaxKind.ImportType ? node :
                 node.kind === SyntaxKind.BindingElement && node.propertyName ? node.propertyName : node.name;
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4354,6 +4354,7 @@ namespace ts {
 
         /* @internal */ getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(symbol: Symbol): readonly TypeParameter[] | undefined;
         /* @internal */ isDeclarationVisible(node: Declaration | AnyImportSyntax): boolean;
+        /* @internal */ isPropertyAccessible(node: Node, isSuper: boolean, writing: boolean, type: Type, prop: Symbol): boolean;
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4216,7 +4216,7 @@ namespace ts {
 
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): string | number | undefined;
         isValidPropertyAccess(node: PropertyAccessExpression | QualifiedName | ImportTypeNode, propertyName: string): boolean;
-        /** Exclude accesses to private properties or methods with a `this` parameter that `type` doesn't satisfy. */
+        /** Exclude accesses to private properties. */
         /* @internal */ isValidPropertyAccessForCompletions(node: PropertyAccessExpression | ImportTypeNode | QualifiedName, type: Type, property: Symbol): boolean;
         /** Follow all aliases to get the original symbol. */
         getAliasedSymbol(symbol: Symbol): Symbol;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4355,7 +4355,7 @@ namespace ts {
 
         /* @internal */ getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(symbol: Symbol): readonly TypeParameter[] | undefined;
         /* @internal */ isDeclarationVisible(node: Declaration | AnyImportSyntax): boolean;
-        /* @internal */ isPropertyAccessible(node: Node, isSuper: boolean, writing: boolean, type: Type, prop: Symbol): boolean;
+        /* @internal */ isPropertyAccessible(node: Node, isSuper: boolean, isWrite: boolean, type: Type, property: Symbol): boolean;
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4355,7 +4355,7 @@ namespace ts {
 
         /* @internal */ getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(symbol: Symbol): readonly TypeParameter[] | undefined;
         /* @internal */ isDeclarationVisible(node: Declaration | AnyImportSyntax): boolean;
-        /* @internal */ isPropertyAccessible(node: Node, isSuper: boolean, isWrite: boolean, type: Type, property: Symbol): boolean;
+        /* @internal */ isPropertyAccessible(node: Node, isSuper: boolean, isWrite: boolean, containingType: Type, property: Symbol): boolean;
     }
 
     /* @internal */

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2207,17 +2207,22 @@ namespace ts.Completions {
                         canGetType = isExpression(rootDeclaration.parent.parent) && !!typeChecker.getContextualType(rootDeclaration.parent.parent as Expression);
                     }
                 }
-                if (canGetType) {
+                if (canGetType) { // here
                     const typeForObject = typeChecker.getTypeAtLocation(objectLikeContainer);
                     if (!typeForObject) return GlobalsSearch.Fail;
                     // In a binding pattern, get only known properties (unless in the same scope).
                     // Everywhere else we will get all possible properties.
-                    const containerClass = getContainingClass(objectLikeContainer);
-                    typeMembers = typeChecker.getPropertiesOfType(typeForObject).filter(symbol =>
-                        // either public
-                        !(getDeclarationModifierFlagsFromSymbol(symbol) & ModifierFlags.NonPublicAccessibilityModifier)
-                        // or we're in it
-                        || containerClass && contains(typeForObject.symbol.declarations, containerClass));
+
+                    // const containerClass = getContainingClass(objectLikeContainer);
+                    typeMembers = typeChecker.getPropertiesOfType(typeForObject).filter(propertySymbol => {
+                        return typeChecker.isPropertyAccessible(objectLikeContainer, /*isSuper*/ false, /*writing*/ false, typeForObject, propertySymbol);
+                        // return !(getDeclarationModifierFlagsFromSymbol(propertySymbol) & ModifierFlags.NonPublicAccessibilityModifier)
+                        //     || containerClass && contains(typeForObject.symbol.declarations, containerClass);
+                    });
+                        // // either public
+                        // !(getDeclarationModifierFlagsFromSymbol(symbol) & ModifierFlags.NonPublicAccessibilityModifier)
+                        // // or we're in it
+                        // || containerClass && contains(typeForObject.symbol.declarations, containerClass));
                     existingMembers = objectLikeContainer.elements;
                 }
             }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2213,22 +2213,12 @@ namespace ts.Completions {
                         canGetType = isExpression(rootDeclaration.parent.parent) && !!typeChecker.getContextualType(rootDeclaration.parent.parent as Expression);
                     }
                 }
-                if (canGetType) { // here
+                if (canGetType) {
                     const typeForObject = typeChecker.getTypeAtLocation(objectLikeContainer);
                     if (!typeForObject) return GlobalsSearch.Fail;
-                    // In a binding pattern, get only known properties (unless in the same scope).
-                    // Everywhere else we will get all possible properties.
-
-                    // const containerClass = getContainingClass(objectLikeContainer);
                     typeMembers = typeChecker.getPropertiesOfType(typeForObject).filter(propertySymbol => {
                         return typeChecker.isPropertyAccessible(objectLikeContainer, /*isSuper*/ false, /*writing*/ false, typeForObject, propertySymbol);
-                        // return !(getDeclarationModifierFlagsFromSymbol(propertySymbol) & ModifierFlags.NonPublicAccessibilityModifier)
-                        //     || containerClass && contains(typeForObject.symbol.declarations, containerClass);
                     });
-                        // // either public
-                        // !(getDeclarationModifierFlagsFromSymbol(symbol) & ModifierFlags.NonPublicAccessibilityModifier)
-                        // // or we're in it
-                        // || containerClass && contains(typeForObject.symbol.declarations, containerClass));
                     existingMembers = objectLikeContainer.elements;
                 }
             }

--- a/tests/cases/fourslash/completionsWrappedClass.ts
+++ b/tests/cases/fourslash/completionsWrappedClass.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+////class Client {
+////    private close() { }
+////    public open() { }
+////}
+////type Wrap<T> = T &
+////{
+////    [K in Extract<keyof T, string> as `${K}Wrapped`]: T[K];
+////};
+////class Service {
+////    method() {
+////        let service = undefined as unknown as Wrap<Client>;
+////        const { /*a*/ } = service;
+////    }
+////}
+
+verify.completions({ marker: "a", exact: ["open", "openWrapped"] });


### PR DESCRIPTION
This is a very rough draft PR attempting to use the checker's logic for checking property accessibility when filtering visible/accessible properties that should be offered for completion.

This PR was inspired by bug #45045, caused by trying to access a type's undefined symbol when checking if we should offer a property for completions in an object binding pattern (in `tryGetObjectLikeCompletions` from completions).
Looking at the code in completions, I thought the type checker must already do this sort of property accessibility check and set out to see if we could reuse the checker's code for this purpose.

The checker function that does this is `checkPropertyAccessibility`.
This function returns a `boolean` saying if a property access is valid, given a property access-like node, the property's symbol, the type where the property comes from, and some options (`writing` if it's a write access, `isSuper` if we're accessing a super property e.g. `super.foo`).
But, it also reports an invalid property error if the `reportError` flag is set to true.

Based on `checkPropertyAccessibility`, I created the function `checkPropertyAccessibilityAtNode` that has the same implementation, but with two differences:
* `checkPropertyAccessibility` takes as argument nodes that are property access-like only. This is enough for type checking purposes, and also if we are in a completions scenario where we have an actual property access (e.g. `foo.|`), because then we have such a property access-like node. But, in the case of offering completions for an object binding pattern, we are trying to figure out if a property is accessible when we don't yet have a property access-like (i.e. a binding element) node. To that end, the new function `checkPropertyAccessibilityAtNode` accepts any `Node`, indicating the location in the AST where we'd want to access the property.
* unlike `checkPropertyAccessibility`, `checkPropertyAccessibilityAtNode` does not report errors, but instead, if the property access is invalid, it returns diagnostics info (diagnostic message + arguments).

I changed `checkPropertyAccessibility` to call the new `checkPropertyAccessibilityAtNode` and report an error (i.e. call `error(...)`) depending on the returned value.
I also added a `boolean`-returning wrapper over the `checkPropertyAccessibilityAtNode` function (`isPropertyAccessible`), exposed by the checker and used by completions.

I only replaced the existing property accessibility completions-specific code to use the new `isPropertyAccessible` function in `tryGetObjectLikeCompletions`, but there might be other places that could use this new checker function.

The variable/function/type names and overall code structure is in no way ideal, but I wanted to know if the idea makes any sense before investing more time on making things pretty. I'm also very open to suggestions on alternative ways to achieve the same thing, or just explanations on why that sort of reuse shouldn't be done.


