### PR TITLE
Use getFileAndProject in session provideInlayHints to ensure language service updates are applied

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1453,9 +1453,9 @@ namespace ts.server {
         }
 
         private provideInlayHints(args: protocol.InlayHintsRequestArgs) {
-            const { file, languageService } = this.getFileAndLanguageServiceForSyntacticOperation(args);
+            const { file, project } = this.getFileAndProject(args);
             const scriptInfo = this.projectService.getScriptInfoForNormalizedPath(file)!;
-            const hints = languageService.provideInlayHints(file, args, this.getPreferences(file));
+            const hints = project.getLanguageService().provideInlayHints(file, args, this.getPreferences(file));
 
             return hints.map(hint => ({
                 ...hint,

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -191,6 +191,7 @@
         "unittests/tsserver/getExportReferences.ts",
         "unittests/tsserver/getFileReferences.ts",
         "unittests/tsserver/importHelpers.ts",
+        "unittests/tsserver/inlayHints.ts",
         "unittests/tsserver/inferredProjects.ts",
         "unittests/tsserver/jsdocTag.ts",
         "unittests/tsserver/languageService.ts",

--- a/src/testRunner/unittests/tsserver/inlayHints.ts
+++ b/src/testRunner/unittests/tsserver/inlayHints.ts
@@ -1,0 +1,63 @@
+namespace ts.projectSystem {
+    describe("unittests:: tsserver:: inlayHints", () => {
+        const configFile: File = {
+            path: "/a/b/tsconfig.json",
+            content: "{}"
+        };
+        const app: File = {
+            path: "/a/b/app.ts",
+            content: "declare function foo(param: any): void;\nfoo(12);"
+        };
+
+        it("with updateOpen request does not corrupt documents", () => {
+            const host = createServerHost([app, commonFile1, commonFile2, libFile, configFile]);
+            const session = createSession(host);
+            session.executeCommandSeq<protocol.OpenRequest>({
+                command: protocol.CommandTypes.Open,
+                arguments: { file: app.path }
+            });
+            session.executeCommandSeq<protocol.ConfigureRequest>({
+                command: protocol.CommandTypes.Configure,
+                arguments: {
+                    preferences: {
+                        includeInlayParameterNameHints: "all"
+                    } as UserPreferences
+                }
+            });
+            verifyInlayHintResponse(session);
+            session.executeCommandSeq<protocol.UpdateOpenRequest>({
+                command: protocol.CommandTypes.UpdateOpen,
+                arguments: {
+                    changedFiles: [{ fileName: app.path, textChanges: [{ start: { line: 1, offset: 39 }, end: { line: 1, offset: 39 }, newText: "//" }] }]
+                }
+            });
+            verifyInlayHintResponse(session);
+            session.executeCommandSeq<protocol.UpdateOpenRequest>({
+                command: protocol.CommandTypes.UpdateOpen,
+                arguments: {
+                    changedFiles: [{ fileName: app.path, textChanges: [{ start: { line: 1, offset: 41 }, end: { line: 1, offset: 41 }, newText: "c" }] }]
+                }
+            });
+            verifyInlayHintResponse(session);
+
+            function verifyInlayHintResponse(session: TestSession) {
+                verifyParamInlayHint(session.executeCommandSeq<protocol.InlayHintsRequest>({
+                    command: protocol.CommandTypes.ProvideInlayHints,
+                    arguments: {
+                        file: app.path,
+                        start: 0,
+                        length: app.content.length,
+                    }
+                }).response as protocol.InlayHintItem[] | undefined);
+            }
+
+            function verifyParamInlayHint(response: protocol.InlayHintItem[] | undefined) {
+                Debug.assert(response);
+                Debug.assert(response[0]);
+                Debug.assertEqual(response[0].text, "param:");
+                Debug.assertEqual(response[0].position.line, 2);
+                Debug.assertEqual(response[0].position.offset, 5);
+            }
+        });
+    });
+}


### PR DESCRIPTION
Fixes #45320

Credit to @DanielRosenwasser for the actual fix. 

The explanation for _why_ that fixes anything is a bit long winded, though. The issue, as described, appears like a heisenbug - you need to type really fast, and even then, sometimes everything still works fine. That's because, under normal circumstances, `vscode` does 3 things on document edit - request inlay hints, request encoded semantic classifications, and request diagnostics. The later two use `getFileAndProject` already. So what normally would happen is that you'd request inlay hints, see document updates, mark the LS as dirty, calculate inlay hints with the once-updated data, and then semantic classifications or diagnostics would see the dirty marker and flush the old LS and build a new one with the new data. The buggy behavior occurred when there was no semantic classification or diagnostic request to trigger the flush of the old LS - instead, if we got an inlay hint request followed by an update, followed by another inlay hint request, the second inlay hint request would _not_ cause an LS synchronization to occur, and would instead reuse the LS from the first request verbatim. That then causes the positions returned by the LS to drift as the new `lineMap` we map positions with doesn't align with the text still in the old LS, causing the positions to drift until a LS synchronizing protocol request occurs. This all occurs very rarely because it's actually pretty hard to get a `inlayHints` -> `updateOpen` -> `inlayHints` sequence to occur - to cause the editor to issue such a command sequence you need to be typing fast enough that it bails on sending the diagnostics and semantic classifications requests, and also _slow_ enough that it _doesn't_ skip sending the `inlayHints` request. So there's an awkward sweet-spot of typing speed matched up against editor responsiveness that was required to trigger this bug.