### PR TITLE
Adds more Intl.ResolvedDateTimeFormatOptions, and hooks up Intl for ES2021

### DIFF
--- a/src/lib/es2021.d.ts
+++ b/src/lib/es2021.d.ts
@@ -2,3 +2,4 @@
 /// <reference lib="es2021.promise" />
 /// <reference lib="es2021.string" />
 /// <reference lib="es2021.weakref" />
+/// <reference lib="es2021.intl" />

--- a/src/lib/es2021.intl.d.ts
+++ b/src/lib/es2021.intl.d.ts
@@ -12,7 +12,7 @@ declare namespace Intl {
         formatMatcher?: "basic" | "best fit" | "best fit";
         dateStyle?: "full" | "long" | "medium" | "short";
         timeStyle?: "full" | "long" | "medium" | "short";
-        hourCycle?: "h11" | "h12" | "h23" | "h24"
+        hourCycle?: "h11" | "h12" | "h23" | "h24";
         dayPeriod?: "narrow" | "short" | "long";
         fractionalSecondDigits?: 0 | 1 | 2 | 3;
     }

--- a/src/lib/es2021.intl.d.ts
+++ b/src/lib/es2021.intl.d.ts
@@ -8,6 +8,15 @@ declare namespace Intl {
         fractionalSecondDigits?: 0 | 1 | 2 | 3 | undefined;
     }
 
+    interface ResolvedDateTimeFormatOptions {
+        formatMatcher?: "basic" | "best fit" | "best fit";
+        dateStyle?: "full" | "long" | "medium" | "short";
+        timeStyle?: "full" | "long" | "medium" | "short";
+        hourCycle?: "h11" | "h12" | "h23" | "h24"
+        dayPeriod?: "narrow" | "short" | "long";
+        fractionalSecondDigits?: 0 | 1 | 2 | 3;
+    }
+
     interface NumberFormat {
         formatRange(startDate: number | bigint, endDate: number | bigint): string;
         formatRangeToParts(startDate: number | bigint, endDate: number | bigint): NumberFormatPart[];

--- a/tests/baselines/reference/formatToPartsBigInt.symbols
+++ b/tests/baselines/reference/formatToPartsBigInt.symbols
@@ -4,16 +4,16 @@
 // Test Intl methods with new parameter type
 new Intl.NumberFormat("fr").formatToParts(3000n);
 >new Intl.NumberFormat("fr").formatToParts : Symbol(Intl.NumberFormat.formatToParts, Decl(lib.es2018.intl.d.ts, --, --))
->Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
->Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --) ... and 1 more)
->NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
+>Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2021.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --) ... and 2 more)
+>NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2021.intl.d.ts, --, --))
 >formatToParts : Symbol(Intl.NumberFormat.formatToParts, Decl(lib.es2018.intl.d.ts, --, --))
 
 new Intl.NumberFormat("fr").formatToParts(BigInt(123));
 >new Intl.NumberFormat("fr").formatToParts : Symbol(Intl.NumberFormat.formatToParts, Decl(lib.es2018.intl.d.ts, --, --))
->Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
->Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --) ... and 1 more)
->NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
+>Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2021.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --) ... and 2 more)
+>NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2021.intl.d.ts, --, --))
 >formatToParts : Symbol(Intl.NumberFormat.formatToParts, Decl(lib.es2018.intl.d.ts, --, --))
 >BigInt : Symbol(BigInt, Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
 


### PR DESCRIPTION
1. Looks like if you were on `target: es2021` the file `es2021.intl` wasn't added to your globals, so some of #45647 wasn't applied
2. I added the properties raised in #45420

fixes #45420