### PR TITLE
Fix indexing error in guessDirectorySymlink

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6381,9 +6381,11 @@ namespace ts {
         const aParts = getPathComponents(getNormalizedAbsolutePath(a, cwd));
         const bParts = getPathComponents(getNormalizedAbsolutePath(b, cwd));
         let isDirectory = false;
-        while (!isNodeModulesOrScopedPackageDirectory(aParts[aParts.length - 2], getCanonicalFileName) &&
+        while (aParts.length && bParts.length &&
+            !isNodeModulesOrScopedPackageDirectory(aParts[aParts.length - 2], getCanonicalFileName) &&
             !isNodeModulesOrScopedPackageDirectory(bParts[bParts.length - 2], getCanonicalFileName) &&
-            getCanonicalFileName(aParts[aParts.length - 1]) === getCanonicalFileName(bParts[bParts.length - 1])) {
+            getCanonicalFileName(aParts[aParts.length - 1]) === getCanonicalFileName(bParts[bParts.length - 1])
+        ) {
             aParts.pop();
             bParts.pop();
             isDirectory = true;
@@ -6393,8 +6395,8 @@ namespace ts {
 
     // KLUDGE: Don't assume one 'node_modules' links to another. More likely a single directory inside the node_modules is the symlink.
     // ALso, don't assume that an `@foo` directory is linked. More likely the contents of that are linked.
-    function isNodeModulesOrScopedPackageDirectory(s: string, getCanonicalFileName: GetCanonicalFileName): boolean {
-        return getCanonicalFileName(s) === "node_modules" || startsWith(s, "@");
+    function isNodeModulesOrScopedPackageDirectory(s: string | undefined, getCanonicalFileName: GetCanonicalFileName): boolean {
+        return s !== undefined && (getCanonicalFileName(s) === "node_modules" || startsWith(s, "@"));
     }
 
     function stripLeadingDirectorySeparator(s: string): string | undefined {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6381,7 +6381,8 @@ namespace ts {
         const aParts = getPathComponents(getNormalizedAbsolutePath(a, cwd));
         const bParts = getPathComponents(getNormalizedAbsolutePath(b, cwd));
         let isDirectory = false;
-        while (aParts.length && bParts.length &&
+        while (
+            aParts.length >= 2 && bParts.length >= 2 &&
             !isNodeModulesOrScopedPackageDirectory(aParts[aParts.length - 2], getCanonicalFileName) &&
             !isNodeModulesOrScopedPackageDirectory(bParts[bParts.length - 2], getCanonicalFileName) &&
             getCanonicalFileName(aParts[aParts.length - 1]) === getCanonicalFileName(bParts[bParts.length - 1])

--- a/src/testRunner/unittests/tsserver/symlinkCache.ts
+++ b/src/testRunner/unittests/tsserver/symlinkCache.ts
@@ -57,6 +57,11 @@ namespace ts.projectSystem {
                 { real: "/packages/dep/", realPath: "/packages/dep/" as Path }
             );
         });
+
+        it("works for paths close to the root", () => {
+            const cache = createSymlinkCache("/", createGetCanonicalFileName(/*useCaseSensitiveFileNames*/ false));
+            cache.setSymlinkedDirectoryFromSymlinkedFile("/foo", "/one/two/foo"); // Used to crash, #44953
+        });
     });
 
     function setup() {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #44953

I tried for about an hour to reverse engineer a failing test, but I wasn’t getting particularly close. I think some prerequisites of the failure are using project references, `useSourceOfProjectReferenceRedirect` (which I think requires watch/tsserver, not tsc?), and having some symlinks.

At any rate, I think the logical flaw this fixes is pretty obvious on its own and shouldn’t be held up by the fact that it’s only observable under pretty complicated conditions. This is something that would have been written correctly from the beginning, without tests, if written under `--noUncheckedIndexedAccess`.
