### PR TITLE
Revert binding pattern inference changes, but only for tuples

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25442,7 +25442,8 @@ namespace ts {
                 if (result) {
                     return result;
                 }
-                if (!(contextFlags! & ContextFlags.SkipBindingPatterns) && isBindingPattern(declaration.name)) {
+                if (!(contextFlags! & ContextFlags.SkipObjectBindingPatterns) && isObjectBindingPattern(declaration.name) ||
+                    !(contextFlags! & ContextFlags.SkipArrayBindingPatterns) && isArrayBindingPattern(declaration.name)) {
                     // This is less a contextual type and more an implied shape - in some cases, this may be undesirable
                     return getTypeFromBindingPattern(declaration.name, /*includePatternInType*/ true, /*reportErrors*/ false);
                 }
@@ -28750,7 +28751,7 @@ namespace ts {
             // 'let f: (x: string) => number = wrap(s => s.length)', we infer from the declared type of 'f' to the
             // return type of 'wrap'.
             if (node.kind !== SyntaxKind.Decorator) {
-                const contextualType = getContextualType(node, ContextFlags.SkipBindingPatterns);
+                const contextualType = getContextualType(node, ContextFlags.SkipObjectBindingPatterns);
                 if (contextualType) {
                     // We clone the inference context to avoid disturbing a resolution in progress for an
                     // outer call expression. Effectively we just want a snapshot of whatever has been

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4409,7 +4409,9 @@ namespace ts {
         Signature      = 1 << 0, // Obtaining contextual signature
         NoConstraints  = 1 << 1, // Don't obtain type variable constraints
         Completions    = 1 << 2, // Ignore inference to current node and parent nodes out to the containing call for completions
-        SkipBindingPatterns = 1 << 3, // Ignore contextual types applied by binding patterns
+        SkipArrayBindingPatterns = 1 << 3,  // Ignore contextual types applied by array binding patterns
+        SkipObjectBindingPatterns = 1 << 4, // Ignore contextual types applied by object binding patterns
+        SkipBindingPatterns = SkipArrayBindingPatterns | SkipObjectBindingPatterns,
     }
 
     // NOTE: If modifying this enum, must modify `TypeFormatFlags` too!

--- a/tests/baselines/reference/destructuringTuple.errors.txt
+++ b/tests/baselines/reference/destructuringTuple.errors.txt
@@ -1,3 +1,10 @@
+tests/cases/compiler/destructuringTuple.ts(11,7): error TS2461: Type 'number' is not an array type.
+tests/cases/compiler/destructuringTuple.ts(11,48): error TS2769: No overload matches this call.
+  Overload 1 of 3, '(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number, initialValue: number): number', gave the following error.
+    Type 'never[]' is not assignable to type 'number'.
+  Overload 2 of 3, '(callbackfn: (previousValue: [], currentValue: number, currentIndex: number, array: number[]) => [], initialValue: []): []', gave the following error.
+    Type 'never[]' is not assignable to type '[]'.
+      Target allows only 0 element(s) but source may have more.
 tests/cases/compiler/destructuringTuple.ts(11,60): error TS2769: No overload matches this call.
   Overload 1 of 2, '(...items: ConcatArray<never>[]): never[]', gave the following error.
     Argument of type 'number' is not assignable to parameter of type 'ConcatArray<never>'.
@@ -5,7 +12,7 @@ tests/cases/compiler/destructuringTuple.ts(11,60): error TS2769: No overload mat
     Argument of type 'number' is not assignable to parameter of type 'ConcatArray<never>'.
 
 
-==== tests/cases/compiler/destructuringTuple.ts (1 errors) ====
+==== tests/cases/compiler/destructuringTuple.ts (3 errors) ====
     declare var tuple: [boolean, number, ...string[]];
     
     const [a, b, c, ...rest] = tuple;
@@ -17,6 +24,17 @@ tests/cases/compiler/destructuringTuple.ts(11,60): error TS2769: No overload mat
     // Repros from #32140
     
     const [oops1] = [1, 2, 3].reduce((accu, el) => accu.concat(el), []);
+          ~~~~~~~
+!!! error TS2461: Type 'number' is not an array type.
+                                                   ~~~~~~~~~~~~~~~
+!!! error TS2769: No overload matches this call.
+!!! error TS2769:   Overload 1 of 3, '(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number, initialValue: number): number', gave the following error.
+!!! error TS2769:     Type 'never[]' is not assignable to type 'number'.
+!!! error TS2769:   Overload 2 of 3, '(callbackfn: (previousValue: [], currentValue: number, currentIndex: number, array: number[]) => [], initialValue: []): []', gave the following error.
+!!! error TS2769:     Type 'never[]' is not assignable to type '[]'.
+!!! error TS2769:       Target allows only 0 element(s) but source may have more.
+!!! related TS6502 /.ts/lib.es5.d.ts:1429:24: The expected type comes from the return type of this signature.
+!!! related TS6502 /.ts/lib.es5.d.ts:1435:27: The expected type comes from the return type of this signature.
                                                                ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(...items: ConcatArray<never>[]): never[]', gave the following error.

--- a/tests/baselines/reference/destructuringTuple.types
+++ b/tests/baselines/reference/destructuringTuple.types
@@ -23,20 +23,20 @@ declare var receiver: typeof tuple;
 // Repros from #32140
 
 const [oops1] = [1, 2, 3].reduce((accu, el) => accu.concat(el), []);
->oops1 : never
->[1, 2, 3].reduce((accu, el) => accu.concat(el), []) : never[]
+>oops1 : any
+>[1, 2, 3].reduce((accu, el) => accu.concat(el), []) : number
 >[1, 2, 3].reduce : { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: number[]) => U, initialValue: U): U; }
 >[1, 2, 3] : number[]
 >1 : 1
 >2 : 2
 >3 : 3
 >reduce : { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: number[]) => U, initialValue: U): U; }
->(accu, el) => accu.concat(el) : (accu: never[], el: number) => never[]
->accu : never[]
+>(accu, el) => accu.concat(el) : (accu: [], el: number) => never[]
+>accu : []
 >el : number
 >accu.concat(el) : never[]
 >accu.concat : { (...items: ConcatArray<never>[]): never[]; (...items: ConcatArray<never>[]): never[]; }
->accu : never[]
+>accu : []
 >concat : { (...items: ConcatArray<never>[]): never[]; (...items: ConcatArray<never>[]): never[]; }
 >el : number
 >[] : never[]

--- a/tests/baselines/reference/destructuringTuple2.js
+++ b/tests/baselines/reference/destructuringTuple2.js
@@ -1,0 +1,7 @@
+//// [destructuringTuple2.ts]
+declare const f: <T>(cb: () => T) => T;
+const [a, b, c] = f(() => [1, "hi", true]);
+
+
+//// [destructuringTuple2.js]
+var _a = f(function () { return [1, "hi", true]; }), a = _a[0], b = _a[1], c = _a[2];

--- a/tests/baselines/reference/destructuringTuple2.symbols
+++ b/tests/baselines/reference/destructuringTuple2.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/destructuringTuple2.ts ===
+declare const f: <T>(cb: () => T) => T;
+>f : Symbol(f, Decl(destructuringTuple2.ts, 0, 13))
+>T : Symbol(T, Decl(destructuringTuple2.ts, 0, 18))
+>cb : Symbol(cb, Decl(destructuringTuple2.ts, 0, 21))
+>T : Symbol(T, Decl(destructuringTuple2.ts, 0, 18))
+>T : Symbol(T, Decl(destructuringTuple2.ts, 0, 18))
+
+const [a, b, c] = f(() => [1, "hi", true]);
+>a : Symbol(a, Decl(destructuringTuple2.ts, 1, 7))
+>b : Symbol(b, Decl(destructuringTuple2.ts, 1, 9))
+>c : Symbol(c, Decl(destructuringTuple2.ts, 1, 12))
+>f : Symbol(f, Decl(destructuringTuple2.ts, 0, 13))
+

--- a/tests/baselines/reference/destructuringTuple2.types
+++ b/tests/baselines/reference/destructuringTuple2.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/destructuringTuple2.ts ===
+declare const f: <T>(cb: () => T) => T;
+>f : <T>(cb: () => T) => T
+>cb : () => T
+
+const [a, b, c] = f(() => [1, "hi", true]);
+>a : number
+>b : string
+>c : boolean
+>f(() => [1, "hi", true]) : [number, string, boolean]
+>f : <T>(cb: () => T) => T
+>() => [1, "hi", true] : () => [number, string, boolean]
+>[1, "hi", true] : [number, string, true]
+>1 : 1
+>"hi" : "hi"
+>true : true
+

--- a/tests/cases/compiler/destructuringTuple2.ts
+++ b/tests/cases/compiler/destructuringTuple2.ts
@@ -1,0 +1,2 @@
+declare const f: <T>(cb: () => T) => T;
+const [a, b, c] = f(() => [1, "hi", true]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Partial revert of #45719—we now let an _array_ binding pattern turn inference of an array into a tuple, which is really nice. I still think the behavior we were seeing for _object_ binding patterns was undesirable, and #45846 supports that hypothesis since all the related errors were due to a tuple turning into an array.
