### PR TITLE
Resolve with -lib in TypeScript lib lookup via node-style resolution

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2884,9 +2884,9 @@ namespace ts {
         }
 
         function pathForLibFile(libFileName: string): string {
-            // Support resolving to lib.dom.d.ts -> @typescript/dom, and
-            //                      lib.dom.iterable.d.ts -> @typescript/dom/iterable
-            //                      lib.es2015.symbol.wellknown.d.ts -> @typescript/es2015/symbol-wellknown
+            // Support resolving to lib.dom.d.ts -> @typescript/lib-dom, and
+            //                      lib.dom.iterable.d.ts -> @typescript/lib-dom/iterable
+            //                      lib.es2015.symbol.wellknown.d.ts -> @typescript/lib-es2015/symbol-wellknown
             const components = libFileName.split(".");
             let path = components[1];
             let i = 2;
@@ -2895,7 +2895,7 @@ namespace ts {
                 i++;
             }
             const resolveFrom = combinePaths(currentDirectory, `__lib_node_modules_lookup_${libFileName}__.ts`);
-            const localOverrideModuleResult = resolveModuleName("@typescript/" + path, resolveFrom, { moduleResolution: ModuleResolutionKind.NodeJs }, host, moduleResolutionCache);
+            const localOverrideModuleResult = resolveModuleName("@typescript/lib-" + path, resolveFrom, { moduleResolution: ModuleResolutionKind.NodeJs }, host, moduleResolutionCache);
             if (localOverrideModuleResult?.resolvedModule) {
                 return localOverrideModuleResult.resolvedModule.resolvedFileName;
             }

--- a/tests/baselines/reference/libTypeScriptOverrideSimple.errors.txt
+++ b/tests/baselines/reference/libTypeScriptOverrideSimple.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/index.ts(6,1): error TS2304: Cannot find name 'window'.
 
 
-==== /node_modules/@typescript/dom/index.d.ts (0 errors) ====
+==== /node_modules/@typescript/lib-dom/index.d.ts (0 errors) ====
     interface ABC { abc: string }
 ==== tests/cases/compiler/index.ts (1 errors) ====
     /// <reference lib="dom" />

--- a/tests/baselines/reference/libTypeScriptOverrideSimple.symbols
+++ b/tests/baselines/reference/libTypeScriptOverrideSimple.symbols
@@ -1,4 +1,4 @@
-=== /node_modules/@typescript/dom/index.d.ts ===
+=== /node_modules/@typescript/lib-dom/index.d.ts ===
 interface ABC { abc: string }
 >ABC : Symbol(ABC, Decl(index.d.ts, 0, 0))
 >abc : Symbol(ABC.abc, Decl(index.d.ts, 0, 15))

--- a/tests/baselines/reference/libTypeScriptOverrideSimple.types
+++ b/tests/baselines/reference/libTypeScriptOverrideSimple.types
@@ -1,4 +1,4 @@
-=== /node_modules/@typescript/dom/index.d.ts ===
+=== /node_modules/@typescript/lib-dom/index.d.ts ===
 interface ABC { abc: string }
 >abc : string
 

--- a/tests/baselines/reference/libTypeScriptSubfileResolving.errors.txt
+++ b/tests/baselines/reference/libTypeScriptSubfileResolving.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/index.ts(6,1): error TS2304: Cannot find name 'window'.
 
 
-==== /node_modules/@typescript/dom/index.d.ts (0 errors) ====
+==== /node_modules/@typescript/lib-dom/index.d.ts (0 errors) ====
     // NOOP
-==== /node_modules/@typescript/dom/iterable.d.ts (0 errors) ====
+==== /node_modules/@typescript/lib-dom/iterable.d.ts (0 errors) ====
     interface DOMIterable { abc: string }
 ==== tests/cases/compiler/index.ts (1 errors) ====
     /// <reference lib="dom.iterable" />

--- a/tests/baselines/reference/libTypeScriptSubfileResolving.symbols
+++ b/tests/baselines/reference/libTypeScriptSubfileResolving.symbols
@@ -1,6 +1,6 @@
-=== /node_modules/@typescript/dom/index.d.ts ===
+=== /node_modules/@typescript/lib-dom/index.d.ts ===
 // NOOP
-No type information for this code.=== /node_modules/@typescript/dom/iterable.d.ts ===
+No type information for this code.=== /node_modules/@typescript/lib-dom/iterable.d.ts ===
 interface DOMIterable { abc: string }
 >DOMIterable : Symbol(DOMIterable, Decl(iterable.d.ts, 0, 0))
 >abc : Symbol(DOMIterable.abc, Decl(iterable.d.ts, 0, 23))

--- a/tests/baselines/reference/libTypeScriptSubfileResolving.types
+++ b/tests/baselines/reference/libTypeScriptSubfileResolving.types
@@ -1,6 +1,6 @@
-=== /node_modules/@typescript/dom/index.d.ts ===
+=== /node_modules/@typescript/lib-dom/index.d.ts ===
 // NOOP
-No type information for this code.=== /node_modules/@typescript/dom/iterable.d.ts ===
+No type information for this code.=== /node_modules/@typescript/lib-dom/iterable.d.ts ===
 interface DOMIterable { abc: string }
 >abc : string
 

--- a/tests/cases/compiler/libTypeScriptOverrideSimple.ts
+++ b/tests/cases/compiler/libTypeScriptOverrideSimple.ts
@@ -1,4 +1,4 @@
-// @Filename: /node_modules/@typescript/dom/index.d.ts
+// @Filename: /node_modules/@typescript/lib-dom/index.d.ts
 interface ABC { abc: string }
 // @Filename: index.ts
 /// <reference lib="dom" />

--- a/tests/cases/compiler/libTypeScriptSubfileResolving.ts
+++ b/tests/cases/compiler/libTypeScriptSubfileResolving.ts
@@ -1,6 +1,6 @@
-// @Filename: /node_modules/@typescript/dom/index.d.ts
+// @Filename: /node_modules/@typescript/lib-dom/index.d.ts
 // NOOP
-// @Filename: /node_modules/@typescript/dom/iterable.d.ts
+// @Filename: /node_modules/@typescript/lib-dom/iterable.d.ts
 interface DOMIterable { abc: string }
 // @Filename: index.ts
 /// <reference lib="dom.iterable" />


### PR DESCRIPTION
Fixes #45993

https://github.com/microsoft/TypeScript/pull/45771 introduced a way to write something like:

```json
{
  "dependencies": {
    "@typescript/dom": "npm:@types/web"
  }
}
```

This PR changes that to be:

```json
{
  "dependencies": {
    "@typescript/lib-dom": "npm:@types/web"
  }
}
```