### PR TITLE
fix(45850): Generated code when re-exporting a const enum using "preserveConstEnums": true is inconsistent

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24468,7 +24468,19 @@ namespace ts {
         }
 
         function isExportOrExportExpression(location: Node) {
-            return !!findAncestor(location, e => e.parent && isExportAssignment(e.parent) && e.parent.expression === e && isEntityNameExpression(e));
+            return !!findAncestor(location, n => {
+                const parent = n.parent;
+                if (parent === undefined) {
+                    return "quit";
+                }
+                if (isExportAssignment(parent)) {
+                    return parent.expression === n && isEntityNameExpression(n);
+                }
+                if (isExportSpecifier(parent)) {
+                    return parent.name === n || parent.propertyName === n;
+                }
+                return false;
+            });
         }
 
         function markAliasReferenced(symbol: Symbol, location: Node) {

--- a/tests/baselines/reference/constEnumPreserveEmitNamedExport1.js
+++ b/tests/baselines/reference/constEnumPreserveEmitNamedExport1.js
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/constEnumPreserveEmitNamedExport1.ts] ////
+
+//// [a.ts]
+const enum A {
+    Foo
+};
+export { A };
+
+//// [b.ts]
+import { A } from './a';
+export { A };
+
+
+//// [a.js]
+var A;
+(function (A) {
+    A[A["Foo"] = 0] = "Foo";
+})(A || (A = {}));
+;
+export { A };
+//// [b.js]
+import { A } from './a';
+export { A };

--- a/tests/baselines/reference/constEnumPreserveEmitNamedExport1.symbols
+++ b/tests/baselines/reference/constEnumPreserveEmitNamedExport1.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/a.ts ===
+const enum A {
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+    Foo
+>Foo : Symbol(A.Foo, Decl(a.ts, 0, 14))
+
+};
+export { A };
+>A : Symbol(A, Decl(a.ts, 3, 8))
+
+=== tests/cases/compiler/b.ts ===
+import { A } from './a';
+>A : Symbol(A, Decl(b.ts, 0, 8))
+
+export { A };
+>A : Symbol(A, Decl(b.ts, 1, 8))
+

--- a/tests/baselines/reference/constEnumPreserveEmitNamedExport1.types
+++ b/tests/baselines/reference/constEnumPreserveEmitNamedExport1.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/a.ts ===
+const enum A {
+>A : A
+
+    Foo
+>Foo : A.Foo
+
+};
+export { A };
+>A : typeof A
+
+=== tests/cases/compiler/b.ts ===
+import { A } from './a';
+>A : typeof A
+
+export { A };
+>A : typeof A
+

--- a/tests/baselines/reference/constEnumPreserveEmitNamedExport2.js
+++ b/tests/baselines/reference/constEnumPreserveEmitNamedExport2.js
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/constEnumPreserveEmitNamedExport2.ts] ////
+
+//// [a.ts]
+const enum A {
+    Foo
+};
+export { A };
+
+//// [b.ts]
+import { A } from './a';
+export { A as B };
+
+
+//// [a.js]
+var A;
+(function (A) {
+    A[A["Foo"] = 0] = "Foo";
+})(A || (A = {}));
+;
+export { A };
+//// [b.js]
+import { A } from './a';
+export { A as B };

--- a/tests/baselines/reference/constEnumPreserveEmitNamedExport2.symbols
+++ b/tests/baselines/reference/constEnumPreserveEmitNamedExport2.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/a.ts ===
+const enum A {
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+    Foo
+>Foo : Symbol(A.Foo, Decl(a.ts, 0, 14))
+
+};
+export { A };
+>A : Symbol(A, Decl(a.ts, 3, 8))
+
+=== tests/cases/compiler/b.ts ===
+import { A } from './a';
+>A : Symbol(A, Decl(b.ts, 0, 8))
+
+export { A as B };
+>A : Symbol(A, Decl(b.ts, 0, 8))
+>B : Symbol(B, Decl(b.ts, 1, 8))
+

--- a/tests/baselines/reference/constEnumPreserveEmitNamedExport2.types
+++ b/tests/baselines/reference/constEnumPreserveEmitNamedExport2.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/a.ts ===
+const enum A {
+>A : A
+
+    Foo
+>Foo : A.Foo
+
+};
+export { A };
+>A : typeof A
+
+=== tests/cases/compiler/b.ts ===
+import { A } from './a';
+>A : typeof A
+
+export { A as B };
+>A : typeof A
+>B : typeof A
+

--- a/tests/cases/compiler/constEnumPreserveEmitNamedExport1.ts
+++ b/tests/cases/compiler/constEnumPreserveEmitNamedExport1.ts
@@ -1,0 +1,12 @@
+// @preserveConstEnums: true
+// @target: esnext
+
+// @filename: a.ts
+const enum A {
+    Foo
+};
+export { A };
+
+// @filename: b.ts
+import { A } from './a';
+export { A };

--- a/tests/cases/compiler/constEnumPreserveEmitNamedExport2.ts
+++ b/tests/cases/compiler/constEnumPreserveEmitNamedExport2.ts
@@ -1,0 +1,12 @@
+// @preserveConstEnums: true
+// @target: esnext
+
+// @filename: a.ts
+const enum A {
+    Foo
+};
+export { A };
+
+// @filename: b.ts
+import { A } from './a';
+export { A as B };


### PR DESCRIPTION
Fixes #45850