### PR TITLE
fix(45501): VS Code removes spaces between empty object literals even if insertSpaceAfterOpeningAndBeforeClosingEmptyBraces is true

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -95,7 +95,6 @@ namespace ts.formatting {
             // Also should not apply to })
             rule("SpaceBetweenCloseBraceAndElse", SyntaxKind.CloseBraceToken, SyntaxKind.ElseKeyword, [isNonJsxSameLineTokenContext], RuleAction.InsertSpace),
             rule("SpaceBetweenCloseBraceAndWhile", SyntaxKind.CloseBraceToken, SyntaxKind.WhileKeyword, [isNonJsxSameLineTokenContext], RuleAction.InsertSpace),
-            rule("NoSpaceBetweenEmptyBraceBrackets", SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken, [isNonJsxSameLineTokenContext, isObjectContext], RuleAction.DeleteSpace),
 
             // Add a space after control dec context if the next character is an open bracket ex: 'if (false)[a, b] = [1, 2];' -> 'if (false) [a, b] = [1, 2];'
             rule("SpaceAfterConditionalClosingParen", SyntaxKind.CloseParenToken, SyntaxKind.OpenBracketToken, [isControlDeclContext], RuleAction.InsertSpace),
@@ -270,9 +269,9 @@ namespace ts.formatting {
             // Insert a space after { and before } in single-line contexts, but remove space from empty object literals {}.
             rule("SpaceAfterOpenBrace", SyntaxKind.OpenBraceToken, anyToken, [isOptionEnabledOrUndefined("insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces"), isBraceWrappedContext], RuleAction.InsertSpace),
             rule("SpaceBeforeCloseBrace", anyToken, SyntaxKind.CloseBraceToken, [isOptionEnabledOrUndefined("insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces"), isBraceWrappedContext], RuleAction.InsertSpace),
-            rule("NoSpaceBetweenEmptyBraceBrackets", SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken, [isNonJsxSameLineTokenContext, isObjectContext], RuleAction.DeleteSpace),
             rule("NoSpaceAfterOpenBrace", SyntaxKind.OpenBraceToken, anyToken, [isOptionDisabled("insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces"), isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
             rule("NoSpaceBeforeCloseBrace", anyToken, SyntaxKind.CloseBraceToken, [isOptionDisabled("insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces"), isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
+            rule("NoSpaceBetweenEmptyBraceBrackets", SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken, [isOptionDisabledOrUndefined("insertSpaceAfterOpeningAndBeforeClosingEmptyBraces"), isNonJsxSameLineTokenContext, isObjectContext], RuleAction.DeleteSpace),
 
             // Insert a space after opening and before closing empty brace brackets
             rule("SpaceBetweenEmptyBraceBrackets", SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken, [isOptionEnabled("insertSpaceAfterOpeningAndBeforeClosingEmptyBraces")], RuleAction.InsertSpace),

--- a/tests/cases/fourslash/formattingNoSpaceBetweenEmptyBraceBrackets.ts
+++ b/tests/cases/fourslash/formattingNoSpaceBetweenEmptyBraceBrackets.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts"/>
+
+////const a = { };
+////const b = {};
+
+format.setOption("insertSpaceAfterOpeningAndBeforeClosingEmptyBraces", false);
+format.document();
+verify.currentFileContentIs(
+`const a = {};
+const b = {};`
+);

--- a/tests/cases/fourslash/formattingSpaceBetweenEmptyBraceBrackets.ts
+++ b/tests/cases/fourslash/formattingSpaceBetweenEmptyBraceBrackets.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts"/>
+
+////const a = { };
+////const b = {};
+
+format.setOption("insertSpaceAfterOpeningAndBeforeClosingEmptyBraces", true);
+format.document();
+verify.currentFileContentIs(
+`const a = { };
+const b = { };`
+);


### PR DESCRIPTION
Fixes #45501