### PR TITLE
fix: typo spelling grammar

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -6902,7 +6902,7 @@ interface HTMLIFrameElement extends HTMLElement {
      */
     src: string;
     /**
-     * Sets or retrives the content of the page that is to contain.
+     * Sets or retrieves the content of the page that is to contain.
      */
     srcdoc: string;
     /**

--- a/lib/protocol.d.ts
+++ b/lib/protocol.d.ts
@@ -2167,7 +2167,7 @@ declare namespace ts.server.protocol {
     }
     interface ConfigFileDiagnosticEventBody {
         /**
-         * The file which trigged the searching and error-checking of the config file
+         * The file which triggered the searching and error-checking of the config file
          */
         triggerFile: string;
         /**

--- a/lib/tsserverlibrary.d.ts
+++ b/lib/tsserverlibrary.d.ts
@@ -5141,12 +5141,12 @@ declare namespace ts {
         createHash?(data: string): string;
         /**
          * Use to check file presence for source files and
-         * if resolveModuleNames is not provided (complier is in charge of module resolution) then module files as well
+         * if resolveModuleNames is not provided (compiler is in charge of module resolution) then module files as well
          */
         fileExists(path: string): boolean;
         /**
          * Use to read file text for source files and
-         * if resolveModuleNames is not provided (complier is in charge of module resolution) then module files as well
+         * if resolveModuleNames is not provided (compiler is in charge of module resolution) then module files as well
          */
         readFile(path: string, encoding?: string): string | undefined;
         /** If provided, used for module resolution as well as to handle directory structure */
@@ -5198,7 +5198,7 @@ declare namespace ts {
         extraFileExtensions?: readonly FileExtensionInfo[];
         /**
          * Used to generate source file names from the config file and its include, exclude, files rules
-         * and also to cache the directory stucture
+         * and also to cache the directory structure
          */
         readDirectory(path: string, extensions?: readonly string[], exclude?: readonly string[], include?: readonly string[], depth?: number): string[];
     }
@@ -5274,7 +5274,7 @@ declare namespace ts {
         getNextInvalidatedProject(cancellationToken?: CancellationToken): InvalidatedProject<T> | undefined;
     }
     /**
-     * Create a function that reports watch status by writing to the system and handles the formating of the diagnostic
+     * Create a function that reports watch status by writing to the system and handles the formatting of the diagnostic
      */
     function createBuilderStatusReporter(system: System, pretty?: boolean): DiagnosticReporter;
     function createSolutionBuilderHost<T extends BuilderProgram = EmitAndSemanticDiagnosticsBuilderProgram>(system?: System, createProgram?: CreateProgram<T>, reportDiagnostic?: DiagnosticReporter, reportSolutionBuilderStatus?: DiagnosticReporter, reportErrorSummary?: ReportEmitErrorSummary): SolutionBuilderHost<T>;
@@ -8494,7 +8494,7 @@ declare namespace ts.server.protocol {
          */
         replacementSpan?: TextSpan;
         /**
-         * Indicates whether commiting this completion entry will require additional code actions to be
+         * Indicates whether committing this completion entry will require additional code actions to be
          * made to avoid errors. The CompletionEntryDetails will have these actions.
          */
         hasAction?: true;
@@ -8777,7 +8777,7 @@ declare namespace ts.server.protocol {
         includeLinePosition?: boolean;
     }
     /**
-     * Response object for synchronous sematic diagnostics request.
+     * Response object for synchronous semantic diagnostics request.
      */
     interface SemanticDiagnosticsSyncResponse extends Response {
         body?: Diagnostic[] | DiagnosticWithLinePosition[];
@@ -8950,7 +8950,7 @@ declare namespace ts.server.protocol {
     }
     interface ConfigFileDiagnosticEventBody {
         /**
-         * The file which trigged the searching and error-checking of the config file
+         * The file which triggered the searching and error-checking of the config file
          */
         triggerFile: string;
         /**

--- a/lib/typescript.d.ts
+++ b/lib/typescript.d.ts
@@ -5141,12 +5141,12 @@ declare namespace ts {
         createHash?(data: string): string;
         /**
          * Use to check file presence for source files and
-         * if resolveModuleNames is not provided (complier is in charge of module resolution) then module files as well
+         * if resolveModuleNames is not provided (compiler is in charge of module resolution) then module files as well
          */
         fileExists(path: string): boolean;
         /**
          * Use to read file text for source files and
-         * if resolveModuleNames is not provided (complier is in charge of module resolution) then module files as well
+         * if resolveModuleNames is not provided (compiler is in charge of module resolution) then module files as well
          */
         readFile(path: string, encoding?: string): string | undefined;
         /** If provided, used for module resolution as well as to handle directory structure */
@@ -5198,7 +5198,7 @@ declare namespace ts {
         extraFileExtensions?: readonly FileExtensionInfo[];
         /**
          * Used to generate source file names from the config file and its include, exclude, files rules
-         * and also to cache the directory stucture
+         * and also to cache the directory structure
          */
         readDirectory(path: string, extensions?: readonly string[], exclude?: readonly string[], include?: readonly string[], depth?: number): string[];
     }
@@ -5274,7 +5274,7 @@ declare namespace ts {
         getNextInvalidatedProject(cancellationToken?: CancellationToken): InvalidatedProject<T> | undefined;
     }
     /**
-     * Create a function that reports watch status by writing to the system and handles the formating of the diagnostic
+     * Create a function that reports watch status by writing to the system and handles the formatting of the diagnostic
      */
     function createBuilderStatusReporter(system: System, pretty?: boolean): DiagnosticReporter;
     function createSolutionBuilderHost<T extends BuilderProgram = EmitAndSemanticDiagnosticsBuilderProgram>(system?: System, createProgram?: CreateProgram<T>, reportDiagnostic?: DiagnosticReporter, reportSolutionBuilderStatus?: DiagnosticReporter, reportErrorSummary?: ReportEmitErrorSummary): SolutionBuilderHost<T>;
@@ -5578,7 +5578,7 @@ declare namespace ts {
         /**
          * Gets errors indicating invalid syntax in a file.
          *
-         * In English, "this cdeo have, erorrs" is syntactically invalid because it has typos,
+         * In English, "this cdeo have, errors" is syntactically invalid because it has typos,
          * grammatical errors, and misplaced punctuation. Likewise, examples of syntax
          * errors in TypeScript are missing parentheses in an `if` statement, mismatched
          * curly braces, and using a reserved keyword as a variable name.

--- a/lib/typescriptServices.d.ts
+++ b/lib/typescriptServices.d.ts
@@ -5141,12 +5141,12 @@ declare namespace ts {
         createHash?(data: string): string;
         /**
          * Use to check file presence for source files and
-         * if resolveModuleNames is not provided (complier is in charge of module resolution) then module files as well
+         * if resolveModuleNames is not provided (compiler is in charge of module resolution) then module files as well
          */
         fileExists(path: string): boolean;
         /**
          * Use to read file text for source files and
-         * if resolveModuleNames is not provided (complier is in charge of module resolution) then module files as well
+         * if resolveModuleNames is not provided (compiler is in charge of module resolution) then module files as well
          */
         readFile(path: string, encoding?: string): string | undefined;
         /** If provided, used for module resolution as well as to handle directory structure */
@@ -5198,7 +5198,7 @@ declare namespace ts {
         extraFileExtensions?: readonly FileExtensionInfo[];
         /**
          * Used to generate source file names from the config file and its include, exclude, files rules
-         * and also to cache the directory stucture
+         * and also to cache the directory structure
          */
         readDirectory(path: string, extensions?: readonly string[], exclude?: readonly string[], include?: readonly string[], depth?: number): string[];
     }
@@ -5274,7 +5274,7 @@ declare namespace ts {
         getNextInvalidatedProject(cancellationToken?: CancellationToken): InvalidatedProject<T> | undefined;
     }
     /**
-     * Create a function that reports watch status by writing to the system and handles the formating of the diagnostic
+     * Create a function that reports watch status by writing to the system and handles the formatting of the diagnostic
      */
     function createBuilderStatusReporter(system: System, pretty?: boolean): DiagnosticReporter;
     function createSolutionBuilderHost<T extends BuilderProgram = EmitAndSemanticDiagnosticsBuilderProgram>(system?: System, createProgram?: CreateProgram<T>, reportDiagnostic?: DiagnosticReporter, reportSolutionBuilderStatus?: DiagnosticReporter, reportErrorSummary?: ReportEmitErrorSummary): SolutionBuilderHost<T>;

--- a/scripts/open-user-pr.ts
+++ b/scripts/open-user-pr.ts
@@ -38,7 +38,7 @@ gh.pulls.create({
     head: `${userName}:${branchName}`,
     base: branchName === masterBranchname ? "main" : masterBranchname,
     body:
-`${process.env.SOURCE_ISSUE ? `This test run was triggerd by a request on https://github.com/Microsoft/TypeScript/pull/${process.env.SOURCE_ISSUE} `+"\n" : ""}Please review the diff and merge if no changes are unexpected.
+`${process.env.SOURCE_ISSUE ? `This test run was triggered by a request on https://github.com/Microsoft/TypeScript/pull/${process.env.SOURCE_ISSUE} `+"\n" : ""}Please review the diff and merge if no changes are unexpected.
 You can view the build log [here](https://typescript.visualstudio.com/TypeScript/_build/index?buildId=${process.env.BUILD_BUILDID}&_a=summary).
 
 cc ${reviewers.map(r => "@" + r).join(" ")}`,

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -1099,7 +1099,7 @@ namespace ts {
             let savedAffectedFilesPendingEmitIndex;
             // Backup and restore affected pendings emit state for non emit Builder if noEmitOnError is enabled and emitBuildInfo could be written in case there are errors
             // This ensures pending files to emit is updated in tsbuildinfo
-            // Note that when there are no errors, emit proceeds as if everything is emitted as it is callers reponsibility to write the files to disk if at all (because its builder that doesnt track files to emit)
+            // Note that when there are no errors, emit proceeds as if everything is emitted as it is callers responsibility to write the files to disk if at all (because its builder that doesnt track files to emit)
             if (kind !== BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram &&
                 !targetSourceFile &&
                 !outFile(state.compilerOptions) &&

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31430,7 +31430,7 @@ namespace ts {
 
         function isAssignmentToReadonlyEntity(expr: Expression, symbol: Symbol, assignmentKind: AssignmentKind) {
             if (assignmentKind === AssignmentKind.None) {
-                // no assigment means it doesn't matter whether the entity is readonly
+                // no assignment means it doesn't matter whether the entity is readonly
                 return false;
             }
             if (isReadonlySymbol(symbol)) {
@@ -34510,7 +34510,7 @@ namespace ts {
                     // SyntaxKind.ElementAccessExpression - `thing["aField"] = 42;` or `thing["aField"];` (with a doc comment on it)
                     // or SyntaxKind.PropertyAccessExpression - `thing.aField = 42;`
                     // all of which are pretty much always values, or at least imply a value meaning.
-                    // It may be apprpriate to treat these as aliases in the future.
+                    // It may be appropriate to treat these as aliases in the future.
                         return DeclarationSpaces.ExportValue;
                     default:
                         return Debug.failBadSyntaxKind(d);

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -934,7 +934,7 @@ namespace ts {
             name: "out",
             type: "string",
             affectsEmit: true,
-            isFilePath: false, // This is intentionally broken to support compatability with existing tsconfig files
+            isFilePath: false, // This is intentionally broken to support compatibility with existing tsconfig files
             // for correct behaviour, please use outFile
             category: Diagnostics.Backwards_Compatibility,
             paramType: Diagnostics.FILE,
@@ -3166,7 +3166,7 @@ namespace ts {
      * @param basePath The base path for any relative file specifications.
      * @param options Compiler options.
      * @param host The host used to resolve files and directories.
-     * @param extraFileExtensions optionaly file extra file extension information from host
+     * @param extraFileExtensions optionally file extra file extension information from host
      */
     /* @internal */
     export function getFileNamesFromConfigSpecs(

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1681,7 +1681,7 @@ namespace ts {
 
     /**
      * A host may load a module from a global cache of typings.
-     * This is the minumum code needed to expose that functionality; the rest is in the host.
+     * This is the minimum code needed to expose that functionality; the rest is in the host.
      */
     /* @internal */
     export function loadModuleFromGlobalCache(moduleName: string, projectName: string | undefined, compilerOptions: CompilerOptions, host: ModuleResolutionHost, globalCache: string, packageJsonInfoCache: PackageJsonInfoCache): ResolvedModuleWithFailedLookupLocations {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1553,7 +1553,7 @@ namespace ts {
 
         /**
          * Provides a better error message than the generic "';' expected" if possible for
-         * known common variants of a missing semicolon, such as from a mispelled names.
+         * known common variants of a missing semicolon, such as from a misspelled names.
          *
          * @param node Node preceding the expected semicolon location.
          */

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -114,7 +114,7 @@ namespace ts {
         thisName?: Identifier;
 
         /*
-         * set to true if node contains lexical 'this' so we can mark function that wraps convered loop body as 'CapturedThis' for subsequent substitution.
+         * set to true if node contains lexical 'this' so we can mark function that wraps covered loop body as 'CapturedThis' for subsequent substitution.
          */
         containsLexicalThis?: boolean;
 

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -150,7 +150,7 @@ namespace ts {
     }
 
     /**
-     * Create a function that reports watch status by writing to the system and handles the formating of the diagnostic
+     * Create a function that reports watch status by writing to the system and handles the formatting of the diagnostic
      */
     export function createBuilderStatusReporter(system: System, pretty?: boolean): DiagnosticReporter {
         return diagnostic => {

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -7,7 +7,7 @@ namespace ts {
     } : undefined;
 
     /**
-     * Create a function that reports error by writing to the system and handles the formating of the diagnostic
+     * Create a function that reports error by writing to the system and handles the formatting of the diagnostic
      */
     export function createDiagnosticReporter(system: System, pretty?: boolean): DiagnosticReporter {
         const host: FormatDiagnosticsHost = system === sys && sysFormatDiagnosticsHost ? sysFormatDiagnosticsHost : {
@@ -64,7 +64,7 @@ namespace ts {
     }
 
     /**
-     * Create a function that reports watch status by writing to the system and handles the formating of the diagnostic
+     * Create a function that reports watch status by writing to the system and handles the formatting of the diagnostic
      */
     export function createWatchStatusReporter(system: System, pretty?: boolean): WatchStatusReporter {
         return pretty ?

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -77,12 +77,12 @@ namespace ts {
 
         /**
          * Use to check file presence for source files and
-         * if resolveModuleNames is not provided (complier is in charge of module resolution) then module files as well
+         * if resolveModuleNames is not provided (compiler is in charge of module resolution) then module files as well
          */
         fileExists(path: string): boolean;
         /**
          * Use to read file text for source files and
-         * if resolveModuleNames is not provided (complier is in charge of module resolution) then module files as well
+         * if resolveModuleNames is not provided (compiler is in charge of module resolution) then module files as well
          */
         readFile(path: string, encoding?: string): string | undefined;
 

--- a/src/harness/harnessGlobals.ts
+++ b/src/harness/harnessGlobals.ts
@@ -8,7 +8,7 @@ var _chai: typeof import("chai") = require("chai");
 globalThis.assert = _chai.assert;
 {
     // chai's builtin `assert.isFalse` is featureful but slow - we don't use those features,
-    // so we'll just overwrite it as an alterative to migrating a bunch of code off of chai
+    // so we'll just overwrite it as an alternative to migrating a bunch of code off of chai
     assert.isFalse = (expr: any, msg: string) => { if (expr !== false) throw new Error(msg); };
 
     const assertDeepImpl = assert.deepEqual;

--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -6911,7 +6911,7 @@ interface HTMLIFrameElement extends HTMLElement {
      */
     src: string;
     /**
-     * Sets or retrives the content of the page that is to contain.
+     * Sets or retrieves the content of the page that is to contain.
      */
     srcdoc: string;
     /**

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1473,7 +1473,7 @@ namespace ts.server.protocol {
     /* @internal */
     export interface ProjectFiles {
         /**
-         * Information about project verison
+         * Information about project version
          */
         info?: ProjectVersionInfo;
         /**
@@ -2278,7 +2278,7 @@ namespace ts.server.protocol {
          */
         replacementSpan?: TextSpan;
         /**
-         * Indicates whether commiting this completion entry will require additional code actions to be
+         * Indicates whether committing this completion entry will require additional code actions to be
          * made to avoid errors. The CompletionEntryDetails will have these actions.
          */
         hasAction?: true;
@@ -2812,7 +2812,7 @@ namespace ts.server.protocol {
 
     export interface ConfigFileDiagnosticEventBody {
         /**
-         * The file which trigged the searching and error-checking of the config file
+         * The file which triggered the searching and error-checking of the config file
          */
         triggerFile: string;
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1213,7 +1213,7 @@ namespace ts.FindAllReferences {
             }
         }
 
-        /** Search for all occurences of an identifier in a source file (and filter out the ones that match). */
+        /** Search for all occurrences of an identifier in a source file (and filter out the ones that match). */
         function searchForName(sourceFile: SourceFile, search: Search, state: State): void {
             if (getNameTable(sourceFile).get(search.escapedText) !== undefined) {
                 getReferencesInSourceFile(sourceFile, search, state);
@@ -2047,7 +2047,7 @@ namespace ts.FindAllReferences {
         function forEachRelatedSymbol<T>(
             symbol: Symbol, location: Node, checker: TypeChecker, isForRenamePopulateSearchSymbolSet: boolean, onlyIncludeBindingElementAtReferenceLocation: boolean,
             /**
-             * @param baseSymbol This symbol means one property/mehtod from base class or interface when it is not null or undefined,
+             * @param baseSymbol This symbol means one property/method from base class or interface when it is not null or undefined,
              */
             cbSymbol: (symbol: Symbol, rootSymbol?: Symbol, baseSymbol?: Symbol, kind?: NodeEntryKind) => T | undefined,
             allowBaseTypes: (rootSymbol: Symbol) => boolean,

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -55,7 +55,7 @@ namespace ts.formatting {
          */
         getIndentation(): number;
         /**
-         * Prefered relative indentation for child nodes.
+         * Preferred relative indentation for child nodes.
          * Delta is used to carry the indentation info
          * foo(bar({
          *     $

--- a/src/services/refactors/convertOverloadListToSingleSignature.ts
+++ b/src/services/refactors/convertOverloadListToSingleSignature.ts
@@ -121,7 +121,7 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
         function getNewParametersForCombinedSignature(signatureDeclarations: (MethodSignature | MethodDeclaration | CallSignatureDeclaration | ConstructorDeclaration | ConstructSignatureDeclaration | FunctionDeclaration)[]): NodeArray<ParameterDeclaration> {
             const lastSig = signatureDeclarations[signatureDeclarations.length - 1];
             if (isFunctionLikeDeclaration(lastSig) && lastSig.body) {
-                // Trim away implementation signature arguments (they should already be compatible with overloads, but are likely less precise to guarantee compatability with the overloads)
+                // Trim away implementation signature arguments (they should already be compatible with overloads, but are likely less precise to guarantee compatibility with the overloads)
                 signatureDeclarations = signatureDeclarations.slice(0, signatureDeclarations.length - 1);
             }
             return factory.createNodeArray([

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1501,7 +1501,7 @@ namespace ts {
                             return documentRegistry.updateDocumentWithKey(fileName, path, newSettings, documentRegistryBucketKey, hostFileInformation.scriptSnapshot, hostFileInformation.version, hostFileInformation.scriptKind);
                         }
                         else {
-                            // Release old source file and fall through to aquire new file with new script kind
+                            // Release old source file and fall through to acquire new file with new script kind
                             documentRegistry.releaseDocumentWithKey(oldSourceFile.resolvedPath, documentRegistry.getKeyForCompilationSettings(program.getCompilerOptions()), oldSourceFile.scriptKind);
                         }
                     }

--- a/src/testRunner/unittests/convertToBase64.ts
+++ b/src/testRunner/unittests/convertToBase64.ts
@@ -7,7 +7,7 @@ namespace ts {
         }
 
         if (Buffer) {
-            it("Converts ASCII charaters correctly", () => {
+            it("Converts ASCII characters correctly", () => {
                 runTest(" !\"#$ %&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~");
             });
 

--- a/src/testRunner/unittests/printer.ts
+++ b/src/testRunner/unittests/printer.ts
@@ -93,7 +93,7 @@ namespace ts {
             });
         });
 
-        describe("No duplicate ref directives when emiting .d.ts->.d.ts", () => {
+        describe("No duplicate ref directives when emitting .d.ts->.d.ts", () => {
             it("without statements", () => {
                 const host = new fakes.CompilerHost(new vfs.FileSystem(true, {
                     files: {

--- a/src/testRunner/unittests/services/languageService.ts
+++ b/src/testRunner/unittests/services/languageService.ts
@@ -42,7 +42,7 @@ export function Component(x: Config): any;`
             });
         }
         // Regression test for GH #18245 - bug in single line comment writer caused a debug assertion when attempting
-        //  to write an alias to a module's default export was referrenced across files and had no default export
+        //  to write an alias to a module's default export was referenced across files and had no default export
         it("should be able to create a language service which can respond to deinition requests without throwing", () => {
             const languageService = createLanguageService();
             const definitions = languageService.getDefinitionAtPosition("foo.ts", 160); // 160 is the latter `vueTemplateHtml` position

--- a/src/testRunner/unittests/tsbuildWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tsbuildWatch/programUpdates.ts
@@ -698,7 +698,7 @@ export function someFn() { }`),
                     timeouts: checkSingleTimeoutQueueLengthAndRunAndVerifyNoTimeout // Build project2
                 },
                 {
-                    caption: "update aplha config",
+                    caption: "update alpha config",
                     change: sys => sys.writeFile("/a/b/alpha.tsconfig.json", "{}"),
                     timeouts: checkSingleTimeoutQueueLengthAndRun, // build project1
                 },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes typo spelling grammar
## description
fixes typo spelling grammar and replace to correct word with reference from [merriam webster](merriam-webster.com)

## testing
testing not include because just replace the missing typos