### PR TITLE
fix(45999): Inlay hints for parameter declaration should before initializer

### DIFF
--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -279,7 +279,7 @@ namespace ts.InlayHints {
                     continue;
                 }
 
-                addTypeHints(typeDisplayString, param.end);
+                addTypeHints(typeDisplayString, param.name.end);
             }
         }
 

--- a/tests/cases/fourslash/inlayHintsShouldWork65.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork65.ts
@@ -1,0 +1,22 @@
+/// <reference path="fourslash.ts" />
+
+//// type F = (a: string, b: number) => void
+//// const f: F = (a/*a*/,  b/*b*/ = 1) => { }
+
+const [a, b] = test.markers();
+verify.getInlayHints([
+    {
+        text: ': string',
+        position: a.position,
+        kind: ts.InlayHintKind.Type,
+        whitespaceBefore: true
+    },
+    {
+        text: ': number',
+        position: b.position,
+        kind: ts.InlayHintKind.Type,
+        whitespaceBefore: true
+    }
+], undefined, {
+    includeInlayFunctionParameterTypeHints: true
+});


### PR DESCRIPTION
Fixes #45999