### PR TITLE
Pass absolute path to directoryExists

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6634,8 +6634,9 @@ namespace ts {
         const visited = new Map<string, true>();
         const toCanonical = createGetCanonicalFileName(useCaseSensitiveFileNames);
         for (const basePath of patterns.basePaths) {
-            if (directoryExists(basePath)) {
-                visitDirectory(basePath, combinePaths(currentDirectory, basePath), depth);
+            const absoluteBasePath = combinePaths(currentDirectory, basePath);
+            if (directoryExists(absoluteBasePath)) {
+                visitDirectory(basePath, absoluteBasePath, depth);
             }
         }
 


### PR DESCRIPTION
As pointed out by @gretzkiy, the `directoryExists` call added to
`matchFiles` in #44710 should have been passing the absolute path (since
the current directory might not match `currentDirectory`).

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #
