### PR TITLE
Follow and respect export maps when generating module specifiers

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1708,7 +1708,8 @@ namespace ts {
         return idx === -1 ? { packageName: moduleName, rest: "" } : { packageName: moduleName.slice(0, idx), rest: moduleName.slice(idx + 1) };
     }
 
-    function allKeysStartWithDot(obj: MapLike<unknown>) {
+    /* @internal */
+    export function allKeysStartWithDot(obj: MapLike<unknown>) {
         return every(getOwnKeys(obj), k => startsWith(k, "."));
     }
 
@@ -1922,14 +1923,15 @@ namespace ts {
             }
             return toSearchResult(/*value*/ undefined);
         }
+    }
 
-        function isApplicableVersionedTypesKey(conditions: string[], key: string) {
-            if (conditions.indexOf("types") === -1) return false; // only apply versioned types conditions if the types condition is applied
-            if (!startsWith(key, "types@")) return false;
-            const range = VersionRange.tryParse(key.substring("types@".length));
-            if (!range) return false;
-            return range.test(version);
-        }
+    /* @internal */
+    export function isApplicableVersionedTypesKey(conditions: string[], key: string) {
+        if (conditions.indexOf("types") === -1) return false; // only apply versioned types conditions if the types condition is applied
+        if (!startsWith(key, "types@")) return false;
+        const range = VersionRange.tryParse(key.substring("types@".length));
+        if (!range) return false;
+        return range.test(version);
     }
 
     function loadModuleFromNearestNodeModulesDirectory(extensions: Extensions, moduleName: string, directory: string, state: ModuleResolutionState, cache: ModuleResolutionCache | undefined, redirectedReference: ResolvedProjectReference | undefined): SearchResult<Resolved> {

--- a/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=node12).errors.txt
+++ b/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=node12).errors.txt
@@ -1,0 +1,36 @@
+tests/cases/conformance/node/index.ts(2,23): error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(3,14): error TS2742: The inferred type of 'a' cannot be named without a reference to './node_modules/inner/other.js'. This is likely not portable. A type annotation is necessary.
+tests/cases/conformance/node/index.ts(3,19): error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', or 'nodenext', and the 'target' option is set to 'es2017' or higher.
+
+
+==== tests/cases/conformance/node/index.ts (3 errors) ====
+    // esm format file
+    import { Thing } from "inner/other";
+                          ~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+    export const a = (await import("inner")).x();
+                 ~
+!!! error TS2742: The inferred type of 'a' cannot be named without a reference to './node_modules/inner/other.js'. This is likely not portable. A type annotation is necessary.
+                      ~~~~~
+!!! error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', or 'nodenext', and the 'target' option is set to 'es2017' or higher.
+==== tests/cases/conformance/node/node_modules/inner/index.d.ts (0 errors) ====
+    // esm format file
+    export { x } from "./other.js";
+==== tests/cases/conformance/node/node_modules/inner/other.d.ts (0 errors) ====
+    // esm format file
+    export interface Thing {}
+    export const x: () => Thing;
+==== tests/cases/conformance/node/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module",
+        "exports": "./index.js"
+    }
+==== tests/cases/conformance/node/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "type": "module",
+        "exports": "./index.js"
+    }

--- a/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=node12).js
+++ b/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=node12).js
@@ -1,0 +1,30 @@
+//// [tests/cases/conformance/node/nodeModulesExportsBlocksSpecifierResolution.ts] ////
+
+//// [index.ts]
+// esm format file
+import { Thing } from "inner/other";
+export const a = (await import("inner")).x();
+//// [index.d.ts]
+// esm format file
+export { x } from "./other.js";
+//// [other.d.ts]
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+
+//// [index.js]
+export const a = (await import("inner")).x();

--- a/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=node12).symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : Symbol(Thing, Decl(index.ts, 1, 8))
+
+export const a = (await import("inner")).x();
+>a : Symbol(a, Decl(index.ts, 2, 12))
+>(await import("inner")).x : Symbol(x, Decl(index.d.ts, 1, 8))
+>"inner" : Symbol("tests/cases/conformance/node/node_modules/inner/index", Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+
+export const x: () => Thing;
+>x : Symbol(x, Decl(other.d.ts, 2, 12))
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+

--- a/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=node12).types
+++ b/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=node12).types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : any
+
+export const a = (await import("inner")).x();
+>a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>await import("inner") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>import("inner") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>"inner" : "inner"
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+>x : () => Thing
+

--- a/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=node12).types
+++ b/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=node12).types
@@ -7,9 +7,9 @@ export const a = (await import("inner")).x();
 >a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
->(await import("inner")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->await import("inner") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->import("inner") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>(await import("inner")) : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>await import("inner") : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>import("inner") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
 >"inner" : "inner"
 >x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
 

--- a/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).errors.txt
@@ -1,0 +1,33 @@
+tests/cases/conformance/node/index.ts(2,23): error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(3,14): error TS2742: The inferred type of 'a' cannot be named without a reference to './node_modules/inner/other.js'. This is likely not portable. A type annotation is necessary.
+
+
+==== tests/cases/conformance/node/index.ts (2 errors) ====
+    // esm format file
+    import { Thing } from "inner/other";
+                          ~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+    export const a = (await import("inner")).x();
+                 ~
+!!! error TS2742: The inferred type of 'a' cannot be named without a reference to './node_modules/inner/other.js'. This is likely not portable. A type annotation is necessary.
+==== tests/cases/conformance/node/node_modules/inner/index.d.ts (0 errors) ====
+    // esm format file
+    export { x } from "./other.js";
+==== tests/cases/conformance/node/node_modules/inner/other.d.ts (0 errors) ====
+    // esm format file
+    export interface Thing {}
+    export const x: () => Thing;
+==== tests/cases/conformance/node/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module",
+        "exports": "./index.js"
+    }
+==== tests/cases/conformance/node/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "type": "module",
+        "exports": "./index.js"
+    }

--- a/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).js
@@ -1,0 +1,30 @@
+//// [tests/cases/conformance/node/nodeModulesExportsBlocksSpecifierResolution.ts] ////
+
+//// [index.ts]
+// esm format file
+import { Thing } from "inner/other";
+export const a = (await import("inner")).x();
+//// [index.d.ts]
+// esm format file
+export { x } from "./other.js";
+//// [other.d.ts]
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+
+//// [index.js]
+export const a = (await import("inner")).x();

--- a/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : Symbol(Thing, Decl(index.ts, 1, 8))
+
+export const a = (await import("inner")).x();
+>a : Symbol(a, Decl(index.ts, 2, 12))
+>(await import("inner")).x : Symbol(x, Decl(index.d.ts, 1, 8))
+>"inner" : Symbol("tests/cases/conformance/node/node_modules/inner/index", Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+
+export const x: () => Thing;
+>x : Symbol(x, Decl(other.d.ts, 2, 12))
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+

--- a/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : any
+
+export const a = (await import("inner")).x();
+>a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>await import("inner") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>import("inner") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>"inner" : "inner"
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+>x : () => Thing
+

--- a/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).types
@@ -7,9 +7,9 @@ export const a = (await import("inner")).x();
 >a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
->(await import("inner")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->await import("inner") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->import("inner") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>(await import("inner")) : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>await import("inner") : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>import("inner") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
 >"inner" : "inner"
 >x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
 

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=node12).errors.txt
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=node12).errors.txt
@@ -1,0 +1,40 @@
+tests/cases/conformance/node/index.ts(2,23): error TS2307: Cannot find module 'inner/other.js' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(3,19): error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', or 'nodenext', and the 'target' option is set to 'es2017' or higher.
+
+
+==== tests/cases/conformance/node/index.ts (2 errors) ====
+    // esm format file
+    import { Thing } from "inner/other.js"; // should fail
+                          ~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/other.js' or its corresponding type declarations.
+    export const a = (await import("inner")).x();
+                      ~~~~~
+!!! error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', or 'nodenext', and the 'target' option is set to 'es2017' or higher.
+==== tests/cases/conformance/node/node_modules/inner/index.d.ts (0 errors) ====
+    // esm format file
+    export { x } from "./other.js";
+==== tests/cases/conformance/node/node_modules/inner/other.d.ts (0 errors) ====
+    // esm format file
+    export interface Thing {}
+    export const x: () => Thing;
+==== tests/cases/conformance/node/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module",
+        "exports": "./index.js"
+    }
+==== tests/cases/conformance/node/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "type": "module",
+        "exports": {
+            ".": {
+                "default": "./index.js"
+            },
+            "./other": {
+                "default": "./other.js"
+            }
+        }
+    }

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=node12).js
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=node12).js
@@ -1,0 +1,41 @@
+//// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationConditions.ts] ////
+
+//// [index.ts]
+// esm format file
+import { Thing } from "inner/other.js"; // should fail
+export const a = (await import("inner")).x();
+//// [index.d.ts]
+// esm format file
+export { x } from "./other.js";
+//// [other.d.ts]
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        ".": {
+            "default": "./index.js"
+        },
+        "./other": {
+            "default": "./other.js"
+        }
+    }
+}
+
+//// [index.js]
+export const a = (await import("inner")).x();
+
+
+//// [index.d.ts]
+export declare const a: import("inner/other").Thing;

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=node12).symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other.js"; // should fail
+>Thing : Symbol(Thing, Decl(index.ts, 1, 8))
+
+export const a = (await import("inner")).x();
+>a : Symbol(a, Decl(index.ts, 2, 12))
+>(await import("inner")).x : Symbol(x, Decl(index.d.ts, 1, 8))
+>"inner" : Symbol("tests/cases/conformance/node/node_modules/inner/index", Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+
+export const x: () => Thing;
+>x : Symbol(x, Decl(other.d.ts, 2, 12))
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=node12).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=node12).types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other.js"; // should fail
+>Thing : any
+
+export const a = (await import("inner")).x();
+>a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>await import("inner") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>import("inner") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>"inner" : "inner"
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+>x : () => Thing
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=node12).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=node12).types
@@ -7,9 +7,9 @@ export const a = (await import("inner")).x();
 >a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
->(await import("inner")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->await import("inner") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->import("inner") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>(await import("inner")) : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>await import("inner") : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>import("inner") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
 >"inner" : "inner"
 >x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
 

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).errors.txt
@@ -1,0 +1,37 @@
+tests/cases/conformance/node/index.ts(2,23): error TS2307: Cannot find module 'inner/other.js' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/node/index.ts (1 errors) ====
+    // esm format file
+    import { Thing } from "inner/other.js"; // should fail
+                          ~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/other.js' or its corresponding type declarations.
+    export const a = (await import("inner")).x();
+==== tests/cases/conformance/node/node_modules/inner/index.d.ts (0 errors) ====
+    // esm format file
+    export { x } from "./other.js";
+==== tests/cases/conformance/node/node_modules/inner/other.d.ts (0 errors) ====
+    // esm format file
+    export interface Thing {}
+    export const x: () => Thing;
+==== tests/cases/conformance/node/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module",
+        "exports": "./index.js"
+    }
+==== tests/cases/conformance/node/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "type": "module",
+        "exports": {
+            ".": {
+                "default": "./index.js"
+            },
+            "./other": {
+                "default": "./other.js"
+            }
+        }
+    }

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).js
@@ -1,0 +1,41 @@
+//// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationConditions.ts] ////
+
+//// [index.ts]
+// esm format file
+import { Thing } from "inner/other.js"; // should fail
+export const a = (await import("inner")).x();
+//// [index.d.ts]
+// esm format file
+export { x } from "./other.js";
+//// [other.d.ts]
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        ".": {
+            "default": "./index.js"
+        },
+        "./other": {
+            "default": "./other.js"
+        }
+    }
+}
+
+//// [index.js]
+export const a = (await import("inner")).x();
+
+
+//// [index.d.ts]
+export declare const a: import("inner/other").Thing;

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other.js"; // should fail
+>Thing : Symbol(Thing, Decl(index.ts, 1, 8))
+
+export const a = (await import("inner")).x();
+>a : Symbol(a, Decl(index.ts, 2, 12))
+>(await import("inner")).x : Symbol(x, Decl(index.d.ts, 1, 8))
+>"inner" : Symbol("tests/cases/conformance/node/node_modules/inner/index", Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+
+export const x: () => Thing;
+>x : Symbol(x, Decl(other.d.ts, 2, 12))
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other.js"; // should fail
+>Thing : any
+
+export const a = (await import("inner")).x();
+>a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>await import("inner") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>import("inner") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>"inner" : "inner"
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+>x : () => Thing
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).types
@@ -7,9 +7,9 @@ export const a = (await import("inner")).x();
 >a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
->(await import("inner")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->await import("inner") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->import("inner") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>(await import("inner")) : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>await import("inner") : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>import("inner") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
 >"inner" : "inner"
 >x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
 

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=node12).errors.txt
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=node12).errors.txt
@@ -1,0 +1,35 @@
+tests/cases/conformance/node/index.ts(2,23): error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(3,19): error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', or 'nodenext', and the 'target' option is set to 'es2017' or higher.
+
+
+==== tests/cases/conformance/node/index.ts (2 errors) ====
+    // esm format file
+    import { Thing } from "inner/other";
+                          ~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+    export const a = (await import("inner/index.js")).x();
+                      ~~~~~
+!!! error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', or 'nodenext', and the 'target' option is set to 'es2017' or higher.
+==== tests/cases/conformance/node/node_modules/inner/index.d.ts (0 errors) ====
+    // esm format file
+    export { x } from "./other.js";
+==== tests/cases/conformance/node/node_modules/inner/other.d.ts (0 errors) ====
+    // esm format file
+    export interface Thing {}
+    export const x: () => Thing;
+==== tests/cases/conformance/node/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module",
+        "exports": "./index.js"
+    }
+==== tests/cases/conformance/node/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "type": "module",
+        "exports": {
+            "./": "./"
+        }
+    }

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=node12).js
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=node12).js
@@ -1,0 +1,36 @@
+//// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationDirectory.ts] ////
+
+//// [index.ts]
+// esm format file
+import { Thing } from "inner/other";
+export const a = (await import("inner/index.js")).x();
+//// [index.d.ts]
+// esm format file
+export { x } from "./other.js";
+//// [other.d.ts]
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        "./": "./"
+    }
+}
+
+//// [index.js]
+export const a = (await import("inner/index.js")).x();
+
+
+//// [index.d.ts]
+export declare const a: import("inner/other.js").Thing;

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=node12).symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : Symbol(Thing, Decl(index.ts, 1, 8))
+
+export const a = (await import("inner/index.js")).x();
+>a : Symbol(a, Decl(index.ts, 2, 12))
+>(await import("inner/index.js")).x : Symbol(x, Decl(index.d.ts, 1, 8))
+>"inner/index.js" : Symbol("tests/cases/conformance/node/node_modules/inner/index", Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+
+export const x: () => Thing;
+>x : Symbol(x, Decl(other.d.ts, 2, 12))
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=node12).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=node12).types
@@ -7,9 +7,9 @@ export const a = (await import("inner/index.js")).x();
 >a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner/index.js")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner/index.js")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
->(await import("inner/index.js")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->await import("inner/index.js") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->import("inner/index.js") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>(await import("inner/index.js")) : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>await import("inner/index.js") : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>import("inner/index.js") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
 >"inner/index.js" : "inner/index.js"
 >x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
 

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=node12).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=node12).types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : any
+
+export const a = (await import("inner/index.js")).x();
+>a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner/index.js")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner/index.js")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner/index.js")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>await import("inner/index.js") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>import("inner/index.js") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>"inner/index.js" : "inner/index.js"
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+>x : () => Thing
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).errors.txt
@@ -1,0 +1,32 @@
+tests/cases/conformance/node/index.ts(2,23): error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/node/index.ts (1 errors) ====
+    // esm format file
+    import { Thing } from "inner/other";
+                          ~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+    export const a = (await import("inner/index.js")).x();
+==== tests/cases/conformance/node/node_modules/inner/index.d.ts (0 errors) ====
+    // esm format file
+    export { x } from "./other.js";
+==== tests/cases/conformance/node/node_modules/inner/other.d.ts (0 errors) ====
+    // esm format file
+    export interface Thing {}
+    export const x: () => Thing;
+==== tests/cases/conformance/node/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module",
+        "exports": "./index.js"
+    }
+==== tests/cases/conformance/node/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "type": "module",
+        "exports": {
+            "./": "./"
+        }
+    }

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).js
@@ -1,0 +1,36 @@
+//// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationDirectory.ts] ////
+
+//// [index.ts]
+// esm format file
+import { Thing } from "inner/other";
+export const a = (await import("inner/index.js")).x();
+//// [index.d.ts]
+// esm format file
+export { x } from "./other.js";
+//// [other.d.ts]
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        "./": "./"
+    }
+}
+
+//// [index.js]
+export const a = (await import("inner/index.js")).x();
+
+
+//// [index.d.ts]
+export declare const a: import("inner/other.js").Thing;

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : Symbol(Thing, Decl(index.ts, 1, 8))
+
+export const a = (await import("inner/index.js")).x();
+>a : Symbol(a, Decl(index.ts, 2, 12))
+>(await import("inner/index.js")).x : Symbol(x, Decl(index.d.ts, 1, 8))
+>"inner/index.js" : Symbol("tests/cases/conformance/node/node_modules/inner/index", Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+
+export const x: () => Thing;
+>x : Symbol(x, Decl(other.d.ts, 2, 12))
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).types
@@ -7,9 +7,9 @@ export const a = (await import("inner/index.js")).x();
 >a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner/index.js")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner/index.js")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
->(await import("inner/index.js")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->await import("inner/index.js") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->import("inner/index.js") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>(await import("inner/index.js")) : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>await import("inner/index.js") : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>import("inner/index.js") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
 >"inner/index.js" : "inner/index.js"
 >x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
 

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : any
+
+export const a = (await import("inner/index.js")).x();
+>a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner/index.js")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner/index.js")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner/index.js")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>await import("inner/index.js") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>import("inner/index.js") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>"inner/index.js" : "inner/index.js"
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+>x : () => Thing
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=node12).errors.txt
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=node12).errors.txt
@@ -1,0 +1,38 @@
+tests/cases/conformance/node/index.ts(2,23): error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(3,19): error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', or 'nodenext', and the 'target' option is set to 'es2017' or higher.
+tests/cases/conformance/node/index.ts(3,32): error TS2307: Cannot find module 'inner/index.js' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/node/index.ts (3 errors) ====
+    // esm format file
+    import { Thing } from "inner/other";
+                          ~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+    export const a = (await import("inner/index.js")).x();
+                      ~~~~~
+!!! error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', or 'nodenext', and the 'target' option is set to 'es2017' or higher.
+                                   ~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/index.js' or its corresponding type declarations.
+==== tests/cases/conformance/node/node_modules/inner/index.d.ts (0 errors) ====
+    // esm format file
+    export { x } from "./other.js";
+==== tests/cases/conformance/node/node_modules/inner/other.d.ts (0 errors) ====
+    // esm format file
+    export interface Thing {}
+    export const x: () => Thing;
+==== tests/cases/conformance/node/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module",
+        "exports": "./index.js"
+    }
+==== tests/cases/conformance/node/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "type": "module",
+        "exports": {
+            "./*.js": "./*.js"
+        }
+    }

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=node12).js
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=node12).js
@@ -1,0 +1,36 @@
+//// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationPattern.ts] ////
+
+//// [index.ts]
+// esm format file
+import { Thing } from "inner/other";
+export const a = (await import("inner/index.js")).x();
+//// [index.d.ts]
+// esm format file
+export { x } from "./other.js";
+//// [other.d.ts]
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        "./*.js": "./*.js"
+    }
+}
+
+//// [index.js]
+export const a = (await import("inner/index.js")).x();
+
+
+//// [index.d.ts]
+export declare const a: any;

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=node12).symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : Symbol(Thing, Decl(index.ts, 1, 8))
+
+export const a = (await import("inner/index.js")).x();
+>a : Symbol(a, Decl(index.ts, 2, 12))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+
+export const x: () => Thing;
+>x : Symbol(x, Decl(other.d.ts, 2, 12))
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=node12).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=node12).types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : any
+
+export const a = (await import("inner/index.js")).x();
+>a : any
+>(await import("inner/index.js")).x() : any
+>(await import("inner/index.js")).x : any
+>(await import("inner/index.js")) : any
+>await import("inner/index.js") : any
+>import("inner/index.js") : Promise<any>
+>"inner/index.js" : "inner/index.js"
+>x : any
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+>x : () => Thing
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).errors.txt
@@ -1,0 +1,32 @@
+tests/cases/conformance/node/index.ts(2,23): error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/node/index.ts (1 errors) ====
+    // esm format file
+    import { Thing } from "inner/other";
+                          ~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/other' or its corresponding type declarations.
+    export const a = (await import("inner/index.js")).x();
+==== tests/cases/conformance/node/node_modules/inner/index.d.ts (0 errors) ====
+    // esm format file
+    export { x } from "./other.js";
+==== tests/cases/conformance/node/node_modules/inner/other.d.ts (0 errors) ====
+    // esm format file
+    export interface Thing {}
+    export const x: () => Thing;
+==== tests/cases/conformance/node/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module",
+        "exports": "./index.js"
+    }
+==== tests/cases/conformance/node/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "type": "module",
+        "exports": {
+            "./*.js": "./*.js"
+        }
+    }

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).js
@@ -1,0 +1,36 @@
+//// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationPattern.ts] ////
+
+//// [index.ts]
+// esm format file
+import { Thing } from "inner/other";
+export const a = (await import("inner/index.js")).x();
+//// [index.d.ts]
+// esm format file
+export { x } from "./other.js";
+//// [other.d.ts]
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        "./*.js": "./*.js"
+    }
+}
+
+//// [index.js]
+export const a = (await import("inner/index.js")).x();
+
+
+//// [index.d.ts]
+export declare const a: import("inner/other.js").Thing;

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : Symbol(Thing, Decl(index.ts, 1, 8))
+
+export const a = (await import("inner/index.js")).x();
+>a : Symbol(a, Decl(index.ts, 2, 12))
+>(await import("inner/index.js")).x : Symbol(x, Decl(index.d.ts, 1, 8))
+>"inner/index.js" : Symbol("tests/cases/conformance/node/node_modules/inner/index", Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : Symbol(x, Decl(index.d.ts, 1, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+
+export const x: () => Thing;
+>x : Symbol(x, Decl(other.d.ts, 2, 12))
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 0))
+

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).types
@@ -7,9 +7,9 @@ export const a = (await import("inner/index.js")).x();
 >a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner/index.js")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
 >(await import("inner/index.js")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
->(await import("inner/index.js")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->await import("inner/index.js") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
->import("inner/index.js") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>(await import("inner/index.js")) : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>await import("inner/index.js") : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>import("inner/index.js") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
 >"inner/index.js" : "inner/index.js"
 >x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
 

--- a/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import { Thing } from "inner/other";
+>Thing : any
+
+export const a = (await import("inner/index.js")).x();
+>a : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner/index.js")).x() : import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner/index.js")).x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+>(await import("inner/index.js")) : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>await import("inner/index.js") : { default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }
+>import("inner/index.js") : Promise<{ default: typeof import("tests/cases/conformance/node/node_modules/inner/index"); x: () => import("tests/cases/conformance/node/node_modules/inner/other").Thing; }>
+>"inner/index.js" : "inner/index.js"
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// esm format file
+export { x } from "./other.js";
+>x : () => import("tests/cases/conformance/node/node_modules/inner/other").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+>x : () => Thing
+

--- a/tests/baselines/reference/tsbuild/moduleSpecifiers/initial-build/synthesized-module-specifiers-across-projects-resolve-correctly.js
+++ b/tests/baselines/reference/tsbuild/moduleSpecifiers/initial-build/synthesized-module-specifiers-across-projects-resolve-correctly.js
@@ -1,0 +1,405 @@
+Input::
+//// [/lib/lib.d.ts]
+
+
+//// [/lib/lib.es2020.full.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/src/src-dogs/dog.ts]
+import { DogConfig } from 'src-types';
+import { DOG_CONFIG } from './dogconfig.js';
+
+export abstract class Dog {
+
+    public static getCapabilities(): DogConfig {
+        return DOG_CONFIG;
+    }
+}
+
+
+//// [/src/src-dogs/dogconfig.ts]
+import { DogConfig } from 'src-types';
+
+export const DOG_CONFIG: DogConfig = {
+    name: 'Default dog',
+};
+
+
+//// [/src/src-dogs/index.ts]
+export * from 'src-types';
+export * from './lassie/lassiedog.js';
+
+
+//// [/src/src-dogs/lassie/lassieconfig.ts]
+import { DogConfig } from 'src-types';
+
+export const LASSIE_CONFIG: DogConfig = { name: 'Lassie' };
+
+
+//// [/src/src-dogs/lassie/lassiedog.ts]
+import { Dog } from '../dog.js';
+import { LASSIE_CONFIG } from './lassieconfig.js';
+
+export class LassieDog extends Dog {
+    protected static getDogConfig = () => LASSIE_CONFIG;
+}
+
+
+//// [/src/src-dogs/node_modules] symlink(/src)
+//// [/src/src-dogs/package.json]
+{
+    "type": "module",
+    "exports": "./index.js"
+}
+
+//// [/src/src-dogs/tsconfig.json]
+{
+    "extends": "../tsconfig-base.json",
+    "compilerOptions": {
+        "composite": true
+    },
+    "references": [
+        { "path": "../src-types" }
+    ],
+    "include": [
+        "**/*"
+    ]
+}
+
+//// [/src/src-types/dogconfig.ts]
+export interface DogConfig {
+    name: string;
+}
+
+//// [/src/src-types/index.ts]
+export * from './dogconfig.js';
+
+//// [/src/src-types/node_modules] symlink(/src)
+//// [/src/src-types/package.json]
+{
+    "type": "module",
+    "exports": "./index.js"
+}
+
+//// [/src/src-types/tsconfig.json]
+{
+    "extends": "../tsconfig-base.json",
+    "compilerOptions": {
+        "composite": true
+    },
+    "include": [
+        "**/*"
+    ]
+}
+
+//// [/src/tsconfig-base.json]
+{
+    "compilerOptions": {
+        "declaration": true,
+        "module": "node12"
+    }
+}
+
+
+
+Output::
+/lib/tsc -b src/src-types src/src-dogs --verbose
+[[90m12:00:00 AM[0m] Projects in this build: 
+    * src/src-types/tsconfig.json
+    * src/src-dogs/tsconfig.json
+
+[[90m12:00:00 AM[0m] Project 'src/src-types/tsconfig.json' is out of date because output file 'src/src-types/dogconfig.js' does not exist
+
+[[90m12:00:00 AM[0m] Building project '/src/src-types/tsconfig.json'...
+
+[[90m12:00:00 AM[0m] Project 'src/src-dogs/tsconfig.json' is out of date because output file 'src/src-dogs/dog.js' does not exist
+
+[[90m12:00:00 AM[0m] Building project '/src/src-dogs/tsconfig.json'...
+
+exitCode:: ExitStatus.Success
+
+
+//// [/src/src-dogs/dog.d.ts]
+import { DogConfig } from 'src-types';
+export declare abstract class Dog {
+    static getCapabilities(): DogConfig;
+}
+
+
+//// [/src/src-dogs/dog.js]
+import { DOG_CONFIG } from './dogconfig.js';
+export class Dog {
+    static getCapabilities() {
+        return DOG_CONFIG;
+    }
+}
+
+
+//// [/src/src-dogs/dogconfig.d.ts]
+import { DogConfig } from 'src-types';
+export declare const DOG_CONFIG: DogConfig;
+
+
+//// [/src/src-dogs/dogconfig.js]
+export const DOG_CONFIG = {
+    name: 'Default dog',
+};
+
+
+//// [/src/src-dogs/index.d.ts]
+export * from 'src-types';
+export * from './lassie/lassiedog.js';
+
+
+//// [/src/src-dogs/index.js]
+export * from 'src-types';
+export * from './lassie/lassiedog.js';
+
+
+//// [/src/src-dogs/lassie/lassieconfig.d.ts]
+import { DogConfig } from 'src-types';
+export declare const LASSIE_CONFIG: DogConfig;
+
+
+//// [/src/src-dogs/lassie/lassieconfig.js]
+export const LASSIE_CONFIG = { name: 'Lassie' };
+
+
+//// [/src/src-dogs/lassie/lassiedog.d.ts]
+import { Dog } from '../dog.js';
+export declare class LassieDog extends Dog {
+    protected static getDogConfig: () => import("../index.js").DogConfig;
+}
+
+
+//// [/src/src-dogs/lassie/lassiedog.js]
+import { Dog } from '../dog.js';
+import { LASSIE_CONFIG } from './lassieconfig.js';
+export class LassieDog extends Dog {
+}
+LassieDog.getDogConfig = () => LASSIE_CONFIG;
+
+
+//// [/src/src-dogs/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.es2020.full.d.ts","../src-types/dogconfig.d.ts","../src-types/index.d.ts","./dogconfig.ts","./dog.ts","./lassie/lassieconfig.ts","./lassie/lassiedog.ts","./index.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true,"impliedFormat":1},"-2632060142-export interface DogConfig {\r\n    name: string;\r\n}\r\n","-5608794531-export * from './dogconfig.js';\r\n","1966273863-import { DogConfig } from 'src-types';\n\nexport const DOG_CONFIG: DogConfig = {\n    name: 'Default dog',\n};\n","6091345804-import { DogConfig } from 'src-types';\nimport { DOG_CONFIG } from './dogconfig.js';\n\nexport abstract class Dog {\n\n    public static getCapabilities(): DogConfig {\n        return DOG_CONFIG;\n    }\n}\n","4440579024-import { DogConfig } from 'src-types';\n\nexport const LASSIE_CONFIG: DogConfig = { name: 'Lassie' };\n","-32303727812-import { Dog } from '../dog.js';\nimport { LASSIE_CONFIG } from './lassieconfig.js';\n\nexport class LassieDog extends Dog {\n    protected static getDogConfig = () => LASSIE_CONFIG;\n}\n","-15974991320-export * from 'src-types';\nexport * from './lassie/lassiedog.js';\n"],"options":{"composite":true,"declaration":true,"module":100},"fileIdsList":[[3,4],[3],[3,7],[5,6],[2]],"referencedMap":[[5,1],[4,2],[8,3],[6,2],[7,4],[3,5]],"exportedModulesMap":[[5,1],[4,2],[8,3],[6,2],[7,4],[3,5]],"semanticDiagnosticsPerFile":[1,5,4,8,6,7,2,3]},"version":"FakeTSVersion"}
+
+//// [/src/src-dogs/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.es2020.full.d.ts",
+      "../src-types/dogconfig.d.ts",
+      "../src-types/index.d.ts",
+      "./dogconfig.ts",
+      "./dog.ts",
+      "./lassie/lassieconfig.ts",
+      "./lassie/lassiedog.ts",
+      "./index.ts"
+    ],
+    "fileNamesList": [
+      [
+        "../src-types/index.d.ts",
+        "./dogconfig.ts"
+      ],
+      [
+        "../src-types/index.d.ts"
+      ],
+      [
+        "../src-types/index.d.ts",
+        "./lassie/lassiedog.ts"
+      ],
+      [
+        "./dog.ts",
+        "./lassie/lassieconfig.ts"
+      ],
+      [
+        "../src-types/dogconfig.d.ts"
+      ]
+    ],
+    "fileInfos": {
+      "../../lib/lib.es2020.full.d.ts": {
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "signature": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "affectsGlobalScope": true,
+        "impliedFormat": 1
+      },
+      "../src-types/dogconfig.d.ts": {
+        "version": "-2632060142-export interface DogConfig {\r\n    name: string;\r\n}\r\n",
+        "signature": "-2632060142-export interface DogConfig {\r\n    name: string;\r\n}\r\n"
+      },
+      "../src-types/index.d.ts": {
+        "version": "-5608794531-export * from './dogconfig.js';\r\n",
+        "signature": "-5608794531-export * from './dogconfig.js';\r\n"
+      },
+      "./dogconfig.ts": {
+        "version": "1966273863-import { DogConfig } from 'src-types';\n\nexport const DOG_CONFIG: DogConfig = {\n    name: 'Default dog',\n};\n",
+        "signature": "1966273863-import { DogConfig } from 'src-types';\n\nexport const DOG_CONFIG: DogConfig = {\n    name: 'Default dog',\n};\n"
+      },
+      "./dog.ts": {
+        "version": "6091345804-import { DogConfig } from 'src-types';\nimport { DOG_CONFIG } from './dogconfig.js';\n\nexport abstract class Dog {\n\n    public static getCapabilities(): DogConfig {\n        return DOG_CONFIG;\n    }\n}\n",
+        "signature": "6091345804-import { DogConfig } from 'src-types';\nimport { DOG_CONFIG } from './dogconfig.js';\n\nexport abstract class Dog {\n\n    public static getCapabilities(): DogConfig {\n        return DOG_CONFIG;\n    }\n}\n"
+      },
+      "./lassie/lassieconfig.ts": {
+        "version": "4440579024-import { DogConfig } from 'src-types';\n\nexport const LASSIE_CONFIG: DogConfig = { name: 'Lassie' };\n",
+        "signature": "4440579024-import { DogConfig } from 'src-types';\n\nexport const LASSIE_CONFIG: DogConfig = { name: 'Lassie' };\n"
+      },
+      "./lassie/lassiedog.ts": {
+        "version": "-32303727812-import { Dog } from '../dog.js';\nimport { LASSIE_CONFIG } from './lassieconfig.js';\n\nexport class LassieDog extends Dog {\n    protected static getDogConfig = () => LASSIE_CONFIG;\n}\n",
+        "signature": "-32303727812-import { Dog } from '../dog.js';\nimport { LASSIE_CONFIG } from './lassieconfig.js';\n\nexport class LassieDog extends Dog {\n    protected static getDogConfig = () => LASSIE_CONFIG;\n}\n"
+      },
+      "./index.ts": {
+        "version": "-15974991320-export * from 'src-types';\nexport * from './lassie/lassiedog.js';\n",
+        "signature": "-15974991320-export * from 'src-types';\nexport * from './lassie/lassiedog.js';\n"
+      }
+    },
+    "options": {
+      "composite": true,
+      "declaration": true,
+      "module": 100
+    },
+    "referencedMap": {
+      "./dog.ts": [
+        "../src-types/index.d.ts",
+        "./dogconfig.ts"
+      ],
+      "./dogconfig.ts": [
+        "../src-types/index.d.ts"
+      ],
+      "./index.ts": [
+        "../src-types/index.d.ts",
+        "./lassie/lassiedog.ts"
+      ],
+      "./lassie/lassieconfig.ts": [
+        "../src-types/index.d.ts"
+      ],
+      "./lassie/lassiedog.ts": [
+        "./dog.ts",
+        "./lassie/lassieconfig.ts"
+      ],
+      "../src-types/index.d.ts": [
+        "../src-types/dogconfig.d.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "./dog.ts": [
+        "../src-types/index.d.ts",
+        "./dogconfig.ts"
+      ],
+      "./dogconfig.ts": [
+        "../src-types/index.d.ts"
+      ],
+      "./index.ts": [
+        "../src-types/index.d.ts",
+        "./lassie/lassiedog.ts"
+      ],
+      "./lassie/lassieconfig.ts": [
+        "../src-types/index.d.ts"
+      ],
+      "./lassie/lassiedog.ts": [
+        "./dog.ts",
+        "./lassie/lassieconfig.ts"
+      ],
+      "../src-types/index.d.ts": [
+        "../src-types/dogconfig.d.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.es2020.full.d.ts",
+      "./dog.ts",
+      "./dogconfig.ts",
+      "./index.ts",
+      "./lassie/lassieconfig.ts",
+      "./lassie/lassiedog.ts",
+      "../src-types/dogconfig.d.ts",
+      "../src-types/index.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1802
+}
+
+//// [/src/src-types/dogconfig.d.ts]
+export interface DogConfig {
+    name: string;
+}
+
+
+//// [/src/src-types/dogconfig.js]
+export {};
+
+
+//// [/src/src-types/index.d.ts]
+export * from './dogconfig.js';
+
+
+//// [/src/src-types/index.js]
+export * from './dogconfig.js';
+
+
+//// [/src/src-types/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.es2020.full.d.ts","./dogconfig.ts","./index.ts"],"fileInfos":[{"version":"-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }","affectsGlobalScope":true,"impliedFormat":1},"-5575793279-export interface DogConfig {\n    name: string;\n}","-6189272282-export * from './dogconfig.js';"],"options":{"composite":true,"declaration":true,"module":100},"fileIdsList":[[2]],"referencedMap":[[3,1]],"exportedModulesMap":[[3,1]],"semanticDiagnosticsPerFile":[1,2,3]},"version":"FakeTSVersion"}
+
+//// [/src/src-types/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.es2020.full.d.ts",
+      "./dogconfig.ts",
+      "./index.ts"
+    ],
+    "fileNamesList": [
+      [
+        "./dogconfig.ts"
+      ]
+    ],
+    "fileInfos": {
+      "../../lib/lib.es2020.full.d.ts": {
+        "version": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "signature": "-7698705165-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }",
+        "affectsGlobalScope": true,
+        "impliedFormat": 1
+      },
+      "./dogconfig.ts": {
+        "version": "-5575793279-export interface DogConfig {\n    name: string;\n}",
+        "signature": "-5575793279-export interface DogConfig {\n    name: string;\n}"
+      },
+      "./index.ts": {
+        "version": "-6189272282-export * from './dogconfig.js';",
+        "signature": "-6189272282-export * from './dogconfig.js';"
+      }
+    },
+    "options": {
+      "composite": true,
+      "declaration": true,
+      "module": 100
+    },
+    "referencedMap": {
+      "./index.ts": [
+        "./dogconfig.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "./index.ts": [
+        "./dogconfig.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.es2020.full.d.ts",
+      "./dogconfig.ts",
+      "./index.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 829
+}
+

--- a/tests/cases/conformance/node/nodeModulesExportsBlocksSpecifierResolution.ts
+++ b/tests/cases/conformance/node/nodeModulesExportsBlocksSpecifierResolution.ts
@@ -1,0 +1,27 @@
+// @module: node12,nodenext
+// @declaration: true
+// @filename: index.ts
+// esm format file
+import { Thing } from "inner/other";
+export const a = (await import("inner")).x();
+// @filename: node_modules/inner/index.d.ts
+// esm format file
+export { x } from "./other.js";
+// @filename: node_modules/inner/other.d.ts
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+// @filename: package.json
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+// @filename: node_modules/inner/package.json
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}

--- a/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationConditions.ts
+++ b/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationConditions.ts
@@ -1,0 +1,34 @@
+// @module: node12,nodenext
+// @declaration: true
+// @filename: index.ts
+// esm format file
+import { Thing } from "inner/other.js"; // should fail
+export const a = (await import("inner")).x();
+// @filename: node_modules/inner/index.d.ts
+// esm format file
+export { x } from "./other.js";
+// @filename: node_modules/inner/other.d.ts
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+// @filename: package.json
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+// @filename: node_modules/inner/package.json
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        ".": {
+            "default": "./index.js"
+        },
+        "./other": {
+            "default": "./other.js"
+        }
+    }
+}

--- a/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationDirectory.ts
+++ b/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationDirectory.ts
@@ -1,0 +1,29 @@
+// @module: node12,nodenext
+// @declaration: true
+// @filename: index.ts
+// esm format file
+import { Thing } from "inner/other";
+export const a = (await import("inner/index.js")).x();
+// @filename: node_modules/inner/index.d.ts
+// esm format file
+export { x } from "./other.js";
+// @filename: node_modules/inner/other.d.ts
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+// @filename: package.json
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+// @filename: node_modules/inner/package.json
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        "./": "./"
+    }
+}

--- a/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationPattern.ts
+++ b/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationPattern.ts
@@ -1,0 +1,29 @@
+// @module: node12,nodenext
+// @declaration: true
+// @filename: index.ts
+// esm format file
+import { Thing } from "inner/other";
+export const a = (await import("inner/index.js")).x();
+// @filename: node_modules/inner/index.d.ts
+// esm format file
+export { x } from "./other.js";
+// @filename: node_modules/inner/other.d.ts
+// esm format file
+export interface Thing {}
+export const x: () => Thing;
+// @filename: package.json
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+// @filename: node_modules/inner/package.json
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        "./*.js": "./*.js"
+    }
+}


### PR DESCRIPTION
This partially fixes one of the known limitations of declaration emit for the `module: node12` emit mode(s). With this, our specifier generation code (used both both declaration emit and auto imports) will follow `exports` maps when looking for specifiers to use. `imports` and package self-names are still unused, however (but I believe in all cases those can be replaced safely with relative paths or other package paths, so don't have to be used - unlike `exports` which blocks external access to files other than through its aliases).