### PR TITLE
Fix for resolvedTrueType and resolvedFalseType of conditionType not resolved

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5616,8 +5616,8 @@ namespace ts {
         root: ConditionalRoot;
         checkType: Type;
         extendsType: Type;
-        resolvedTrueType: Type;
-        resolvedFalseType: Type;
+        resolvedTrueType?: Type;
+        resolvedFalseType?: Type;
         /* @internal */
         resolvedInferredTrueType?: Type; // The `trueType` instantiated with the `combinedMapper`, if present
         /* @internal */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2722,8 +2722,8 @@ declare namespace ts {
         root: ConditionalRoot;
         checkType: Type;
         extendsType: Type;
-        resolvedTrueType: Type;
-        resolvedFalseType: Type;
+        resolvedTrueType?: Type;
+        resolvedFalseType?: Type;
     }
     export interface TemplateLiteralType extends InstantiableType {
         texts: readonly string[];

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2722,8 +2722,8 @@ declare namespace ts {
         root: ConditionalRoot;
         checkType: Type;
         extendsType: Type;
-        resolvedTrueType: Type;
-        resolvedFalseType: Type;
+        resolvedTrueType?: Type;
+        resolvedFalseType?: Type;
     }
     export interface TemplateLiteralType extends InstantiableType {
         texts: readonly string[];


### PR DESCRIPTION
This PR fixes the issue with `resolvedTrueType` and `resolvedFalseType` of `conditionType` not being resolved when used in the compiler API. These changes were made as suggested in this comment: https://github.com/microsoft/TypeScript/issues/45537#issuecomment-903956382

All unit tests were run locally and executed successfully using `gulp runtests-parallel`.

**NOTE:** This is my first PR in the TypeScript open source project. I am open to any supportive feedback to help me become a better contributor in this space as I learn TypeScript, including any suggestions based on the code I've changed here. Thanks in advance!

Fixes #45537 
