### PR TITLE
Track non-null unknown types in control flow analysis

### DIFF
--- a/tests/baselines/reference/controlFlowTypeofObject.errors.txt
+++ b/tests/baselines/reference/controlFlowTypeofObject.errors.txt
@@ -1,0 +1,77 @@
+tests/cases/conformance/controlFlow/controlFlowTypeofObject.ts(66,13): error TS2345: Argument of type 'object | null' is not assignable to parameter of type 'object'.
+  Type 'null' is not assignable to type 'object'.
+
+
+==== tests/cases/conformance/controlFlow/controlFlowTypeofObject.ts (1 errors) ====
+    declare function obj(x: object): void;
+    
+    function f1(x: unknown) {
+        if (!x) {
+            return;
+        }
+        if (typeof x === 'object') {
+            obj(x);
+        }
+    }
+    
+    function f2(x: unknown) {
+        if (x === null) {
+            return;
+        }
+        if (typeof x === 'object') {
+            obj(x);
+        }
+    }
+    
+    function f3(x: unknown) {
+        if (x == null) {
+            return;
+        }
+        if (typeof x === 'object') {
+            obj(x);
+        }
+    }
+    
+    function f4(x: unknown) {
+        if (x == undefined) {
+            return;
+        }
+        if (typeof x === 'object') {
+            obj(x);
+        }
+    }
+    
+    function f5(x: unknown) {
+        if (!!true) {
+            if (!x) {
+                return;
+            }
+        }
+        else {
+            if (x === null) {
+                return;
+            }
+        }
+        if (typeof x === 'object') {
+            obj(x);
+        }
+    }
+    
+    function f6(x: unknown) {
+        if (x === null) {
+            x;
+        }
+        else {
+            x;
+            if (typeof x === 'object') {
+                obj(x);
+            }
+        }
+        if (typeof x === 'object') {
+            obj(x);  // Error
+                ~
+!!! error TS2345: Argument of type 'object | null' is not assignable to parameter of type 'object'.
+!!! error TS2345:   Type 'null' is not assignable to type 'object'.
+        }
+    }
+    

--- a/tests/baselines/reference/controlFlowTypeofObject.js
+++ b/tests/baselines/reference/controlFlowTypeofObject.js
@@ -1,0 +1,144 @@
+//// [controlFlowTypeofObject.ts]
+declare function obj(x: object): void;
+
+function f1(x: unknown) {
+    if (!x) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+
+function f2(x: unknown) {
+    if (x === null) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+
+function f3(x: unknown) {
+    if (x == null) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+
+function f4(x: unknown) {
+    if (x == undefined) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+
+function f5(x: unknown) {
+    if (!!true) {
+        if (!x) {
+            return;
+        }
+    }
+    else {
+        if (x === null) {
+            return;
+        }
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+
+function f6(x: unknown) {
+    if (x === null) {
+        x;
+    }
+    else {
+        x;
+        if (typeof x === 'object') {
+            obj(x);
+        }
+    }
+    if (typeof x === 'object') {
+        obj(x);  // Error
+    }
+}
+
+
+//// [controlFlowTypeofObject.js]
+"use strict";
+function f1(x) {
+    if (!x) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+function f2(x) {
+    if (x === null) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+function f3(x) {
+    if (x == null) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+function f4(x) {
+    if (x == undefined) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+function f5(x) {
+    if (!!true) {
+        if (!x) {
+            return;
+        }
+    }
+    else {
+        if (x === null) {
+            return;
+        }
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+function f6(x) {
+    if (x === null) {
+        x;
+    }
+    else {
+        x;
+        if (typeof x === 'object') {
+            obj(x);
+        }
+    }
+    if (typeof x === 'object') {
+        obj(x); // Error
+    }
+}
+
+
+//// [controlFlowTypeofObject.d.ts]
+declare function obj(x: object): void;
+declare function f1(x: unknown): void;
+declare function f2(x: unknown): void;
+declare function f3(x: unknown): void;
+declare function f4(x: unknown): void;
+declare function f5(x: unknown): void;
+declare function f6(x: unknown): void;

--- a/tests/baselines/reference/controlFlowTypeofObject.symbols
+++ b/tests/baselines/reference/controlFlowTypeofObject.symbols
@@ -1,0 +1,136 @@
+=== tests/cases/conformance/controlFlow/controlFlowTypeofObject.ts ===
+declare function obj(x: object): void;
+>obj : Symbol(obj, Decl(controlFlowTypeofObject.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 0, 21))
+
+function f1(x: unknown) {
+>f1 : Symbol(f1, Decl(controlFlowTypeofObject.ts, 0, 38))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 2, 12))
+
+    if (!x) {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 2, 12))
+
+        return;
+    }
+    if (typeof x === 'object') {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 2, 12))
+
+        obj(x);
+>obj : Symbol(obj, Decl(controlFlowTypeofObject.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 2, 12))
+    }
+}
+
+function f2(x: unknown) {
+>f2 : Symbol(f2, Decl(controlFlowTypeofObject.ts, 9, 1))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 11, 12))
+
+    if (x === null) {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 11, 12))
+
+        return;
+    }
+    if (typeof x === 'object') {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 11, 12))
+
+        obj(x);
+>obj : Symbol(obj, Decl(controlFlowTypeofObject.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 11, 12))
+    }
+}
+
+function f3(x: unknown) {
+>f3 : Symbol(f3, Decl(controlFlowTypeofObject.ts, 18, 1))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 20, 12))
+
+    if (x == null) {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 20, 12))
+
+        return;
+    }
+    if (typeof x === 'object') {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 20, 12))
+
+        obj(x);
+>obj : Symbol(obj, Decl(controlFlowTypeofObject.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 20, 12))
+    }
+}
+
+function f4(x: unknown) {
+>f4 : Symbol(f4, Decl(controlFlowTypeofObject.ts, 27, 1))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 29, 12))
+
+    if (x == undefined) {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 29, 12))
+>undefined : Symbol(undefined)
+
+        return;
+    }
+    if (typeof x === 'object') {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 29, 12))
+
+        obj(x);
+>obj : Symbol(obj, Decl(controlFlowTypeofObject.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 29, 12))
+    }
+}
+
+function f5(x: unknown) {
+>f5 : Symbol(f5, Decl(controlFlowTypeofObject.ts, 36, 1))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 38, 12))
+
+    if (!!true) {
+        if (!x) {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 38, 12))
+
+            return;
+        }
+    }
+    else {
+        if (x === null) {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 38, 12))
+
+            return;
+        }
+    }
+    if (typeof x === 'object') {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 38, 12))
+
+        obj(x);
+>obj : Symbol(obj, Decl(controlFlowTypeofObject.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 38, 12))
+    }
+}
+
+function f6(x: unknown) {
+>f6 : Symbol(f6, Decl(controlFlowTypeofObject.ts, 52, 1))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 54, 12))
+
+    if (x === null) {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 54, 12))
+
+        x;
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 54, 12))
+    }
+    else {
+        x;
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 54, 12))
+
+        if (typeof x === 'object') {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 54, 12))
+
+            obj(x);
+>obj : Symbol(obj, Decl(controlFlowTypeofObject.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 54, 12))
+        }
+    }
+    if (typeof x === 'object') {
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 54, 12))
+
+        obj(x);  // Error
+>obj : Symbol(obj, Decl(controlFlowTypeofObject.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowTypeofObject.ts, 54, 12))
+    }
+}
+

--- a/tests/baselines/reference/controlFlowTypeofObject.types
+++ b/tests/baselines/reference/controlFlowTypeofObject.types
@@ -1,0 +1,179 @@
+=== tests/cases/conformance/controlFlow/controlFlowTypeofObject.ts ===
+declare function obj(x: object): void;
+>obj : (x: object) => void
+>x : object
+
+function f1(x: unknown) {
+>f1 : (x: unknown) => void
+>x : unknown
+
+    if (!x) {
+>!x : boolean
+>x : unknown
+
+        return;
+    }
+    if (typeof x === 'object') {
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        obj(x);
+>obj(x) : void
+>obj : (x: object) => void
+>x : object
+    }
+}
+
+function f2(x: unknown) {
+>f2 : (x: unknown) => void
+>x : unknown
+
+    if (x === null) {
+>x === null : boolean
+>x : unknown
+>null : null
+
+        return;
+    }
+    if (typeof x === 'object') {
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        obj(x);
+>obj(x) : void
+>obj : (x: object) => void
+>x : object
+    }
+}
+
+function f3(x: unknown) {
+>f3 : (x: unknown) => void
+>x : unknown
+
+    if (x == null) {
+>x == null : boolean
+>x : unknown
+>null : null
+
+        return;
+    }
+    if (typeof x === 'object') {
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        obj(x);
+>obj(x) : void
+>obj : (x: object) => void
+>x : object
+    }
+}
+
+function f4(x: unknown) {
+>f4 : (x: unknown) => void
+>x : unknown
+
+    if (x == undefined) {
+>x == undefined : boolean
+>x : unknown
+>undefined : undefined
+
+        return;
+    }
+    if (typeof x === 'object') {
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        obj(x);
+>obj(x) : void
+>obj : (x: object) => void
+>x : object
+    }
+}
+
+function f5(x: unknown) {
+>f5 : (x: unknown) => void
+>x : unknown
+
+    if (!!true) {
+>!!true : true
+>!true : false
+>true : true
+
+        if (!x) {
+>!x : boolean
+>x : unknown
+
+            return;
+        }
+    }
+    else {
+        if (x === null) {
+>x === null : boolean
+>x : unknown
+>null : null
+
+            return;
+        }
+    }
+    if (typeof x === 'object') {
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        obj(x);
+>obj(x) : void
+>obj : (x: object) => void
+>x : object
+    }
+}
+
+function f6(x: unknown) {
+>f6 : (x: unknown) => void
+>x : unknown
+
+    if (x === null) {
+>x === null : boolean
+>x : unknown
+>null : null
+
+        x;
+>x : null
+    }
+    else {
+        x;
+>x : unknown
+
+        if (typeof x === 'object') {
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+            obj(x);
+>obj(x) : void
+>obj : (x: object) => void
+>x : object
+        }
+    }
+    if (typeof x === 'object') {
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        obj(x);  // Error
+>obj(x) : void
+>obj : (x: object) => void
+>x : object | null
+    }
+}
+

--- a/tests/cases/conformance/controlFlow/controlFlowTypeofObject.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowTypeofObject.ts
@@ -1,0 +1,71 @@
+// @strict: true
+// @declaration: true
+
+declare function obj(x: object): void;
+
+function f1(x: unknown) {
+    if (!x) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+
+function f2(x: unknown) {
+    if (x === null) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+
+function f3(x: unknown) {
+    if (x == null) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+
+function f4(x: unknown) {
+    if (x == undefined) {
+        return;
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+
+function f5(x: unknown) {
+    if (!!true) {
+        if (!x) {
+            return;
+        }
+    }
+    else {
+        if (x === null) {
+            return;
+        }
+    }
+    if (typeof x === 'object') {
+        obj(x);
+    }
+}
+
+function f6(x: unknown) {
+    if (x === null) {
+        x;
+    }
+    else {
+        x;
+        if (typeof x === 'object') {
+            obj(x);
+        }
+    }
+    if (typeof x === 'object') {
+        obj(x);  // Error
+    }
+}


### PR DESCRIPTION
With this PR we fix the following long standing issue:

```ts
declare function obj(x: object): void;

function foo(x: unknown) {
    if (typeof x === 'object' && x !== null) obj(x);  // Ok
    if (x !== null && typeof x === 'object') obj(x);  // Was error, now ok
}
```

Above, the order of the checks mattered because `unknown` is an "indivisible" non-union type and therefore a check for `x !== null` couldn't narrow `x` in the second `if` statement. We implemented a partial fix in #37507, but this only worked for truthy checks combined with `typeof` checks using the `&&` operator in the same expression.

With this PR we remove the partial fix and instead introduce an internal `nonNullUnknownType` that is used in control flow analysis to represent an `unknown` type that is known to be non-null. The non-null unknown type results when the `unknown` type is subjected to a truthiness check or an `x !== null` check, and when the non-null unknown is subsequently subjected to a `typeof x === 'object'` check, we narrow to `object` instead of `object | null`. Because we rely on control flow analysis, this solution properly reflects the effects of non-null checks in separate expressions or statements:

```ts
function bar(x: unknown) {
    if (!x) {
        return;
    }
    if (typeof x === 'object') {
        obj(x);  // Was error, now ok
    }
}
```

Fixes #28131.