### PR TITLE
Treat Array TypeReference the same as ArrayType in tuple rest type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15914,11 +15914,23 @@ namespace ts {
                         node = (node as TupleTypeNode).elements[0];
                         if (node.kind === SyntaxKind.RestType || node.kind === SyntaxKind.NamedTupleMember && (node as NamedTupleMember).dotDotDotToken) {
                             return getArrayElementTypeNode((node as RestTypeNode | NamedTupleMember).type);
+                        } else {
+                            return node;
                         }
                     }
                     break;
                 case SyntaxKind.ArrayType:
                     return (node as ArrayTypeNode).elementType;
+                case SyntaxKind.TypeReference:
+                    const typeName = (node as TypeReferenceNode).typeName;
+                    if (isIdentifier(typeName)) {
+                        const s = getResolvedSymbol(typeName);
+                        
+                        // @TODO: figure out why `isArrayLikeType(getTypeOfSymbol(s))` does not work
+                        if (s === globalArrayType.symbol || s === globalReadonlyArrayType.symbol) {
+                            return (node as TypeReferenceNode).typeArguments![0];
+                        }
+                    }
             }
             return undefined;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15937,23 +15937,11 @@ namespace ts {
                         node = (node as TupleTypeNode).elements[0];
                         if (node.kind === SyntaxKind.RestType || node.kind === SyntaxKind.NamedTupleMember && (node as NamedTupleMember).dotDotDotToken) {
                             return getArrayElementTypeNode((node as RestTypeNode | NamedTupleMember).type);
-                        } else {
-                            return node;
                         }
                     }
                     break;
                 case SyntaxKind.ArrayType:
                     return (node as ArrayTypeNode).elementType;
-                case SyntaxKind.TypeReference:
-                    const typeName = (node as TypeReferenceNode).typeName;
-                    if (isIdentifier(typeName)) {
-                        const s = getResolvedSymbol(typeName);
-                        
-                        // @TODO: figure out why `isArrayLikeType(getTypeOfSymbol(s))` does not work
-                        if (s === globalArrayType.symbol || s === globalReadonlyArrayType.symbol) {
-                            return (node as TypeReferenceNode).typeArguments![0];
-                        }
-                    }
             }
             return undefined;
         }


### PR DESCRIPTION
This is probably a naive attempt to fix #45641.

All of this work now:
```ts
type T1<C> = [C, ...T1<C>[]] | number;
type T2<C> = [C, ...Array<T2<C>>] | number;
type T3<C> = [C, ...[T3<C>]] | number;
```

However the code will probably fail if `Array` is aliased.

I would appreciate some guidance for this. If this is the right direction, I'll add tests.

Fixes #45641.
