### PR TITLE
Simplify a branch of the Awaited type and clean up comments

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1477,13 +1477,11 @@ interface Promise<T> {
  */
 type Awaited<T> =
     T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
-        T extends object ? // `await` only unwraps object types with a callable then. Non-object types are not unwrapped.
-            T extends { then(onfulfilled: infer F): any } ? // thenable, extracts the first argument to `then()`
-                F extends ((value: infer V) => any) ? // if the argument to `then` is callable, extracts the argument
-                    Awaited<V> : // recursively unwrap the value
-                    never : // the argument to `then` was not callable.
-            T : // argument was not an object
-        T; // non-thenable
+        T extends object & { then(onfulfilled: infer F): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+            F extends ((value: infer V) => any) ? // if the argument to `then` is callable, extracts the argument
+                Awaited<V> : // recursively unwrap the value
+                never : // the argument to `then` was not callable
+        T; // non-object or non-thenable
 
 interface ArrayLike<T> {
     readonly length: number;


### PR DESCRIPTION
This condenses two branches of `Awaited<T>` into a single branch and does some minor comment cleanup.

Fixes https://github.com/microsoft/TypeScript/pull/45350/files/d83915c0cdd51cd08ca8d65f37bdea68d45c3415#r708960215
