### PR TITLE
Revert "Stop looking at binding patterns for type argument inference"

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25445,8 +25445,7 @@ namespace ts {
                 if (result) {
                     return result;
                 }
-                if (!(contextFlags! & ContextFlags.SkipBindingPatterns) && isBindingPattern(declaration.name)) {
-                    // This is less a contextual type and more an implied shape - in some cases, this may be undesirable
+                if (!(contextFlags! & ContextFlags.SkipBindingPatterns) && isBindingPattern(declaration.name)) { // This is less a contextual type and more an implied shape - in some cases, this may be undesirable
                     return getTypeFromBindingPattern(declaration.name, /*includePatternInType*/ true, /*reportErrors*/ false);
                 }
             }
@@ -28753,7 +28752,7 @@ namespace ts {
             // 'let f: (x: string) => number = wrap(s => s.length)', we infer from the declared type of 'f' to the
             // return type of 'wrap'.
             if (node.kind !== SyntaxKind.Decorator) {
-                const contextualType = getContextualType(node, ContextFlags.SkipBindingPatterns);
+                const contextualType = getContextualType(node, every(signature.typeParameters, p => !!getDefaultFromTypeParameter(p)) ? ContextFlags.SkipBindingPatterns : ContextFlags.None);
                 if (contextualType) {
                     // We clone the inference context to avoid disturbing a resolution in progress for an
                     // outer call expression. Effectively we just want a snapshot of whatever has been

--- a/tests/baselines/reference/destructuringTuple.errors.txt
+++ b/tests/baselines/reference/destructuringTuple.errors.txt
@@ -1,3 +1,10 @@
+tests/cases/compiler/destructuringTuple.ts(11,7): error TS2461: Type 'number' is not an array type.
+tests/cases/compiler/destructuringTuple.ts(11,48): error TS2769: No overload matches this call.
+  Overload 1 of 3, '(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number, initialValue: number): number', gave the following error.
+    Type 'never[]' is not assignable to type 'number'.
+  Overload 2 of 3, '(callbackfn: (previousValue: [], currentValue: number, currentIndex: number, array: number[]) => [], initialValue: []): []', gave the following error.
+    Type 'never[]' is not assignable to type '[]'.
+      Target allows only 0 element(s) but source may have more.
 tests/cases/compiler/destructuringTuple.ts(11,60): error TS2769: No overload matches this call.
   Overload 1 of 2, '(...items: ConcatArray<never>[]): never[]', gave the following error.
     Argument of type 'number' is not assignable to parameter of type 'ConcatArray<never>'.
@@ -5,7 +12,7 @@ tests/cases/compiler/destructuringTuple.ts(11,60): error TS2769: No overload mat
     Argument of type 'number' is not assignable to parameter of type 'ConcatArray<never>'.
 
 
-==== tests/cases/compiler/destructuringTuple.ts (1 errors) ====
+==== tests/cases/compiler/destructuringTuple.ts (3 errors) ====
     declare var tuple: [boolean, number, ...string[]];
     
     const [a, b, c, ...rest] = tuple;
@@ -17,6 +24,17 @@ tests/cases/compiler/destructuringTuple.ts(11,60): error TS2769: No overload mat
     // Repros from #32140
     
     const [oops1] = [1, 2, 3].reduce((accu, el) => accu.concat(el), []);
+          ~~~~~~~
+!!! error TS2461: Type 'number' is not an array type.
+                                                   ~~~~~~~~~~~~~~~
+!!! error TS2769: No overload matches this call.
+!!! error TS2769:   Overload 1 of 3, '(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number, initialValue: number): number', gave the following error.
+!!! error TS2769:     Type 'never[]' is not assignable to type 'number'.
+!!! error TS2769:   Overload 2 of 3, '(callbackfn: (previousValue: [], currentValue: number, currentIndex: number, array: number[]) => [], initialValue: []): []', gave the following error.
+!!! error TS2769:     Type 'never[]' is not assignable to type '[]'.
+!!! error TS2769:       Target allows only 0 element(s) but source may have more.
+!!! related TS6502 /.ts/lib.es5.d.ts:1412:24: The expected type comes from the return type of this signature.
+!!! related TS6502 /.ts/lib.es5.d.ts:1418:27: The expected type comes from the return type of this signature.
                                                                ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(...items: ConcatArray<never>[]): never[]', gave the following error.

--- a/tests/baselines/reference/destructuringTuple.errors.txt
+++ b/tests/baselines/reference/destructuringTuple.errors.txt
@@ -33,8 +33,8 @@ tests/cases/compiler/destructuringTuple.ts(11,60): error TS2769: No overload mat
 !!! error TS2769:   Overload 2 of 3, '(callbackfn: (previousValue: [], currentValue: number, currentIndex: number, array: number[]) => [], initialValue: []): []', gave the following error.
 !!! error TS2769:     Type 'never[]' is not assignable to type '[]'.
 !!! error TS2769:       Target allows only 0 element(s) but source may have more.
-!!! related TS6502 /.ts/lib.es5.d.ts:1412:24: The expected type comes from the return type of this signature.
-!!! related TS6502 /.ts/lib.es5.d.ts:1418:27: The expected type comes from the return type of this signature.
+!!! related TS6502 /.ts/lib.es5.d.ts:1429:24: The expected type comes from the return type of this signature.
+!!! related TS6502 /.ts/lib.es5.d.ts:1435:27: The expected type comes from the return type of this signature.
                                                                ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(...items: ConcatArray<never>[]): never[]', gave the following error.

--- a/tests/baselines/reference/destructuringTuple.types
+++ b/tests/baselines/reference/destructuringTuple.types
@@ -23,20 +23,20 @@ declare var receiver: typeof tuple;
 // Repros from #32140
 
 const [oops1] = [1, 2, 3].reduce((accu, el) => accu.concat(el), []);
->oops1 : never
->[1, 2, 3].reduce((accu, el) => accu.concat(el), []) : never[]
+>oops1 : any
+>[1, 2, 3].reduce((accu, el) => accu.concat(el), []) : number
 >[1, 2, 3].reduce : { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: number[]) => U, initialValue: U): U; }
 >[1, 2, 3] : number[]
 >1 : 1
 >2 : 2
 >3 : 3
 >reduce : { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: number[]) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: number[]) => U, initialValue: U): U; }
->(accu, el) => accu.concat(el) : (accu: never[], el: number) => never[]
->accu : never[]
+>(accu, el) => accu.concat(el) : (accu: [], el: number) => never[]
+>accu : []
 >el : number
 >accu.concat(el) : never[]
 >accu.concat : { (...items: ConcatArray<never>[]): never[]; (...items: ConcatArray<never>[]): never[]; }
->accu : never[]
+>accu : []
 >concat : { (...items: ConcatArray<never>[]): never[]; (...items: ConcatArray<never>[]): never[]; }
 >el : number
 >[] : never[]

--- a/tests/cases/fourslash/completionsBindingPatternAffectsInference.ts
+++ b/tests/cases/fourslash/completionsBindingPatternAffectsInference.ts
@@ -1,9 +1,0 @@
-/// <reference path="fourslash.ts" />
-
-//// declare function pick<T, K extends keyof T>(keys: K[], obj: T): Pick<T, K>;
-//// const { /**/ } = pick(['b'], { a: 'a', b: 'b' });
-
-verify.completions({
-  marker: "",
-  exact: ["b"]
-});


### PR DESCRIPTION
Reverts microsoft/TypeScript#45719