### PR TITLE
feat(45295): Consider adding setting that only shows inlay hint parameter names for simple literals (string, number, bool)

### DIFF
--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -579,7 +579,7 @@ namespace ts {
     }
 
     export interface InlayHintsOptions extends UserPreferences {
-        readonly includeInlayParameterNameHints?: "none" | "literals" | "all";
+        readonly includeInlayParameterNameHints?: "none" | "literals" | "primitiveLiterals" | "all";
         readonly includeInlayParameterNameHintsWhenArgumentMatchesName?: boolean;
         readonly includeInlayFunctionParameterTypeHints?: boolean,
         readonly includeInlayVariableTypeHints?: boolean;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5766,7 +5766,7 @@ declare namespace ts {
         includeInsertTextCompletions?: boolean;
     }
     interface InlayHintsOptions extends UserPreferences {
-        readonly includeInlayParameterNameHints?: "none" | "literals" | "all";
+        readonly includeInlayParameterNameHints?: "none" | "literals" | "primitiveLiterals" | "all";
         readonly includeInlayParameterNameHintsWhenArgumentMatchesName?: boolean;
         readonly includeInlayFunctionParameterTypeHints?: boolean;
         readonly includeInlayVariableTypeHints?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5766,7 +5766,7 @@ declare namespace ts {
         includeInsertTextCompletions?: boolean;
     }
     interface InlayHintsOptions extends UserPreferences {
-        readonly includeInlayParameterNameHints?: "none" | "literals" | "all";
+        readonly includeInlayParameterNameHints?: "none" | "literals" | "primitiveLiterals" | "all";
         readonly includeInlayParameterNameHintsWhenArgumentMatchesName?: boolean;
         readonly includeInlayFunctionParameterTypeHints?: boolean;
         readonly includeInlayVariableTypeHints?: boolean;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -645,7 +645,7 @@ declare namespace FourSlashInterface {
         readonly importModuleSpecifierEnding?: "minimal" | "index" | "js";
     }
     interface InlayHintsOptions extends UserPreferences {
-        readonly includeInlayParameterNameHints?: "none" | "literals" | "all";
+        readonly includeInlayParameterNameHints?: "none" | "literals" | "primitiveLiterals" | "all";
         readonly includeInlayParameterNameHintsWhenArgumentMatchesName?: boolean;
         readonly includeInlayFunctionParameterTypeHints?: boolean;
         readonly includeInlayVariableTypeHints?: boolean;

--- a/tests/cases/fourslash/inlayHintsShouldWork65.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork65.ts
@@ -1,0 +1,85 @@
+/// <reference path="fourslash.ts" />
+
+////function foo(
+////    a: number,
+////    b: number,
+////    c: number,
+////    d: number,
+////    e: number,
+////    f: number,
+////    g: number,
+////    h: number,
+////    i: number
+////) {}
+////
+////foo(
+////    /*a*/+"",
+////    /*b*/+``,
+////    /*c*/+{},
+////    /*d*/+[],
+////    /*e*/+/a/,
+////    /*f*/+Infinity,
+////    /*g*/+NaN,
+////    /*h*/+function() {},
+////    /*i*/+(() => {}),
+////);
+
+const [a, b, c, d, e, f, g, h, i] = test.markers();
+verify.getInlayHints([
+    {
+        text: "a:",
+        position: a.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "b:",
+        position: b.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "c:",
+        position: c.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "d:",
+        position: d.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "e:",
+        position: e.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "f:",
+        position: f.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "g:",
+        position: g.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "h:",
+        position: h.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "i:",
+        position: i.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    }
+], undefined, {
+    includeInlayParameterNameHints: "literals"
+});

--- a/tests/cases/fourslash/inlayHints_primitiveLiterals1.ts
+++ b/tests/cases/fourslash/inlayHints_primitiveLiterals1.ts
@@ -1,0 +1,86 @@
+/// <reference path="fourslash.ts" />
+
+////function foo(
+////    a: string,
+////    b: undefined,
+////    c: null,
+////    d: boolean,
+////    e: boolean,
+////    f: number,
+////    g: number,
+////    h: number,
+////    i: bigint
+////) {
+////}
+////
+////foo(
+////    /*a*/"hello",
+////    /*b*/undefined,
+////    /*c*/null,
+////    /*d*/true,
+////    /*e*/false,
+////    /*f*/Infinity,
+////    /*g*/-Infinity,
+////    /*h*/NaN,
+////    /*i*/123n
+////);
+
+const [a, b, c, d, e, f, g, h, i] = test.markers();
+verify.getInlayHints([
+    {
+        text: "a:",
+        position: a.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "b:",
+        position: b.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "c:",
+        position: c.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "d:",
+        position: d.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "e:",
+        position: e.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "f:",
+        position: f.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "g:",
+        position: g.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "h:",
+        position: h.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: "i:",
+        position: i.position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    }
+], undefined, {
+    includeInlayParameterNameHints: "primitiveLiterals"
+});

--- a/tests/cases/fourslash/inlayHints_primitiveLiterals2.ts
+++ b/tests/cases/fourslash/inlayHints_primitiveLiterals2.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+////function foo(
+////    a: number[],
+////    b: { x: number; y: number; },
+////    c: () => void,
+////    d: () => void,
+////    e: RegExp,
+////    f: string,
+////    g: string
+////) {}
+////
+////foo(
+////    /*a*/[1],
+////    /*b*/{ x: 1, y: 1 },
+////    /*c*/() => {},
+////    /*d*/function () {},
+////    /*e*//foo/i,
+////    /*f*/``
+////    /*g*/`${1} ${2} ${3}`
+////);
+
+verify.getInlayHints([], undefined, {
+    includeInlayParameterNameHints: "primitiveLiterals"
+});


### PR DESCRIPTION
Fixes #45295