### PR TITLE
fix(26058): add MergeTuple for Object.assign's return type

### DIFF
--- a/lib/lib.es2015.core.d.ts
+++ b/lib/lib.es2015.core.d.ts
@@ -282,16 +282,16 @@ interface NumberConstructor {
 type Undefined2Object<T> = T extends undefined ? {} : T;
 
 /**
-* Remove the first tow item of tuple
+* Remove the first two item of tuple
 */
 type RemoveFirstTwo<T extends unknown[], First, Second> =  T extends [a: First, b: Second, ...rest: infer P] ? P : [];
 
 /**
 * Convert tuple to intersection with tuple item's type
 */
-type Tuple2Intersection<T extends unknown[]> = T[2] extends undefined
+type MergeTuple<T extends unknown[]> = T[2] extends undefined
   ? Undefined2Object<T[0]> & Undefined2Object<T[1]>
-  : Tuple2Intersection<[T[0], T[1]]> & Tuple2Intersection<RemoveFirstTwo<T, T[0], T[1]>>;
+  : MergeTuple<[T[0], T[1]]> & MergeTuple<RemoveFirstTwo<T, T[0], T[1]>>;
 
 interface ObjectConstructor {
     /**
@@ -300,7 +300,7 @@ interface ObjectConstructor {
      * @param target The target object to copy to.
      * @param sources One or more source objects from which to copy properties
      */
-    assign<T extends object, R extends object[]>(target: T, ...sources: R): Tuple2Intersection<[T, ...R]>;
+    assign<T extends object, R extends object[]>(target: T, ...sources: R): MergeTuple<[T, ...R]>;
     /**
      * Returns an array of all symbol properties found directly on object o.
      * @param o Object to retrieve the symbols from.

--- a/lib/lib.es2015.core.d.ts
+++ b/lib/lib.es2015.core.d.ts
@@ -276,42 +276,31 @@ interface NumberConstructor {
     parseInt(string: string, radix?: number): number;
 }
 
+/**
+* Return a empty object type if the param's type is undefined
+*/
+type Undefined2Object<T> = T extends undefined ? {} : T;
+
+/**
+* Remove the first tow item of tuple
+*/
+type RemoveFirstTwo<T extends unknown[], First, Second> =  T extends [a: First, b: Second, ...rest: infer P] ? P : [];
+
+/**
+* Convert tuple to intersection with tuple item's type
+*/
+type Tuple2Intersection<T extends unknown[]> = T[2] extends undefined
+  ? Undefined2Object<T[0]> & Undefined2Object<T[1]>
+  : Tuple2Intersection<[T[0], T[1]]> & Tuple2Intersection<RemoveFirstTwo<T, T[0], T[1]>>;
+
 interface ObjectConstructor {
-    /**
-     * Copy the values of all of the enumerable own properties from one or more source objects to a
-     * target object. Returns the target object.
-     * @param target The target object to copy to.
-     * @param source The source object from which to copy properties.
-     */
-    assign<T, U>(target: T, source: U): T & U;
-
-    /**
-     * Copy the values of all of the enumerable own properties from one or more source objects to a
-     * target object. Returns the target object.
-     * @param target The target object to copy to.
-     * @param source1 The first source object from which to copy properties.
-     * @param source2 The second source object from which to copy properties.
-     */
-    assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
-
-    /**
-     * Copy the values of all of the enumerable own properties from one or more source objects to a
-     * target object. Returns the target object.
-     * @param target The target object to copy to.
-     * @param source1 The first source object from which to copy properties.
-     * @param source2 The second source object from which to copy properties.
-     * @param source3 The third source object from which to copy properties.
-     */
-    assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
-
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
      * target object. Returns the target object.
      * @param target The target object to copy to.
      * @param sources One or more source objects from which to copy properties
      */
-    assign(target: object, ...sources: any[]): any;
-
+    assign<T extends object, R extends object[]>(target: T, ...sources: R): Tuple2Intersection<[T, ...R]>;
     /**
      * Returns an array of all symbol properties found directly on object o.
      * @param o Object to retrieve the symbols from.


### PR DESCRIPTION
Add MergeTuple type, it support convert tuple to intersection. So, Object.assign can use it to define return type better.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

```typescript
/**
* Return a empty object type if the param's type is undefined
*/
type Undefined2Object<T> = T extends undefined ? {} : T;

/**
* Remove the first two item of tuple
*/
type RemoveFirstTwo<T extends unknown[], First, Second> =  T extends [a: First, b: Second, ...rest: infer P] ? P : [];

/**
* Convert tuple to intersection with tuple item's type
*/
type MergeTuple<T extends unknown[]> = T[2] extends undefined
  ? Undefined2Object<T[0]> & Undefined2Object<T[1]>
  : MergeTuple<[T[0], T[1]]> & MergeTuple<RemoveFirstTwo<T, T[0], T[1]>>;
```

Fixes #
https://github.com/microsoft/TypeScript/issues/26058