### PR TITLE
Fix GH-32798: Allow == null to narrow unknown to null | undefined

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23895,7 +23895,7 @@ namespace ts {
                     assumeTrue = !assumeTrue;
                 }
                 const valueType = getTypeOfExpression(value);
-                if ((type.flags & TypeFlags.Unknown) && (operator === SyntaxKind.EqualsEqualsToken) && (valueType.flags & TypeFlags.Null)) {
+                if (assumeTrue && (type.flags & TypeFlags.Unknown) && (operator === SyntaxKind.EqualsEqualsToken) && (valueType.flags & TypeFlags.Null)) {
                     return getUnionType([nullType, undefinedType]);
                 }
                 if ((type.flags & TypeFlags.Unknown) && assumeTrue && (operator === SyntaxKind.EqualsEqualsEqualsToken || operator === SyntaxKind.ExclamationEqualsEqualsToken)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23895,7 +23895,7 @@ namespace ts {
                     assumeTrue = !assumeTrue;
                 }
                 const valueType = getTypeOfExpression(value);
-                if (assumeTrue && (type.flags & TypeFlags.Unknown) && (operator === SyntaxKind.EqualsEqualsToken) && (valueType.flags & TypeFlags.Null)) {
+                if (assumeTrue && (type.flags & TypeFlags.Unknown) && (operator === SyntaxKind.EqualsEqualsToken || operator === SyntaxKind.ExclamationEqualsToken) && (valueType.flags & TypeFlags.Null)) {
                     return getUnionType([nullType, undefinedType]);
                 }
                 if ((type.flags & TypeFlags.Unknown) && assumeTrue && (operator === SyntaxKind.EqualsEqualsEqualsToken || operator === SyntaxKind.ExclamationEqualsEqualsToken)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23895,6 +23895,9 @@ namespace ts {
                     assumeTrue = !assumeTrue;
                 }
                 const valueType = getTypeOfExpression(value);
+                if ((type.flags & TypeFlags.Unknown) && (operator === SyntaxKind.EqualsEqualsToken) && (valueType.flags & TypeFlags.Null)) {
+                    return getUnionType([nullType, undefinedType]);
+                }
                 if ((type.flags & TypeFlags.Unknown) && assumeTrue && (operator === SyntaxKind.EqualsEqualsEqualsToken || operator === SyntaxKind.ExclamationEqualsEqualsToken)) {
                     if (valueType.flags & (TypeFlags.Primitive | TypeFlags.NonPrimitive)) {
                         return valueType;

--- a/tests/baselines/reference/narrowByEquality.errors.txt
+++ b/tests/baselines/reference/narrowByEquality.errors.txt
@@ -75,3 +75,8 @@ tests/cases/compiler/narrowByEquality.ts(55,9): error TS2322: Type 'string | num
         xUnknown;
     }
     
+    if (xUnknown != null) {
+        xUnknown;
+    }
+    
+    

--- a/tests/baselines/reference/narrowByEquality.errors.txt
+++ b/tests/baselines/reference/narrowByEquality.errors.txt
@@ -73,9 +73,13 @@ tests/cases/compiler/narrowByEquality.ts(55,9): error TS2322: Type 'string | num
     // From issue #32798
     if (xUnknown == null) {
         xUnknown;
+    } else {
+        xUnknown
     }
     
     if (xUnknown != null) {
+        xUnknown;
+    } else {
         xUnknown;
     }
     

--- a/tests/baselines/reference/narrowByEquality.errors.txt
+++ b/tests/baselines/reference/narrowByEquality.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/narrowByEquality.ts(53,15): error TS2322: Type 'string | number' is not assignable to type 'number'.
+tests/cases/compiler/narrowByEquality.ts(54,15): error TS2322: Type 'string | number' is not assignable to type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/narrowByEquality.ts(54,9): error TS2322: Type 'string | number' is not assignable to type 'number'.
+tests/cases/compiler/narrowByEquality.ts(55,9): error TS2322: Type 'string | number' is not assignable to type 'number'.
   Type 'string' is not assignable to type 'number'.
 
 
@@ -9,6 +9,7 @@ tests/cases/compiler/narrowByEquality.ts(54,9): error TS2322: Type 'string | num
     declare let n: number;
     declare let s: string;
     declare let b: boolean;
+    declare let xUnknown: unknown;
     
     if (x == n) {
         x;
@@ -67,5 +68,10 @@ tests/cases/compiler/narrowByEquality.ts(54,9): error TS2322: Type 'string | num
 !!! error TS2322:   Type 'string' is not assignable to type 'number'.
         }
         return 0;
+    }
+    
+    // From issue #32798
+    if (xUnknown == null) {
+        xUnknown;
     }
     

--- a/tests/baselines/reference/narrowByEquality.js
+++ b/tests/baselines/reference/narrowByEquality.js
@@ -63,6 +63,11 @@ if (xUnknown == null) {
     xUnknown;
 }
 
+if (xUnknown != null) {
+    xUnknown;
+}
+
+
 
 //// [narrowByEquality.js]
 "use strict";
@@ -107,5 +112,8 @@ function test(level) {
 }
 // From issue #32798
 if (xUnknown == null) {
+    xUnknown;
+}
+if (xUnknown != null) {
     xUnknown;
 }

--- a/tests/baselines/reference/narrowByEquality.js
+++ b/tests/baselines/reference/narrowByEquality.js
@@ -61,9 +61,13 @@ function test(level: number | string):number {
 // From issue #32798
 if (xUnknown == null) {
     xUnknown;
+} else {
+    xUnknown
 }
 
 if (xUnknown != null) {
+    xUnknown;
+} else {
     xUnknown;
 }
 
@@ -114,6 +118,12 @@ function test(level) {
 if (xUnknown == null) {
     xUnknown;
 }
+else {
+    xUnknown;
+}
 if (xUnknown != null) {
+    xUnknown;
+}
+else {
     xUnknown;
 }

--- a/tests/baselines/reference/narrowByEquality.js
+++ b/tests/baselines/reference/narrowByEquality.js
@@ -3,6 +3,7 @@ declare let x: number | string | boolean
 declare let n: number;
 declare let s: string;
 declare let b: boolean;
+declare let xUnknown: unknown;
 
 if (x == n) {
     x;
@@ -57,6 +58,11 @@ function test(level: number | string):number {
     return 0;
 }
 
+// From issue #32798
+if (xUnknown == null) {
+    xUnknown;
+}
+
 
 //// [narrowByEquality.js]
 "use strict";
@@ -98,4 +104,8 @@ function test(level) {
         return level;
     }
     return 0;
+}
+// From issue #32798
+if (xUnknown == null) {
+    xUnknown;
 }

--- a/tests/baselines/reference/narrowByEquality.symbols
+++ b/tests/baselines/reference/narrowByEquality.symbols
@@ -122,3 +122,11 @@ if (xUnknown == null) {
 >xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
 }
 
+if (xUnknown != null) {
+>xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
+
+    xUnknown;
+>xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
+}
+
+

--- a/tests/baselines/reference/narrowByEquality.symbols
+++ b/tests/baselines/reference/narrowByEquality.symbols
@@ -120,11 +120,19 @@ if (xUnknown == null) {
 
     xUnknown;
 >xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
+
+} else {
+    xUnknown
+>xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
 }
 
 if (xUnknown != null) {
 >xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
 
+    xUnknown;
+>xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
+
+} else {
     xUnknown;
 >xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
 }

--- a/tests/baselines/reference/narrowByEquality.symbols
+++ b/tests/baselines/reference/narrowByEquality.symbols
@@ -11,6 +11,9 @@ declare let s: string;
 declare let b: boolean;
 >b : Symbol(b, Decl(narrowByEquality.ts, 3, 11))
 
+declare let xUnknown: unknown;
+>xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
+
 if (x == n) {
 >x : Symbol(x, Decl(narrowByEquality.ts, 0, 11))
 >n : Symbol(n, Decl(narrowByEquality.ts, 1, 11))
@@ -71,43 +74,51 @@ if (x == false) {
 }
 
 declare let xAndObj: number | string | boolean | object
->xAndObj : Symbol(xAndObj, Decl(narrowByEquality.ts, 37, 11))
+>xAndObj : Symbol(xAndObj, Decl(narrowByEquality.ts, 38, 11))
 
 if (xAndObj == {}) {
->xAndObj : Symbol(xAndObj, Decl(narrowByEquality.ts, 37, 11))
+>xAndObj : Symbol(xAndObj, Decl(narrowByEquality.ts, 38, 11))
 
     xAndObj;
->xAndObj : Symbol(xAndObj, Decl(narrowByEquality.ts, 37, 11))
+>xAndObj : Symbol(xAndObj, Decl(narrowByEquality.ts, 38, 11))
 }
 
 if (x == xAndObj) {
 >x : Symbol(x, Decl(narrowByEquality.ts, 0, 11))
->xAndObj : Symbol(xAndObj, Decl(narrowByEquality.ts, 37, 11))
+>xAndObj : Symbol(xAndObj, Decl(narrowByEquality.ts, 38, 11))
 
     x;
 >x : Symbol(x, Decl(narrowByEquality.ts, 0, 11))
 
     xAndObj;
->xAndObj : Symbol(xAndObj, Decl(narrowByEquality.ts, 37, 11))
+>xAndObj : Symbol(xAndObj, Decl(narrowByEquality.ts, 38, 11))
 }
 
 // Repro from #24991
 
 function test(level: number | string):number {
->test : Symbol(test, Decl(narrowByEquality.ts, 46, 1))
->level : Symbol(level, Decl(narrowByEquality.ts, 50, 14))
+>test : Symbol(test, Decl(narrowByEquality.ts, 47, 1))
+>level : Symbol(level, Decl(narrowByEquality.ts, 51, 14))
 
     if (level == +level) {
->level : Symbol(level, Decl(narrowByEquality.ts, 50, 14))
->level : Symbol(level, Decl(narrowByEquality.ts, 50, 14))
+>level : Symbol(level, Decl(narrowByEquality.ts, 51, 14))
+>level : Symbol(level, Decl(narrowByEquality.ts, 51, 14))
 
         const q2: number = level; // error
->q2 : Symbol(q2, Decl(narrowByEquality.ts, 52, 13))
->level : Symbol(level, Decl(narrowByEquality.ts, 50, 14))
+>q2 : Symbol(q2, Decl(narrowByEquality.ts, 53, 13))
+>level : Symbol(level, Decl(narrowByEquality.ts, 51, 14))
 
         return level;
->level : Symbol(level, Decl(narrowByEquality.ts, 50, 14))
+>level : Symbol(level, Decl(narrowByEquality.ts, 51, 14))
     }
     return 0;
+}
+
+// From issue #32798
+if (xUnknown == null) {
+>xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
+
+    xUnknown;
+>xUnknown : Symbol(xUnknown, Decl(narrowByEquality.ts, 4, 11))
 }
 

--- a/tests/baselines/reference/narrowByEquality.types
+++ b/tests/baselines/reference/narrowByEquality.types
@@ -141,6 +141,10 @@ if (xUnknown == null) {
 
     xUnknown;
 >xUnknown : null | undefined
+
+} else {
+    xUnknown
+>xUnknown : unknown
 }
 
 if (xUnknown != null) {
@@ -150,6 +154,10 @@ if (xUnknown != null) {
 
     xUnknown;
 >xUnknown : unknown
+
+} else {
+    xUnknown;
+>xUnknown : null | undefined
 }
 
 

--- a/tests/baselines/reference/narrowByEquality.types
+++ b/tests/baselines/reference/narrowByEquality.types
@@ -143,3 +143,13 @@ if (xUnknown == null) {
 >xUnknown : null | undefined
 }
 
+if (xUnknown != null) {
+>xUnknown != null : boolean
+>xUnknown : unknown
+>null : null
+
+    xUnknown;
+>xUnknown : unknown
+}
+
+

--- a/tests/baselines/reference/narrowByEquality.types
+++ b/tests/baselines/reference/narrowByEquality.types
@@ -11,6 +11,9 @@ declare let s: string;
 declare let b: boolean;
 >b : boolean
 
+declare let xUnknown: unknown;
+>xUnknown : unknown
+
 if (x == n) {
 >x == n : boolean
 >x : string | number | boolean
@@ -128,5 +131,15 @@ function test(level: number | string):number {
     }
     return 0;
 >0 : 0
+}
+
+// From issue #32798
+if (xUnknown == null) {
+>xUnknown == null : boolean
+>xUnknown : unknown
+>null : null
+
+    xUnknown;
+>xUnknown : null | undefined
 }
 

--- a/tests/cases/compiler/narrowByEquality.ts
+++ b/tests/cases/compiler/narrowByEquality.ts
@@ -62,9 +62,13 @@ function test(level: number | string):number {
 // From issue #32798
 if (xUnknown == null) {
     xUnknown;
+} else {
+    xUnknown
 }
 
 if (xUnknown != null) {
+    xUnknown;
+} else {
     xUnknown;
 }
 

--- a/tests/cases/compiler/narrowByEquality.ts
+++ b/tests/cases/compiler/narrowByEquality.ts
@@ -63,3 +63,8 @@ function test(level: number | string):number {
 if (xUnknown == null) {
     xUnknown;
 }
+
+if (xUnknown != null) {
+    xUnknown;
+}
+

--- a/tests/cases/compiler/narrowByEquality.ts
+++ b/tests/cases/compiler/narrowByEquality.ts
@@ -4,6 +4,7 @@ declare let x: number | string | boolean
 declare let n: number;
 declare let s: string;
 declare let b: boolean;
+declare let xUnknown: unknown;
 
 if (x == n) {
     x;
@@ -56,4 +57,9 @@ function test(level: number | string):number {
         return level;
     }
     return 0;
+}
+
+// From issue #32798
+if (xUnknown == null) {
+    xUnknown;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #GH-32798
