### PR TITLE
feat(45010): handle unclosed fragment in `getJsxClosingTagAtPosition`

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2593,14 +2593,14 @@ namespace ts {
 
     export interface JsxExpression extends Expression {
         readonly kind: SyntaxKind.JsxExpression;
-        readonly parent: JsxElement | JsxAttributeLike;
+        readonly parent: JsxElement | JsxFragment | JsxAttributeLike;
         readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
         readonly expression?: Expression;
     }
 
     export interface JsxText extends LiteralLikeNode {
         readonly kind: SyntaxKind.JsxText;
-        readonly parent: JsxElement;
+        readonly parent: JsxElement | JsxFragment;
         readonly containsOnlyTriviaWhiteSpaces: boolean;
     }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1180,7 +1180,7 @@ namespace ts.Completions {
             case SyntaxKind.CaseKeyword:
                 return getSwitchedType(cast(parent, isCaseClause), checker);
             case SyntaxKind.OpenBraceToken:
-                return isJsxExpression(parent) && parent.parent.kind !== SyntaxKind.JsxElement ? checker.getContextualTypeForJsxAttribute(parent.parent) : undefined;
+                return isJsxExpression(parent) && !isJsxElement(parent.parent) && !isJsxFragment(parent.parent) ? checker.getContextualTypeForJsxAttribute(parent.parent) : undefined;
             default:
                 const argInfo = SignatureHelp.getArgumentInfoForCompletions(previousToken, position, sourceFile);
                 return argInfo ?

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2088,9 +2088,14 @@ namespace ts {
             const token = findPrecedingToken(position, sourceFile);
             if (!token) return undefined;
             const element = token.kind === SyntaxKind.GreaterThanToken && isJsxOpeningElement(token.parent) ? token.parent.parent
-                : isJsxText(token) ? token.parent : undefined;
+                : isJsxText(token) && isJsxElement(token.parent) ? token.parent : undefined;
             if (element && isUnclosedTag(element)) {
                 return { newText: `</${element.openingElement.tagName.getText(sourceFile)}>` };
+            }
+            const fragment = token.kind === SyntaxKind.GreaterThanToken && isJsxOpeningFragment(token.parent) ? token.parent.parent
+                : isJsxText(token) && isJsxFragment(token.parent) ? token.parent : undefined;
+            if (fragment && isUnclosedFragment(fragment)) {
+                return { newText: "</>" };
             }
         }
 
@@ -2332,6 +2337,10 @@ namespace ts {
         function isUnclosedTag({ openingElement, closingElement, parent }: JsxElement): boolean {
             return !tagNamesAreEquivalent(openingElement.tagName, closingElement.tagName) ||
                 isJsxElement(parent) && tagNamesAreEquivalent(openingElement.tagName, parent.openingElement.tagName) && isUnclosedTag(parent);
+        }
+
+        function isUnclosedFragment({ closingFragment, parent }: JsxFragment): boolean {
+            return !!(closingFragment.flags & NodeFlags.ThisNodeHasError) || (isJsxFragment(parent) && isUnclosedFragment(parent));
         }
 
         function getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): TextSpan | undefined {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1381,13 +1381,13 @@ declare namespace ts {
     }
     export interface JsxExpression extends Expression {
         readonly kind: SyntaxKind.JsxExpression;
-        readonly parent: JsxElement | JsxAttributeLike;
+        readonly parent: JsxElement | JsxFragment | JsxAttributeLike;
         readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
         readonly expression?: Expression;
     }
     export interface JsxText extends LiteralLikeNode {
         readonly kind: SyntaxKind.JsxText;
-        readonly parent: JsxElement;
+        readonly parent: JsxElement | JsxFragment;
         readonly containsOnlyTriviaWhiteSpaces: boolean;
     }
     export type JsxChild = JsxText | JsxExpression | JsxElement | JsxSelfClosingElement | JsxFragment;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1381,13 +1381,13 @@ declare namespace ts {
     }
     export interface JsxExpression extends Expression {
         readonly kind: SyntaxKind.JsxExpression;
-        readonly parent: JsxElement | JsxAttributeLike;
+        readonly parent: JsxElement | JsxFragment | JsxAttributeLike;
         readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
         readonly expression?: Expression;
     }
     export interface JsxText extends LiteralLikeNode {
         readonly kind: SyntaxKind.JsxText;
-        readonly parent: JsxElement;
+        readonly parent: JsxElement | JsxFragment;
         readonly containsOnlyTriviaWhiteSpaces: boolean;
     }
     export type JsxChild = JsxText | JsxExpression | JsxElement | JsxSelfClosingElement | JsxFragment;

--- a/tests/cases/fourslash/autoCloseFragment.ts
+++ b/tests/cases/fourslash/autoCloseFragment.ts
@@ -35,7 +35,7 @@
 
 // @Filename: /8.tsx
 ////const x = <div>
-////    <div>/*8*/</div>
+////    <>/*8*/</>
 ////</div>;
 
 verify.jsxClosingTag({

--- a/tests/cases/fourslash/autoCloseFragment.ts
+++ b/tests/cases/fourslash/autoCloseFragment.ts
@@ -1,0 +1,51 @@
+/// <reference path='fourslash.ts' />
+
+// Using separate files for each example to avoid unclosed JSX tags affecting other tests.
+
+// @Filename: /0.tsx
+////const x = <>/*0*/;
+
+// @Filename: /1.tsx
+////const x = <> foo/*1*/ </>;
+
+// @Filename: /2.tsx
+////const x = <></>/*2*/;
+
+// @Filename: /3.tsx
+////const x = </>/*3*/;
+
+// @Filename: /4.tsx
+////const x = <div>
+////    <>/*4*/
+////    </div>
+////</>;
+
+// @Filename: /5.tsx
+////const x = <> text /*5*/;
+
+// @Filename: /6.tsx
+////const x = <>
+////    <>/*6*/
+////</>;
+
+// @Filename: /7.tsx
+////const x = <div>
+////    <>/*7*/
+////</div>;
+
+// @Filename: /8.tsx
+////const x = <div>
+////    <div>/*8*/</div>
+////</div>;
+
+verify.jsxClosingTag({
+    0: { newText: "</>" },
+    1: undefined,
+    2: undefined,
+    3: undefined,
+    4: { newText: "</>" },
+    5: { newText: "</>" },
+    6: { newText: "</>" },
+    7: { newText: "</>" },
+    8: undefined,
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes https://github.com/microsoft/TypeScript/issues/45010

This PR attempts to handle unclosed jsx fragment in language service so that it will auto-complete on vscode.
I used `NodeFlags.ThisNodeHasError` directly to detect the parse error related to the closing fragment, which might not be the most reliable way to check unclosed fragment, but at least for the test cases I added (mostly the copy of existing `autoCloseTag.ts`), it seems to be working.
Please let me know if this is a right approach or if there's a better way to do it.
I would appreciate any feedback, thanks a lot!
