### PR TITLE
Adds back NumberFormatPartType to the global types from intl

### DIFF
--- a/src/lib/es2018.intl.d.ts
+++ b/src/lib/es2018.intl.d.ts
@@ -40,9 +40,10 @@ declare namespace Intl {
     // We can only have one definition for 'type' in TypeScript, and so you can learn where the keys come from here:
     type ES2018NumberFormatPartType = "literal" | "nan" | "infinity" | "percent" | "integer" | "group" | "decimal" | "fraction" | "plusSign" | "minusSign" | "percentSign" | "currency" | "code" | "symbol" | "name";
     type ES2020NumberFormatPartType = "compact" | "exponentInteger" | "exponentMinusSign" | "exponentSeparator" | "unit" | "unknown";
+    type NumberFormatPartType = ES2018NumberFormatPartType | ES2020NumberFormatPartType;
 
     interface NumberFormatPart {
-        type: ES2018NumberFormatPartType | ES2020NumberFormatPartType;
+        type: NumberFormatPartType;
         value: string;
     }
 


### PR DESCRIPTION
We switched to do:

```ts
    type ES2018NumberFormatPartType = "literal" | "nan" | "infinity" | "percent" | "integer" | "group" | "decimal" | "fraction" | "plusSign" | "minusSign" | "percentSign" | "currency" | "code" | "symbol" | "name";
    type ES2020NumberFormatPartType = "compact" | "exponentInteger" | "exponentMinusSign" | "exponentSeparator" | "unit" | "unknown";
```

So it was documented what options version are available, but in the process broke CI on DT because a module relied on `NumberFormatPartType` being available globally.