### PR TITLE
fix(sourcemap): accept a sourceMappingURL that ends with a newline

### DIFF
--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -322,7 +322,7 @@ namespace ts {
     }
 
     // Sometimes tools can see the following line as a source mapping url comment, so we mangle it a bit (the [M])
-    const sourceMapCommentRegExp = /^\/\/[@#] source[M]appingURL=(.+)$/;
+    const sourceMapCommentRegExp = /^\/\/[@#] source[M]appingURL=(.+)\n?$/;
     const whitespaceOrMapCommentRegExp = /^\s*(\/\/[@#] .*)?$/;
 
     export interface LineInfo {

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -322,7 +322,8 @@ namespace ts {
     }
 
     // Sometimes tools can see the following line as a source mapping url comment, so we mangle it a bit (the [M])
-    const sourceMapCommentRegExp = /^\/\/[@#] source[M]appingURL=(.+)\n?$/;
+    const sourceMapCommentRegExp = /^\/\/[@#] source[M]appingURL=(.+)\r?\n?$/;
+
     const whitespaceOrMapCommentRegExp = /^\s*(\/\/[@#] .*)?$/;
 
     export interface LineInfo {


### PR DESCRIPTION
Fixes #45982

After I upgraded my TypeScript I noticed my sourcemaps broke. I bisected down to #44197, which
seem to subtly change the regex matching the sourceMappingURL so that it will not match
if the line ends with '\n'.

The old regex ended with `\s*` to match and trim all whitespace.
The new regex doesn't have that I guess for performance? But because `.` does not match `\n`, and
getLineText preserves the ending `\n`, this does not match any line that isn't the last one in the
file.

I am happy to add a test if someone points me to the correct place for it. I tried to add
a fourslash test but I couldn't seem to create a file where the last line was a newline.

