### PR TITLE
Add a failing test case for contextual type not being provided

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25950,7 +25950,7 @@ namespace ts {
                 const inferenceContext = getInferenceContext(node);
                 // If no inferences have been made, nothing is gained from instantiating as type parameters
                 // would just be replaced with their defaults similar to the apparent type.
-                if (inferenceContext && some(inferenceContext.inferences, hasInferenceCandidates)) {
+                if (inferenceContext && some(inferenceContext.inferences, info => hasInferenceCandidates(info) || !!info.inferredType)) {
                     // For contextual signatures we incorporate all inferences made so far, e.g. from return
                     // types as well as arguments to the left in a function call.
                     if (contextFlags && contextFlags & ContextFlags.Signature) {

--- a/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.errors.txt
@@ -1,0 +1,92 @@
+tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts(79,16): error TS7006: Parameter 'ev' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts (1 errors) ====
+    export interface TypegenDisabled {
+      "@@xstate/typegen": false;
+    }
+    export interface TypegenEnabled {
+      "@@xstate/typegen": true;
+    }
+    interface TypegenMeta extends TypegenEnabled {
+      eventsCausingActions: Record<string, string>;
+    }
+    
+    type Prop<T, K> = K extends keyof T ? T[K] : never
+    
+    type TypegenConstraint = TypegenMeta | TypegenDisabled;
+    
+    interface EventObject {
+      type: string;
+    }
+    
+    interface MachineConfig<TTypesMeta = TypegenDisabled> {
+      types?: TTypesMeta;
+    }
+    
+    type ActionFunction<
+      TEvent extends EventObject,
+    > = (
+      event: TEvent,
+    ) => void;
+    
+    interface MachineOptions {
+      actions?: Record<string, ActionFunction<EventObject>>
+    }
+    
+    type TypegenMachineOptionsActions<
+      TEvent extends EventObject,
+      TTypesMeta,
+      TEventsCausingActions = Prop<TTypesMeta, "eventsCausingActions">
+    > = {
+      [K in keyof TEventsCausingActions]?: ActionFunction<
+        Extract<TEvent, { type: TEventsCausingActions[K] } >
+      >;
+    };
+    
+    type GenerateActionsConfigPart<
+      TEvent extends EventObject,
+      TTypesMeta,
+    > = {
+      actions?: TypegenMachineOptionsActions<TEvent, TTypesMeta>;
+    };
+    
+    type MaybeTypegenMachineOptions<
+      TEvent extends EventObject,
+      TTypesMeta = TypegenDisabled
+    > = TTypesMeta extends TypegenEnabled
+      ? GenerateActionsConfigPart<TEvent, TTypesMeta>
+      : MachineOptions;
+    
+    interface Model<TEvent extends EventObject> {
+      createMachine: {
+        <TTypesMeta extends TypegenConstraint = TypegenDisabled>(
+          config: MachineConfig<TTypesMeta>,
+          implementations?: MaybeTypegenMachineOptions<
+            TEvent,
+            TTypesMeta
+          >
+        ): void;
+      };
+    }
+    
+    const model = {} as Model<
+      {
+        type: "SAMPLE";
+      }
+    >;
+    
+    model.createMachine(
+      {},
+      {
+        actions: {
+          custom: (ev) => {
+                   ~~
+!!! error TS7006: Parameter 'ev' implicitly has an 'any' type.
+            ev.type // string
+            ev.unknown // Error
+          },
+        },
+      }
+    );
+    

--- a/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts(79,16): error TS7006: Parameter 'ev' implicitly has an 'any' type.
+tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts(81,12): error TS2339: Property 'unknown' does not exist on type 'EventObject'.
 
 
 ==== tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts (1 errors) ====
@@ -81,10 +81,10 @@ tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTyp
       {
         actions: {
           custom: (ev) => {
-                   ~~
-!!! error TS7006: Parameter 'ev' implicitly has an 'any' type.
             ev.type // string
             ev.unknown // Error
+               ~~~~~~~
+!!! error TS2339: Property 'unknown' does not exist on type 'EventObject'.
           },
         },
       }

--- a/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.js
+++ b/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.js
@@ -1,0 +1,100 @@
+//// [contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts]
+export interface TypegenDisabled {
+  "@@xstate/typegen": false;
+}
+export interface TypegenEnabled {
+  "@@xstate/typegen": true;
+}
+interface TypegenMeta extends TypegenEnabled {
+  eventsCausingActions: Record<string, string>;
+}
+
+type Prop<T, K> = K extends keyof T ? T[K] : never
+
+type TypegenConstraint = TypegenMeta | TypegenDisabled;
+
+interface EventObject {
+  type: string;
+}
+
+interface MachineConfig<TTypesMeta = TypegenDisabled> {
+  types?: TTypesMeta;
+}
+
+type ActionFunction<
+  TEvent extends EventObject,
+> = (
+  event: TEvent,
+) => void;
+
+interface MachineOptions {
+  actions?: Record<string, ActionFunction<EventObject>>
+}
+
+type TypegenMachineOptionsActions<
+  TEvent extends EventObject,
+  TTypesMeta,
+  TEventsCausingActions = Prop<TTypesMeta, "eventsCausingActions">
+> = {
+  [K in keyof TEventsCausingActions]?: ActionFunction<
+    Extract<TEvent, { type: TEventsCausingActions[K] } >
+  >;
+};
+
+type GenerateActionsConfigPart<
+  TEvent extends EventObject,
+  TTypesMeta,
+> = {
+  actions?: TypegenMachineOptionsActions<TEvent, TTypesMeta>;
+};
+
+type MaybeTypegenMachineOptions<
+  TEvent extends EventObject,
+  TTypesMeta = TypegenDisabled
+> = TTypesMeta extends TypegenEnabled
+  ? GenerateActionsConfigPart<TEvent, TTypesMeta>
+  : MachineOptions;
+
+interface Model<TEvent extends EventObject> {
+  createMachine: {
+    <TTypesMeta extends TypegenConstraint = TypegenDisabled>(
+      config: MachineConfig<TTypesMeta>,
+      implementations?: MaybeTypegenMachineOptions<
+        TEvent,
+        TTypesMeta
+      >
+    ): void;
+  };
+}
+
+const model = {} as Model<
+  {
+    type: "SAMPLE";
+  }
+>;
+
+model.createMachine(
+  {},
+  {
+    actions: {
+      custom: (ev) => {
+        ev.type // string
+        ev.unknown // Error
+      },
+    },
+  }
+);
+
+
+//// [contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.js]
+"use strict";
+exports.__esModule = true;
+var model = {};
+model.createMachine({}, {
+    actions: {
+        custom: function (ev) {
+            ev.type; // string
+            ev.unknown; // Error
+        }
+    }
+});

--- a/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.symbols
+++ b/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.symbols
@@ -1,0 +1,217 @@
+=== tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts ===
+export interface TypegenDisabled {
+>TypegenDisabled : Symbol(TypegenDisabled, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 0, 0))
+
+  "@@xstate/typegen": false;
+>"@@xstate/typegen" : Symbol(TypegenDisabled["@@xstate/typegen"], Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 0, 34))
+}
+export interface TypegenEnabled {
+>TypegenEnabled : Symbol(TypegenEnabled, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 2, 1))
+
+  "@@xstate/typegen": true;
+>"@@xstate/typegen" : Symbol(TypegenEnabled["@@xstate/typegen"], Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 3, 33))
+}
+interface TypegenMeta extends TypegenEnabled {
+>TypegenMeta : Symbol(TypegenMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 5, 1))
+>TypegenEnabled : Symbol(TypegenEnabled, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 2, 1))
+
+  eventsCausingActions: Record<string, string>;
+>eventsCausingActions : Symbol(TypegenMeta.eventsCausingActions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 6, 46))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+}
+
+type Prop<T, K> = K extends keyof T ? T[K] : never
+>Prop : Symbol(Prop, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 8, 1))
+>T : Symbol(T, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 10, 10))
+>K : Symbol(K, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 10, 12))
+>K : Symbol(K, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 10, 12))
+>T : Symbol(T, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 10, 10))
+>T : Symbol(T, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 10, 10))
+>K : Symbol(K, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 10, 12))
+
+type TypegenConstraint = TypegenMeta | TypegenDisabled;
+>TypegenConstraint : Symbol(TypegenConstraint, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 10, 50))
+>TypegenMeta : Symbol(TypegenMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 5, 1))
+>TypegenDisabled : Symbol(TypegenDisabled, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 0, 0))
+
+interface EventObject {
+>EventObject : Symbol(EventObject, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 12, 55))
+
+  type: string;
+>type : Symbol(EventObject.type, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 14, 23))
+}
+
+interface MachineConfig<TTypesMeta = TypegenDisabled> {
+>MachineConfig : Symbol(MachineConfig, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 16, 1))
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 18, 24))
+>TypegenDisabled : Symbol(TypegenDisabled, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 0, 0))
+
+  types?: TTypesMeta;
+>types : Symbol(MachineConfig.types, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 18, 55))
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 18, 24))
+}
+
+type ActionFunction<
+>ActionFunction : Symbol(ActionFunction, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 20, 1))
+
+  TEvent extends EventObject,
+>TEvent : Symbol(TEvent, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 22, 20))
+>EventObject : Symbol(EventObject, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 12, 55))
+
+> = (
+  event: TEvent,
+>event : Symbol(event, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 24, 5))
+>TEvent : Symbol(TEvent, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 22, 20))
+
+) => void;
+
+interface MachineOptions {
+>MachineOptions : Symbol(MachineOptions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 26, 10))
+
+  actions?: Record<string, ActionFunction<EventObject>>
+>actions : Symbol(MachineOptions.actions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 28, 26))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>ActionFunction : Symbol(ActionFunction, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 20, 1))
+>EventObject : Symbol(EventObject, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 12, 55))
+}
+
+type TypegenMachineOptionsActions<
+>TypegenMachineOptionsActions : Symbol(TypegenMachineOptionsActions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 30, 1))
+
+  TEvent extends EventObject,
+>TEvent : Symbol(TEvent, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 32, 34))
+>EventObject : Symbol(EventObject, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 12, 55))
+
+  TTypesMeta,
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 33, 29))
+
+  TEventsCausingActions = Prop<TTypesMeta, "eventsCausingActions">
+>TEventsCausingActions : Symbol(TEventsCausingActions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 34, 13))
+>Prop : Symbol(Prop, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 8, 1))
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 33, 29))
+
+> = {
+  [K in keyof TEventsCausingActions]?: ActionFunction<
+>K : Symbol(K, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 37, 3))
+>TEventsCausingActions : Symbol(TEventsCausingActions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 34, 13))
+>ActionFunction : Symbol(ActionFunction, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 20, 1))
+
+    Extract<TEvent, { type: TEventsCausingActions[K] } >
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>TEvent : Symbol(TEvent, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 32, 34))
+>type : Symbol(type, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 38, 21))
+>TEventsCausingActions : Symbol(TEventsCausingActions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 34, 13))
+>K : Symbol(K, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 37, 3))
+
+  >;
+};
+
+type GenerateActionsConfigPart<
+>GenerateActionsConfigPart : Symbol(GenerateActionsConfigPart, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 40, 2))
+
+  TEvent extends EventObject,
+>TEvent : Symbol(TEvent, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 42, 31))
+>EventObject : Symbol(EventObject, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 12, 55))
+
+  TTypesMeta,
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 43, 29))
+
+> = {
+  actions?: TypegenMachineOptionsActions<TEvent, TTypesMeta>;
+>actions : Symbol(actions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 45, 5))
+>TypegenMachineOptionsActions : Symbol(TypegenMachineOptionsActions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 30, 1))
+>TEvent : Symbol(TEvent, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 42, 31))
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 43, 29))
+
+};
+
+type MaybeTypegenMachineOptions<
+>MaybeTypegenMachineOptions : Symbol(MaybeTypegenMachineOptions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 47, 2))
+
+  TEvent extends EventObject,
+>TEvent : Symbol(TEvent, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 49, 32))
+>EventObject : Symbol(EventObject, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 12, 55))
+
+  TTypesMeta = TypegenDisabled
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 50, 29))
+>TypegenDisabled : Symbol(TypegenDisabled, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 0, 0))
+
+> = TTypesMeta extends TypegenEnabled
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 50, 29))
+>TypegenEnabled : Symbol(TypegenEnabled, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 2, 1))
+
+  ? GenerateActionsConfigPart<TEvent, TTypesMeta>
+>GenerateActionsConfigPart : Symbol(GenerateActionsConfigPart, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 40, 2))
+>TEvent : Symbol(TEvent, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 49, 32))
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 50, 29))
+
+  : MachineOptions;
+>MachineOptions : Symbol(MachineOptions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 26, 10))
+
+interface Model<TEvent extends EventObject> {
+>Model : Symbol(Model, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 54, 19))
+>TEvent : Symbol(TEvent, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 56, 16))
+>EventObject : Symbol(EventObject, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 12, 55))
+
+  createMachine: {
+>createMachine : Symbol(Model.createMachine, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 56, 45))
+
+    <TTypesMeta extends TypegenConstraint = TypegenDisabled>(
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 58, 5))
+>TypegenConstraint : Symbol(TypegenConstraint, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 10, 50))
+>TypegenDisabled : Symbol(TypegenDisabled, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 0, 0))
+
+      config: MachineConfig<TTypesMeta>,
+>config : Symbol(config, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 58, 61))
+>MachineConfig : Symbol(MachineConfig, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 16, 1))
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 58, 5))
+
+      implementations?: MaybeTypegenMachineOptions<
+>implementations : Symbol(implementations, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 59, 40))
+>MaybeTypegenMachineOptions : Symbol(MaybeTypegenMachineOptions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 47, 2))
+
+        TEvent,
+>TEvent : Symbol(TEvent, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 56, 16))
+
+        TTypesMeta
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 58, 5))
+
+      >
+    ): void;
+  };
+}
+
+const model = {} as Model<
+>model : Symbol(model, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 68, 5))
+>Model : Symbol(Model, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 54, 19))
+  {
+    type: "SAMPLE";
+>type : Symbol(type, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 69, 3))
+  }
+>;
+
+model.createMachine(
+>model.createMachine : Symbol(Model.createMachine, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 56, 45))
+>model : Symbol(model, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 68, 5))
+>createMachine : Symbol(Model.createMachine, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 56, 45))
+
+  {},
+  {
+    actions: {
+>actions : Symbol(actions, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 76, 3))
+
+      custom: (ev) => {
+>custom : Symbol(custom, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 77, 14))
+>ev : Symbol(ev, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 78, 15))
+
+        ev.type // string
+>ev : Symbol(ev, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 78, 15))
+
+        ev.unknown // Error
+>ev : Symbol(ev, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 78, 15))
+
+      },
+    },
+  }
+);
+

--- a/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.symbols
+++ b/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.symbols
@@ -205,7 +205,9 @@ model.createMachine(
 >ev : Symbol(ev, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 78, 15))
 
         ev.type // string
+>ev.type : Symbol(EventObject.type, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 14, 23))
 >ev : Symbol(ev, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 78, 15))
+>type : Symbol(EventObject.type, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 14, 23))
 
         ev.unknown // Error
 >ev : Symbol(ev, Decl(contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts, 78, 15))

--- a/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.types
+++ b/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.types
@@ -1,0 +1,144 @@
+=== tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts ===
+export interface TypegenDisabled {
+  "@@xstate/typegen": false;
+>"@@xstate/typegen" : false
+>false : false
+}
+export interface TypegenEnabled {
+  "@@xstate/typegen": true;
+>"@@xstate/typegen" : true
+>true : true
+}
+interface TypegenMeta extends TypegenEnabled {
+  eventsCausingActions: Record<string, string>;
+>eventsCausingActions : Record<string, string>
+}
+
+type Prop<T, K> = K extends keyof T ? T[K] : never
+>Prop : Prop<T, K>
+
+type TypegenConstraint = TypegenMeta | TypegenDisabled;
+>TypegenConstraint : TypegenConstraint
+
+interface EventObject {
+  type: string;
+>type : string
+}
+
+interface MachineConfig<TTypesMeta = TypegenDisabled> {
+  types?: TTypesMeta;
+>types : TTypesMeta | undefined
+}
+
+type ActionFunction<
+>ActionFunction : ActionFunction<TEvent>
+
+  TEvent extends EventObject,
+> = (
+  event: TEvent,
+>event : TEvent
+
+) => void;
+
+interface MachineOptions {
+  actions?: Record<string, ActionFunction<EventObject>>
+>actions : Record<string, ActionFunction<EventObject>> | undefined
+}
+
+type TypegenMachineOptionsActions<
+>TypegenMachineOptionsActions : TypegenMachineOptionsActions<TEvent, TTypesMeta, TEventsCausingActions>
+
+  TEvent extends EventObject,
+  TTypesMeta,
+  TEventsCausingActions = Prop<TTypesMeta, "eventsCausingActions">
+> = {
+  [K in keyof TEventsCausingActions]?: ActionFunction<
+    Extract<TEvent, { type: TEventsCausingActions[K] } >
+>type : TEventsCausingActions[K]
+
+  >;
+};
+
+type GenerateActionsConfigPart<
+>GenerateActionsConfigPart : GenerateActionsConfigPart<TEvent, TTypesMeta>
+
+  TEvent extends EventObject,
+  TTypesMeta,
+> = {
+  actions?: TypegenMachineOptionsActions<TEvent, TTypesMeta>;
+>actions : TypegenMachineOptionsActions<TEvent, TTypesMeta, Prop<TTypesMeta, "eventsCausingActions">> | undefined
+
+};
+
+type MaybeTypegenMachineOptions<
+>MaybeTypegenMachineOptions : MaybeTypegenMachineOptions<TEvent, TTypesMeta>
+
+  TEvent extends EventObject,
+  TTypesMeta = TypegenDisabled
+> = TTypesMeta extends TypegenEnabled
+  ? GenerateActionsConfigPart<TEvent, TTypesMeta>
+  : MachineOptions;
+
+interface Model<TEvent extends EventObject> {
+  createMachine: {
+>createMachine : <TTypesMeta extends TypegenConstraint = TypegenDisabled>(config: MachineConfig<TTypesMeta>, implementations?: MaybeTypegenMachineOptions<TEvent, TTypesMeta> | undefined) => void
+
+    <TTypesMeta extends TypegenConstraint = TypegenDisabled>(
+      config: MachineConfig<TTypesMeta>,
+>config : MachineConfig<TTypesMeta>
+
+      implementations?: MaybeTypegenMachineOptions<
+>implementations : MaybeTypegenMachineOptions<TEvent, TTypesMeta> | undefined
+
+        TEvent,
+        TTypesMeta
+      >
+    ): void;
+  };
+}
+
+const model = {} as Model<
+>model : Model<{ type: "SAMPLE"; }>
+>{} as Model<  {    type: "SAMPLE";  }> : Model<{ type: "SAMPLE"; }>
+>{} : {}
+  {
+    type: "SAMPLE";
+>type : "SAMPLE"
+  }
+>;
+
+model.createMachine(
+>model.createMachine(  {},  {    actions: {      custom: (ev) => {        ev.type // string        ev.unknown // Error      },    },  }) : void
+>model.createMachine : <TTypesMeta extends TypegenConstraint = TypegenDisabled>(config: MachineConfig<TTypesMeta>, implementations?: MaybeTypegenMachineOptions<{ type: "SAMPLE"; }, TTypesMeta> | undefined) => void
+>model : Model<{ type: "SAMPLE"; }>
+>createMachine : <TTypesMeta extends TypegenConstraint = TypegenDisabled>(config: MachineConfig<TTypesMeta>, implementations?: MaybeTypegenMachineOptions<{ type: "SAMPLE"; }, TTypesMeta> | undefined) => void
+
+  {},
+>{} : {}
+  {
+>{    actions: {      custom: (ev) => {        ev.type // string        ev.unknown // Error      },    },  } : { actions: { custom: (ev: any) => void; }; }
+
+    actions: {
+>actions : { custom: (ev: any) => void; }
+>{      custom: (ev) => {        ev.type // string        ev.unknown // Error      },    } : { custom: (ev: any) => void; }
+
+      custom: (ev) => {
+>custom : (ev: any) => void
+>(ev) => {        ev.type // string        ev.unknown // Error      } : (ev: any) => void
+>ev : any
+
+        ev.type // string
+>ev.type : any
+>ev : any
+>type : any
+
+        ev.unknown // Error
+>ev.unknown : any
+>ev : any
+>unknown : any
+
+      },
+    },
+  }
+);
+

--- a/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.types
+++ b/tests/baselines/reference/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.types
@@ -116,25 +116,25 @@ model.createMachine(
   {},
 >{} : {}
   {
->{    actions: {      custom: (ev) => {        ev.type // string        ev.unknown // Error      },    },  } : { actions: { custom: (ev: any) => void; }; }
+>{    actions: {      custom: (ev) => {        ev.type // string        ev.unknown // Error      },    },  } : { actions: { custom: (ev: EventObject) => void; }; }
 
     actions: {
->actions : { custom: (ev: any) => void; }
->{      custom: (ev) => {        ev.type // string        ev.unknown // Error      },    } : { custom: (ev: any) => void; }
+>actions : { custom: (ev: EventObject) => void; }
+>{      custom: (ev) => {        ev.type // string        ev.unknown // Error      },    } : { custom: (ev: EventObject) => void; }
 
       custom: (ev) => {
->custom : (ev: any) => void
->(ev) => {        ev.type // string        ev.unknown // Error      } : (ev: any) => void
->ev : any
+>custom : (ev: EventObject) => void
+>(ev) => {        ev.type // string        ev.unknown // Error      } : (ev: EventObject) => void
+>ev : EventObject
 
         ev.type // string
->ev.type : any
->ev : any
->type : any
+>ev.type : string
+>ev : EventObject
+>type : string
 
         ev.unknown // Error
 >ev.unknown : any
->ev : any
+>ev : EventObject
 >unknown : any
 
       },

--- a/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts
+++ b/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectFunctionPropertyWithResolvedConditionalType.ts
@@ -1,0 +1,87 @@
+// @strict: true
+
+export interface TypegenDisabled {
+  "@@xstate/typegen": false;
+}
+export interface TypegenEnabled {
+  "@@xstate/typegen": true;
+}
+interface TypegenMeta extends TypegenEnabled {
+  eventsCausingActions: Record<string, string>;
+}
+
+type Prop<T, K> = K extends keyof T ? T[K] : never
+
+type TypegenConstraint = TypegenMeta | TypegenDisabled;
+
+interface EventObject {
+  type: string;
+}
+
+interface MachineConfig<TTypesMeta = TypegenDisabled> {
+  types?: TTypesMeta;
+}
+
+type ActionFunction<
+  TEvent extends EventObject,
+> = (
+  event: TEvent,
+) => void;
+
+interface MachineOptions {
+  actions?: Record<string, ActionFunction<EventObject>>
+}
+
+type TypegenMachineOptionsActions<
+  TEvent extends EventObject,
+  TTypesMeta,
+  TEventsCausingActions = Prop<TTypesMeta, "eventsCausingActions">
+> = {
+  [K in keyof TEventsCausingActions]?: ActionFunction<
+    Extract<TEvent, { type: TEventsCausingActions[K] } >
+  >;
+};
+
+type GenerateActionsConfigPart<
+  TEvent extends EventObject,
+  TTypesMeta,
+> = {
+  actions?: TypegenMachineOptionsActions<TEvent, TTypesMeta>;
+};
+
+type MaybeTypegenMachineOptions<
+  TEvent extends EventObject,
+  TTypesMeta = TypegenDisabled
+> = TTypesMeta extends TypegenEnabled
+  ? GenerateActionsConfigPart<TEvent, TTypesMeta>
+  : MachineOptions;
+
+interface Model<TEvent extends EventObject> {
+  createMachine: {
+    <TTypesMeta extends TypegenConstraint = TypegenDisabled>(
+      config: MachineConfig<TTypesMeta>,
+      implementations?: MaybeTypegenMachineOptions<
+        TEvent,
+        TTypesMeta
+      >
+    ): void;
+  };
+}
+
+const model = {} as Model<
+  {
+    type: "SAMPLE";
+  }
+>;
+
+model.createMachine(
+  {},
+  {
+    actions: {
+      custom: (ev) => {
+        ev.type // string
+        ev.unknown // Error
+      },
+    },
+  }
+);


### PR DESCRIPTION
Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)

There is no issue yet about this, I've been debugging this for hours and managed to fix my case by patching TS. So I figured out I would just prepare a PR with the proposed change.

* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally

Not quite, but that's because I get:
```
[12:30:24] Starting 'runTestsParallel'...
[12:30:24] Running tests with config: {"light":true,"workerCount":8,"taskConfigsFolder":"/var/folders/ws/tlwxqvs5407f21nxy7w8bgr80000gp/T/ts-tests2","noColor":false,"timeout":40000,"keepFailed":false}
[12:30:24] > node built/local/run.js
/TypeScript/built/local/run.js:186752
 break;
 ^^^^^

SyntaxError: Illegal break statement
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47
```

In a sense, I'm creating this PR to trigger CI and to check if there are any failures related to existing tests because I can't run the test suite locally.

* [x] There are new or updated unit tests validating the change

---

Fixes this [TS playground](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBASwHY2FAZgQwMbDgFQE8xgBzYJAEQQGdMAjAG2ABM4BvAKDjgCIABfiBoxMqAPQxiZCrwBccLIxrAA3JwC+nUJFiIUaLLgLTySAKJIGzNlx4ChIscEmnZCmFACuazZ2SoGDh4RCRmALLAonCgqEgsNCZhFJbWrBzccOLicAAWmABuyKRwMLm0cGBQECSwhHloePRQwJgA1olleMjojUjG6NCluXgABqEyVLRpLKNw2JgqmcAFFDA0AMKYXjTFAILYMAgQSDQKAErA2NAsADwiUMUANHAPxQB86lqcUiRwAArVMC3fAvADS7zgAF44GCYiA4gk4G1gIQIOgCHAAPwEADaYIAunAFEgVmhOD9pElJhsTg9MAFodSIlFMHAAD7MijUOhMVjqfwGILGcyrFAAeXoACsrvA7KVpAo3khSF8KQFDME4OEcOVSbSkOgEKQQRMaJFojCJmYeTNIfLfsAaFiFPgzRbMGrKX8DkcTgAxLz9P1IW6ZfCitbwxGJSMS6Wyp6cSEwgAUyzFMFdcZgSYAlNDIQUIAgWAKNcK8DrsHrgOKwCHEvKcI2XXBLtcoHdlaQXr7jkhA8GB7cc5KZYd3u8-N6Qm4kNXa-XG-26WGeBHM9GKEixwnDkmN+7WYeCDnNttdirV6cmYCaqbpOaT3wySgLzt9ocBzReNOUxkPD4voyKouiZ6Zh+V6kDeNAEm2N5Dt+JzrjwcDmAiUAtiCOYvOwCokNmkFbJ+17Iac+JEhocCQpknyaAKjpwAA4hQaDOLBBpGqQ-yYLAqGblGsQ7rGmbjom4bHqISYAc25HOq686LsgdYNj+sE4ZmLxuk+Hr0RojFUjqhD0MA1oUMppLLj+Ak5tu8SiWs4kHpJumsky5lTLyNjJh5UlssJDlchYVh8iwmQ4qxpJYagnEnNxvH8YJKDaf5048AolmqY25ZCkYVYQCwwCMJpQkIiJ6FifuMD2pk2AtM4WUKPKPCPiQz7RIFSKeQa9KMla862mF7zpmhaHXIaxqZbqKlccabVOnpp5jQgAC2YDMKtaxiD+bbGaZnlZdZa6ZGNG64adZ06e1HqXTw6VoXmCjFqW6g8AZM4TSIcCrYVxVMuw1GLNqf0lZkLUEcACi8AAyns4T-AAMuYvBvXAWj0Zwv1FYwAB09WtKgWWjYBaHZJDZwcEDTaXeT9iCMIogSI6ZjyKU3i+GNdMxMRl5fo2zW0zkY3YDsMAQKtCgAORwwjyNS0LaFaFzOTK+jp4Qy2P6C2d8xixLCipisBZQrVus8CsuOOndZM5Pw6wALQ6LKTtQNUUA2xbBS40GbRIBAADuSA2xoy3q5kWh5uoQA).

The code in the playground is not really what I have in my project. The version here is doesn't make much sense but it's distilled out of my repository and I'm unsure how to minimize it further or make a more compelling minimal test case.

I've been really curious about what is happening here and why this case doesn't infer correctly so I went into the rabbit hole of debugging this. You might find the details listed below helpful as I have only a vague understanding of what is happening here.

1. I've realized that the [`resolveCall`](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L29358) is a good starting point of this debugging session.
2. Since we only have a single signature for this `model.createMachine` call we end up calling this `chooseOverload` [here](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L29447)
3. Because we are not `isSingleNonGenericCandidate` we are skipping over [this block](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L29571) and end up calling `inferTypeArguments` [here](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L29603)
4. We end up calling `checkExpressionWithContextualType` [here](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L28805) which leads to [`contextuallyCheckFunctionExpressionOrObjectLiteralMethod`](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L31592) being called 
5. and in here we can check out the end of the road - why this doesn't get contextually types. It's because we end up in [here](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L31618), calling `assignNonContextualParameterTypes`. This means that preceding lines of code were not able to resolve the contextual parameter types
6. By tracing it back we can spot that `contextualSignature` has been computed to `undefined` [here](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L31596)
7. Let's dive into this then. The problem turns out to be that we have 5 types in the union [here](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L26368). 2 of those types are function types and thus we try grab their signatures and compare them [here](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L26375) and unfortunately they are not the same so we bail out of this function by returning `undefined` (this is actually a tad interesting, shouldn't an intersection of functions be returned in such a case? not sure how helpful for the real-life code that would be though).
8. Ok, so the problem is that fucntion parameters have different types at a given position - that makes some sense. However, we might notice that we should~ actually only have a single function on the list. The reason why we have two is that each of them is coming from a different branch of the conditional type. My understanding though is that the branch could have been taken here (and it is, since this is not a generic context or anything like that, everything is "concrete") and we could have had only a single function here (the mentioned union of types could be smaller) and thus we would be able to return a signaute from this `getContextualSignature`. After all we wouldn't even compare that single signature with anything else and thus this call would just "succeed".
9. This seemed like a problem - why the inferred generic type parameter is not taken into account and why the conditional type was not "resolved" here? Maybe it's some issue with the order of operations or stuff like that?
10. That union type is coming from this [`getApparentTypeOfContextualType` call](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L26359) so let's go in there to see what happens.
11. We quickly end up in the [`instantiateContextualType`](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L25948) and we try to check [this condition](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L25953) (`inferenceContext && some(inferenceContext.inferences, hasInferenceCandidates)`) before actually instantiating that contextual type.
12. [`hasInferenceCandidates` simply checks `!!(info.candidates || info.contraCandidates)`](https://github.com/microsoft/TypeScript/blob/6495544770e4eda0ad1be83898b8d1103daba984/src/compiler/checker.ts#L33231-L33233) and it turns out that both of those are `undefined` so we bail out from the instatiation.
13. I've noticed in here though that `info.inferredType` is available! So we don't have any inference candidates but we already have the inferred type. So conceptually it made sense for me to include that in the check and try it out. It turned out that it indeed fixed my issue 🎉 

I can't be sure if my patch is a bandaid or not - maybe the problem is that `hasInferenceCandidates` should return `true` here, taking `info.inferredType` into account. Or maybe `info.candidates` or `info.contraCandidates` should be set (and `hasInferenceCandidates` should return `true` based on that). I can't be sure because my knowledge about TS internals is very limited. I leave that assessment for smarter people than me.

I'm also not entirely sure what triggers the problem in my repro case - there is a high chance that it could be slimmed down even further. The title of my test might also not be the best - because of my limited understanding of the problem. If you can name/phrase the issue better then I would gladly update it.

It's definitely interesting though that having `eventsCausingActions` property on the generic type constraint (that is later on used by one of the conditional type branches) is changing how it behaves. If we just remove it then the issue disappears - which here is an OK workaround because I don't really need to have that property on that constraint. It still feels though that landing a fix for this could potentially allow for more things to be contextually inferred which sounds like a win.
