### PR TITLE
Minimal fix for auto-importing node_modules in node12/nodenext

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -619,7 +619,7 @@ namespace ts.moduleSpecifiers {
         const nodeModulesDirectoryName = moduleSpecifier.substring(parts.topLevelPackageNameIndex + 1);
         const packageName = getPackageNameFromTypesPackageName(nodeModulesDirectoryName);
         // For classic resolution, only allow importing from node_modules/@types, not other node_modules
-        return getEmitModuleResolutionKind(options) !== ModuleResolutionKind.NodeJs && packageName === nodeModulesDirectoryName ? undefined : packageName;
+        return getEmitModuleResolutionKind(options) === ModuleResolutionKind.Classic && packageName === nodeModulesDirectoryName ? undefined : packageName;
 
         function tryDirectoryWithPackageJson(packageRootIndex: number) {
             const packageRootPath = path.substring(0, packageRootIndex);

--- a/tests/cases/fourslash/autoImport_node12_node_modules1.ts
+++ b/tests/cases/fourslash/autoImport_node12_node_modules1.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+// @module: node12
+
+// @Filename: /node_modules/undici/index.d.ts
+//// export function request(): any;
+
+// @Filename: /index.mts
+//// request/**/
+
+verify.importFixModuleSpecifiers("", ["undici"]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes auto imports in node12/nodenext trying to import from node_modules as a relative path. @weswigham is working on more comprehensive changes to module specifier resolution, but this makes it generally usable in the meantime.
