### PR TITLE
Some cleanup around inlay hints types to get more-precise checking.

### DIFF
--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -653,7 +653,7 @@ namespace ts.server {
 
             return response.body!.map(item => ({ // TODO: GH#18217
                 ...item,
-                kind: item.kind as InlayHintKind | undefined,
+                kind: item.kind as InlayHintKind,
                 position: this.lineOffsetToPosition(file, item.position),
             }));
         }

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2562,11 +2562,7 @@ namespace ts.server.protocol {
         body?: SignatureHelpItems;
     }
 
-    export const enum InlayHintKind {
-        Type = "Type",
-        Parameter = "Parameter",
-        Enum = "Enum",
-    }
+    export type InlayHintKind = "Type" | "Parameter" | "Enum";
 
     export interface InlayHintsRequestArgs extends FileRequestArgs {
         /**
@@ -2587,7 +2583,7 @@ namespace ts.server.protocol {
     export interface InlayHintItem {
         text: string;
         position: Location;
-        kind?: InlayHintKind;
+        kind: InlayHintKind;
         whitespaceBefore?: boolean;
         whitespaceAfter?: boolean;
     }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1452,7 +1452,7 @@ namespace ts.server {
             });
         }
 
-        private provideInlayHints(args: protocol.InlayHintsRequestArgs) {
+        private provideInlayHints(args: protocol.InlayHintsRequestArgs): readonly protocol.InlayHintItem[] {
             const { file, project } = this.getFileAndProject(args);
             const scriptInfo = this.projectService.getScriptInfoForNormalizedPath(file)!;
             const hints = project.getLanguageService().provideInlayHints(file, args, this.getPreferences(file));

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -720,7 +720,7 @@ namespace ts {
     export interface InlayHint {
         text: string;
         position: number;
-        kind?: InlayHintKind;
+        kind: InlayHintKind;
         whitespaceBefore?: boolean;
         whitespaceAfter?: boolean;
     }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5886,7 +5886,7 @@ declare namespace ts {
     interface InlayHint {
         text: string;
         position: number;
-        kind?: InlayHintKind;
+        kind: InlayHintKind;
         whitespaceBefore?: boolean;
         whitespaceAfter?: boolean;
     }
@@ -8739,11 +8739,7 @@ declare namespace ts.server.protocol {
     interface SignatureHelpResponse extends Response {
         body?: SignatureHelpItems;
     }
-    enum InlayHintKind {
-        Type = "Type",
-        Parameter = "Parameter",
-        Enum = "Enum"
-    }
+    type InlayHintKind = "Type" | "Parameter" | "Enum";
     interface InlayHintsRequestArgs extends FileRequestArgs {
         /**
          * Start position of the span.
@@ -8761,7 +8757,7 @@ declare namespace ts.server.protocol {
     interface InlayHintItem {
         text: string;
         position: Location;
-        kind?: InlayHintKind;
+        kind: InlayHintKind;
         whitespaceBefore?: boolean;
         whitespaceAfter?: boolean;
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5886,7 +5886,7 @@ declare namespace ts {
     interface InlayHint {
         text: string;
         position: number;
-        kind?: InlayHintKind;
+        kind: InlayHintKind;
         whitespaceBefore?: boolean;
         whitespaceAfter?: boolean;
     }


### PR DESCRIPTION
Right now, inlay hints incorrectly report that their `kind` might be optional. We also don't validate that the response has the shape that we're promising, so this PR ensures that we get at least some checking there.