### PR TITLE
feat(45549): track string literal references within call expressions

### DIFF
--- a/tests/cases/fourslash/renameStringPropertyNames1.ts
+++ b/tests/cases/fourslash/renameStringPropertyNames1.ts
@@ -1,0 +1,24 @@
+/// <reference path='fourslash.ts' />
+
+////interface A {
+////  [|[|{| "contextRangeIndex": 0 |}prop|]: string;|]
+////}
+////
+////declare function f(a: A, k: keyof A): void;
+////declare let a: A;
+////f(a, "[|prop|]");
+////
+////declare const f2: <T>(a: T, b: keyof T) => void;
+////f2({
+////  [|[|{| "contextRangeIndex": 3 |}prop|]: () => {}|]
+////}, "[|prop|]");
+////
+////declare const f3: <K extends string>(a: K, b: { [_ in K]: unknown }) => void;
+////f3("[|prop|]", {
+////  [|[|{| "contextRangeIndex": 7 |}prop|]: () => {}|]
+////});
+
+const [r0Def, r0, r1, r2Def, r2, r3, r4, r5Def, r5] = test.ranges();
+verify.renameLocations([r0, r1], [r0, r1]);
+verify.renameLocations([r2, r3], [r2, r3]);
+verify.renameLocations([r4, r5], [r4, r5]);


### PR DESCRIPTION
    * Enables string literals in call expression to refer to property names.
    * Enables property names in call expression to refer to string literals.
    * Changes string literal rename/reference behavior when string literals are in a call expression.
      Previously, all string references with matching text would reference one another globally and
      allow renaming even if such an operation would result in a compiler error.

Fixes #45549
