### PR TITLE
Allow diag code specification in ts-expect-errors

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2442,6 +2442,10 @@
         "category": "Error",
         "code": 2578
     },
+    "'@ts-expect-error' unexpected due to error code mismatch.": {
+        "category": "Error",
+        "code": 2579
+    },
     "Cannot find name '{0}'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.": {
         "category": "Error",
         "code": 2580

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1939,7 +1939,12 @@ namespace ts {
             const { diagnostics, directives } = getDiagnosticsWithPrecedingDirectives(sourceFile, sourceFile.commentDirectives, flatDiagnostics);
 
             for (const errorExpectation of directives.getUnusedExpectations()) {
-                diagnostics.push(createDiagnosticForRange(sourceFile, errorExpectation.range, Diagnostics.Unused_ts_expect_error_directive));
+                if (errorExpectation.code) {
+                    diagnostics.push(createDiagnosticForRange(sourceFile, errorExpectation.range, Diagnostics.ts_expect_error_unexpected_due_to_error_code_mismatch));
+                }
+                else {
+                    diagnostics.push(createDiagnosticForRange(sourceFile, errorExpectation.range, Diagnostics.Unused_ts_expect_error_directive));
+                }
             }
 
             return diagnostics;
@@ -1968,7 +1973,7 @@ namespace ts {
          * @returns The line index marked as preceding the diagnostic, or -1 if none was.
          */
         function markPrecedingCommentDirectiveLine(diagnostic: Diagnostic, directives: CommentDirectivesMap) {
-            const { file, start } = diagnostic;
+            const { file, start, code } = diagnostic;
             if (!file) {
                 return -1;
             }
@@ -1978,7 +1983,7 @@ namespace ts {
             let line = computeLineAndCharacterOfPosition(lineStarts, start!).line - 1; // TODO: GH#18217
             while (line >= 0) {
                 // As soon as that line is known to have a comment directive, use that
-                if (directives.markUsed(line)) {
+                if (directives.markUsed(line, code)) {
                     return line;
                 }
 

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -286,12 +286,12 @@ namespace ts {
     /**
      * Test for whether a single line comment with leading whitespace trimmed's text contains a directive.
      */
-    const commentDirectiveRegExSingleLine = /^\/\/\/?\s*@(ts-expect-error|ts-ignore)/;
+    const commentDirectiveRegExSingleLine = /^\/\/\/?\s*@(ts-expect-error|ts-ignore)(?: TS(\d+))?/;
 
     /**
      * Test for whether a multi-line comment with leading whitespace trimmed's last line contains a directive.
      */
-    const commentDirectiveRegExMultiLine = /^(?:\/|\*)*\s*@(ts-expect-error|ts-ignore)/;
+    const commentDirectiveRegExMultiLine = /^(?:\/|\*)*\s*@(ts-expect-error|ts-ignore)(?: TS(\d+))?/;
 
     function lookupInUnicodeMap(code: number, map: readonly number[]): boolean {
         // Bail out quickly if it couldn't possibly be in the map.
@@ -2194,7 +2194,7 @@ namespace ts {
             commentDirectiveRegEx: RegExp,
             lineStart: number,
         ) {
-            const type = getDirectiveFromComment(trimStringStart(text), commentDirectiveRegEx);
+            const {type, code} = getDirectiveFromComment(trimStringStart(text), commentDirectiveRegEx);
             if (type === undefined) {
                 return commentDirectives;
             }
@@ -2204,6 +2204,7 @@ namespace ts {
                 {
                     range: { pos: lineStart, end: pos },
                     type,
+                    code
                 },
             );
         }
@@ -2211,18 +2212,19 @@ namespace ts {
         function getDirectiveFromComment(text: string, commentDirectiveRegEx: RegExp) {
             const match = commentDirectiveRegEx.exec(text);
             if (!match) {
-                return undefined;
+                return { type: undefined, code: undefined };
             }
-
+            let type;
             switch (match[1]) {
                 case "ts-expect-error":
-                    return CommentDirectiveType.ExpectError;
-
+                    type = CommentDirectiveType.ExpectError;
+                    break;
                 case "ts-ignore":
-                    return CommentDirectiveType.Ignore;
+                    type = CommentDirectiveType.Ignore;
+                    break;
             }
 
-            return undefined;
+            return {type, code: match[2]};
         }
 
         /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3624,6 +3624,7 @@ namespace ts {
     export interface CommentDirective {
         range: TextRange;
         type: CommentDirectiveType,
+        code?: string | undefined
     }
 
     /* @internal */
@@ -8528,7 +8529,7 @@ namespace ts {
     /* @internal */
     export interface CommentDirectivesMap {
         getUnusedExpectations(): CommentDirective[];
-        markUsed(matchedLine: number): boolean;
+        markUsed(matchedLine: number, diagCode: number): boolean;
     }
 
     export interface UserPreferences {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -458,11 +458,14 @@ namespace ts {
                 .map(([_, directive]) => directive);
         }
 
-        function markUsed(line: number) {
-            if (!directivesByLine.has(`${line}`)) {
+        function markUsed(line: number, diagCode: number) {
+            const directive = directivesByLine.get(`${line}`);
+            if (!directive) {
                 return false;
             }
-
+            if(directive.type === CommentDirectiveType.ExpectError && directive.code !== undefined && parseInt(directive.code, 10) !== diagCode) {
+                return false;
+            }
             usedLines.set(`${line}`, true);
             return true;
         }

--- a/tests/baselines/reference/ts-expect-error.errors.txt
+++ b/tests/baselines/reference/ts-expect-error.errors.txt
@@ -1,15 +1,17 @@
 tests/cases/conformance/directives/ts-expect-error.ts(8,1): error TS2578: Unused '@ts-expect-error' directive.
 tests/cases/conformance/directives/ts-expect-error.ts(11,1): error TS2578: Unused '@ts-expect-error' directive.
-tests/cases/conformance/directives/ts-expect-error.ts(21,1): error TS2578: Unused '@ts-expect-error' directive.
-tests/cases/conformance/directives/ts-expect-error.ts(24,1): error TS2578: Unused '@ts-expect-error' directive.
-tests/cases/conformance/directives/ts-expect-error.ts(28,1): error TS2578: Unused '@ts-expect-error' directive.
-tests/cases/conformance/directives/ts-expect-error.ts(31,5): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/directives/ts-expect-error.ts(37,2): error TS2367: This condition will always return 'false' since the types 'true' and 'false' have no overlap.
-tests/cases/conformance/directives/ts-expect-error.ts(39,2): error TS2367: This condition will always return 'false' since the types 'true' and 'false' have no overlap.
-tests/cases/conformance/directives/ts-expect-error.ts(40,2): error TS2367: This condition will always return 'false' since the types 'true' and 'false' have no overlap.
+tests/cases/conformance/directives/ts-expect-error.ts(24,1): error TS2579: '@ts-expect-error' unexpected due to error code mismatch.
+tests/cases/conformance/directives/ts-expect-error.ts(25,5): error TS2322: Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/directives/ts-expect-error.ts(27,1): error TS2578: Unused '@ts-expect-error' directive.
+tests/cases/conformance/directives/ts-expect-error.ts(30,1): error TS2578: Unused '@ts-expect-error' directive.
+tests/cases/conformance/directives/ts-expect-error.ts(34,1): error TS2578: Unused '@ts-expect-error' directive.
+tests/cases/conformance/directives/ts-expect-error.ts(37,5): error TS2322: Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/directives/ts-expect-error.ts(43,2): error TS2367: This condition will always return 'false' since the types 'true' and 'false' have no overlap.
+tests/cases/conformance/directives/ts-expect-error.ts(45,2): error TS2367: This condition will always return 'false' since the types 'true' and 'false' have no overlap.
+tests/cases/conformance/directives/ts-expect-error.ts(46,2): error TS2367: This condition will always return 'false' since the types 'true' and 'false' have no overlap.
 
 
-==== tests/cases/conformance/directives/ts-expect-error.ts (9 errors) ====
+==== tests/cases/conformance/directives/ts-expect-error.ts (11 errors) ====
     // @ts-expect-error additional commenting
     var invalidCommentedFancySingle: number = 'nope';
     
@@ -30,9 +32,19 @@ tests/cases/conformance/directives/ts-expect-error.ts(40,2): error TS2367: This 
     // @ts-expect-error
     var invalidCommentedPlainSingle: number = 'nope';
     
+    // @ts-expect-error TS2322
+    var matchedTsCodeCommentedPlainSingleWithCode: number = 'nope';
+    
     /*
      @ts-expect-error */
     var invalidCommentedPlainMulti: number = 'nope';
+    
+    // @ts-expect-error TS9999
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2579: '@ts-expect-error' unexpected due to error code mismatch.
+    var mismatchedTsCodeCommentedPlainSingleWithCode: number = 'nope';
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'string' is not assignable to type 'number'.
     
     // @ts-expect-error
     ~~~~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/ts-expect-error.js
+++ b/tests/baselines/reference/ts-expect-error.js
@@ -15,9 +15,15 @@ var validCommentedFancyMulti: string = 'nope';
 // @ts-expect-error
 var invalidCommentedPlainSingle: number = 'nope';
 
+// @ts-expect-error TS2322
+var matchedTsCodeCommentedPlainSingleWithCode: number = 'nope';
+
 /*
  @ts-expect-error */
 var invalidCommentedPlainMulti: number = 'nope';
+
+// @ts-expect-error TS9999
+var mismatchedTsCodeCommentedPlainSingleWithCode: number = 'nope';
 
 // @ts-expect-error
 var validCommentedPlainSingle: string = 'nope';
@@ -52,9 +58,13 @@ var validCommentedFancySingle = 'nope';
 var validCommentedFancyMulti = 'nope';
 // @ts-expect-error
 var invalidCommentedPlainSingle = 'nope';
+// @ts-expect-error TS2322
+var matchedTsCodeCommentedPlainSingleWithCode = 'nope';
 /*
  @ts-expect-error */
 var invalidCommentedPlainMulti = 'nope';
+// @ts-expect-error TS9999
+var mismatchedTsCodeCommentedPlainSingleWithCode = 'nope';
 // @ts-expect-error
 var validCommentedPlainSingle = 'nope';
 /* @ts-expect-error */

--- a/tests/baselines/reference/ts-expect-error.symbols
+++ b/tests/baselines/reference/ts-expect-error.symbols
@@ -20,48 +20,56 @@ var validCommentedFancyMulti: string = 'nope';
 var invalidCommentedPlainSingle: number = 'nope';
 >invalidCommentedPlainSingle : Symbol(invalidCommentedPlainSingle, Decl(ts-expect-error.ts, 14, 3))
 
+// @ts-expect-error TS2322
+var matchedTsCodeCommentedPlainSingleWithCode: number = 'nope';
+>matchedTsCodeCommentedPlainSingleWithCode : Symbol(matchedTsCodeCommentedPlainSingleWithCode, Decl(ts-expect-error.ts, 17, 3))
+
 /*
  @ts-expect-error */
 var invalidCommentedPlainMulti: number = 'nope';
->invalidCommentedPlainMulti : Symbol(invalidCommentedPlainMulti, Decl(ts-expect-error.ts, 18, 3))
+>invalidCommentedPlainMulti : Symbol(invalidCommentedPlainMulti, Decl(ts-expect-error.ts, 21, 3))
+
+// @ts-expect-error TS9999
+var mismatchedTsCodeCommentedPlainSingleWithCode: number = 'nope';
+>mismatchedTsCodeCommentedPlainSingleWithCode : Symbol(mismatchedTsCodeCommentedPlainSingleWithCode, Decl(ts-expect-error.ts, 24, 3))
 
 // @ts-expect-error
 var validCommentedPlainSingle: string = 'nope';
->validCommentedPlainSingle : Symbol(validCommentedPlainSingle, Decl(ts-expect-error.ts, 21, 3))
+>validCommentedPlainSingle : Symbol(validCommentedPlainSingle, Decl(ts-expect-error.ts, 27, 3))
 
 /* @ts-expect-error */
 var validCommentedPlainMulti1: string = 'nope';
->validCommentedPlainMulti1 : Symbol(validCommentedPlainMulti1, Decl(ts-expect-error.ts, 24, 3))
+>validCommentedPlainMulti1 : Symbol(validCommentedPlainMulti1, Decl(ts-expect-error.ts, 30, 3))
 
 /*
 @ts-expect-error */
 var validCommentedPlainMulti2: string = 'nope';
->validCommentedPlainMulti2 : Symbol(validCommentedPlainMulti2, Decl(ts-expect-error.ts, 28, 3))
+>validCommentedPlainMulti2 : Symbol(validCommentedPlainMulti2, Decl(ts-expect-error.ts, 34, 3))
 
 var invalidPlain: number = 'nope';
->invalidPlain : Symbol(invalidPlain, Decl(ts-expect-error.ts, 30, 3))
+>invalidPlain : Symbol(invalidPlain, Decl(ts-expect-error.ts, 36, 3))
 
 var validPlain: string = 'nope';
->validPlain : Symbol(validPlain, Decl(ts-expect-error.ts, 32, 3))
+>validPlain : Symbol(validPlain, Decl(ts-expect-error.ts, 38, 3))
 
 // @ts-expect-error
 (({ a: true } as const).a === false); // <-- compiles (as expected via comment)
->({ a: true } as const).a : Symbol(a, Decl(ts-expect-error.ts, 35, 3))
->a : Symbol(a, Decl(ts-expect-error.ts, 35, 3))
->a : Symbol(a, Decl(ts-expect-error.ts, 35, 3))
+>({ a: true } as const).a : Symbol(a, Decl(ts-expect-error.ts, 41, 3))
+>a : Symbol(a, Decl(ts-expect-error.ts, 41, 3))
+>a : Symbol(a, Decl(ts-expect-error.ts, 41, 3))
 
 (({ a: true } as const).a === false); // Should error
->({ a: true } as const).a : Symbol(a, Decl(ts-expect-error.ts, 36, 3))
->a : Symbol(a, Decl(ts-expect-error.ts, 36, 3))
->a : Symbol(a, Decl(ts-expect-error.ts, 36, 3))
+>({ a: true } as const).a : Symbol(a, Decl(ts-expect-error.ts, 42, 3))
+>a : Symbol(a, Decl(ts-expect-error.ts, 42, 3))
+>a : Symbol(a, Decl(ts-expect-error.ts, 42, 3))
 
 (({ a: true } as const).a === false); // error
->({ a: true } as const).a : Symbol(a, Decl(ts-expect-error.ts, 38, 3))
->a : Symbol(a, Decl(ts-expect-error.ts, 38, 3))
->a : Symbol(a, Decl(ts-expect-error.ts, 38, 3))
+>({ a: true } as const).a : Symbol(a, Decl(ts-expect-error.ts, 44, 3))
+>a : Symbol(a, Decl(ts-expect-error.ts, 44, 3))
+>a : Symbol(a, Decl(ts-expect-error.ts, 44, 3))
 
 (({ a: true } as const).a === false); // error
->({ a: true } as const).a : Symbol(a, Decl(ts-expect-error.ts, 39, 3))
->a : Symbol(a, Decl(ts-expect-error.ts, 39, 3))
->a : Symbol(a, Decl(ts-expect-error.ts, 39, 3))
+>({ a: true } as const).a : Symbol(a, Decl(ts-expect-error.ts, 45, 3))
+>a : Symbol(a, Decl(ts-expect-error.ts, 45, 3))
+>a : Symbol(a, Decl(ts-expect-error.ts, 45, 3))
 

--- a/tests/baselines/reference/ts-expect-error.types
+++ b/tests/baselines/reference/ts-expect-error.types
@@ -25,10 +25,20 @@ var invalidCommentedPlainSingle: number = 'nope';
 >invalidCommentedPlainSingle : number
 >'nope' : "nope"
 
+// @ts-expect-error TS2322
+var matchedTsCodeCommentedPlainSingleWithCode: number = 'nope';
+>matchedTsCodeCommentedPlainSingleWithCode : number
+>'nope' : "nope"
+
 /*
  @ts-expect-error */
 var invalidCommentedPlainMulti: number = 'nope';
 >invalidCommentedPlainMulti : number
+>'nope' : "nope"
+
+// @ts-expect-error TS9999
+var mismatchedTsCodeCommentedPlainSingleWithCode: number = 'nope';
+>mismatchedTsCodeCommentedPlainSingleWithCode : number
 >'nope' : "nope"
 
 // @ts-expect-error

--- a/tests/cases/conformance/directives/ts-expect-error.ts
+++ b/tests/cases/conformance/directives/ts-expect-error.ts
@@ -14,9 +14,15 @@ var validCommentedFancyMulti: string = 'nope';
 // @ts-expect-error
 var invalidCommentedPlainSingle: number = 'nope';
 
+// @ts-expect-error TS2322
+var matchedTsCodeCommentedPlainSingleWithCode: number = 'nope';
+
 /*
  @ts-expect-error */
 var invalidCommentedPlainMulti: number = 'nope';
+
+// @ts-expect-error TS9999
+var mismatchedTsCodeCommentedPlainSingleWithCode: number = 'nope';
 
 // @ts-expect-error
 var validCommentedPlainSingle: string = 'nope';


### PR DESCRIPTION
Fixes #45937

PR made at this point more for illustrative purposes, but it is working just fine as is