### PR TITLE
Adds support for overwriting `lib` references via the TSConfig 

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5929,6 +5929,11 @@ namespace ts {
         name: string;
     }
 
+    export interface LibReplaceReference {
+        replace: string;
+        with: string;
+    }
+
     export interface ProjectReference {
         /** A normalized path on disk */
         path: string;
@@ -5963,7 +5968,8 @@ namespace ts {
         FixedChunkSize,
     }
 
-    export type CompilerOptionsValue = string | number | boolean | (string | number)[] | string[] | MapLike<string[]> | PluginImport[] | ProjectReference[] | null | undefined;
+    type LibType = (string | LibReplaceReference)[]
+    export type CompilerOptionsValue = string | number | boolean | (string | number)[] | string[] | MapLike<string[]> | PluginImport[] | ProjectReference[] | LibType | null | undefined;
 
     export interface CompilerOptions {
         /*@internal*/ all?: boolean;
@@ -6010,7 +6016,7 @@ namespace ts {
         isolatedModules?: boolean;
         jsx?: JsxEmit;
         keyofStringsOnly?: boolean;
-        lib?: string[];
+        lib?: (string | LibReplaceReference)[];
         /*@internal*/listEmittedFiles?: boolean;
         /*@internal*/listFiles?: boolean;
         /*@internal*/explainFiles?: boolean;
@@ -6246,7 +6252,7 @@ namespace ts {
     /* @internal */
     export interface CommandLineOptionBase {
         name: string;
-        type: "string" | "number" | "boolean" | "object" | "list" | ESMap<string, number | string>;    // a value of a primitive type, or an object literal mapping named values to actual values
+        type: "string" | "number" | "boolean" | "object" | "list" | ESMap<string, number | string | { replace: string, with: string } >;    // a value of a primitive type, or an object literal mapping named values to actual values
         isFilePath?: boolean;                                   // True if option value is a path or fileName
         shortName?: string;                                     // A short mnemonic for convenience - for instance, 'h' can be used in place of 'help'
         description?: DiagnosticMessage;                        // The message describing what the command line switch does.
@@ -6278,6 +6284,11 @@ namespace ts {
     }
 
     /* @internal */
+    export interface CommandLineOptionLibType extends CommandLineOptionBase {
+        type: ESMap<string, number | string | { replace: string, with: string } >;  // an object showing what to replace
+    }
+
+    /* @internal */
     export interface AlternateModeDiagnostics {
         diagnostic: DiagnosticMessage;
         getOptionsNameMap: () => OptionsNameMap;
@@ -6301,11 +6312,11 @@ namespace ts {
     /* @internal */
     export interface CommandLineOptionOfListType extends CommandLineOptionBase {
         type: "list";
-        element: CommandLineOptionOfCustomType | CommandLineOptionOfPrimitiveType | TsConfigOnlyOption;
+        element: CommandLineOptionLibType | CommandLineOptionOfCustomType | CommandLineOptionOfPrimitiveType | TsConfigOnlyOption;
     }
 
     /* @internal */
-    export type CommandLineOption = CommandLineOptionOfCustomType | CommandLineOptionOfPrimitiveType | TsConfigOnlyOption | CommandLineOptionOfListType;
+    export type CommandLineOption = CommandLineOptionLibType | CommandLineOptionOfCustomType | CommandLineOptionOfPrimitiveType | TsConfigOnlyOption | CommandLineOptionOfListType;
 
     /* @internal */
     export const enum CharacterCodes {

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -278,7 +278,7 @@ namespace ts {
                     reason.packageId && packageIdToString(reason.packageId),
                 );
             case FileIncludeKind.LibFile:
-                if (reason.index !== undefined) return chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Library_0_specified_in_compilerOptions, options.lib![reason.index]);
+                if (reason.index !== undefined) return chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Library_0_specified_in_compilerOptions, options.lib![reason.index] as string);
                 const target = forEachEntry(targetOptionDeclaration.type, (value, key) => value === options.target ? key : undefined);
                 return chainDiagnosticMessages(
                     /*details*/ undefined,

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -327,6 +327,7 @@ namespace FourSlash {
                         Harness.Compiler.getDefaultLibrarySourceFile()!.text, /*isRootFile*/ false);
 
                     compilationOptions.lib?.forEach(fileName => {
+                        if (!ts.isString(fileName)) return;
                         const libFile = Harness.Compiler.getDefaultLibrarySourceFile(fileName);
                         ts.Debug.assertIsDefined(libFile, `Could not find lib file '${fileName}'`);
                         if (libFile) {

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -1079,7 +1079,13 @@ namespace Harness {
         const option = ts.forEach(ts.optionDeclarations, decl => ts.equateStringsCaseInsensitive(decl.name, varyBy) ? decl : undefined);
         if (option) {
             if (typeof option.type === "object") {
-                return option.type;
+                // Array.from(option.type.values()).every(v => typeof v === "string" || typeof v === "number")
+                if(varyBy === "lib") {
+
+                    ts.Debug.assert("Can't vary a test which uses lib, because it can contain objects" + JSON.stringify(option));
+                }
+                return option.type as ts.ReadonlyESMap<string, string | number>;
+
             }
             if (option.type === "boolean") {
                 return booleanVaryByStarSettingValues || (booleanVaryByStarSettingValues = new ts.Map(ts.getEntries({

--- a/tests/baselines/reference/customLibReplacement.errors.txt
+++ b/tests/baselines/reference/customLibReplacement.errors.txt
@@ -1,0 +1,14 @@
+/index.ts(5,1): error TS2304: Cannot find name 'window'.
+
+
+==== /fake-dom.d.ts (0 errors) ====
+    interface ABC {}
+    
+==== /index.ts (1 errors) ====
+    /// <reference lib="dom" />
+    const a: ABC = {}
+    
+    // This should raise ebcause 'window' is not set in the replacement for DOM
+    window
+    ~~~~~~
+!!! error TS2304: Cannot find name 'window'.

--- a/tests/baselines/reference/customLibReplacement.js
+++ b/tests/baselines/reference/customLibReplacement.js
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/customLibReplacement.ts] ////
+
+//// [fake-dom.d.ts]
+interface ABC {}
+
+//// [index.ts]
+/// <reference lib="dom" />
+const a: ABC = {}
+
+// This should raise ebcause 'window' is not set in the replacement for DOM
+window
+
+//// [index.js]
+/// <reference lib="dom" />
+var a = {};
+// This should raise ebcause 'window' is not set in the replacement for DOM
+window;

--- a/tests/baselines/reference/customLibReplacement.symbols
+++ b/tests/baselines/reference/customLibReplacement.symbols
@@ -1,0 +1,12 @@
+=== /fake-dom.d.ts ===
+interface ABC {}
+>ABC : Symbol(ABC, Decl(fake-dom.d.ts, 0, 0))
+
+=== /index.ts ===
+/// <reference lib="dom" />
+const a: ABC = {}
+>a : Symbol(a, Decl(index.ts, 1, 5))
+>ABC : Symbol(ABC, Decl(fake-dom.d.ts, 0, 0))
+
+// This should raise ebcause 'window' is not set in the replacement for DOM
+window

--- a/tests/baselines/reference/customLibReplacement.types
+++ b/tests/baselines/reference/customLibReplacement.types
@@ -1,0 +1,13 @@
+=== /fake-dom.d.ts ===
+interface ABC {}
+No type information for this code.
+No type information for this code.=== /index.ts ===
+/// <reference lib="dom" />
+const a: ABC = {}
+>a : ABC
+>{} : {}
+
+// This should raise ebcause 'window' is not set in the replacement for DOM
+window
+>window : any
+

--- a/tests/cases/compiler/customLibReplacement.ts
+++ b/tests/cases/compiler/customLibReplacement.ts
@@ -1,0 +1,10 @@
+// @lib: es2015,{ "replace": "dom", "with": "./fake-dom.d.ts" }
+// @Filename: /fake-dom.d.ts
+interface ABC {}
+
+// @Filename: index.ts
+/// <reference lib="dom" />
+const a: ABC = {}
+
+// This should raise ebcause 'window' is not set in the replacement for DOM
+window


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/44795

This PR changes the lib file resolving based on whether you have included an override in your `tsconfig.json`, so for example:

```
{
  "compilerOptions": {
    "target": "es2015",
    "lib": ["es2015", { replace: "dom", with: "@types/web" }]
  }
}
```

Would never access `lib.dom.d.ts` if it were imported via a `/// <reference lib="dom" />` - it would redirect to `@types/web` resolved relative to the `tsconfig.json` which is how it would be referred to by DT modules and libraries. 

---

### PR TODO

 - [ ] Resolve the `with` to a real file path during tsconfig creation, so that it can be used later before the checker starts up (and by which point we've lost the reference to the tsconfig filepath)
 - [ ]  Add some error handling
 - [ ] Cleanup all the 'do not ship with theses
 - [ ] Add a getLib helper which returns `string[]`
 - [ ] Test with symlinks (e.g. replace dom where the file is a symlink, and where the dir where the file lives is a symlink)