### PR TITLE
Fixed trimming comments on the remaining range

### DIFF
--- a/tests/cases/fourslash/server/formatTrimRemainingRangets
+++ b/tests/cases/fourslash/server/formatTrimRemainingRangets
@@ -1,0 +1,13 @@
+/// <reference path="../fourslash.ts"/>
+
+////     ;
+////     /*
+////     
+//// */
+
+format.document();
+verify.currentFileContentIs(
+`;
+    /*
+ 
+*/`);


### PR DESCRIPTION
Fixes #45526 

The bug above happens because the "remaining range" contains all comments that are last in the range. This have already been trimmed in `indentTriviaItems` creating duplicate edits.

This PR fixes that by excluding from the remaining range the comment trivia.