### PR TITLE
Go back to the old spelling of Intl's NumberFormatPartTypes to not break DT

### DIFF
--- a/src/lib/es2018.intl.d.ts
+++ b/src/lib/es2018.intl.d.ts
@@ -40,10 +40,10 @@ declare namespace Intl {
     // We can only have one definition for 'type' in TypeScript, and so you can learn where the keys come from here:
     type ES2018NumberFormatPartType = "literal" | "nan" | "infinity" | "percent" | "integer" | "group" | "decimal" | "fraction" | "plusSign" | "minusSign" | "percentSign" | "currency" | "code" | "symbol" | "name";
     type ES2020NumberFormatPartType = "compact" | "exponentInteger" | "exponentMinusSign" | "exponentSeparator" | "unit" | "unknown";
-    type NumberFormatPartType = ES2018NumberFormatPartType | ES2020NumberFormatPartType;
+    type NumberFormatPartTypes = ES2018NumberFormatPartType | ES2020NumberFormatPartType;
 
     interface NumberFormatPart {
-        type: NumberFormatPartType;
+        type: NumberFormatPartTypes;
         value: string;
     }
 


### PR DESCRIPTION
Hah, sigh - in #45820 I added back the type `NumberFormatPartType` for DT libraries, but it was actually typoed in the original as `NumberFormatPartTypes` and I didn't respect that. I debated a bit between making a duplicate type with `@deprecated`, but realistically at this point I think it's pretty much set and there's not really much need to change it.

See DT logs: https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=110080&view=logs&j=8635df7d-ecde-52a7-c7a8-84b998e35690&t=c264d665-0b79-59b7-7e04-9965cbe74860

> node_modules/@formatjs/intl-unified-numberformat/lib/intl-unified-numberformat.d.ts(83,57): error TS2724: 'Intl' has no exported member named 'NumberFormatPartTypes'. Did you mean 'NumberFormatPartType'?
