### PR TITLE
Separate intersection type resolution process for publicly and non-publicly accessible mixin construct signatures

### DIFF
--- a/tests/baselines/reference/mixinClassesConstructorAccessibility.errors.txt
+++ b/tests/baselines/reference/mixinClassesConstructorAccessibility.errors.txt
@@ -1,0 +1,75 @@
+tests/cases/conformance/classes/mixinClassesConstructorAccessibility.ts(53,3): error TS2673: Constructor of class 'PrivateConstructorMixin' is private and only accessible within the class declaration.
+tests/cases/conformance/classes/mixinClassesConstructorAccessibility.ts(54,3): error TS2673: Constructor of class 'PrivateConstructorMixinGenericBaseType' is private and only accessible within the class declaration.
+tests/cases/conformance/classes/mixinClassesConstructorAccessibility.ts(56,3): error TS2674: Constructor of class 'ProtectedConstructorMixin' is protected and only accessible within the class declaration.
+tests/cases/conformance/classes/mixinClassesConstructorAccessibility.ts(57,3): error TS2674: Constructor of class 'ProtectedConstructorMixinGenericBaseType' is protected and only accessible within the class declaration.
+
+
+==== tests/cases/conformance/classes/mixinClassesConstructorAccessibility.ts (4 errors) ====
+    function PrivateConstructorMixinGenericBaseType<TBase extends new(...args: any[]) => any>(Base: TBase) {
+        return class PrivateConstructorMixinGenericBaseType extends Base {
+          private constructor(...args: any[]) {
+            super();
+          }
+        }
+      }
+      
+      function PrivateConstructorMixin(Base: new(...args: any[]) => any) {
+        return class PrivateConstructorMixin extends Base {
+          private constructor(...args: any[]) {
+            super();
+          }
+        }
+      }
+      
+      function ProtectedConstructorMixinGenericBaseType<TBase extends new(...args: any[]) => any>(Base: TBase) {
+        return class ProtectedConstructorMixinGenericBaseType extends Base {
+          protected constructor(...args: any[]) {
+            super();
+          }
+        }
+      }
+      
+      function ProtectedConstructorMixin(Base: new(...args: any[]) => any) {
+        return class ProtectedConstructorMixin extends Base {
+          protected constructor(...args: any[]) {
+            super();
+          }
+        }
+      }
+      
+      function PublicConstructorMixinGenericBaseType(Base: new(...args: any[]) => any) {
+        return class PublicConstructorMixinGenericBaseType extends Base {
+          constructor(...args: any[]) {
+            super();
+          }
+        }
+      }
+      
+      function PublicConstructorMixin(Base: new(...args: any[]) => any) {
+        return class PublicConstructorMixin extends Base {
+          constructor(...args: any[]) {
+            super();
+          }
+        }
+      }
+      
+      class Base {
+        constructor() {}
+      }
+      
+      new (PrivateConstructorMixin(Base))(); // error: PrivateConstructorMixin is private
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2673: Constructor of class 'PrivateConstructorMixin' is private and only accessible within the class declaration.
+      new (PrivateConstructorMixinGenericBaseType(Base))(); // error: PrivateConstructorMixinGenericBaseType is private
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2673: Constructor of class 'PrivateConstructorMixinGenericBaseType' is private and only accessible within the class declaration.
+      
+      new (ProtectedConstructorMixin(Base))(); // error: ProtectedConstructorMixin is protected
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2674: Constructor of class 'ProtectedConstructorMixin' is protected and only accessible within the class declaration.
+      new (ProtectedConstructorMixinGenericBaseType(Base))(); // error: ProtectedConstructorMixinGenericBaseType is protected
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2674: Constructor of class 'ProtectedConstructorMixinGenericBaseType' is protected and only accessible within the class declaration.
+      
+      new (PublicConstructorMixin(Base))();
+      new (PublicConstructorMixinGenericBaseType(Base))();

--- a/tests/baselines/reference/mixinClassesConstructorAccessibility.js
+++ b/tests/baselines/reference/mixinClassesConstructorAccessibility.js
@@ -1,0 +1,167 @@
+//// [mixinClassesConstructorAccessibility.ts]
+function PrivateConstructorMixinGenericBaseType<TBase extends new(...args: any[]) => any>(Base: TBase) {
+    return class PrivateConstructorMixinGenericBaseType extends Base {
+      private constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  function PrivateConstructorMixin(Base: new(...args: any[]) => any) {
+    return class PrivateConstructorMixin extends Base {
+      private constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  function ProtectedConstructorMixinGenericBaseType<TBase extends new(...args: any[]) => any>(Base: TBase) {
+    return class ProtectedConstructorMixinGenericBaseType extends Base {
+      protected constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  function ProtectedConstructorMixin(Base: new(...args: any[]) => any) {
+    return class ProtectedConstructorMixin extends Base {
+      protected constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  function PublicConstructorMixinGenericBaseType(Base: new(...args: any[]) => any) {
+    return class PublicConstructorMixinGenericBaseType extends Base {
+      constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  function PublicConstructorMixin(Base: new(...args: any[]) => any) {
+    return class PublicConstructorMixin extends Base {
+      constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  class Base {
+    constructor() {}
+  }
+  
+  new (PrivateConstructorMixin(Base))(); // error: PrivateConstructorMixin is private
+  new (PrivateConstructorMixinGenericBaseType(Base))(); // error: PrivateConstructorMixinGenericBaseType is private
+  
+  new (ProtectedConstructorMixin(Base))(); // error: ProtectedConstructorMixin is protected
+  new (ProtectedConstructorMixinGenericBaseType(Base))(); // error: ProtectedConstructorMixinGenericBaseType is protected
+  
+  new (PublicConstructorMixin(Base))();
+  new (PublicConstructorMixinGenericBaseType(Base))();
+
+//// [mixinClassesConstructorAccessibility.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+function PrivateConstructorMixinGenericBaseType(Base) {
+    return /** @class */ (function (_super) {
+        __extends(PrivateConstructorMixinGenericBaseType, _super);
+        function PrivateConstructorMixinGenericBaseType() {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return _super.call(this) || this;
+        }
+        return PrivateConstructorMixinGenericBaseType;
+    }(Base));
+}
+function PrivateConstructorMixin(Base) {
+    return /** @class */ (function (_super) {
+        __extends(PrivateConstructorMixin, _super);
+        function PrivateConstructorMixin() {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return _super.call(this) || this;
+        }
+        return PrivateConstructorMixin;
+    }(Base));
+}
+function ProtectedConstructorMixinGenericBaseType(Base) {
+    return /** @class */ (function (_super) {
+        __extends(ProtectedConstructorMixinGenericBaseType, _super);
+        function ProtectedConstructorMixinGenericBaseType() {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return _super.call(this) || this;
+        }
+        return ProtectedConstructorMixinGenericBaseType;
+    }(Base));
+}
+function ProtectedConstructorMixin(Base) {
+    return /** @class */ (function (_super) {
+        __extends(ProtectedConstructorMixin, _super);
+        function ProtectedConstructorMixin() {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return _super.call(this) || this;
+        }
+        return ProtectedConstructorMixin;
+    }(Base));
+}
+function PublicConstructorMixinGenericBaseType(Base) {
+    return /** @class */ (function (_super) {
+        __extends(PublicConstructorMixinGenericBaseType, _super);
+        function PublicConstructorMixinGenericBaseType() {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return _super.call(this) || this;
+        }
+        return PublicConstructorMixinGenericBaseType;
+    }(Base));
+}
+function PublicConstructorMixin(Base) {
+    return /** @class */ (function (_super) {
+        __extends(PublicConstructorMixin, _super);
+        function PublicConstructorMixin() {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return _super.call(this) || this;
+        }
+        return PublicConstructorMixin;
+    }(Base));
+}
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    return Base;
+}());
+new (PrivateConstructorMixin(Base))(); // error: PrivateConstructorMixin is private
+new (PrivateConstructorMixinGenericBaseType(Base))(); // error: PrivateConstructorMixinGenericBaseType is private
+new (ProtectedConstructorMixin(Base))(); // error: ProtectedConstructorMixin is protected
+new (ProtectedConstructorMixinGenericBaseType(Base))(); // error: ProtectedConstructorMixinGenericBaseType is protected
+new (PublicConstructorMixin(Base))();
+new (PublicConstructorMixinGenericBaseType(Base))();

--- a/tests/baselines/reference/mixinClassesConstructorAccessibility.symbols
+++ b/tests/baselines/reference/mixinClassesConstructorAccessibility.symbols
@@ -1,0 +1,143 @@
+=== tests/cases/conformance/classes/mixinClassesConstructorAccessibility.ts ===
+function PrivateConstructorMixinGenericBaseType<TBase extends new(...args: any[]) => any>(Base: TBase) {
+>PrivateConstructorMixinGenericBaseType : Symbol(PrivateConstructorMixinGenericBaseType, Decl(mixinClassesConstructorAccessibility.ts, 0, 0))
+>TBase : Symbol(TBase, Decl(mixinClassesConstructorAccessibility.ts, 0, 48))
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 0, 66))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 0, 90))
+>TBase : Symbol(TBase, Decl(mixinClassesConstructorAccessibility.ts, 0, 48))
+
+    return class PrivateConstructorMixinGenericBaseType extends Base {
+>PrivateConstructorMixinGenericBaseType : Symbol(PrivateConstructorMixinGenericBaseType, Decl(mixinClassesConstructorAccessibility.ts, 1, 10))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 0, 90))
+
+      private constructor(...args: any[]) {
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 2, 26))
+
+        super();
+>super : Symbol(TBase, Decl(mixinClassesConstructorAccessibility.ts, 0, 48))
+      }
+    }
+  }
+  
+  function PrivateConstructorMixin(Base: new(...args: any[]) => any) {
+>PrivateConstructorMixin : Symbol(PrivateConstructorMixin, Decl(mixinClassesConstructorAccessibility.ts, 6, 3))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 8, 35))
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 8, 45))
+
+    return class PrivateConstructorMixin extends Base {
+>PrivateConstructorMixin : Symbol(PrivateConstructorMixin, Decl(mixinClassesConstructorAccessibility.ts, 9, 10))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 8, 35))
+
+      private constructor(...args: any[]) {
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 10, 26))
+
+        super();
+>super : Symbol(__type, Decl(mixinClassesConstructorAccessibility.ts, 8, 40))
+      }
+    }
+  }
+  
+  function ProtectedConstructorMixinGenericBaseType<TBase extends new(...args: any[]) => any>(Base: TBase) {
+>ProtectedConstructorMixinGenericBaseType : Symbol(ProtectedConstructorMixinGenericBaseType, Decl(mixinClassesConstructorAccessibility.ts, 14, 3))
+>TBase : Symbol(TBase, Decl(mixinClassesConstructorAccessibility.ts, 16, 52))
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 16, 70))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 16, 94))
+>TBase : Symbol(TBase, Decl(mixinClassesConstructorAccessibility.ts, 16, 52))
+
+    return class ProtectedConstructorMixinGenericBaseType extends Base {
+>ProtectedConstructorMixinGenericBaseType : Symbol(ProtectedConstructorMixinGenericBaseType, Decl(mixinClassesConstructorAccessibility.ts, 17, 10))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 16, 94))
+
+      protected constructor(...args: any[]) {
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 18, 28))
+
+        super();
+>super : Symbol(TBase, Decl(mixinClassesConstructorAccessibility.ts, 16, 52))
+      }
+    }
+  }
+  
+  function ProtectedConstructorMixin(Base: new(...args: any[]) => any) {
+>ProtectedConstructorMixin : Symbol(ProtectedConstructorMixin, Decl(mixinClassesConstructorAccessibility.ts, 22, 3))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 24, 37))
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 24, 47))
+
+    return class ProtectedConstructorMixin extends Base {
+>ProtectedConstructorMixin : Symbol(ProtectedConstructorMixin, Decl(mixinClassesConstructorAccessibility.ts, 25, 10))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 24, 37))
+
+      protected constructor(...args: any[]) {
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 26, 28))
+
+        super();
+>super : Symbol(__type, Decl(mixinClassesConstructorAccessibility.ts, 24, 42))
+      }
+    }
+  }
+  
+  function PublicConstructorMixinGenericBaseType(Base: new(...args: any[]) => any) {
+>PublicConstructorMixinGenericBaseType : Symbol(PublicConstructorMixinGenericBaseType, Decl(mixinClassesConstructorAccessibility.ts, 30, 3))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 32, 49))
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 32, 59))
+
+    return class PublicConstructorMixinGenericBaseType extends Base {
+>PublicConstructorMixinGenericBaseType : Symbol(PublicConstructorMixinGenericBaseType, Decl(mixinClassesConstructorAccessibility.ts, 33, 10))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 32, 49))
+
+      constructor(...args: any[]) {
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 34, 18))
+
+        super();
+>super : Symbol(__type, Decl(mixinClassesConstructorAccessibility.ts, 32, 54))
+      }
+    }
+  }
+  
+  function PublicConstructorMixin(Base: new(...args: any[]) => any) {
+>PublicConstructorMixin : Symbol(PublicConstructorMixin, Decl(mixinClassesConstructorAccessibility.ts, 38, 3))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 40, 34))
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 40, 44))
+
+    return class PublicConstructorMixin extends Base {
+>PublicConstructorMixin : Symbol(PublicConstructorMixin, Decl(mixinClassesConstructorAccessibility.ts, 41, 10))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 40, 34))
+
+      constructor(...args: any[]) {
+>args : Symbol(args, Decl(mixinClassesConstructorAccessibility.ts, 42, 18))
+
+        super();
+>super : Symbol(__type, Decl(mixinClassesConstructorAccessibility.ts, 40, 39))
+      }
+    }
+  }
+  
+  class Base {
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 46, 3))
+
+    constructor() {}
+  }
+  
+  new (PrivateConstructorMixin(Base))(); // error: PrivateConstructorMixin is private
+>PrivateConstructorMixin : Symbol(PrivateConstructorMixin, Decl(mixinClassesConstructorAccessibility.ts, 6, 3))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 46, 3))
+
+  new (PrivateConstructorMixinGenericBaseType(Base))(); // error: PrivateConstructorMixinGenericBaseType is private
+>PrivateConstructorMixinGenericBaseType : Symbol(PrivateConstructorMixinGenericBaseType, Decl(mixinClassesConstructorAccessibility.ts, 0, 0))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 46, 3))
+  
+  new (ProtectedConstructorMixin(Base))(); // error: ProtectedConstructorMixin is protected
+>ProtectedConstructorMixin : Symbol(ProtectedConstructorMixin, Decl(mixinClassesConstructorAccessibility.ts, 22, 3))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 46, 3))
+
+  new (ProtectedConstructorMixinGenericBaseType(Base))(); // error: ProtectedConstructorMixinGenericBaseType is protected
+>ProtectedConstructorMixinGenericBaseType : Symbol(ProtectedConstructorMixinGenericBaseType, Decl(mixinClassesConstructorAccessibility.ts, 14, 3))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 46, 3))
+  
+  new (PublicConstructorMixin(Base))();
+>PublicConstructorMixin : Symbol(PublicConstructorMixin, Decl(mixinClassesConstructorAccessibility.ts, 38, 3))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 46, 3))
+
+  new (PublicConstructorMixinGenericBaseType(Base))();
+>PublicConstructorMixinGenericBaseType : Symbol(PublicConstructorMixinGenericBaseType, Decl(mixinClassesConstructorAccessibility.ts, 30, 3))
+>Base : Symbol(Base, Decl(mixinClassesConstructorAccessibility.ts, 46, 3))
+

--- a/tests/baselines/reference/mixinClassesConstructorAccessibility.types
+++ b/tests/baselines/reference/mixinClassesConstructorAccessibility.types
@@ -1,0 +1,169 @@
+=== tests/cases/conformance/classes/mixinClassesConstructorAccessibility.ts ===
+function PrivateConstructorMixinGenericBaseType<TBase extends new(...args: any[]) => any>(Base: TBase) {
+>PrivateConstructorMixinGenericBaseType : <TBase extends new (...args: any[]) => any>(Base: TBase) => { new (...args: any[]): PrivateConstructorMixinGenericBaseType; prototype: PrivateConstructorMixinGenericBaseType<any>.PrivateConstructorMixinGenericBaseType; } & TBase
+>args : any[]
+>Base : TBase
+
+    return class PrivateConstructorMixinGenericBaseType extends Base {
+>class PrivateConstructorMixinGenericBaseType extends Base {      private constructor(...args: any[]) {        super();      }    } : { new (...args: any[]): PrivateConstructorMixinGenericBaseType; prototype: PrivateConstructorMixinGenericBaseType<any>.PrivateConstructorMixinGenericBaseType; } & TBase
+>PrivateConstructorMixinGenericBaseType : { new (...args: any[]): PrivateConstructorMixinGenericBaseType; prototype: PrivateConstructorMixinGenericBaseType<any>.PrivateConstructorMixinGenericBaseType; } & TBase
+>Base : TBase
+
+      private constructor(...args: any[]) {
+>args : any[]
+
+        super();
+>super() : void
+>super : TBase
+      }
+    }
+  }
+  
+  function PrivateConstructorMixin(Base: new(...args: any[]) => any) {
+>PrivateConstructorMixin : (Base: new (...args: any[]) => any) => typeof PrivateConstructorMixin
+>Base : new (...args: any[]) => any
+>args : any[]
+
+    return class PrivateConstructorMixin extends Base {
+>class PrivateConstructorMixin extends Base {      private constructor(...args: any[]) {        super();      }    } : typeof PrivateConstructorMixin
+>PrivateConstructorMixin : typeof PrivateConstructorMixin
+>Base : new (...args: any[]) => any
+
+      private constructor(...args: any[]) {
+>args : any[]
+
+        super();
+>super() : void
+>super : new (...args: any[]) => any
+      }
+    }
+  }
+  
+  function ProtectedConstructorMixinGenericBaseType<TBase extends new(...args: any[]) => any>(Base: TBase) {
+>ProtectedConstructorMixinGenericBaseType : <TBase extends new (...args: any[]) => any>(Base: TBase) => { new (...args: any[]): ProtectedConstructorMixinGenericBaseType; prototype: ProtectedConstructorMixinGenericBaseType<any>.ProtectedConstructorMixinGenericBaseType; } & TBase
+>args : any[]
+>Base : TBase
+
+    return class ProtectedConstructorMixinGenericBaseType extends Base {
+>class ProtectedConstructorMixinGenericBaseType extends Base {      protected constructor(...args: any[]) {        super();      }    } : { new (...args: any[]): ProtectedConstructorMixinGenericBaseType; prototype: ProtectedConstructorMixinGenericBaseType<any>.ProtectedConstructorMixinGenericBaseType; } & TBase
+>ProtectedConstructorMixinGenericBaseType : { new (...args: any[]): ProtectedConstructorMixinGenericBaseType; prototype: ProtectedConstructorMixinGenericBaseType<any>.ProtectedConstructorMixinGenericBaseType; } & TBase
+>Base : TBase
+
+      protected constructor(...args: any[]) {
+>args : any[]
+
+        super();
+>super() : void
+>super : TBase
+      }
+    }
+  }
+  
+  function ProtectedConstructorMixin(Base: new(...args: any[]) => any) {
+>ProtectedConstructorMixin : (Base: new (...args: any[]) => any) => typeof ProtectedConstructorMixin
+>Base : new (...args: any[]) => any
+>args : any[]
+
+    return class ProtectedConstructorMixin extends Base {
+>class ProtectedConstructorMixin extends Base {      protected constructor(...args: any[]) {        super();      }    } : typeof ProtectedConstructorMixin
+>ProtectedConstructorMixin : typeof ProtectedConstructorMixin
+>Base : new (...args: any[]) => any
+
+      protected constructor(...args: any[]) {
+>args : any[]
+
+        super();
+>super() : void
+>super : new (...args: any[]) => any
+      }
+    }
+  }
+  
+  function PublicConstructorMixinGenericBaseType(Base: new(...args: any[]) => any) {
+>PublicConstructorMixinGenericBaseType : (Base: new (...args: any[]) => any) => typeof PublicConstructorMixinGenericBaseType
+>Base : new (...args: any[]) => any
+>args : any[]
+
+    return class PublicConstructorMixinGenericBaseType extends Base {
+>class PublicConstructorMixinGenericBaseType extends Base {      constructor(...args: any[]) {        super();      }    } : typeof PublicConstructorMixinGenericBaseType
+>PublicConstructorMixinGenericBaseType : typeof PublicConstructorMixinGenericBaseType
+>Base : new (...args: any[]) => any
+
+      constructor(...args: any[]) {
+>args : any[]
+
+        super();
+>super() : void
+>super : new (...args: any[]) => any
+      }
+    }
+  }
+  
+  function PublicConstructorMixin(Base: new(...args: any[]) => any) {
+>PublicConstructorMixin : (Base: new (...args: any[]) => any) => typeof PublicConstructorMixin
+>Base : new (...args: any[]) => any
+>args : any[]
+
+    return class PublicConstructorMixin extends Base {
+>class PublicConstructorMixin extends Base {      constructor(...args: any[]) {        super();      }    } : typeof PublicConstructorMixin
+>PublicConstructorMixin : typeof PublicConstructorMixin
+>Base : new (...args: any[]) => any
+
+      constructor(...args: any[]) {
+>args : any[]
+
+        super();
+>super() : void
+>super : new (...args: any[]) => any
+      }
+    }
+  }
+  
+  class Base {
+>Base : Base
+
+    constructor() {}
+  }
+  
+  new (PrivateConstructorMixin(Base))(); // error: PrivateConstructorMixin is private
+>new (PrivateConstructorMixin(Base))() : any
+>(PrivateConstructorMixin(Base)) : typeof PrivateConstructorMixin
+>PrivateConstructorMixin(Base) : typeof PrivateConstructorMixin
+>PrivateConstructorMixin : (Base: new (...args: any[]) => any) => typeof PrivateConstructorMixin
+>Base : typeof Base
+
+  new (PrivateConstructorMixinGenericBaseType(Base))(); // error: PrivateConstructorMixinGenericBaseType is private
+>new (PrivateConstructorMixinGenericBaseType(Base))() : any
+>(PrivateConstructorMixinGenericBaseType(Base)) : { new (...args: any[]): PrivateConstructorMixinGenericBaseType<typeof Base>.PrivateConstructorMixinGenericBaseType; prototype: PrivateConstructorMixinGenericBaseType<any>.PrivateConstructorMixinGenericBaseType; } & typeof Base
+>PrivateConstructorMixinGenericBaseType(Base) : { new (...args: any[]): PrivateConstructorMixinGenericBaseType<typeof Base>.PrivateConstructorMixinGenericBaseType; prototype: PrivateConstructorMixinGenericBaseType<any>.PrivateConstructorMixinGenericBaseType; } & typeof Base
+>PrivateConstructorMixinGenericBaseType : <TBase extends new (...args: any[]) => any>(Base: TBase) => { new (...args: any[]): PrivateConstructorMixinGenericBaseType; prototype: PrivateConstructorMixinGenericBaseType<any>.PrivateConstructorMixinGenericBaseType; } & TBase
+>Base : typeof Base
+  
+  new (ProtectedConstructorMixin(Base))(); // error: ProtectedConstructorMixin is protected
+>new (ProtectedConstructorMixin(Base))() : any
+>(ProtectedConstructorMixin(Base)) : typeof ProtectedConstructorMixin
+>ProtectedConstructorMixin(Base) : typeof ProtectedConstructorMixin
+>ProtectedConstructorMixin : (Base: new (...args: any[]) => any) => typeof ProtectedConstructorMixin
+>Base : typeof Base
+
+  new (ProtectedConstructorMixinGenericBaseType(Base))(); // error: ProtectedConstructorMixinGenericBaseType is protected
+>new (ProtectedConstructorMixinGenericBaseType(Base))() : any
+>(ProtectedConstructorMixinGenericBaseType(Base)) : { new (...args: any[]): ProtectedConstructorMixinGenericBaseType<typeof Base>.ProtectedConstructorMixinGenericBaseType; prototype: ProtectedConstructorMixinGenericBaseType<any>.ProtectedConstructorMixinGenericBaseType; } & typeof Base
+>ProtectedConstructorMixinGenericBaseType(Base) : { new (...args: any[]): ProtectedConstructorMixinGenericBaseType<typeof Base>.ProtectedConstructorMixinGenericBaseType; prototype: ProtectedConstructorMixinGenericBaseType<any>.ProtectedConstructorMixinGenericBaseType; } & typeof Base
+>ProtectedConstructorMixinGenericBaseType : <TBase extends new (...args: any[]) => any>(Base: TBase) => { new (...args: any[]): ProtectedConstructorMixinGenericBaseType; prototype: ProtectedConstructorMixinGenericBaseType<any>.ProtectedConstructorMixinGenericBaseType; } & TBase
+>Base : typeof Base
+  
+  new (PublicConstructorMixin(Base))();
+>new (PublicConstructorMixin(Base))() : PublicConstructorMixin
+>(PublicConstructorMixin(Base)) : typeof PublicConstructorMixin
+>PublicConstructorMixin(Base) : typeof PublicConstructorMixin
+>PublicConstructorMixin : (Base: new (...args: any[]) => any) => typeof PublicConstructorMixin
+>Base : typeof Base
+
+  new (PublicConstructorMixinGenericBaseType(Base))();
+>new (PublicConstructorMixinGenericBaseType(Base))() : PublicConstructorMixinGenericBaseType
+>(PublicConstructorMixinGenericBaseType(Base)) : typeof PublicConstructorMixinGenericBaseType
+>PublicConstructorMixinGenericBaseType(Base) : typeof PublicConstructorMixinGenericBaseType
+>PublicConstructorMixinGenericBaseType : (Base: new (...args: any[]) => any) => typeof PublicConstructorMixinGenericBaseType
+>Base : typeof Base
+

--- a/tests/cases/conformance/classes/mixinClassesConstructorAccessibility.ts
+++ b/tests/cases/conformance/classes/mixinClassesConstructorAccessibility.ts
@@ -1,0 +1,60 @@
+function PrivateConstructorMixinGenericBaseType<TBase extends new(...args: any[]) => any>(Base: TBase) {
+    return class PrivateConstructorMixinGenericBaseType extends Base {
+      private constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  function PrivateConstructorMixin(Base: new(...args: any[]) => any) {
+    return class PrivateConstructorMixin extends Base {
+      private constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  function ProtectedConstructorMixinGenericBaseType<TBase extends new(...args: any[]) => any>(Base: TBase) {
+    return class ProtectedConstructorMixinGenericBaseType extends Base {
+      protected constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  function ProtectedConstructorMixin(Base: new(...args: any[]) => any) {
+    return class ProtectedConstructorMixin extends Base {
+      protected constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  function PublicConstructorMixinGenericBaseType(Base: new(...args: any[]) => any) {
+    return class PublicConstructorMixinGenericBaseType extends Base {
+      constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  function PublicConstructorMixin(Base: new(...args: any[]) => any) {
+    return class PublicConstructorMixin extends Base {
+      constructor(...args: any[]) {
+        super();
+      }
+    }
+  }
+  
+  class Base {
+    constructor() {}
+  }
+  
+  new (PrivateConstructorMixin(Base))(); // error: PrivateConstructorMixin is private
+  new (PrivateConstructorMixinGenericBaseType(Base))(); // error: PrivateConstructorMixinGenericBaseType is private
+  
+  new (ProtectedConstructorMixin(Base))(); // error: ProtectedConstructorMixin is protected
+  new (ProtectedConstructorMixinGenericBaseType(Base))(); // error: ProtectedConstructorMixinGenericBaseType is protected
+  
+  new (PublicConstructorMixin(Base))();
+  new (PublicConstructorMixinGenericBaseType(Base))();


### PR DESCRIPTION
Fixes #42264

In `checker.ts > resolveIntersectionTypeMembers()`, instead of discarding and merging all mixin constructor signatures, we do so only for mixins with publicly accessible constructor signatures. Private or protected constructor signatures of mixins are not discarded/merged, and instead are added to the intersection type's constructor signatures.

**Details on bug cause are provided in [my comment to the bug report](https://github.com/microsoft/TypeScript/issues/42264#issuecomment-913928347).**  