### PR TITLE
improve response time of invalid rename attempts

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1537,6 +1537,11 @@ namespace ts.server {
             const position = this.getPositionInFile(args, file);
             const projects = this.getProjects(args);
 
+            const renameInfo = this.mapRenameInfo(
+                this.getRenameInfo(args), Debug.checkDefined(this.projectService.getScriptInfo(file)));
+
+            if (!renameInfo.canRename) return { info: renameInfo, locs: [] };
+
             const locations = combineProjectOutputForRenameLocations(
                 projects,
                 this.getDefaultProject(args),
@@ -1546,9 +1551,6 @@ namespace ts.server {
                 this.getPreferences(file)
             );
             if (!simplifiedResult) return locations;
-
-            const defaultProject = this.getDefaultProject(args);
-            const renameInfo: protocol.RenameInfo = this.mapRenameInfo(defaultProject.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: this.getPreferences(file).allowRenameOfImportPath }), Debug.checkDefined(this.projectService.getScriptInfo(file)));
             return { info: renameInfo, locs: this.toSpanGroups(locations) };
         }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1536,15 +1536,15 @@ namespace ts.server {
             const file = toNormalizedPath(args.file);
             const position = this.getPositionInFile(args, file);
             const projects = this.getProjects(args);
+            const defaultProject = this.getDefaultProject(args);
+            const renameInfo: protocol.RenameInfo = this.mapRenameInfo(
+                defaultProject.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: this.getPreferences(file).allowRenameOfImportPath }), Debug.checkDefined(this.projectService.getScriptInfo(file)));
 
-            const renameInfo = this.mapRenameInfo(
-                this.getRenameInfo(args), Debug.checkDefined(this.projectService.getScriptInfo(file)));
-
-            if (!renameInfo.canRename) return { info: renameInfo, locs: [] };
+            if (!renameInfo.canRename) return simplifiedResult ? { info: renameInfo, locs: [] } : [];
 
             const locations = combineProjectOutputForRenameLocations(
                 projects,
-                this.getDefaultProject(args),
+                defaultProject,
                 { fileName: args.file, pos: position },
                 !!args.findInStrings,
                 !!args.findInComments,

--- a/src/services/rename.ts
+++ b/src/services/rename.ts
@@ -111,7 +111,7 @@ namespace ts.Rename {
         return createTextSpan(start, width);
     }
 
-    function nodeIsEligibleForRename(node: Node): boolean {
+    export function nodeIsEligibleForRename(node: Node): boolean {
         switch (node.kind) {
             case SyntaxKind.Identifier:
             case SyntaxKind.PrivateIdentifier:

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1750,6 +1750,7 @@ namespace ts {
             synchronizeHostData();
             const sourceFile = getValidSourceFile(fileName);
             const node = getAdjustedRenameLocation(getTouchingPropertyName(sourceFile, position));
+            if (!Rename.nodeIsEligibleForRename(node)) return undefined;
             if (isIdentifier(node) && (isJsxOpeningElement(node.parent) || isJsxClosingElement(node.parent)) && isIntrinsicJsxName(node.escapedText)) {
                 const { openingElement, closingElement } = node.parent.parent;
                 return [openingElement, closingElement].map((node): RenameLocation => {

--- a/src/testRunner/unittests/tsserver/rename.ts
+++ b/src/testRunner/unittests/tsserver/rename.ts
@@ -14,16 +14,7 @@ namespace ts.projectSystem {
                     canRename: false,
                     localizedErrorMessage: "You cannot rename this element."
                 },
-                locs: [{
-                    file: bTs.path,
-                    locs: [
-                        protocolRenameSpanFromSubstring({
-                            fileText: bTs.content,
-                            text: "./a",
-                            contextText: bTs.content
-                        })
-                    ]
-                }],
+                locs: [],
             });
 
             // rename succeeds with allowRenameOfImportPath enabled in host


### PR DESCRIPTION
Fixes #45942 

it seems work is done computing `RenameLocation[]` we're not going to use, as the rename attempt response body log includes:  
```typescript
{
   "info":{
      "canRename":false,
      "locs":[ // many !nodeIsEligibleForRename items here]
   }
}
```
 
on my machine returning an empty `locs` makes the response time fast and pretty constant, about `3ms` compared to a few seconds. (in large projects)

<details>
<summary>TS repo, 3 runs each</summary>

before:
`6359.3685ms`
`2650.6442ms`
`8156.8394ms`

after:
`2.8690ms`
`0.3090ms`
`0.3085ms`
</details>

i've inlined some questions on the changes i did as i'm not sure about some stuff. 