### PR TITLE
Infer a string indexer instead of a numeric for Any computed property (#45629)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26394,7 +26394,7 @@ namespace ts {
         function isSymbolWithSymbolName(symbol: Symbol) {
             const firstDecl = symbol.declarations?.[0];
             return isKnownSymbol(symbol) || (firstDecl && isNamedDeclaration(firstDecl) && isComputedPropertyName(firstDecl.name) &&
-                isTypeAssignableToKind(checkComputedPropertyName(firstDecl.name), TypeFlags.ESSymbol));
+                isTypeAssignableToKind(checkComputedPropertyName(firstDecl.name), TypeFlags.ESSymbol, /*strict*/ true));
         }
 
         function getObjectLiteralIndexInfo(node: ObjectLiteralExpression, offset: number, properties: Symbol[], keyType: Type): IndexInfo {
@@ -26566,7 +26566,10 @@ namespace ts {
 
                 if (computedNameType && !(computedNameType.flags & TypeFlags.StringOrNumberLiteralOrUnique)) {
                     if (isTypeAssignableTo(computedNameType, stringNumberSymbolType)) {
-                        if (isTypeAssignableTo(computedNameType, numberType)) {
+                        if (computedNameType.flags & TypeFlags.Any) {
+                            hasComputedStringProperty = true;
+                        }
+                        else if (isTypeAssignableTo(computedNameType, numberType)) {
                             hasComputedNumberProperty = true;
                         }
                         else if (isTypeAssignableTo(computedNameType, esSymbolType)) {

--- a/tests/baselines/reference/FunctionDeclaration8_es6.types
+++ b/tests/baselines/reference/FunctionDeclaration8_es6.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration8_es6.ts ===
 var v = { [yield]: foo }
->v : { [x: number]: any; }
->{ [yield]: foo } : { [x: number]: any; }
+>v : { [x: string]: any; }
+>{ [yield]: foo } : { [x: string]: any; }
 >[yield] : any
 >yield : any
 >foo : any

--- a/tests/baselines/reference/FunctionDeclaration9_es6.types
+++ b/tests/baselines/reference/FunctionDeclaration9_es6.types
@@ -3,8 +3,8 @@ function * foo() {
 >foo : () => Generator<any, void, unknown>
 
   var v = { [yield]: foo }
->v : { [x: number]: () => Generator<any, void, unknown>; }
->{ [yield]: foo } : { [x: number]: () => Generator<any, void, unknown>; }
+>v : { [x: string]: () => Generator<any, void, unknown>; }
+>{ [yield]: foo } : { [x: string]: () => Generator<any, void, unknown>; }
 >[yield] : () => Generator<any, void, unknown>
 >yield : any
 >foo : () => Generator<any, void, unknown>

--- a/tests/baselines/reference/FunctionPropertyAssignments5_es6.types
+++ b/tests/baselines/reference/FunctionPropertyAssignments5_es6.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments5_es6.ts ===
 var v = { *[foo()]() { } }
->v : { [x: number]: () => Generator<never, void, unknown>; }
->{ *[foo()]() { } } : { [x: number]: () => Generator<never, void, unknown>; }
+>v : { [x: string]: () => Generator<never, void, unknown>; }
+>{ *[foo()]() { } } : { [x: string]: () => Generator<never, void, unknown>; }
 >[foo()] : () => Generator<never, void, unknown>
 >foo() : any
 >foo : any

--- a/tests/baselines/reference/asyncArrowFunction8_es2017.types
+++ b/tests/baselines/reference/asyncArrowFunction8_es2017.types
@@ -4,8 +4,8 @@ var foo = async (): Promise<void> => {
 >async (): Promise<void> => {  var v = { [await]: foo }} : () => Promise<void>
 
   var v = { [await]: foo }
->v : { [x: number]: () => Promise<void>; }
->{ [await]: foo } : { [x: number]: () => Promise<void>; }
+>v : { [x: string]: () => Promise<void>; }
+>{ [await]: foo } : { [x: string]: () => Promise<void>; }
 >[await] : () => Promise<void>
 >await : any
 > : any

--- a/tests/baselines/reference/asyncArrowFunction8_es5.types
+++ b/tests/baselines/reference/asyncArrowFunction8_es5.types
@@ -4,8 +4,8 @@ var foo = async (): Promise<void> => {
 >async (): Promise<void> => {  var v = { [await]: foo }} : () => Promise<void>
 
   var v = { [await]: foo }
->v : { [x: number]: () => Promise<void>; }
->{ [await]: foo } : { [x: number]: () => Promise<void>; }
+>v : { [x: string]: () => Promise<void>; }
+>{ [await]: foo } : { [x: string]: () => Promise<void>; }
 >[await] : () => Promise<void>
 >await : any
 > : any

--- a/tests/baselines/reference/asyncArrowFunction8_es6.types
+++ b/tests/baselines/reference/asyncArrowFunction8_es6.types
@@ -4,8 +4,8 @@ var foo = async (): Promise<void> => {
 >async (): Promise<void> => {  var v = { [await]: foo }} : () => Promise<void>
 
   var v = { [await]: foo }
->v : { [x: number]: () => Promise<void>; }
->{ [await]: foo } : { [x: number]: () => Promise<void>; }
+>v : { [x: string]: () => Promise<void>; }
+>{ [await]: foo } : { [x: string]: () => Promise<void>; }
 >[await] : () => Promise<void>
 >await : any
 > : any

--- a/tests/baselines/reference/asyncFunctionDeclaration8_es2017.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration8_es2017.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration8_es2017.ts ===
 var v = { [await]: foo }
->v : { [x: number]: any; }
->{ [await]: foo } : { [x: number]: any; }
+>v : { [x: string]: any; }
+>{ [await]: foo } : { [x: string]: any; }
 >[await] : any
 >await : any
 >foo : any

--- a/tests/baselines/reference/asyncFunctionDeclaration8_es5.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration8_es5.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration8_es5.ts ===
 var v = { [await]: foo }
->v : { [x: number]: any; }
->{ [await]: foo } : { [x: number]: any; }
+>v : { [x: string]: any; }
+>{ [await]: foo } : { [x: string]: any; }
 >[await] : any
 >await : any
 >foo : any

--- a/tests/baselines/reference/asyncFunctionDeclaration8_es6.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration8_es6.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration8_es6.ts ===
 var v = { [await]: foo }
->v : { [x: number]: any; }
->{ [await]: foo } : { [x: number]: any; }
+>v : { [x: string]: any; }
+>{ [await]: foo } : { [x: string]: any; }
 >[await] : any
 >await : any
 >foo : any

--- a/tests/baselines/reference/asyncFunctionDeclaration9_es2017.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration9_es2017.types
@@ -3,8 +3,8 @@ async function foo(): Promise<void> {
 >foo : () => Promise<void>
 
   var v = { [await]: foo }
->v : { [x: number]: () => Promise<void>; }
->{ [await]: foo } : { [x: number]: () => Promise<void>; }
+>v : { [x: string]: () => Promise<void>; }
+>{ [await]: foo } : { [x: string]: () => Promise<void>; }
 >[await] : () => Promise<void>
 >await : any
 > : any

--- a/tests/baselines/reference/asyncFunctionDeclaration9_es5.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration9_es5.types
@@ -3,8 +3,8 @@ async function foo(): Promise<void> {
 >foo : () => Promise<void>
 
   var v = { [await]: foo }
->v : { [x: number]: () => Promise<void>; }
->{ [await]: foo } : { [x: number]: () => Promise<void>; }
+>v : { [x: string]: () => Promise<void>; }
+>{ [await]: foo } : { [x: string]: () => Promise<void>; }
 >[await] : () => Promise<void>
 >await : any
 > : any

--- a/tests/baselines/reference/asyncFunctionDeclaration9_es6.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration9_es6.types
@@ -3,8 +3,8 @@ async function foo(): Promise<void> {
 >foo : () => Promise<void>
 
   var v = { [await]: foo }
->v : { [x: number]: () => Promise<void>; }
->{ [await]: foo } : { [x: number]: () => Promise<void>; }
+>v : { [x: string]: () => Promise<void>; }
+>{ [await]: foo } : { [x: string]: () => Promise<void>; }
 >[await] : () => Promise<void>
 >await : any
 > : any

--- a/tests/baselines/reference/classStaticBlock26.types
+++ b/tests/baselines/reference/classStaticBlock26.types
@@ -15,8 +15,8 @@ class C {
     }
     static {
         ({ [await]: 1 }); // illegal
->({ [await]: 1 }) : { [x: number]: number; }
->{ [await]: 1 } : { [x: number]: number; }
+>({ [await]: 1 }) : { [x: string]: number; }
+>{ [await]: 1 } : { [x: string]: number; }
 >[await] : number
 >await : any
 > : any

--- a/tests/baselines/reference/classUsedBeforeInitializedVariables.types
+++ b/tests/baselines/reference/classUsedBeforeInitializedVariables.types
@@ -69,7 +69,7 @@ class Test {
 
     withinObjectLiteral: any = {
 >withinObjectLiteral : any
->{        [this.withinObjectLiteral]: true,    } : { [x: number]: boolean; }
+>{        [this.withinObjectLiteral]: true,    } : { [x: string]: boolean; }
 
         [this.withinObjectLiteral]: true,
 >[this.withinObjectLiteral] : boolean
@@ -82,7 +82,7 @@ class Test {
 
     withinObjectLiteralGetterName: any = {
 >withinObjectLiteralGetterName : any
->{        get [this.withinObjectLiteralGetterName]() {            return true;        }    } : { [x: number]: boolean; }
+>{        get [this.withinObjectLiteralGetterName]() {            return true;        }    } : { [x: string]: boolean; }
 
         get [this.withinObjectLiteralGetterName]() {
 >[this.withinObjectLiteralGetterName] : boolean
@@ -97,7 +97,7 @@ class Test {
 
     withinObjectLiteralSetterName: any = {
 >withinObjectLiteralSetterName : any
->{        set [this.withinObjectLiteralSetterName](_: any) {}    } : { [x: number]: any; }
+>{        set [this.withinObjectLiteralSetterName](_: any) {}    } : { [x: string]: any; }
 
         set [this.withinObjectLiteralSetterName](_: any) {}
 >[this.withinObjectLiteralSetterName] : any

--- a/tests/baselines/reference/computedPropertiesInDestructuring1.types
+++ b/tests/baselines/reference/computedPropertiesInDestructuring1.types
@@ -163,8 +163,8 @@ let [{[foo.toExponential()]: bar7}] = [{bar: "bar"}];
 
 [{[foo()]: bar4}] = [{bar: "bar"}];
 >[{[foo()]: bar4}] = [{bar: "bar"}] : [{ bar: string; }]
->[{[foo()]: bar4}] : [{ [x: number]: any; }]
->{[foo()]: bar4} : { [x: number]: any; }
+>[{[foo()]: bar4}] : [{ [x: string]: any; }]
+>{[foo()]: bar4} : { [x: string]: any; }
 >[foo()] : any
 >foo() : any
 >foo : string
@@ -176,8 +176,8 @@ let [{[foo.toExponential()]: bar7}] = [{bar: "bar"}];
 
 [{[(1 + {})]: bar4}] = [{bar: "bar"}];
 >[{[(1 + {})]: bar4}] = [{bar: "bar"}] : [{ bar: string; }]
->[{[(1 + {})]: bar4}] : [{ [x: number]: any; }]
->{[(1 + {})]: bar4} : { [x: number]: any; }
+>[{[(1 + {})]: bar4}] : [{ [x: string]: any; }]
+>{[(1 + {})]: bar4} : { [x: string]: any; }
 >[(1 + {})] : any
 >(1 + {}) : any
 >1 + {} : any

--- a/tests/baselines/reference/computedPropertiesInDestructuring1_ES6.types
+++ b/tests/baselines/reference/computedPropertiesInDestructuring1_ES6.types
@@ -170,8 +170,8 @@ let [{[foo.toExponential()]: bar7}] = [{bar: "bar"}];
 
 [{[foo()]: bar4}] = [{bar: "bar"}];
 >[{[foo()]: bar4}] = [{bar: "bar"}] : [{ bar: string; }]
->[{[foo()]: bar4}] : [{ [x: number]: any; }]
->{[foo()]: bar4} : { [x: number]: any; }
+>[{[foo()]: bar4}] : [{ [x: string]: any; }]
+>{[foo()]: bar4} : { [x: string]: any; }
 >[foo()] : any
 >foo() : any
 >foo : string
@@ -183,8 +183,8 @@ let [{[foo.toExponential()]: bar7}] = [{bar: "bar"}];
 
 [{[(1 + {})]: bar4}] = [{bar: "bar"}];
 >[{[(1 + {})]: bar4}] = [{bar: "bar"}] : [{ bar: string; }]
->[{[(1 + {})]: bar4}] : [{ [x: number]: any; }]
->{[(1 + {})]: bar4} : { [x: number]: any; }
+>[{[(1 + {})]: bar4}] : [{ [x: string]: any; }]
+>{[(1 + {})]: bar4} : { [x: string]: any; }
 >[(1 + {})] : any
 >(1 + {}) : any
 >1 + {} : any

--- a/tests/baselines/reference/computedPropertyNames18_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames18_ES5.types
@@ -3,8 +3,8 @@ function foo() {
 >foo : () => void
 
     var obj = {
->obj : { [x: number]: number; }
->{        [this.bar]: 0    } : { [x: number]: number; }
+>obj : { [x: string]: number; }
+>{        [this.bar]: 0    } : { [x: string]: number; }
 
         [this.bar]: 0
 >[this.bar] : number

--- a/tests/baselines/reference/computedPropertyNames18_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames18_ES6.types
@@ -3,8 +3,8 @@ function foo() {
 >foo : () => void
 
     var obj = {
->obj : { [x: number]: number; }
->{        [this.bar]: 0    } : { [x: number]: number; }
+>obj : { [x: string]: number; }
+>{        [this.bar]: 0    } : { [x: string]: number; }
 
         [this.bar]: 0
 >[this.bar] : number

--- a/tests/baselines/reference/computedPropertyNames19_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames19_ES5.types
@@ -3,8 +3,8 @@ module M {
 >M : typeof M
 
     var obj = {
->obj : { [x: number]: number; }
->{        [this.bar]: 0    } : { [x: number]: number; }
+>obj : { [x: string]: number; }
+>{        [this.bar]: 0    } : { [x: string]: number; }
 
         [this.bar]: 0
 >[this.bar] : number

--- a/tests/baselines/reference/computedPropertyNames19_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames19_ES6.types
@@ -3,8 +3,8 @@ module M {
 >M : typeof M
 
     var obj = {
->obj : { [x: number]: number; }
->{        [this.bar]: 0    } : { [x: number]: number; }
+>obj : { [x: string]: number; }
+>{        [this.bar]: 0    } : { [x: string]: number; }
 
         [this.bar]: 0
 >[this.bar] : number

--- a/tests/baselines/reference/computedPropertyNames20_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames20_ES5.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/computedProperties/computedPropertyNames20_ES5.ts ===
 var obj = {
->obj : { [x: number]: number; }
->{    [this.bar]: 0} : { [x: number]: number; }
+>obj : { [x: string]: number; }
+>{    [this.bar]: 0} : { [x: string]: number; }
 
     [this.bar]: 0
 >[this.bar] : number

--- a/tests/baselines/reference/computedPropertyNames20_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames20_ES6.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/computedProperties/computedPropertyNames20_ES6.ts ===
 var obj = {
->obj : { [x: number]: number; }
->{    [this.bar]: 0} : { [x: number]: number; }
+>obj : { [x: string]: number; }
+>{    [this.bar]: 0} : { [x: string]: number; }
 
     [this.bar]: 0
 >[this.bar] : number

--- a/tests/baselines/reference/computedPropertyNames23_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames23_ES5.types
@@ -13,7 +13,7 @@ class C {
 
         { [this.bar()]: 1 }[0]
 >{ [this.bar()]: 1 }[0] : number
->{ [this.bar()]: 1 } : { [x: number]: number; }
+>{ [this.bar()]: 1 } : { [x: string]: number; }
 >[this.bar()] : number
 >this.bar() : any
 >this.bar : any

--- a/tests/baselines/reference/computedPropertyNames23_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames23_ES6.types
@@ -13,7 +13,7 @@ class C {
 
         { [this.bar()]: 1 }[0]
 >{ [this.bar()]: 1 }[0] : number
->{ [this.bar()]: 1 } : { [x: number]: number; }
+>{ [this.bar()]: 1 } : { [x: string]: number; }
 >[this.bar()] : number
 >this.bar() : any
 >this.bar : any

--- a/tests/baselines/reference/computedPropertyNames26_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames26_ES5.types
@@ -18,7 +18,7 @@ class C extends Base {
 
         { [super.bar()]: 1 }[0]
 >{ [super.bar()]: 1 }[0] : number
->{ [super.bar()]: 1 } : { [x: number]: number; }
+>{ [super.bar()]: 1 } : { [x: string]: number; }
 >[super.bar()] : number
 >super.bar() : any
 >super.bar : any

--- a/tests/baselines/reference/computedPropertyNames26_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames26_ES6.types
@@ -20,7 +20,7 @@ class C extends Base {
 
         { [super.bar()]: 1 }[0]
 >{ [super.bar()]: 1 }[0] : number
->{ [super.bar()]: 1 } : { [x: number]: number; }
+>{ [super.bar()]: 1 } : { [x: string]: number; }
 >[super.bar()] : number
 >super.bar() : any
 >super.bar : any

--- a/tests/baselines/reference/computedPropertyNames48_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames48_ES5.types
@@ -14,7 +14,7 @@ var a: any;
 extractIndexer({
 >extractIndexer({    [a]: ""}) : string
 >extractIndexer : <T>(p: { [n: number]: T; }) => T
->{    [a]: ""} : { [x: number]: string; }
+>{    [a]: ""} : { [x: string]: string; }
 
     [a]: ""
 >[a] : string

--- a/tests/baselines/reference/computedPropertyNames48_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames48_ES6.types
@@ -14,7 +14,7 @@ var a: any;
 extractIndexer({
 >extractIndexer({    [a]: ""}) : string
 >extractIndexer : <T>(p: { [n: number]: T; }) => T
->{    [a]: ""} : { [x: number]: string; }
+>{    [a]: ""} : { [x: string]: string; }
 
     [a]: ""
 >[a] : string

--- a/tests/baselines/reference/es5-asyncFunctionObjectLiterals.types
+++ b/tests/baselines/reference/es5-asyncFunctionObjectLiterals.types
@@ -51,9 +51,9 @@ async function objectLiteral2() {
 >objectLiteral2 : () => Promise<void>
 
     x = {
->x = {        [await a]: y,        b: z    } : { [x: number]: any; b: any; }
+>x = {        [await a]: y,        b: z    } : { [x: string]: any; b: any; }
 >x : any
->{        [await a]: y,        b: z    } : { [x: number]: any; b: any; }
+>{        [await a]: y,        b: z    } : { [x: string]: any; b: any; }
 
         [await a]: y,
 >[await a] : any
@@ -72,9 +72,9 @@ async function objectLiteral3() {
 >objectLiteral3 : () => Promise<void>
 
     x = {
->x = {        [a]: await y,        b: z    } : { [x: number]: any; b: any; }
+>x = {        [a]: await y,        b: z    } : { [x: string]: any; b: any; }
 >x : any
->{        [a]: await y,        b: z    } : { [x: number]: any; b: any; }
+>{        [a]: await y,        b: z    } : { [x: string]: any; b: any; }
 
         [a]: await y,
 >[a] : any
@@ -93,9 +93,9 @@ async function objectLiteral4() {
 >objectLiteral4 : () => Promise<void>
 
     x = {
->x = {        a: await y,        [b]: z    } : { [x: number]: any; a: any; }
+>x = {        a: await y,        [b]: z    } : { [x: string]: any; a: any; }
 >x : any
->{        a: await y,        [b]: z    } : { [x: number]: any; a: any; }
+>{        a: await y,        [b]: z    } : { [x: string]: any; a: any; }
 
         a: await y,
 >a : any
@@ -114,9 +114,9 @@ async function objectLiteral5() {
 >objectLiteral5 : () => Promise<void>
 
     x = {
->x = {        a: y,        [await b]: z    } : { [x: number]: any; a: any; }
+>x = {        a: y,        [await b]: z    } : { [x: string]: any; a: any; }
 >x : any
->{        a: y,        [await b]: z    } : { [x: number]: any; a: any; }
+>{        a: y,        [await b]: z    } : { [x: string]: any; a: any; }
 
         a: y,
 >a : any
@@ -135,9 +135,9 @@ async function objectLiteral6() {
 >objectLiteral6 : () => Promise<void>
 
     x = {
->x = {        a: y,        [b]: await z    } : { [x: number]: any; a: any; }
+>x = {        a: y,        [b]: await z    } : { [x: string]: any; a: any; }
 >x : any
->{        a: y,        [b]: await z    } : { [x: number]: any; a: any; }
+>{        a: y,        [b]: await z    } : { [x: string]: any; a: any; }
 
         a: y,
 >a : any

--- a/tests/baselines/reference/es5-yieldFunctionObjectLiterals.types
+++ b/tests/baselines/reference/es5-yieldFunctionObjectLiterals.types
@@ -135,8 +135,8 @@ function* objectLiteral6() {
 >objectLiteral6 : () => Generator<any, void, unknown>
 
     const x = {
->x : { [x: number]: number; a: number; c: number; }
->{        a: 1,        [yield]: 2,        c: 4,    } : { [x: number]: number; a: number; c: number; }
+>x : { [x: string]: number; a: number; c: number; }
+>{        a: 1,        [yield]: 2,        c: 4,    } : { [x: string]: number; a: number; c: number; }
 
         a: 1,
 >a : number
@@ -157,8 +157,8 @@ function* objectLiteral7() {
 >objectLiteral7 : () => Generator<number, void, unknown>
 
     const x = {
->x : { [x: number]: any; a: number; c: number; }
->{        a: 1,        [yield]: yield 2,        c: 4,    } : { [x: number]: any; a: number; c: number; }
+>x : { [x: string]: any; a: number; c: number; }
+>{        a: 1,        [yield]: yield 2,        c: 4,    } : { [x: string]: any; a: number; c: number; }
 
         a: 1,
 >a : number

--- a/tests/baselines/reference/generatorTypeCheck41.types
+++ b/tests/baselines/reference/generatorTypeCheck41.types
@@ -3,8 +3,8 @@ function* g() {
 >g : () => Generator<number, void, unknown>
 
     let x = {
->x : { [x: number]: number; }
->{        [yield 0]: 0    } : { [x: number]: number; }
+>x : { [x: string]: number; }
+>{        [yield 0]: 0    } : { [x: string]: number; }
 
         [yield 0]: 0
 >[yield 0] : number

--- a/tests/baselines/reference/generatorTypeCheck42.types
+++ b/tests/baselines/reference/generatorTypeCheck42.types
@@ -3,8 +3,8 @@ function* g() {
 >g : () => Generator<number, void, unknown>
 
     let x = {
->x : { [x: number]: () => void; }
->{        [yield 0]() {        }    } : { [x: number]: () => void; }
+>x : { [x: string]: () => void; }
+>{        [yield 0]() {        }    } : { [x: string]: () => void; }
 
         [yield 0]() {
 >[yield 0] : () => void

--- a/tests/baselines/reference/generatorTypeCheck43.types
+++ b/tests/baselines/reference/generatorTypeCheck43.types
@@ -3,8 +3,8 @@ function* g() {
 >g : () => Generator<number, void, unknown>
 
     let x = {
->x : { [x: number]: () => Generator<never, void, unknown>; }
->{        *[yield 0]() {        }    } : { [x: number]: () => Generator<never, void, unknown>; }
+>x : { [x: string]: () => Generator<never, void, unknown>; }
+>{        *[yield 0]() {        }    } : { [x: string]: () => Generator<never, void, unknown>; }
 
         *[yield 0]() {
 >[yield 0] : () => Generator<never, void, unknown>

--- a/tests/baselines/reference/generatorTypeCheck44.types
+++ b/tests/baselines/reference/generatorTypeCheck44.types
@@ -3,8 +3,8 @@ function* g() {
 >g : () => Generator<number, void, unknown>
 
     let x = {
->x : { [x: number]: number; }
->{        get [yield 0]() {            return 0;        }    } : { [x: number]: number; }
+>x : { [x: string]: number; }
+>{        get [yield 0]() {            return 0;        }    } : { [x: string]: number; }
 
         get [yield 0]() {
 >[yield 0] : number

--- a/tests/baselines/reference/indexSignatures1.errors.txt
+++ b/tests/baselines/reference/indexSignatures1.errors.txt
@@ -508,3 +508,7 @@ tests/cases/conformance/types/members/indexSignatures1.ts(312,43): error TS2322:
 !!! error TS2322: Type '{ [sym]: string; }' is not assignable to type '{ [key: number]: string; }'.
 !!! error TS2322:   Object literal may only specify known properties, and '[sym]' does not exist in type '{ [key: number]: string; }'.
     
+    declare let anyVar: any;
+    const obj4 = { [anyVar]: "s" };
+    obj4["s"];
+    

--- a/tests/baselines/reference/indexSignatures1.js
+++ b/tests/baselines/reference/indexSignatures1.js
@@ -312,6 +312,10 @@ const obj1: { [key: symbol]: string } = { [sym]: 'hello '};
 const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Permitted for backwards compatibility
 const obj3: { [key: number]: string } = { [sym]: 'hello '};  // Error
 
+declare let anyVar: any;
+const obj4 = { [anyVar]: "s" };
+obj4["s"];
+
 
 //// [indexSignatures1.js]
 "use strict";
@@ -475,6 +479,8 @@ const aa = { [sym]: '123' };
 const obj1 = { [sym]: 'hello ' };
 const obj2 = { [sym]: 'hello ' }; // Permitted for backwards compatibility
 const obj3 = { [sym]: 'hello ' }; // Error
+const obj4 = { [anyVar]: "s" };
+obj4["s"];
 
 
 //// [indexSignatures1.d.ts]
@@ -659,4 +665,8 @@ declare const obj2: {
 };
 declare const obj3: {
     [key: number]: string;
+};
+declare let anyVar: any;
+declare const obj4: {
+    [x: string]: string;
 };

--- a/tests/baselines/reference/indexSignatures1.symbols
+++ b/tests/baselines/reference/indexSignatures1.symbols
@@ -899,3 +899,14 @@ const obj3: { [key: number]: string } = { [sym]: 'hello '};  // Error
 >[sym] : Symbol([sym], Decl(indexSignatures1.ts, 311, 41))
 >sym : Symbol(sym, Decl(indexSignatures1.ts, 2, 5))
 
+declare let anyVar: any;
+>anyVar : Symbol(anyVar, Decl(indexSignatures1.ts, 313, 11))
+
+const obj4 = { [anyVar]: "s" };
+>obj4 : Symbol(obj4, Decl(indexSignatures1.ts, 314, 5))
+>[anyVar] : Symbol([anyVar], Decl(indexSignatures1.ts, 314, 14))
+>anyVar : Symbol(anyVar, Decl(indexSignatures1.ts, 313, 11))
+
+obj4["s"];
+>obj4 : Symbol(obj4, Decl(indexSignatures1.ts, 314, 5))
+

--- a/tests/baselines/reference/indexSignatures1.types
+++ b/tests/baselines/reference/indexSignatures1.types
@@ -1051,3 +1051,18 @@ const obj3: { [key: number]: string } = { [sym]: 'hello '};  // Error
 >sym : unique symbol
 >'hello ' : "hello "
 
+declare let anyVar: any;
+>anyVar : any
+
+const obj4 = { [anyVar]: "s" };
+>obj4 : { [x: string]: string; }
+>{ [anyVar]: "s" } : { [x: string]: string; }
+>[anyVar] : string
+>anyVar : any
+>"s" : "s"
+
+obj4["s"];
+>obj4["s"] : string
+>obj4 : { [x: string]: string; }
+>"s" : "s"
+

--- a/tests/baselines/reference/invalidNewTarget.es5.types
+++ b/tests/baselines/reference/invalidNewTarget.es5.types
@@ -73,8 +73,8 @@ class C {
 }
 
 const O = {
->O : { [x: number]: any; k(): any; readonly l: any; m: any; n: any; }
->{    [new.target]: undefined,    k() { return new.target; },    get l() { return new.target; },    set m(_) { _ = new.target; },    n: new.target,} : { [x: number]: undefined; k(): any; readonly l: any; m: any; n: any; }
+>O : { [x: string]: any; k(): any; readonly l: any; m: any; n: any; }
+>{    [new.target]: undefined,    k() { return new.target; },    get l() { return new.target; },    set m(_) { _ = new.target; },    n: new.target,} : { [x: string]: any; k(): any; readonly l: any; m: any; n: any; }
 
     [new.target]: undefined,
 >[new.target] : undefined

--- a/tests/baselines/reference/invalidNewTarget.es6.types
+++ b/tests/baselines/reference/invalidNewTarget.es6.types
@@ -73,8 +73,8 @@ class C {
 }
 
 const O = {
->O : { [x: number]: any; k(): any; readonly l: any; m: any; n: any; }
->{    [new.target]: undefined,    k() { return new.target; },    get l() { return new.target; },    set m(_) { _ = new.target; },    n: new.target,} : { [x: number]: undefined; k(): any; readonly l: any; m: any; n: any; }
+>O : { [x: string]: any; k(): any; readonly l: any; m: any; n: any; }
+>{    [new.target]: undefined,    k() { return new.target; },    get l() { return new.target; },    set m(_) { _ = new.target; },    n: new.target,} : { [x: string]: any; k(): any; readonly l: any; m: any; n: any; }
 
     [new.target]: undefined,
 >[new.target] : undefined

--- a/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.types
+++ b/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.types
@@ -60,8 +60,8 @@ Math.sign(1);
 
 // Using ES6 object
 var o = {
->o : { [x: number]: (value: any) => boolean; a: number; }
->{    a: 2,    [Symbol.hasInstance](value: any) {        return false;    }} : { [x: number]: (value: any) => boolean; a: number; }
+>o : { [x: string]: number | ((value: any) => boolean); a: number; }
+>{    a: 2,    [Symbol.hasInstance](value: any) {        return false;    }} : { [x: string]: number | ((value: any) => boolean); a: number; }
 
     a: 2,
 >a : number
@@ -81,7 +81,7 @@ var o = {
 o.hasOwnProperty(Symbol.hasInstance);
 >o.hasOwnProperty(Symbol.hasInstance) : boolean
 >o.hasOwnProperty : (v: PropertyKey) => boolean
->o : { [x: number]: (value: any) => boolean; a: number; }
+>o : { [x: string]: number | ((value: any) => boolean); a: number; }
 >hasOwnProperty : (v: PropertyKey) => boolean
 >Symbol.hasInstance : any
 >Symbol : any
@@ -140,8 +140,8 @@ var s = Symbol();
 
 // Using ES6 wellknown-symbol
 const o1 = {
->o1 : { [x: number]: (value: any) => boolean; }
->{    [Symbol.hasInstance](value: any) {        return false;    }} : { [x: number]: (value: any) => boolean; }
+>o1 : { [x: string]: (value: any) => boolean; }
+>{    [Symbol.hasInstance](value: any) {        return false;    }} : { [x: string]: (value: any) => boolean; }
 
     [Symbol.hasInstance](value: any) {
 >[Symbol.hasInstance] : (value: any) => boolean

--- a/tests/baselines/reference/parser.asyncGenerators.classMethods.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.classMethods.es2018.types
@@ -239,8 +239,8 @@ class C22 {
 >f : () => AsyncGenerator<any, void, unknown>
 
         const x = { [yield]: 1 };
->x : { [x: number]: number; }
->{ [yield]: 1 } : { [x: number]: number; }
+>x : { [x: string]: number; }
+>{ [yield]: 1 } : { [x: string]: number; }
 >[yield] : number
 >yield : any
 >1 : 1

--- a/tests/baselines/reference/parser.asyncGenerators.functionDeclarations.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.functionDeclarations.es2018.types
@@ -147,8 +147,8 @@ async function * f21() {
 >f21 : () => AsyncGenerator<any, void, unknown>
 
     const x = { [yield]: 1 };
->x : { [x: number]: number; }
->{ [yield]: 1 } : { [x: number]: number; }
+>x : { [x: string]: number; }
+>{ [yield]: 1 } : { [x: string]: number; }
 >[yield] : number
 >yield : any
 >1 : 1

--- a/tests/baselines/reference/parser.asyncGenerators.functionExpressions.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.functionExpressions.es2018.types
@@ -186,8 +186,8 @@ const f21 = async function *() {
 >async function *() {    const x = { [yield]: 1 };} : () => AsyncGenerator<any, void, unknown>
 
     const x = { [yield]: 1 };
->x : { [x: number]: number; }
->{ [yield]: 1 } : { [x: number]: number; }
+>x : { [x: string]: number; }
+>{ [yield]: 1 } : { [x: string]: number; }
 >[yield] : number
 >yield : any
 >1 : 1

--- a/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.es2018.types
@@ -251,8 +251,8 @@ const o21 = {
 >f : () => AsyncGenerator<any, void, unknown>
 
         const x = { [yield]: 1 };
->x : { [x: number]: number; }
->{ [yield]: 1 } : { [x: number]: number; }
+>x : { [x: string]: number; }
+>{ [yield]: 1 } : { [x: string]: number; }
 >[yield] : number
 >yield : any
 >1 : 1

--- a/tests/baselines/reference/parserComputedPropertyName1.types
+++ b/tests/baselines/reference/parserComputedPropertyName1.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName1.ts ===
 var v = { [e] };
->v : { [x: number]: any; }
->{ [e] } : { [x: number]: any; }
+>v : { [x: string]: any; }
+>{ [e] } : { [x: string]: any; }
 >[e] : any
 >e : any
 > : any

--- a/tests/baselines/reference/parserComputedPropertyName17.types
+++ b/tests/baselines/reference/parserComputedPropertyName17.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName17.ts ===
 var v = { set [e](v) { } }
->v : { [x: number]: any; }
->{ set [e](v) { } } : { [x: number]: any; }
+>v : { [x: string]: any; }
+>{ set [e](v) { } } : { [x: string]: any; }
 >[e] : any
 >e : any
 >v : any

--- a/tests/baselines/reference/parserComputedPropertyName2.types
+++ b/tests/baselines/reference/parserComputedPropertyName2.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName2.ts ===
 var v = { [e]: 1 };
->v : { [x: number]: number; }
->{ [e]: 1 } : { [x: number]: number; }
+>v : { [x: string]: number; }
+>{ [e]: 1 } : { [x: string]: number; }
 >[e] : number
 >e : any
 >1 : 1

--- a/tests/baselines/reference/parserComputedPropertyName3.types
+++ b/tests/baselines/reference/parserComputedPropertyName3.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName3.ts ===
 var v = { [e]() { } };
->v : { [x: number]: () => void; }
->{ [e]() { } } : { [x: number]: () => void; }
+>v : { [x: string]: () => void; }
+>{ [e]() { } } : { [x: string]: () => void; }
 >[e] : () => void
 >e : any
 

--- a/tests/baselines/reference/parserComputedPropertyName37.types
+++ b/tests/baselines/reference/parserComputedPropertyName37.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName37.ts ===
 var v = {
->v : { [x: number]: number; }
->{    [public]: 0} : { [x: number]: number; }
+>v : { [x: string]: number; }
+>{    [public]: 0} : { [x: string]: number; }
 
     [public]: 0
 >[public] : number

--- a/tests/baselines/reference/parserComputedPropertyName4.types
+++ b/tests/baselines/reference/parserComputedPropertyName4.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName4.ts ===
 var v = { get [e]() { } };
->v : { [x: number]: void; }
->{ get [e]() { } } : { [x: number]: void; }
+>v : { [x: string]: void; }
+>{ get [e]() { } } : { [x: string]: void; }
 >[e] : void
 >e : any
 

--- a/tests/baselines/reference/parserComputedPropertyName5.types
+++ b/tests/baselines/reference/parserComputedPropertyName5.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName5.ts ===
 var v = { public get [e]() { } };
->v : { [x: number]: void; }
->{ public get [e]() { } } : { [x: number]: void; }
+>v : { [x: string]: void; }
+>{ public get [e]() { } } : { [x: string]: void; }
 >[e] : void
 >e : any
 

--- a/tests/baselines/reference/parserComputedPropertyName6.types
+++ b/tests/baselines/reference/parserComputedPropertyName6.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName6.ts ===
 var v = { [e]: 1, [e + e]: 2 };
->v : { [x: number]: number; }
->{ [e]: 1, [e + e]: 2 } : { [x: number]: number; }
+>v : { [x: string]: number; }
+>{ [e]: 1, [e + e]: 2 } : { [x: string]: number; }
 >[e] : number
 >e : any
 >1 : 1

--- a/tests/baselines/reference/parserES5ComputedPropertyName2.types
+++ b/tests/baselines/reference/parserES5ComputedPropertyName2.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName2.ts ===
 var v = { [e]: 1 };
->v : { [x: number]: number; }
->{ [e]: 1 } : { [x: number]: number; }
+>v : { [x: string]: number; }
+>{ [e]: 1 } : { [x: string]: number; }
 >[e] : number
 >e : any
 >1 : 1

--- a/tests/baselines/reference/parserES5ComputedPropertyName3.types
+++ b/tests/baselines/reference/parserES5ComputedPropertyName3.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName3.ts ===
 var v = { [e]() { } };
->v : { [x: number]: () => void; }
->{ [e]() { } } : { [x: number]: () => void; }
+>v : { [x: string]: () => void; }
+>{ [e]() { } } : { [x: string]: () => void; }
 >[e] : () => void
 >e : any
 

--- a/tests/baselines/reference/parserES5ComputedPropertyName4.types
+++ b/tests/baselines/reference/parserES5ComputedPropertyName4.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName4.ts ===
 var v = { get [e]() { } };
->v : { [x: number]: void; }
->{ get [e]() { } } : { [x: number]: void; }
+>v : { [x: string]: void; }
+>{ get [e]() { } } : { [x: string]: void; }
 >[e] : void
 >e : any
 

--- a/tests/baselines/reference/parserSymbolIndexer5.types
+++ b/tests/baselines/reference/parserSymbolIndexer5.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer5.ts ===
 var x = {
->x : { [x: number]: any; "": any; }
->{    [s: symbol]: ""} : { [x: number]: any; "": any; }
+>x : { [x: string]: any; "": any; }
+>{    [s: symbol]: ""} : { [x: string]: any; "": any; }
 
     [s: symbol]: ""
 >[s : any

--- a/tests/baselines/reference/privateIndexer2.types
+++ b/tests/baselines/reference/privateIndexer2.types
@@ -3,7 +3,7 @@
 
 var x = {
 >x : any
->{    private [x: string]: string;} : { [x: number]: any; string: any; }
+>{    private [x: string]: string;} : { [x: string]: any; string: any; }
 
     private [x: string]: string;
 >[x : any

--- a/tests/baselines/reference/requireOfJsonFileWithComputedPropertyName.types
+++ b/tests/baselines/reference/requireOfJsonFileWithComputedPropertyName.types
@@ -1,26 +1,26 @@
 === tests/cases/compiler/file1.ts ===
 import b1 = require('./b.json');
->b1 : { [x: number]: number; }
+>b1 : { [x: string]: number; }
 
 let x = b1;
->x : { [x: number]: number; }
->b1 : { [x: number]: number; }
+>x : { [x: string]: number; }
+>b1 : { [x: string]: number; }
 
 import b2 = require('./b.json');
->b2 : { [x: number]: number; }
+>b2 : { [x: string]: number; }
 
 if (x) {
->x : { [x: number]: number; }
+>x : { [x: string]: number; }
 
     x = b2;
->x = b2 : { [x: number]: number; }
->x : { [x: number]: number; }
->b2 : { [x: number]: number; }
+>x = b2 : { [x: string]: number; }
+>x : { [x: string]: number; }
+>b2 : { [x: string]: number; }
 }
 
 === tests/cases/compiler/b.json ===
 {
->{    [a]: 10} : { [x: number]: number; }
+>{    [a]: 10} : { [x: string]: number; }
 
     [a]: 10
 >[a] : number

--- a/tests/baselines/reference/symbolProperty52.types
+++ b/tests/baselines/reference/symbolProperty52.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/Symbols/symbolProperty52.ts ===
 var obj = {
->obj : { [x: number]: number; }
->{    [Symbol.nonsense]: 0} : { [x: number]: number; }
+>obj : { [x: string]: number; }
+>{    [Symbol.nonsense]: 0} : { [x: string]: number; }
 
     [Symbol.nonsense]: 0
 >[Symbol.nonsense] : number
@@ -14,12 +14,12 @@ var obj = {
 
 obj = {};
 >obj = {} : {}
->obj : { [x: number]: number; }
+>obj : { [x: string]: number; }
 >{} : {}
 
 obj[Symbol.nonsense];
 >obj[Symbol.nonsense] : number
->obj : { [x: number]: number; }
+>obj : { [x: string]: number; }
 >Symbol.nonsense : any
 >Symbol : SymbolConstructor
 >nonsense : any

--- a/tests/cases/conformance/types/members/indexSignatures1.ts
+++ b/tests/cases/conformance/types/members/indexSignatures1.ts
@@ -314,3 +314,7 @@ const aa: AA = { [sym]: '123' };
 const obj1: { [key: symbol]: string } = { [sym]: 'hello '};
 const obj2: { [key: string]: string } = { [sym]: 'hello '};  // Permitted for backwards compatibility
 const obj3: { [key: number]: string } = { [sym]: 'hello '};  // Error
+
+declare let anyVar: any;
+const obj4 = { [anyVar]: "s" };
+obj4["s"];


### PR DESCRIPTION
Fixes #45629.
