### PR TITLE
Fix typo

### DIFF
--- a/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts
+++ b/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts
@@ -190,16 +190,16 @@ module GenericSignaturesValid {
     }
 
     interface I2 extends Base2 {
-        a: <T>(x?: T) => T; // error, not identical and contextual signature instatiation can't make inference from T to T
+        a: <T>(x?: T) => T; // error, not identical and contextual signature instantiation can't make inference from T to T
     }
 
     interface I3 extends Base2 {
-        a: <T>(x: T) => T; // error, not identical and contextual signature instatiation can't make inference from T to T
+        a: <T>(x: T) => T; // error, not identical and contextual signature instantiation can't make inference from T to T
     }
 
 
     interface I4 extends Base2 {
-        a2: <T>() => T; // error, not identical and contextual signature instatiation can't make inference from T to T
+        a2: <T>() => T; // error, not identical and contextual signature instantiation can't make inference from T to T
     }
 
     interface I5 extends Base2 {
@@ -229,7 +229,7 @@ module GenericSignaturesValid {
 
 
     interface I11 extends Base2 {
-        a4: <T>() => T; // error, not identical and contextual signature instatiation can't make inference from T to T
+        a4: <T>() => T; // error, not identical and contextual signature instantiation can't make inference from T to T
     }
 
     interface I12 extends Base2 {
@@ -246,7 +246,7 @@ module GenericSignaturesValid {
 
 
     interface I15 extends Base2 {
-        a5: <T>() => T; // error, not identical and contextual signature instatiation can't make inference from T to T
+        a5: <T>() => T; // error, not identical and contextual signature instantiation can't make inference from T to T
     }
 
     interface I16 extends Base2 {


### PR DESCRIPTION
Fix typo in subtypingWithGenericCallSignaturesWithOptionalParameters.ts:

instatiation -> instantiation
