### PR TITLE
fix(26635): JSdoc casts should only work when directly attached to an expression

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33411,7 +33411,7 @@ namespace ts {
         }
 
         function checkParenthesizedExpression(node: ParenthesizedExpression, checkMode?: CheckMode): Type {
-            if (isJSDocTypeAssertion(node)) {
+            if (hasJSDocNodes(node) && isJSDocTypeAssertion(node)) {
                 const type = getJSDocTypeAssertionType(node);
                 return checkAssertionWorker(type, type, node.expression, checkMode);
             }

--- a/tests/baselines/reference/jsdocTypeCast.errors.txt
+++ b/tests/baselines/reference/jsdocTypeCast.errors.txt
@@ -1,0 +1,26 @@
+tests/cases/compiler/jsdocTypeCast.js(6,9): error TS2322: Type 'string' is not assignable to type '"a" | "b"'.
+tests/cases/compiler/jsdocTypeCast.js(10,9): error TS2322: Type 'string' is not assignable to type '"a" | "b"'.
+
+
+==== tests/cases/compiler/jsdocTypeCast.js (2 errors) ====
+    /**
+     * @param {string} x
+     */
+     function f(x) {
+        /** @type {'a' | 'b'} */
+        let a = (x); // Error
+            ~
+!!! error TS2322: Type 'string' is not assignable to type '"a" | "b"'.
+        a;
+    
+        /** @type {'a' | 'b'} */
+        let b = (((x))); // Error
+            ~
+!!! error TS2322: Type 'string' is not assignable to type '"a" | "b"'.
+        b;
+    
+        /** @type {'a' | 'b'} */
+        let c = /** @type {'a' | 'b'} */ (x); // Ok
+        c;
+    }
+    

--- a/tests/baselines/reference/jsdocTypeCast.js
+++ b/tests/baselines/reference/jsdocTypeCast.js
@@ -1,0 +1,34 @@
+//// [jsdocTypeCast.js]
+/**
+ * @param {string} x
+ */
+ function f(x) {
+    /** @type {'a' | 'b'} */
+    let a = (x); // Error
+    a;
+
+    /** @type {'a' | 'b'} */
+    let b = (((x))); // Error
+    b;
+
+    /** @type {'a' | 'b'} */
+    let c = /** @type {'a' | 'b'} */ (x); // Ok
+    c;
+}
+
+
+//// [jsdocTypeCast.js]
+/**
+ * @param {string} x
+ */
+function f(x) {
+    /** @type {'a' | 'b'} */
+    var a = (x); // Error
+    a;
+    /** @type {'a' | 'b'} */
+    var b = (((x))); // Error
+    b;
+    /** @type {'a' | 'b'} */
+    var c = /** @type {'a' | 'b'} */ (x); // Ok
+    c;
+}

--- a/tests/baselines/reference/jsdocTypeCast.symbols
+++ b/tests/baselines/reference/jsdocTypeCast.symbols
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/jsdocTypeCast.js ===
+/**
+ * @param {string} x
+ */
+ function f(x) {
+>f : Symbol(f, Decl(jsdocTypeCast.js, 0, 0))
+>x : Symbol(x, Decl(jsdocTypeCast.js, 3, 12))
+
+    /** @type {'a' | 'b'} */
+    let a = (x); // Error
+>a : Symbol(a, Decl(jsdocTypeCast.js, 5, 7))
+>x : Symbol(x, Decl(jsdocTypeCast.js, 3, 12))
+
+    a;
+>a : Symbol(a, Decl(jsdocTypeCast.js, 5, 7))
+
+    /** @type {'a' | 'b'} */
+    let b = (((x))); // Error
+>b : Symbol(b, Decl(jsdocTypeCast.js, 9, 7))
+>x : Symbol(x, Decl(jsdocTypeCast.js, 3, 12))
+
+    b;
+>b : Symbol(b, Decl(jsdocTypeCast.js, 9, 7))
+
+    /** @type {'a' | 'b'} */
+    let c = /** @type {'a' | 'b'} */ (x); // Ok
+>c : Symbol(c, Decl(jsdocTypeCast.js, 13, 7))
+>x : Symbol(x, Decl(jsdocTypeCast.js, 3, 12))
+
+    c;
+>c : Symbol(c, Decl(jsdocTypeCast.js, 13, 7))
+}
+

--- a/tests/baselines/reference/jsdocTypeCast.types
+++ b/tests/baselines/reference/jsdocTypeCast.types
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/jsdocTypeCast.js ===
+/**
+ * @param {string} x
+ */
+ function f(x) {
+>f : (x: string) => void
+>x : string
+
+    /** @type {'a' | 'b'} */
+    let a = (x); // Error
+>a : "a" | "b"
+>(x) : "a" | "b"
+>x : string
+
+    a;
+>a : "a" | "b"
+
+    /** @type {'a' | 'b'} */
+    let b = (((x))); // Error
+>b : "a" | "b"
+>(((x))) : "a" | "b"
+>((x)) : string
+>(x) : string
+>x : string
+
+    b;
+>b : "a" | "b"
+
+    /** @type {'a' | 'b'} */
+    let c = /** @type {'a' | 'b'} */ (x); // Ok
+>c : "a" | "b"
+>(x) : "a" | "b"
+>x : string
+
+    c;
+>c : "a" | "b"
+}
+

--- a/tests/cases/compiler/jsdocTypeCast.ts
+++ b/tests/cases/compiler/jsdocTypeCast.ts
@@ -1,0 +1,21 @@
+// @allowJs: true
+// @checkJs: true
+// @outDir: ./out
+// @filename: jsdocTypeCast.js
+
+/**
+ * @param {string} x
+ */
+ function f(x) {
+    /** @type {'a' | 'b'} */
+    let a = (x); // Error
+    a;
+
+    /** @type {'a' | 'b'} */
+    let b = (((x))); // Error
+    b;
+
+    /** @type {'a' | 'b'} */
+    let c = /** @type {'a' | 'b'} */ (x); // Ok
+    c;
+}


### PR DESCRIPTION
Fixes #26635