### PR TITLE
fix(33325): Allow running extract refactoring on selected statement even when trailing semicolon is not included in selection

### DIFF
--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -364,10 +364,11 @@ namespace ts.refactor.extractSymbol {
                     return node.expression;
                 }
             }
-            else if (isVariableStatement(node)) {
+            else if (isVariableStatement(node) || isVariableDeclarationList(node)) {
+                const declarations = isVariableStatement(node) ? node.declarationList.declarations : node.declarations;
                 let numInitializers = 0;
                 let lastInitializer: Expression | undefined;
-                for (const declaration of node.declarationList.declarations) {
+                for (const declaration of declarations) {
                     if (declaration.initializer) {
                         numInitializers++;
                         lastInitializer = declaration.initializer;
@@ -383,7 +384,6 @@ namespace ts.refactor.extractSymbol {
                     return node.initializer;
                 }
             }
-
             return node;
         }
 

--- a/src/testRunner/unittests/services/extract/ranges.ts
+++ b/src/testRunner/unittests/services/extract/ranges.ts
@@ -191,7 +191,7 @@ namespace ts {
             testExtractRange("extractRange28", `[#|return [$|1|];|]`);
 
             // For statements
-            testExtractRange("extractRange29", `for ([#|var i = 1|]; i < 2; i++) {}`);
+            testExtractRange("extractRange29", `for ([#|var i = [$|1|]|]; i < 2; i++) {}`);
             testExtractRange("extractRange30", `for (var i = [#|[$|1|]|]; i < 2; i++) {}`);
         });
 

--- a/tests/cases/fourslash/extract-const10.ts
+++ b/tests/cases/fourslash/extract-const10.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////function foo() {
+////    /*a*/const a = [1]/*b*/;
+////    return a;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_1",
+    actionDescription: "Extract to constant in global scope",
+    newContent:
+`const newLocal = [1];
+function foo() {
+    const a = /*RENAME*/newLocal;
+    return a;
+}`
+});


### PR DESCRIPTION
Fixes #33325