### PR TITLE
fix(45417): null and literal-like identifiers do not get inlay hints

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26311,10 +26311,6 @@ namespace ts {
             return isTypeAssignableToKind(checkComputedPropertyName(name), TypeFlags.NumberLike);
         }
 
-        function isInfinityOrNaNString(name: string | __String): boolean {
-            return name === "Infinity" || name === "-Infinity" || name === "NaN";
-        }
-
         function isNumericLiteralName(name: string | __String) {
             // The intent of numeric names is that
             //     - they are names with text in a numeric form, and that

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7367,4 +7367,9 @@ namespace ts {
         }
         return false;
     }
+
+    /* @internal */
+    export function isInfinityOrNaNString(name: string | __String): boolean {
+        return name === "Infinity" || name === "-Infinity" || name === "NaN";
+    }
 }

--- a/src/services/classifier2020.ts
+++ b/src/services/classifier2020.ts
@@ -225,10 +225,6 @@ namespace ts.classifier.v2020 {
         return (isQualifiedName(node.parent) && node.parent.right === node) || (isPropertyAccessExpression(node.parent) && node.parent.name === node);
     }
 
-    function isInfinityOrNaNString(name: __String): boolean {
-        return name === "Infinity" || name === "NaN";
-    }
-
     const tokenFromDeclarationMapping = new Map<SyntaxKind, TokenType>([
         [SyntaxKind.VariableDeclaration, TokenType.variable],
         [SyntaxKind.Parameter, TokenType.parameter],

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -204,15 +204,22 @@ namespace ts.InlayHints {
 
         function isHintableExpression(node: Node) {
             switch (node.kind) {
-                case SyntaxKind.PrefixUnaryExpression:
-                    return isLiteralExpression((node as PrefixUnaryExpression).operand);
+                case SyntaxKind.PrefixUnaryExpression: {
+                    const operand = (node as PrefixUnaryExpression).operand;
+                    return isLiteralExpression(operand) || isIdentifier(operand) && isInfinityOrNaNString(operand.escapedText);
+                }
                 case SyntaxKind.TrueKeyword:
                 case SyntaxKind.FalseKeyword:
                 case SyntaxKind.ArrowFunction:
                 case SyntaxKind.FunctionExpression:
                 case SyntaxKind.ObjectLiteralExpression:
                 case SyntaxKind.ArrayLiteralExpression:
+                case SyntaxKind.NullKeyword:
                     return true;
+                case SyntaxKind.Identifier: {
+                    const name = (node as Identifier).escapedText;
+                    return isUndefined(name) || isInfinityOrNaNString(name);
+                }
             }
             return isLiteralExpression(node);
         }
@@ -309,6 +316,10 @@ namespace ts.InlayHints {
                 Debug.assertIsDefined(typeNode, "should always get typenode");
                 printer.writeNode(EmitHint.Unspecified, typeNode, /*sourceFile*/ file, writer);
             });
+        }
+
+        function isUndefined(name: __String) {
+            return name === "undefined";
         }
     }
 }

--- a/tests/cases/fourslash/inlayHintsShouldWork64.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork64.ts
@@ -1,0 +1,94 @@
+/// <reference path="fourslash.ts" />
+
+////function foo(
+////    a: string,
+////    b: undefined,
+////    c: null,
+////    d: boolean,
+////    e: boolean,
+////    f: number,
+////    g: number,
+////    h: number,
+////    i: RegExp,
+////    j: bigint,
+////) {
+////}
+////
+////foo(
+////    /*a*/"hello",
+////    /*b*/undefined,
+////    /*c*/null,
+////    /*d*/true,
+////    /*e*/false,
+////    /*f*/Infinity,
+////    /*g*/-Infinity,
+////    /*h*/NaN,
+////    /*i*//hello/g,
+////    /*j*/123n,
+////);
+
+const [a, b, c, d, e, f, g, h, i, j] = test.markers();
+verify.getInlayHints([
+    {
+        text: "a:",
+        position: a.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "b:",
+        position: b.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "c:",
+        position: c.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "d:",
+        position: d.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "e:",
+        position: e.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "f:",
+        position: f.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "g:",
+        position: g.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "h:",
+        position: h.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "i:",
+        position: i.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "j:",
+        position: j.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    }
+], undefined, {
+    includeInlayParameterNameHints: "literals"
+});


### PR DESCRIPTION
Fixes #45417