### PR TITLE
Update parameter types of RegExp `compile` method

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -944,7 +944,7 @@ interface RegExp {
     lastIndex: number;
 
     // Non-standard extensions
-    compile(): this;
+    compile(pattern: string, flags?: string): this;
 }
 
 interface RegExpConstructor {


### PR DESCRIPTION
<!--
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change
-->

This PR updates the parameter types of RegExp `compile` method. The parameter names and types follow the convention used in RegExp constructor (line 952).

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile

Fixes #46030
