### PR TITLE
fix(45393): show parameter name hints for unary literal expressions

### DIFF
--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -203,7 +203,18 @@ namespace ts.InlayHints {
         }
 
         function isHintableExpression(node: Node) {
-            return isLiteralExpression(node) || isBooleanLiteral(node) || isArrowFunction(node) || isFunctionExpression(node) || isObjectLiteralExpression(node) || isArrayLiteralExpression(node);
+            switch (node.kind) {
+                case SyntaxKind.PrefixUnaryExpression:
+                    return isLiteralExpression((node as PrefixUnaryExpression).operand);
+                case SyntaxKind.TrueKeyword:
+                case SyntaxKind.FalseKeyword:
+                case SyntaxKind.ArrowFunction:
+                case SyntaxKind.FunctionExpression:
+                case SyntaxKind.ObjectLiteralExpression:
+                case SyntaxKind.ArrayLiteralExpression:
+                    return true;
+            }
+            return isLiteralExpression(node);
         }
 
         function visitFunctionDeclarationLikeForReturnType(decl: FunctionDeclaration | ArrowFunction | FunctionExpression | MethodDeclaration | GetAccessorDeclaration) {

--- a/tests/cases/fourslash/inlayHintsShouldWork63.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork63.ts
@@ -1,0 +1,34 @@
+/// <reference path="fourslash.ts" />
+
+////function foo(a: number, b: number, c: number, d: number) {}
+////foo(/*a*/1, /*b*/+1, /*c*/-1, /*d*/+"1");
+
+const [a, b, c, d] = test.markers();
+verify.getInlayHints([
+    {
+        text: "a:",
+        position: a.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "b:",
+        position: b.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "c:",
+        position: c.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "d:",
+        position: d.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    }
+], undefined, {
+    includeInlayParameterNameHints: "literals"
+});


### PR DESCRIPTION
Fixes #45393