### PR TITLE
Modify synthetic default generation code for dual-mode module resolution

### DIFF
--- a/tests/baselines/reference/nodeModulesAllowJsSynchronousCallErrors(module=node12).types
+++ b/tests/baselines/reference/nodeModulesAllowJsSynchronousCallErrors(module=node12).types
@@ -23,9 +23,9 @@ export async function f() {
 >"../index.js" : "../index.js"
 
     const mod4 = await import ("./index.js");
->mod4 : typeof mod2
->await import ("./index.js") : typeof mod2
->import ("./index.js") : Promise<typeof mod2>
+>mod4 : { default: typeof mod2; f(): Promise<void>; }
+>await import ("./index.js") : { default: typeof mod2; f(): Promise<void>; }
+>import ("./index.js") : Promise<{ default: typeof mod2; f(): Promise<void>; }>
 >"./index.js" : "./index.js"
 
     h();
@@ -57,9 +57,9 @@ export async function h() {
 >"./index.js" : "./index.js"
 
     const mod4 = await import ("./subfolder/index.js");
->mod4 : typeof mod2
->await import ("./subfolder/index.js") : typeof mod2
->import ("./subfolder/index.js") : Promise<typeof mod2>
+>mod4 : { default: typeof mod2; f(): Promise<void>; }
+>await import ("./subfolder/index.js") : { default: typeof mod2; f(): Promise<void>; }
+>import ("./subfolder/index.js") : Promise<{ default: typeof mod2; f(): Promise<void>; }>
 >"./subfolder/index.js" : "./subfolder/index.js"
 
     f();

--- a/tests/baselines/reference/nodeModulesAllowJsSynchronousCallErrors(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesAllowJsSynchronousCallErrors(module=nodenext).types
@@ -23,9 +23,9 @@ export async function f() {
 >"../index.js" : "../index.js"
 
     const mod4 = await import ("./index.js");
->mod4 : typeof mod2
->await import ("./index.js") : typeof mod2
->import ("./index.js") : Promise<typeof mod2>
+>mod4 : { default: typeof mod2; f(): Promise<void>; }
+>await import ("./index.js") : { default: typeof mod2; f(): Promise<void>; }
+>import ("./index.js") : Promise<{ default: typeof mod2; f(): Promise<void>; }>
 >"./index.js" : "./index.js"
 
     h();
@@ -57,9 +57,9 @@ export async function h() {
 >"./index.js" : "./index.js"
 
     const mod4 = await import ("./subfolder/index.js");
->mod4 : typeof mod2
->await import ("./subfolder/index.js") : typeof mod2
->import ("./subfolder/index.js") : Promise<typeof mod2>
+>mod4 : { default: typeof mod2; f(): Promise<void>; }
+>await import ("./subfolder/index.js") : { default: typeof mod2; f(): Promise<void>; }
+>import ("./subfolder/index.js") : Promise<{ default: typeof mod2; f(): Promise<void>; }>
 >"./subfolder/index.js" : "./subfolder/index.js"
 
     f();

--- a/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=node12).js
+++ b/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=node12).js
@@ -1,0 +1,36 @@
+//// [tests/cases/conformance/node/nodeModulesCjsFormatFileAlwaysHasDefault.ts] ////
+
+//// [index.ts]
+// cjs format file
+export const a = 1;
+//// [index.ts]
+// esm format file
+import mod from "./subfolder/index.js";
+mod;
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module"
+}
+//// [package.json]
+{
+    "type": "commonjs"
+}
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.a = void 0;
+// cjs format file
+exports.a = 1;
+//// [index.js]
+// esm format file
+import mod from "./subfolder/index.js";
+mod;
+
+
+//// [index.d.ts]
+export declare const a = 1;
+//// [index.d.ts]
+export {};

--- a/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=node12).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/node/subfolder/index.ts ===
+// cjs format file
+export const a = 1;
+>a : Symbol(a, Decl(index.ts, 1, 12))
+
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import mod from "./subfolder/index.js";
+>mod : Symbol(mod, Decl(index.ts, 1, 6))
+
+mod;
+>mod : Symbol(mod, Decl(index.ts, 1, 6))
+

--- a/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=node12).types
+++ b/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=node12).types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/node/subfolder/index.ts ===
+// cjs format file
+export const a = 1;
+>a : 1
+>1 : 1
+
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import mod from "./subfolder/index.js";
+>mod : typeof mod
+
+mod;
+>mod : typeof mod
+

--- a/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=nodenext).js
@@ -1,0 +1,36 @@
+//// [tests/cases/conformance/node/nodeModulesCjsFormatFileAlwaysHasDefault.ts] ////
+
+//// [index.ts]
+// cjs format file
+export const a = 1;
+//// [index.ts]
+// esm format file
+import mod from "./subfolder/index.js";
+mod;
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module"
+}
+//// [package.json]
+{
+    "type": "commonjs"
+}
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.a = void 0;
+// cjs format file
+exports.a = 1;
+//// [index.js]
+// esm format file
+import mod from "./subfolder/index.js";
+mod;
+
+
+//// [index.d.ts]
+export declare const a = 1;
+//// [index.d.ts]
+export {};

--- a/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=nodenext).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/node/subfolder/index.ts ===
+// cjs format file
+export const a = 1;
+>a : Symbol(a, Decl(index.ts, 1, 12))
+
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import mod from "./subfolder/index.js";
+>mod : Symbol(mod, Decl(index.ts, 1, 6))
+
+mod;
+>mod : Symbol(mod, Decl(index.ts, 1, 6))
+

--- a/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesCjsFormatFileAlwaysHasDefault(module=nodenext).types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/node/subfolder/index.ts ===
+// cjs format file
+export const a = 1;
+>a : 1
+>1 : 1
+
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import mod from "./subfolder/index.js";
+>mod : typeof mod
+
+mod;
+>mod : typeof mod
+

--- a/tests/baselines/reference/nodeModulesDeclarationEmitDynamicImportWithPackageExports.js
+++ b/tests/baselines/reference/nodeModulesDeclarationEmitDynamicImportWithPackageExports.js
@@ -122,7 +122,9 @@ export {};
 //// [index.d.cts]
 export {};
 //// [other.d.ts]
-export declare const a: typeof import("package/cjs");
+export declare const a: {
+    default: typeof import("package/cjs");
+};
 export declare const b: typeof import("package/mjs");
 export declare const c: typeof import("package");
 export declare const f: {
@@ -134,12 +136,11 @@ export declare const d: {
     default: typeof import("inner/cjs");
     cjsNonmain: true;
 };
-export declare const e: {
-    default: typeof import("inner/mjs");
-    esm: true;
-};
+export declare const e: typeof import("inner/mjs");
 //// [other.d.mts]
-export declare const a: typeof import("package/cjs");
+export declare const a: {
+    default: typeof import("package/cjs");
+};
 export declare const b: typeof import("package/mjs");
 export declare const c: typeof import("package");
 export declare const f: {
@@ -151,12 +152,11 @@ export declare const d: {
     default: typeof import("inner/cjs");
     cjsNonmain: true;
 };
-export declare const e: {
-    default: typeof import("inner/mjs");
-    esm: true;
-};
+export declare const e: typeof import("inner/mjs");
 //// [other.d.cts]
-export declare const a: Promise<typeof import("package/cjs")>;
+export declare const a: Promise<{
+    default: typeof import("package/cjs");
+}>;
 export declare const b: Promise<typeof import("package/mjs")>;
 export declare const c: Promise<typeof import("package")>;
 export declare const f: Promise<{
@@ -168,18 +168,15 @@ export declare const d: Promise<{
     default: typeof import("inner/cjs");
     cjsNonmain: true;
 }>;
-export declare const e: Promise<{
-    default: typeof import("inner/mjs");
-    esm: true;
-}>;
+export declare const e: Promise<typeof import("inner/mjs")>;
 
 
 //// [DtsFileErrors]
 
 
-tests/cases/conformance/node/other.d.cts(2,47): error TS1471: Module 'package/mjs' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
-tests/cases/conformance/node/other.d.cts(3,47): error TS1471: Module 'package' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
-tests/cases/conformance/node/other2.d.cts(6,28): error TS1471: Module 'inner/mjs' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+tests/cases/conformance/node/other.d.cts(4,47): error TS1471: Module 'package/mjs' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+tests/cases/conformance/node/other.d.cts(5,47): error TS1471: Module 'package' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+tests/cases/conformance/node/other2.d.cts(5,47): error TS1471: Module 'inner/mjs' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
 
 
 ==== tests/cases/conformance/node/index.d.ts (0 errors) ====
@@ -192,7 +189,9 @@ tests/cases/conformance/node/other2.d.cts(6,28): error TS1471: Module 'inner/mjs
     export {};
     
 ==== tests/cases/conformance/node/other.d.ts (0 errors) ====
-    export declare const a: typeof import("package/cjs");
+    export declare const a: {
+        default: typeof import("package/cjs");
+    };
     export declare const b: typeof import("package/mjs");
     export declare const c: typeof import("package");
     export declare const f: {
@@ -205,13 +204,12 @@ tests/cases/conformance/node/other2.d.cts(6,28): error TS1471: Module 'inner/mjs
         default: typeof import("inner/cjs");
         cjsNonmain: true;
     };
-    export declare const e: {
-        default: typeof import("inner/mjs");
-        esm: true;
-    };
+    export declare const e: typeof import("inner/mjs");
     
 ==== tests/cases/conformance/node/other.d.mts (0 errors) ====
-    export declare const a: typeof import("package/cjs");
+    export declare const a: {
+        default: typeof import("package/cjs");
+    };
     export declare const b: typeof import("package/mjs");
     export declare const c: typeof import("package");
     export declare const f: {
@@ -224,13 +222,12 @@ tests/cases/conformance/node/other2.d.cts(6,28): error TS1471: Module 'inner/mjs
         default: typeof import("inner/cjs");
         cjsNonmain: true;
     };
-    export declare const e: {
-        default: typeof import("inner/mjs");
-        esm: true;
-    };
+    export declare const e: typeof import("inner/mjs");
     
 ==== tests/cases/conformance/node/other.d.cts (2 errors) ====
-    export declare const a: Promise<typeof import("package/cjs")>;
+    export declare const a: Promise<{
+        default: typeof import("package/cjs");
+    }>;
     export declare const b: Promise<typeof import("package/mjs")>;
                                                   ~~~~~~~~~~~~~
 !!! error TS1471: Module 'package/mjs' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
@@ -247,12 +244,9 @@ tests/cases/conformance/node/other2.d.cts(6,28): error TS1471: Module 'inner/mjs
         default: typeof import("inner/cjs");
         cjsNonmain: true;
     }>;
-    export declare const e: Promise<{
-        default: typeof import("inner/mjs");
-                               ~~~~~~~~~~~
+    export declare const e: Promise<typeof import("inner/mjs")>;
+                                                  ~~~~~~~~~~~
 !!! error TS1471: Module 'inner/mjs' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
-        esm: true;
-    }>;
     
 ==== tests/cases/conformance/node/node_modules/inner/index.d.ts (0 errors) ====
     // cjs format file

--- a/tests/baselines/reference/nodeModulesDeclarationEmitDynamicImportWithPackageExports.types
+++ b/tests/baselines/reference/nodeModulesDeclarationEmitDynamicImportWithPackageExports.types
@@ -10,9 +10,9 @@ No type information for this code.export {};
 No type information for this code.=== tests/cases/conformance/node/other.ts ===
 // esm format file
 export const a = await import("package/cjs");
->a : typeof import("tests/cases/conformance/node/index")
->await import("package/cjs") : typeof import("tests/cases/conformance/node/index")
->import("package/cjs") : Promise<typeof import("tests/cases/conformance/node/index")>
+>a : { default: typeof import("tests/cases/conformance/node/index"); }
+>await import("package/cjs") : { default: typeof import("tests/cases/conformance/node/index"); }
+>import("package/cjs") : Promise<{ default: typeof import("tests/cases/conformance/node/index"); }>
 >"package/cjs" : "package/cjs"
 
 export const b = await import("package/mjs");
@@ -42,17 +42,17 @@ export const d = await import("inner/cjs");
 >"inner/cjs" : "inner/cjs"
 
 export const e = await import("inner/mjs");
->e : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); esm: true; }
->await import("inner/mjs") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); esm: true; }
->import("inner/mjs") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); esm: true; }>
+>e : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>await import("inner/mjs") : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>import("inner/mjs") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
 >"inner/mjs" : "inner/mjs"
 
 === tests/cases/conformance/node/other.mts ===
 // esm format file
 export const a = await import("package/cjs");
->a : typeof import("tests/cases/conformance/node/index")
->await import("package/cjs") : typeof import("tests/cases/conformance/node/index")
->import("package/cjs") : Promise<typeof import("tests/cases/conformance/node/index")>
+>a : { default: typeof import("tests/cases/conformance/node/index"); }
+>await import("package/cjs") : { default: typeof import("tests/cases/conformance/node/index"); }
+>import("package/cjs") : Promise<{ default: typeof import("tests/cases/conformance/node/index"); }>
 >"package/cjs" : "package/cjs"
 
 export const b = await import("package/mjs");
@@ -82,16 +82,16 @@ export const d = await import("inner/cjs");
 >"inner/cjs" : "inner/cjs"
 
 export const e = await import("inner/mjs");
->e : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); esm: true; }
->await import("inner/mjs") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); esm: true; }
->import("inner/mjs") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); esm: true; }>
+>e : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>await import("inner/mjs") : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>import("inner/mjs") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
 >"inner/mjs" : "inner/mjs"
 
 === tests/cases/conformance/node/other.cts ===
 // cjs format file, no TLA
 export const a = import("package/cjs");
->a : Promise<typeof import("tests/cases/conformance/node/index")>
->import("package/cjs") : Promise<typeof import("tests/cases/conformance/node/index")>
+>a : Promise<{ default: typeof import("tests/cases/conformance/node/index"); }>
+>import("package/cjs") : Promise<{ default: typeof import("tests/cases/conformance/node/index"); }>
 >"package/cjs" : "package/cjs"
 
 export const b = import("package/mjs");
@@ -117,8 +117,8 @@ export const d = import("inner/cjs");
 >"inner/cjs" : "inner/cjs"
 
 export const e = import("inner/mjs");
->e : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); esm: true; }>
->import("inner/mjs") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); esm: true; }>
+>e : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
+>import("inner/mjs") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
 >"inner/mjs" : "inner/mjs"
 
 === tests/cases/conformance/node/node_modules/inner/index.d.ts ===

--- a/tests/baselines/reference/nodeModulesSynchronousCallErrors(module=node12).types
+++ b/tests/baselines/reference/nodeModulesSynchronousCallErrors(module=node12).types
@@ -23,9 +23,9 @@ export async function f() {
 >"../index.js" : "../index.js"
 
     const mod4 = await import ("./index.js");
->mod4 : typeof mod2
->await import ("./index.js") : typeof mod2
->import ("./index.js") : Promise<typeof mod2>
+>mod4 : { default: typeof mod2; f(): Promise<void>; }
+>await import ("./index.js") : { default: typeof mod2; f(): Promise<void>; }
+>import ("./index.js") : Promise<{ default: typeof mod2; f(): Promise<void>; }>
 >"./index.js" : "./index.js"
 
     h();
@@ -57,9 +57,9 @@ export async function h() {
 >"./index.js" : "./index.js"
 
     const mod4 = await import ("./subfolder/index.js");
->mod4 : typeof mod2
->await import ("./subfolder/index.js") : typeof mod2
->import ("./subfolder/index.js") : Promise<typeof mod2>
+>mod4 : { default: typeof mod2; f(): Promise<void>; }
+>await import ("./subfolder/index.js") : { default: typeof mod2; f(): Promise<void>; }
+>import ("./subfolder/index.js") : Promise<{ default: typeof mod2; f(): Promise<void>; }>
 >"./subfolder/index.js" : "./subfolder/index.js"
 
     f();

--- a/tests/baselines/reference/nodeModulesSynchronousCallErrors(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesSynchronousCallErrors(module=nodenext).types
@@ -23,9 +23,9 @@ export async function f() {
 >"../index.js" : "../index.js"
 
     const mod4 = await import ("./index.js");
->mod4 : typeof mod2
->await import ("./index.js") : typeof mod2
->import ("./index.js") : Promise<typeof mod2>
+>mod4 : { default: typeof mod2; f(): Promise<void>; }
+>await import ("./index.js") : { default: typeof mod2; f(): Promise<void>; }
+>import ("./index.js") : Promise<{ default: typeof mod2; f(): Promise<void>; }>
 >"./index.js" : "./index.js"
 
     h();
@@ -57,9 +57,9 @@ export async function h() {
 >"./index.js" : "./index.js"
 
     const mod4 = await import ("./subfolder/index.js");
->mod4 : typeof mod2
->await import ("./subfolder/index.js") : typeof mod2
->import ("./subfolder/index.js") : Promise<typeof mod2>
+>mod4 : { default: typeof mod2; f(): Promise<void>; }
+>await import ("./subfolder/index.js") : { default: typeof mod2; f(): Promise<void>; }
+>import ("./subfolder/index.js") : Promise<{ default: typeof mod2; f(): Promise<void>; }>
 >"./subfolder/index.js" : "./subfolder/index.js"
 
     f();

--- a/tests/cases/conformance/node/nodeModulesCjsFormatFileAlwaysHasDefault.ts
+++ b/tests/cases/conformance/node/nodeModulesCjsFormatFileAlwaysHasDefault.ts
@@ -1,0 +1,19 @@
+// @module: node12,nodenext
+// @declaration: true
+// @filename: subfolder/index.ts
+// cjs format file
+export const a = 1;
+// @filename: index.ts
+// esm format file
+import mod from "./subfolder/index.js";
+mod;
+// @filename: package.json
+{
+    "name": "package",
+    "private": true,
+    "type": "module"
+}
+// @filename: subfolder/package.json
+{
+    "type": "commonjs"
+}


### PR DESCRIPTION
`module: node12` was relying on our existing `esModuleInterop` logic for determining if modules should have a synthetic `default` member equivalent to the module shape - this is correct for a cjs format import of another cjs file, however should be wholly disabled for esm/esm imports, and is overcomplicated for esm/cjs imports (which simply always have a synthetic default, no heuristics needed). In this PR, I add the missing logic to our synthetic default selection code to handle these new modal imports.