### PR TITLE
feat: display the tsconfig generated when running tsc --init

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2349,34 +2349,56 @@ namespace ts {
     }
 
     /**
+     * Generate a list of the compiler options whose value is not the default.
+     * @param options commandlineOptions to be evaluated.
+    /** @internal */
+    export function getCompilerOptionsDiffValue(options: CompilerOptions, newLine: string): string {
+        const compilerOptionsMap = getSerializedCompilerOption(options);
+        return getOverwrittenDefaultOptions();
+
+        function makePadding(paddingLength: number): string {
+            return Array(paddingLength + 1).join(" ");
+        }
+
+        function getOverwrittenDefaultOptions() {
+            const result: string[] = [];
+             const tab = makePadding(2);
+            commandOptionsWithoutBuild.forEach(cmd => {
+                if (!cmd.showInSimplifiedHelpView || !compilerOptionsMap.has(cmd.name)) {
+                    return;
+                }
+
+                const newValue = compilerOptionsMap.get(cmd.name);
+                const defaultValue = getDefaultValueForOption(cmd);
+                if (newValue !== defaultValue) {
+                    result.push(`${tab}${cmd.name}: ${newValue}`);
+                }
+                else if (cmd.name in defaultInitCompilerOptions) {
+                    result.push(`${tab}${cmd.name}: ${defaultValue}`);
+                }
+            });
+            return result.join(newLine) + newLine;
+        }
+    }
+
+    /**
+     * Get the compiler options to be written into the tsconfig.json.
+     *
+     * @param options commandlineOptions to be included in the compileOptions.
+     */
+    function getSerializedCompilerOption(options: CompilerOptions): ESMap<string, CompilerOptionsValue> {
+        const compilerOptions = extend(options, defaultInitCompilerOptions);
+        return serializeCompilerOptions(compilerOptions);
+    }
+    /**
      * Generate tsconfig configuration when running command line "--init"
      * @param options commandlineOptions to be generated into tsconfig.json
      * @param fileNames array of filenames to be generated into tsconfig.json
      */
     /* @internal */
     export function generateTSConfig(options: CompilerOptions, fileNames: readonly string[], newLine: string): string {
-        const compilerOptions = extend(options, defaultInitCompilerOptions);
-        const compilerOptionsMap = serializeCompilerOptions(compilerOptions);
+        const compilerOptionsMap = getSerializedCompilerOption(options);
         return writeConfigurations();
-
-        function getDefaultValueForOption(option: CommandLineOption) {
-            switch (option.type) {
-                case "number":
-                    return 1;
-                case "boolean":
-                    return true;
-                case "string":
-                    return option.isFilePath ? "./" : "";
-                case "list":
-                    return [];
-                case "object":
-                    return {};
-                default:
-                    const iterResult = option.type.keys().next();
-                    if (!iterResult.done) return iterResult.value;
-                    return Debug.fail("Expected 'option.type' to have entries.");
-            }
-        }
 
         function makePadding(paddingLength: number): string {
             return Array(paddingLength + 1).join(" ");
@@ -3526,6 +3548,26 @@ namespace ts {
                         return optionStringValue;
                     }
                 })!; // TODO: GH#18217
+        }
+    }
+
+
+    function getDefaultValueForOption(option: CommandLineOption) {
+        switch (option.type) {
+            case "number":
+                return 1;
+            case "boolean":
+                return true;
+            case "string":
+                return option.isFilePath ? "./" : "";
+            case "list":
+                return [];
+            case "object":
+                return {};
+            default:
+                const iterResult = option.type.keys().next();
+                if (!iterResult.done) return iterResult.value;
+                return Debug.fail("Expected 'option.type' to have entries.");
         }
     }
 }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2373,7 +2373,7 @@ namespace ts {
                 if (newValue !== defaultValue) {
                     result.push(`${tab}${cmd.name}: ${newValue}`);
                 }
-                else if (cmd.name in defaultInitCompilerOptions) {
+                else if (hasProperty(defaultInitCompilerOptions, cmd.name)) {
                     result.push(`${tab}${cmd.name}: ${defaultValue}`);
                 }
             });

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2350,7 +2350,7 @@ namespace ts {
 
     /**
      * Generate a list of the compiler options whose value is not the default.
-     * @param options commandlineOptions to be evaluated.
+     * @param options compilerOptions to be evaluated.
     /** @internal */
     export function getCompilerOptionsDiffValue(options: CompilerOptions, newLine: string): string {
         const compilerOptionsMap = getSerializedCompilerOption(options);
@@ -2364,7 +2364,7 @@ namespace ts {
             const result: string[] = [];
              const tab = makePadding(2);
             commandOptionsWithoutBuild.forEach(cmd => {
-                if (!cmd.showInSimplifiedHelpView || !compilerOptionsMap.has(cmd.name)) {
+                if (!compilerOptionsMap.has(cmd.name)) {
                     return;
                 }
 
@@ -2383,7 +2383,6 @@ namespace ts {
 
     /**
      * Get the compiler options to be written into the tsconfig.json.
-     *
      * @param options commandlineOptions to be included in the compileOptions.
      */
     function getSerializedCompilerOption(options: CompilerOptions): ESMap<string, CompilerOptionsValue> {

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -1036,7 +1036,7 @@ namespace ts {
             sys.writeFile(file, generateTSConfig(options, fileNames, sys.newLine));
             const output: string[] = [sys.newLine, ...getHeader(sys,"Created a new tsconfig.json with:")];
             output.push(getCompilerOptionsDiffValue(options, sys.newLine) + sys.newLine + sys.newLine);
-		    output.push(`You can learn more at https://aka.ms/tsconfig.json` + sys.newLine);
+            output.push(`You can learn more at https://aka.ms/tsconfig.json` + sys.newLine);
             for (const line of output) {
                 sys.write(line);
             }

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -354,7 +354,7 @@ namespace ts {
 
     function printEasyHelp(sys: System, simpleOptions: readonly CommandLineOption[]) {
         const colors = createColors(sys);
-        let output: string[] = [...getHelpHeader(sys)];
+        let output: string[] = [...getHeader(sys,`${getDiagnosticText(Diagnostics.tsc_Colon_The_TypeScript_Compiler)} - ${getDiagnosticText(Diagnostics.Version_0, version)}`)];
         output.push(colors.bold(getDiagnosticText(Diagnostics.COMMON_COMMANDS)) + sys.newLine + sys.newLine);
 
         example("tsc", Diagnostics.Compiles_the_current_project_tsconfig_json_in_the_working_directory);
@@ -388,7 +388,7 @@ namespace ts {
     }
 
     function printAllHelp(sys: System, compilerOptions: readonly CommandLineOption[], buildOptions: readonly CommandLineOption[], watchOptions: readonly CommandLineOption[]) {
-        let output: string[] = [...getHelpHeader(sys)];
+        let output: string[] = [...getHeader(sys,`${getDiagnosticText(Diagnostics.tsc_Colon_The_TypeScript_Compiler)} - ${getDiagnosticText(Diagnostics.Version_0, version)}`)];
         output = [...output, ...generateSectionOptionsOutput(sys, getDiagnosticText(Diagnostics.ALL_COMPILER_OPTIONS), compilerOptions, /*subCategory*/ true, /* beforeOptionsDescription */ undefined, formatMessage(/*_dummy*/ undefined, Diagnostics.You_can_learn_about_all_of_the_compiler_options_at_0, "https://aka.ms/tsconfig-reference"))];
         output = [...output, ...generateSectionOptionsOutput(sys, getDiagnosticText(Diagnostics.WATCH_OPTIONS), watchOptions, /*subCategory*/ false, getDiagnosticText(Diagnostics.Including_watch_w_will_start_watching_the_current_project_for_the_file_changes_Once_set_you_can_config_watch_mode_with_Colon))];
         output = [...output, ...generateSectionOptionsOutput(sys, getDiagnosticText(Diagnostics.BUILD_OPTIONS), buildOptions, /*subCategory*/ false, formatMessage(/*_dummy*/ undefined, Diagnostics.Using_build_b_will_make_tsc_behave_more_like_a_build_orchestrator_than_a_compiler_This_is_used_to_trigger_building_composite_projects_which_you_can_learn_more_about_at_0, "https://aka.ms/tsc-composite-builds"))];
@@ -398,32 +398,31 @@ namespace ts {
     }
 
     function printBuildHelp(sys: System, buildOptions: readonly CommandLineOption[]) {
-        let output: string[] = [...getHelpHeader(sys)];
+        let output: string[] = [...getHeader(sys,`${getDiagnosticText(Diagnostics.tsc_Colon_The_TypeScript_Compiler)} - ${getDiagnosticText(Diagnostics.Version_0, version)}`)];
         output = [...output, ...generateSectionOptionsOutput(sys, getDiagnosticText(Diagnostics.BUILD_OPTIONS), buildOptions, /*subCategory*/ false, formatMessage(/*_dummy*/ undefined, Diagnostics.Using_build_b_will_make_tsc_behave_more_like_a_build_orchestrator_than_a_compiler_This_is_used_to_trigger_building_composite_projects_which_you_can_learn_more_about_at_0, "https://aka.ms/tsc-composite-builds"))];
         for (const line of output) {
             sys.write(line);
         }
     }
 
-    function getHelpHeader(sys: System) {
+    function getHeader(sys: System, message: string) {
         const colors = createColors(sys);
         const header: string[] = [];
-        const tscExplanation = `${getDiagnosticText(Diagnostics.tsc_Colon_The_TypeScript_Compiler)} - ${getDiagnosticText(Diagnostics.Version_0, version)}`;
         const terminalWidth = sys.getWidthOfTerminal?.() ?? 0;;
         const tsIconLength = 5;
 
         const tsIconFirstLine = colors.blueBackground(padLeft("", tsIconLength));
         const tsIconSecondLine = colors.blueBackground(colors.brightWhite(padLeft("TS ", tsIconLength)));
         // If we have enough space, print TS icon.
-        if (terminalWidth >= tscExplanation.length + tsIconLength) {
+        if (terminalWidth >= message.length + tsIconLength) {
             // right align of the icon is 120 at most.
             const rightAlign = terminalWidth > 120 ? 120 : terminalWidth;
             const leftAlign = rightAlign - tsIconLength;
-            header.push(padRight(tscExplanation, leftAlign) + tsIconFirstLine + sys.newLine);
+            header.push(padRight(message, leftAlign) + tsIconFirstLine + sys.newLine);
             header.push(padLeft("", leftAlign) + tsIconSecondLine + sys.newLine);
         }
         else {
-            header.push(tscExplanation + sys.newLine);
+            header.push(message + sys.newLine);
             header.push(sys.newLine);
         }
         return header;
@@ -1035,7 +1034,12 @@ namespace ts {
         }
         else {
             sys.writeFile(file, generateTSConfig(options, fileNames, sys.newLine));
-            reportDiagnostic(createCompilerDiagnostic(Diagnostics.Successfully_created_a_tsconfig_json_file));
+            const output: string[] = [sys.newLine, ...getHeader(sys,"Created a new tsconfig.json with:")];
+            output.push(getCompilerOptionsDiffValue(options, sys.newLine) + sys.newLine + sys.newLine);
+		    output.push(`You can learn more at https://aka.ms/tsconfig.json` + sys.newLine);
+            for (const line of output) {
+                sys.write(line);
+            }
         }
 
         return;


### PR DESCRIPTION
this PR improves the output of tsc --init

TODO: Diagnostics text

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #45714
