### PR TITLE
fix(45687): Offer 'convert import to namespace' even when selection extends to next line

### DIFF
--- a/src/services/refactors/convertImport.ts
+++ b/src/services/refactors/convertImport.ts
@@ -55,7 +55,10 @@ namespace ts.refactor {
         const token = getTokenAtPosition(file, span.start);
         const importDecl = considerPartialSpans ? findAncestor(token, isImportDeclaration) : getParentNodeInSpan(token, file, span);
         if (!importDecl || !isImportDeclaration(importDecl)) return { error: "Selection is not an import declaration." };
-        if (importDecl.getEnd() < span.start + span.length) return undefined;
+
+        const end = span.start + span.length;
+        const nextToken = findNextToken(importDecl, importDecl.parent, file);
+        if (nextToken && end > nextToken.getStart()) return undefined;
 
         const { importClause } = importDecl;
         if (!importClause) {

--- a/tests/cases/fourslash/refactorConvertImport_namedToNamespace6.ts
+++ b/tests/cases/fourslash/refactorConvertImport_namedToNamespace6.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+/////*a*/import { join } from "path";
+/////*b*/import * as fs from "fs";
+////
+////fs.readFileSync(join('a', 'b'));
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert import",
+    actionName: "Convert named imports to namespace import",
+    actionDescription: "Convert named imports to namespace import",
+    newContent:
+`import * as path from "path";
+import * as fs from "fs";
+
+fs.readFileSync(path.join('a', 'b'));`,
+});

--- a/tests/cases/fourslash/refactorConvertImport_namedToNamespace7.ts
+++ b/tests/cases/fourslash/refactorConvertImport_namedToNamespace7.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+/////*a*/import { join } from "path";
+////
+/////*b*/
+////join('a', 'b');
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert import",
+    actionName: "Convert named imports to namespace import",
+    actionDescription: "Convert named imports to namespace import",
+    newContent:
+`import * as path from "path";
+
+
+path.join('a', 'b');`,
+});

--- a/tests/cases/fourslash/refactorConvertImport_namedToNamespace8.ts
+++ b/tests/cases/fourslash/refactorConvertImport_namedToNamespace8.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+
+/////*a*/import { join } from "path";
+////import * as fs from "fs";/*b*/
+////
+////fs.readFileSync(join('a', 'b'));
+
+goTo.select("a", "b");
+verify.not.refactorAvailable("Convert import", "Convert named imports to namespace import");

--- a/tests/cases/fourslash/refactorConvertImport_namedToNamespace9.ts
+++ b/tests/cases/fourslash/refactorConvertImport_namedToNamespace9.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+
+/////*a*/import { join } from "path";
+////i/*b*/mport * as fs from "fs";
+////
+////fs.readFileSync(join('a', 'b'));
+
+goTo.select("a", "b");
+verify.not.refactorAvailable("Convert import", "Convert named imports to namespace import");


### PR DESCRIPTION
Fixes #45687