### PR TITLE
allow `typeof this` after for-loops

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22471,8 +22471,11 @@ namespace ts {
         function getFlowCacheKey(node: Node, declaredType: Type, initialType: Type, flowContainer: Node | undefined): string | undefined {
             switch (node.kind) {
                 case SyntaxKind.Identifier:
-                    const symbol = getResolvedSymbol(node as Identifier);
-                    return symbol !== unknownSymbol ? `${flowContainer ? getNodeId(flowContainer) : "-1"}|${getTypeId(declaredType)}|${getTypeId(initialType)}|${getSymbolId(symbol)}` : undefined;
+                    if (!isThisInTypeQuery(node)) {
+                        const symbol = getResolvedSymbol(node as Identifier);
+                        return symbol !== unknownSymbol ? `${flowContainer ? getNodeId(flowContainer) : "-1"}|${getTypeId(declaredType)}|${getTypeId(initialType)}|${getSymbolId(symbol)}` : undefined;
+                    }
+                    // falls through
                 case SyntaxKind.ThisKeyword:
                     return `0|${flowContainer ? getNodeId(flowContainer) : "-1"}|${getTypeId(declaredType)}|${getTypeId(initialType)}`;
                 case SyntaxKind.NonNullExpression:

--- a/tests/baselines/reference/typeofThis.errors.txt
+++ b/tests/baselines/reference/typeofThis.errors.txt
@@ -147,3 +147,24 @@ tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThis.ts(57,24): 
             }
         }
     }
+    
+    class Tests12 {
+        test1() { // OK
+            type Test = typeof this;
+        }
+    
+        test2() { // OK
+            for (;;) {}
+            type Test = typeof this;
+        }
+    
+        test3() { // expected no compile errors
+            for (const dummy in []) {}
+            type Test = typeof this;
+        }
+    
+        test4() { // expected no compile errors
+            for (const dummy of []) {}
+            type Test = typeof this;
+        }
+    }

--- a/tests/baselines/reference/typeofThis.js
+++ b/tests/baselines/reference/typeofThis.js
@@ -122,6 +122,27 @@ class Test11 {
     }
 }
 
+class Tests12 {
+    test1() { // OK
+        type Test = typeof this;
+    }
+
+    test2() { // OK
+        for (;;) {}
+        type Test = typeof this;
+    }
+
+    test3() { // expected no compile errors
+        for (const dummy in []) {}
+        type Test = typeof this;
+    }
+
+    test4() { // expected no compile errors
+        for (const dummy of []) {}
+        type Test = typeof this;
+    }
+}
+
 //// [typeofThis.js]
 "use strict";
 var Test = /** @class */ (function () {
@@ -240,4 +261,22 @@ var Test11 = /** @class */ (function () {
         }
     };
     return Test11;
+}());
+var Tests12 = /** @class */ (function () {
+    function Tests12() {
+    }
+    Tests12.prototype.test1 = function () {
+    };
+    Tests12.prototype.test2 = function () {
+        for (;;) { }
+    };
+    Tests12.prototype.test3 = function () {
+        for (var dummy in []) { }
+    };
+    Tests12.prototype.test4 = function () {
+        for (var _i = 0, _a = []; _i < _a.length; _i++) {
+            var dummy = _a[_i];
+        }
+    };
+    return Tests12;
 }());

--- a/tests/baselines/reference/typeofThis.symbols
+++ b/tests/baselines/reference/typeofThis.symbols
@@ -312,3 +312,42 @@ class Test11 {
         }
     }
 }
+
+class Tests12 {
+>Tests12 : Symbol(Tests12, Decl(typeofThis.ts, 121, 1))
+
+    test1() { // OK
+>test1 : Symbol(Tests12.test1, Decl(typeofThis.ts, 123, 15))
+
+        type Test = typeof this;
+>Test : Symbol(Test, Decl(typeofThis.ts, 124, 13))
+    }
+
+    test2() { // OK
+>test2 : Symbol(Tests12.test2, Decl(typeofThis.ts, 126, 5))
+
+        for (;;) {}
+        type Test = typeof this;
+>Test : Symbol(Test, Decl(typeofThis.ts, 129, 19))
+    }
+
+    test3() { // expected no compile errors
+>test3 : Symbol(Tests12.test3, Decl(typeofThis.ts, 131, 5))
+
+        for (const dummy in []) {}
+>dummy : Symbol(dummy, Decl(typeofThis.ts, 134, 18))
+
+        type Test = typeof this;
+>Test : Symbol(Test, Decl(typeofThis.ts, 134, 34))
+    }
+
+    test4() { // expected no compile errors
+>test4 : Symbol(Tests12.test4, Decl(typeofThis.ts, 136, 5))
+
+        for (const dummy of []) {}
+>dummy : Symbol(dummy, Decl(typeofThis.ts, 139, 18))
+
+        type Test = typeof this;
+>Test : Symbol(Test, Decl(typeofThis.ts, 139, 34))
+    }
+}

--- a/tests/baselines/reference/typeofThis.types
+++ b/tests/baselines/reference/typeofThis.types
@@ -377,3 +377,48 @@ class Test11 {
         }
     }
 }
+
+class Tests12 {
+>Tests12 : Tests12
+
+    test1() { // OK
+>test1 : () => void
+
+        type Test = typeof this;
+>Test : this
+>this : any
+    }
+
+    test2() { // OK
+>test2 : () => void
+
+        for (;;) {}
+        type Test = typeof this;
+>Test : this
+>this : any
+    }
+
+    test3() { // expected no compile errors
+>test3 : () => void
+
+        for (const dummy in []) {}
+>dummy : string
+>[] : never[]
+
+        type Test = typeof this;
+>Test : this
+>this : any
+    }
+
+    test4() { // expected no compile errors
+>test4 : () => void
+
+        for (const dummy of []) {}
+>dummy : never
+>[] : never[]
+
+        type Test = typeof this;
+>Test : this
+>this : any
+    }
+}

--- a/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThis.ts
+++ b/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThis.ts
@@ -123,3 +123,24 @@ class Test11 {
         }
     }
 }
+
+class Tests12 {
+    test1() { // OK
+        type Test = typeof this;
+    }
+
+    test2() { // OK
+        for (;;) {}
+        type Test = typeof this;
+    }
+
+    test3() { // expected no compile errors
+        for (const dummy in []) {}
+        type Test = typeof this;
+    }
+
+    test4() { // expected no compile errors
+        for (const dummy of []) {}
+        type Test = typeof this;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46072
