### PR TITLE
Narrow falsy strings to '' and falsy numbers to 0

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22812,15 +22812,6 @@ namespace ts {
             return type.flags & TypeFlags.UnionOrIntersection ? every((type as UnionOrIntersectionType).types, f) : f(type);
         }
 
-        // TODO: make this actually performant
-        function compactMap<T>(array: T[], f: (item: T) => T | undefined) {
-            const result = compact(map(array, f));
-
-            return result.length === array.length && every(array, (item, i) => item === result[i])
-                ? array
-                : result;
-        }
-
         function filterAndNarrowType(type: Type, narrow: (t: Type) => Type | undefined) {
             if (type.flags & TypeFlags.Union) {
                 const types = (type as UnionType).types;

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -400,6 +400,32 @@ namespace ts {
     }
 
     /**
+     * Maps, filters for truthiness, and avoids allocation if all elements map to themselves.
+     */
+    export function compactMap<T>(array: T[], f: (item: T) => T | undefined): T[] {
+        for (let i = 0; i < array.length; i++) {
+            const mapped = f(array[i]);
+            if (mapped && mapped === array[i]) {
+                continue;
+            }
+
+            const sliced = array.slice(0, i);
+            const compacted = mapped ? [...sliced, mapped] : sliced;
+
+            for (let j = i + 1; j < array.length; j++) {
+                const nextMapped = f(array[j]);
+                if (nextMapped) {
+                    compacted.push(nextMapped);
+                }
+            }
+
+            return compacted;
+        }
+
+        return array;
+    }
+
+    /**
      * Flattens an array containing a mix of array or non-array elements.
      *
      * @param array The array to flatten.

--- a/tests/baselines/reference/classStaticBlock8.types
+++ b/tests/baselines/reference/classStaticBlock8.types
@@ -111,7 +111,7 @@ function foo (v: number) {
 >4 : 4
             }
             switch (v) {
->v : number
+>v : 0 | 1 | 3
 
                 default: break; // valid
             }

--- a/tests/baselines/reference/controlFlowBinaryAndExpression.types
+++ b/tests/baselines/reference/controlFlowBinaryAndExpression.types
@@ -17,7 +17,7 @@ let cond: boolean;
 >0 : 0
 
 x; // string | number
->x : string | number
+>x : number | ""
 
 x = "";
 >x = "" : ""

--- a/tests/baselines/reference/controlFlowDoWhileStatement.types
+++ b/tests/baselines/reference/controlFlowDoWhileStatement.types
@@ -102,7 +102,7 @@ function d() {
 >length : number
 
     x; // number
->x : number
+>x : 0
 }
 function e() {
 >e : () => void

--- a/tests/baselines/reference/controlFlowTruthiness.types
+++ b/tests/baselines/reference/controlFlowTruthiness.types
@@ -18,7 +18,7 @@ function f1() {
     }
     else {
         x; // string | undefined
->x : string | undefined
+>x : "" | undefined
     }
 }
 
@@ -42,7 +42,7 @@ function f2() {
     }
     else {
         x; // string | undefined
->x : string | undefined
+>x : "" | undefined
     }
 }
 
@@ -63,7 +63,7 @@ function f3() {
     }
     else {
         x; // string | undefined
->x : string | undefined
+>x : "" | undefined
     }
 }
 
@@ -82,7 +82,7 @@ function f4() {
 >foo : () => string | undefined
 
         x; // string | undefined
->x : string | undefined
+>x : "" | undefined
     }
     else {
         x; // string
@@ -115,10 +115,10 @@ function f5() {
     }
     else {
         x; // string | undefined
->x : string | undefined
+>x : "" | undefined
 
         y; // string | undefined
->y : string | undefined
+>y : "" | undefined
     }
 }
 
@@ -153,7 +153,7 @@ function f6() {
 >x : string | undefined
 
         y; // string | undefined
->y : string | undefined
+>y : "" | undefined
     }
 }
 

--- a/tests/baselines/reference/expr.types
+++ b/tests/baselines/reference/expr.types
@@ -208,7 +208,7 @@ function f() {
     n||n;
 >n||n : number
 >n : number
->n : number
+>n : 0
 
     n||e;
 >n||e : number
@@ -238,7 +238,7 @@ function f() {
     s||s;
 >s||s : string
 >s : string
->s : string
+>s : ""
 
     s||e;
 >s||e : string | E

--- a/tests/baselines/reference/logicalOrOperatorWithEveryType.types
+++ b/tests/baselines/reference/logicalOrOperatorWithEveryType.types
@@ -171,7 +171,7 @@ var rc3 = a3 || a3;         // number    || number is number
 >rc3 : number
 >a3 || a3 : number
 >a3 : number
->a3 : number
+>a3 : 0
 
 var rc4 = a4 || a3;         // string    || number is string | number
 >rc4 : string | number
@@ -237,7 +237,7 @@ var rd4 = a4 || a4;         // string    || string is string
 >rd4 : string
 >a4 || a4 : string
 >a4 : string
->a4 : string
+>a4 : ""
 
 var rd5 = a5 || a4;         // void      || string is void | string
 >rd5 : string

--- a/tests/baselines/reference/typeGuardsInRightOperandOfOrOrOperator.types
+++ b/tests/baselines/reference/typeGuardsInRightOperandOfOrOrOperator.types
@@ -19,42 +19,42 @@ function foo(x: number | string) {
 >10 : 10
 }
 function foo2(x: number | string) {
->foo2 : (x: number | string) => number | true
+>foo2 : (x: number | string) => true | 0 | 10
 >x : string | number
 
     // modify x in right hand operand
     return typeof x !== "string" || ((x = 10) || x); // string | number
->typeof x !== "string" || ((x = 10) || x) : number | true
+>typeof x !== "string" || ((x = 10) || x) : true | 0 | 10
 >typeof x !== "string" : boolean
 >typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
 >x : string | number
 >"string" : "string"
->((x = 10) || x) : number
->(x = 10) || x : number
+>((x = 10) || x) : 0 | 10
+>(x = 10) || x : 0 | 10
 >(x = 10) : 10
 >x = 10 : 10
 >x : string | number
 >10 : 10
->x : number
+>x : 0
 }
 function foo3(x: number | string) {
->foo3 : (x: number | string) => string | true
+>foo3 : (x: number | string) => true | "" | "hello"
 >x : string | number
 
     // modify x in right hand operand with string type itself
     return typeof x !== "string" || ((x = "hello") || x); // string | number
->typeof x !== "string" || ((x = "hello") || x) : string | true
+>typeof x !== "string" || ((x = "hello") || x) : true | "" | "hello"
 >typeof x !== "string" : boolean
 >typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
 >x : string | number
 >"string" : "string"
->((x = "hello") || x) : string
->(x = "hello") || x : string
+>((x = "hello") || x) : "" | "hello"
+>(x = "hello") || x : "" | "hello"
 >(x = "hello") : "hello"
 >x = "hello" : "hello"
 >x : string | number
 >"hello" : "hello"
->x : string
+>x : ""
 }
 function foo4(x: number | string | boolean) {
 >foo4 : (x: number | string | boolean) => boolean
@@ -103,7 +103,7 @@ function foo5(x: number | string | boolean) {
 >typeof x === "number"  // number | boolean        || x : boolean
 >typeof x === "number" : boolean
 >typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
->x : number | boolean
+>x : 0 | boolean
 >"number" : "number"
 
         || x));   // boolean
@@ -168,7 +168,7 @@ function foo7(x: number | string | boolean) {
 >typeof x === "number"        // change value of x        ? ((x = 10) && x.toString()) // number | boolean | string        // do not change value        : ((y = x) && x.toString()) : string
 >typeof x === "number" : boolean
 >typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
->x : number | boolean
+>x : 0 | boolean
 >"number" : "number"
 
         // change value of x


### PR DESCRIPTION
The existing `filterType` function used by `getTypeWithFacts` <- `narrowTypeByTruthiness` works as a filter: taking in an existing set of types and returning the ones that are allowed. This PR sets up a `filterAndNarrowType` function that can also transform the types given to it into more narrow equivalents. `truthyTypeFilter` is then used by `narrowTypeByTruthiness` to turns primitives into their falsy literals (e.g. `number` -> `0`) when falsy.

~Sending as a draft as requested so we can try this out on real world code.~ Opening as a full PR since it's been a bit and none of the typescript-bot commands have shown any major red flags.

Fixes #45329

