### PR TITLE
Add rich navigation indexing action

### DIFF
--- a/.github/workflow-resources/.lsifrc.json
+++ b/.github/workflow-resources/.lsifrc.json
@@ -1,0 +1,6 @@
+{
+	"project": "../../src/tsconfig.json",
+	"source": "../../package.json",
+	"package": "../../package.json",
+	"out": "../../typescript.lsif"
+}

--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -1,0 +1,36 @@
+name: "Rich Navigation Indexing"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - release-*
+      - dbaeumer/richNav
+  pull_request:
+    branches:
+      - main
+      - release-*
+
+jobs:
+  richnav:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 5
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install dependencies
+        run:  npm ci
+
+      - uses: microsoft/RichCodeNavIndexer@v0.1
+        with:
+          languages: typescript
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          typescriptVersion: 0.6.0-next.17
+          configFiles: .lsifrc.json
+        continue-on-error: true

--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - release-*
-      - dbaeumer/richNav
   pull_request:
     branches:
       - main

--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release-*
+      - dbaeumer/richNav
   pull_request:
     branches:
       - main
@@ -30,6 +31,6 @@ jobs:
         with:
           languages: typescript
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          typescriptVersion: 0.6.0-next.17
-          configFiles: .lsifrc.json
+          typescriptVersion: 0.6.0-next.18
+          configFiles: .github/workflow-resources/.lsifrc.json
         continue-on-error: true

--- a/.lsifrc.json
+++ b/.lsifrc.json
@@ -1,0 +1,6 @@
+{
+	"project": "src/tsconfig.json",
+	"source": "./package.json",
+	"package": "package.json",
+	"out": "typescript.lsif"
+}

--- a/.lsifrc.json
+++ b/.lsifrc.json
@@ -1,6 +1,0 @@
-{
-	"project": "src/tsconfig.json",
-	"source": "./package.json",
-	"package": "package.json",
-	"out": "typescript.lsif"
-}


### PR DESCRIPTION
This PR adds a GitHub action that indexes the repository for the main and release branches (as well as PRs) and stores the index in RichNav. This allows browsing the repository via vscode.dev with support for rich code navigation. 