### PR TITLE
feat(45679): support 'did you mean' diagnostics for string literal union

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17743,7 +17743,7 @@ namespace ts {
                         if (source.flags & TypeFlags.StringLiteral && target.flags & TypeFlags.Union) {
                             const suggestedType = getSuggestedTypeForNonexistentStringLiteralType(source as StringLiteralType, target as UnionType);
                             if (suggestedType) {
-                                reportError(Diagnostics.Type_0_is_not_assignable_to_type_1_Did_you_mean_2, sourceType, targetType, typeToString(suggestedType));
+                                reportError(Diagnostics.Type_0_is_not_assignable_to_type_1_Did_you_mean_2, generalizedSourceType, targetType, typeToString(suggestedType));
                                 return;
                             }
                         }
@@ -28136,7 +28136,7 @@ namespace ts {
 
         function getSuggestedTypeForNonexistentStringLiteralType(source: StringLiteralType, target: UnionType): StringLiteralType | undefined {
             const candidates = target.types.filter((type): type is StringLiteralType => !!(type.flags & TypeFlags.StringLiteral));
-            return getSpellingSuggestion(source.value, candidates, (type) => type.value);
+            return getSpellingSuggestion(source.value, candidates, type => type.value);
         }
 
         /**

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17740,6 +17740,13 @@ namespace ts {
                         message = Diagnostics.Type_0_is_not_assignable_to_type_1_with_exactOptionalPropertyTypes_Colon_true_Consider_adding_undefined_to_the_types_of_the_target_s_properties;
                     }
                     else {
+                        if (source.flags & TypeFlags.StringLiteral && target.flags & TypeFlags.Union) {
+                            const suggestion = getSuggestionForNonexistentStringLiteral(source as StringLiteralType, target as UnionType);
+                            if (suggestion) {
+                                reportError(Diagnostics.Type_0_is_not_assignable_to_type_1_Did_you_mean_2, sourceType, targetType, suggestion);
+                                return;
+                            }
+                        }
                         message = Diagnostics.Type_0_is_not_assignable_to_type_1;
                     }
                 }
@@ -28125,6 +28132,16 @@ namespace ts {
             }
 
             return suggestion;
+        }
+
+        function getSuggestionForNonexistentStringLiteral(source: StringLiteralType, target: UnionType): string | undefined {
+            const candidates: string[] = [];
+            for (const type of target.types) {
+                if (type.flags & TypeFlags.StringLiteral) {
+                    candidates.push((type as StringLiteralType).value);
+                }
+            }
+            return getSpellingSuggestion(source.value, candidates, (name) => name);
         }
 
         /**

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17741,9 +17741,9 @@ namespace ts {
                     }
                     else {
                         if (source.flags & TypeFlags.StringLiteral && target.flags & TypeFlags.Union) {
-                            const suggestion = getSuggestionForNonexistentStringLiteral(source as StringLiteralType, target as UnionType);
-                            if (suggestion) {
-                                reportError(Diagnostics.Type_0_is_not_assignable_to_type_1_Did_you_mean_2, sourceType, targetType, suggestion);
+                            const suggestedType = getSuggestedTypeForNonexistentStringLiteralType(source as StringLiteralType, target as UnionType);
+                            if (suggestedType) {
+                                reportError(Diagnostics.Type_0_is_not_assignable_to_type_1_Did_you_mean_2, sourceType, targetType, typeToString(suggestedType));
                                 return;
                             }
                         }
@@ -28134,14 +28134,9 @@ namespace ts {
             return suggestion;
         }
 
-        function getSuggestionForNonexistentStringLiteral(source: StringLiteralType, target: UnionType): string | undefined {
-            const candidates: string[] = [];
-            for (const type of target.types) {
-                if (type.flags & TypeFlags.StringLiteral) {
-                    candidates.push((type as StringLiteralType).value);
-                }
-            }
-            return getSpellingSuggestion(source.value, candidates, (name) => name);
+        function getSuggestedTypeForNonexistentStringLiteralType(source: StringLiteralType, target: UnionType): StringLiteralType | undefined {
+            const candidates = target.types.filter((type): type is StringLiteralType => !!(type.flags & TypeFlags.StringLiteral));
+            return getSpellingSuggestion(source.value, candidates, (type) => type.value);
         }
 
         /**

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3284,6 +3284,10 @@
         "category": "Error",
         "code": 2819
     },
+    "Type '{0}' is not assignable to type '{1}'. Did you mean '{2}'?": {
+        "category": "Error",
+        "code": 2820
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/didYouMeanStringLiteral.errors.txt
+++ b/tests/baselines/reference/didYouMeanStringLiteral.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/didYouMeanStringLiteral.ts(5,7): error TS2820: Type '"strong"' is not assignable to type 'T1'. Did you mean 'string'?
+tests/cases/compiler/didYouMeanStringLiteral.ts(5,7): error TS2820: Type '"strong"' is not assignable to type 'T1'. Did you mean '"string"'?
 tests/cases/compiler/didYouMeanStringLiteral.ts(6,7): error TS2322: Type '"strong"' is not assignable to type '"number" | "boolean"'.
-tests/cases/compiler/didYouMeanStringLiteral.ts(7,7): error TS2820: Type '"strong"' is not assignable to type '"string" | "boolean"'. Did you mean 'string'?
+tests/cases/compiler/didYouMeanStringLiteral.ts(7,7): error TS2820: Type '"strong"' is not assignable to type '"string" | "boolean"'. Did you mean '"string"'?
 
 
 ==== tests/cases/compiler/didYouMeanStringLiteral.ts (3 errors) ====
@@ -10,11 +10,11 @@ tests/cases/compiler/didYouMeanStringLiteral.ts(7,7): error TS2820: Type '"stron
     
     const t1: T1 = "strong";
           ~~
-!!! error TS2820: Type '"strong"' is not assignable to type 'T1'. Did you mean 'string'?
+!!! error TS2820: Type '"strong"' is not assignable to type 'T1'. Did you mean '"string"'?
     const t2: T2 = "strong";
           ~~
 !!! error TS2322: Type '"strong"' is not assignable to type '"number" | "boolean"'.
     const t3: T3 = "strong";
           ~~
-!!! error TS2820: Type '"strong"' is not assignable to type '"string" | "boolean"'. Did you mean 'string'?
+!!! error TS2820: Type '"strong"' is not assignable to type '"string" | "boolean"'. Did you mean '"string"'?
     

--- a/tests/baselines/reference/didYouMeanStringLiteral.errors.txt
+++ b/tests/baselines/reference/didYouMeanStringLiteral.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/compiler/didYouMeanStringLiteral.ts(5,7): error TS2820: Type '"strong"' is not assignable to type 'T1'. Did you mean 'string'?
+tests/cases/compiler/didYouMeanStringLiteral.ts(6,7): error TS2322: Type '"strong"' is not assignable to type '"number" | "boolean"'.
+tests/cases/compiler/didYouMeanStringLiteral.ts(7,7): error TS2820: Type '"strong"' is not assignable to type '"string" | "boolean"'. Did you mean 'string'?
+
+
+==== tests/cases/compiler/didYouMeanStringLiteral.ts (3 errors) ====
+    type T1 = "string" | "number" | "boolean";
+    type T2 = T1 & ("number" | "boolean"); // "number" | "boolean"
+    type T3 = T1 & ("string" | "boolean"); // "string" | "boolean"
+    
+    const t1: T1 = "strong";
+          ~~
+!!! error TS2820: Type '"strong"' is not assignable to type 'T1'. Did you mean 'string'?
+    const t2: T2 = "strong";
+          ~~
+!!! error TS2322: Type '"strong"' is not assignable to type '"number" | "boolean"'.
+    const t3: T3 = "strong";
+          ~~
+!!! error TS2820: Type '"strong"' is not assignable to type '"string" | "boolean"'. Did you mean 'string'?
+    

--- a/tests/baselines/reference/didYouMeanStringLiteral.js
+++ b/tests/baselines/reference/didYouMeanStringLiteral.js
@@ -1,0 +1,14 @@
+//// [didYouMeanStringLiteral.ts]
+type T1 = "string" | "number" | "boolean";
+type T2 = T1 & ("number" | "boolean"); // "number" | "boolean"
+type T3 = T1 & ("string" | "boolean"); // "string" | "boolean"
+
+const t1: T1 = "strong";
+const t2: T2 = "strong";
+const t3: T3 = "strong";
+
+
+//// [didYouMeanStringLiteral.js]
+var t1 = "strong";
+var t2 = "strong";
+var t3 = "strong";

--- a/tests/baselines/reference/didYouMeanStringLiteral.symbols
+++ b/tests/baselines/reference/didYouMeanStringLiteral.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/didYouMeanStringLiteral.ts ===
+type T1 = "string" | "number" | "boolean";
+>T1 : Symbol(T1, Decl(didYouMeanStringLiteral.ts, 0, 0))
+
+type T2 = T1 & ("number" | "boolean"); // "number" | "boolean"
+>T2 : Symbol(T2, Decl(didYouMeanStringLiteral.ts, 0, 42))
+>T1 : Symbol(T1, Decl(didYouMeanStringLiteral.ts, 0, 0))
+
+type T3 = T1 & ("string" | "boolean"); // "string" | "boolean"
+>T3 : Symbol(T3, Decl(didYouMeanStringLiteral.ts, 1, 38))
+>T1 : Symbol(T1, Decl(didYouMeanStringLiteral.ts, 0, 0))
+
+const t1: T1 = "strong";
+>t1 : Symbol(t1, Decl(didYouMeanStringLiteral.ts, 4, 5))
+>T1 : Symbol(T1, Decl(didYouMeanStringLiteral.ts, 0, 0))
+
+const t2: T2 = "strong";
+>t2 : Symbol(t2, Decl(didYouMeanStringLiteral.ts, 5, 5))
+>T2 : Symbol(T2, Decl(didYouMeanStringLiteral.ts, 0, 42))
+
+const t3: T3 = "strong";
+>t3 : Symbol(t3, Decl(didYouMeanStringLiteral.ts, 6, 5))
+>T3 : Symbol(T3, Decl(didYouMeanStringLiteral.ts, 1, 38))
+

--- a/tests/baselines/reference/didYouMeanStringLiteral.types
+++ b/tests/baselines/reference/didYouMeanStringLiteral.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/didYouMeanStringLiteral.ts ===
+type T1 = "string" | "number" | "boolean";
+>T1 : T1
+
+type T2 = T1 & ("number" | "boolean"); // "number" | "boolean"
+>T2 : "number" | "boolean"
+
+type T3 = T1 & ("string" | "boolean"); // "string" | "boolean"
+>T3 : "string" | "boolean"
+
+const t1: T1 = "strong";
+>t1 : T1
+>"strong" : "strong"
+
+const t2: T2 = "strong";
+>t2 : "number" | "boolean"
+>"strong" : "strong"
+
+const t3: T3 = "strong";
+>t3 : "string" | "boolean"
+>"strong" : "strong"
+

--- a/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.errors.txt
+++ b/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(11,11): error TS2322: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'.
-tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(16,11): error TS2322: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'.
+tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(11,11): error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean 'hddvd'?
+tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(16,11): error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean 'hddvd'?
 
 
 ==== tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts (2 errors) ====
@@ -15,7 +15,7 @@ tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(16,11): error TS232
             { kind: "bluray", },
             { kind: "hdpvd", }
               ~~~~
-!!! error TS2322: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'.
+!!! error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean 'hddvd'?
 !!! related TS6500 tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts:3:13: The expected type comes from property 'kind' which is declared here on type 'Disc'
         ]);
     
@@ -23,7 +23,7 @@ tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(16,11): error TS232
             { kind: "bluray", },
             { kind: "hdpvd", }
               ~~~~
-!!! error TS2322: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'.
+!!! error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean 'hddvd'?
 !!! related TS6500 tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts:3:13: The expected type comes from property 'kind' which is declared here on type 'Disc'
         ];
     }

--- a/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.errors.txt
+++ b/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(11,11): error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean 'hddvd'?
-tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(16,11): error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean 'hddvd'?
+tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(11,11): error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean '"hddvd"'?
+tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(16,11): error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean '"hddvd"'?
 
 
 ==== tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts (2 errors) ====
@@ -15,7 +15,7 @@ tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(16,11): error TS282
             { kind: "bluray", },
             { kind: "hdpvd", }
               ~~~~
-!!! error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean 'hddvd'?
+!!! error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean '"hddvd"'?
 !!! related TS6500 tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts:3:13: The expected type comes from property 'kind' which is declared here on type 'Disc'
         ]);
     
@@ -23,7 +23,7 @@ tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(16,11): error TS282
             { kind: "bluray", },
             { kind: "hdpvd", }
               ~~~~
-!!! error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean 'hddvd'?
+!!! error TS2820: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'. Did you mean '"hddvd"'?
 !!! related TS6500 tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts:3:13: The expected type comes from property 'kind' which is declared here on type 'Disc'
         ];
     }

--- a/tests/cases/compiler/didYouMeanStringLiteral.ts
+++ b/tests/cases/compiler/didYouMeanStringLiteral.ts
@@ -1,0 +1,7 @@
+type T1 = "string" | "number" | "boolean";
+type T2 = T1 & ("number" | "boolean"); // "number" | "boolean"
+type T3 = T1 & ("string" | "boolean"); // "string" | "boolean"
+
+const t1: T1 = "strong";
+const t2: T2 = "strong";
+const t3: T3 = "strong";


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes https://github.com/microsoft/TypeScript/issues/45679

This PR adds a new diagnostic message for assignment type error with "did you mean" suggestion.
I made a new if-branch in `reportRelationError` for the case when `source` is `StringLiteralType` and `target` is `UnionType` and it tries to find suggestion with the existing utility function `getSpellingSuggestion`.
So far I only tested with simple examples I can think of, but if more complicated cases are desired, I'm happy to add more.
So please let me know if that's the case.
Thanks a lot!

EDIT:
I thought I could also try to implement codefix service for this "did you mean" suggestion, but it doesn't look so easy since there seems no way of  obtaining `target` type information at the time of `getCodeActions` in fixSpelling.ts. I might be missing something here, so I would appreciate if there's some advice on this.