### PR TITLE
Fix extension script kind detection for new extensions

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6743,10 +6743,14 @@ namespace ts {
         const ext = fileName.substr(fileName.lastIndexOf("."));
         switch (ext.toLowerCase()) {
             case Extension.Js:
+            case Extension.Cjs:
+            case Extension.Mjs:
                 return ScriptKind.JS;
             case Extension.Jsx:
                 return ScriptKind.JSX;
             case Extension.Ts:
+            case Extension.Cts:
+            case Extension.Mts:
                 return ScriptKind.TS;
             case Extension.Tsx:
                 return ScriptKind.TSX;

--- a/tests/baselines/reference/nodeModulesAllowJsCjsFromJs(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsCjsFromJs(module=node12).symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/node/allowJs/foo.cjs ===
+exports.foo = "foo"
+>exports.foo : Symbol(foo, Decl(foo.cjs, 0, 0))
+>exports : Symbol(foo, Decl(foo.cjs, 0, 0))
+>foo : Symbol(foo, Decl(foo.cjs, 0, 0))
+
+=== tests/cases/conformance/node/allowJs/bar.ts ===
+import foo from "./foo.cjs"
+>foo : Symbol(foo, Decl(bar.ts, 0, 6))
+
+foo.foo;
+>foo.foo : Symbol(foo.foo, Decl(foo.cjs, 0, 0))
+>foo : Symbol(foo, Decl(bar.ts, 0, 6))
+>foo : Symbol(foo.foo, Decl(foo.cjs, 0, 0))
+

--- a/tests/baselines/reference/nodeModulesAllowJsCjsFromJs(module=node12).types
+++ b/tests/baselines/reference/nodeModulesAllowJsCjsFromJs(module=node12).types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/node/allowJs/foo.cjs ===
+exports.foo = "foo"
+>exports.foo = "foo" : "foo"
+>exports.foo : string
+>exports : typeof import("tests/cases/conformance/node/allowJs/foo")
+>foo : string
+>"foo" : "foo"
+
+=== tests/cases/conformance/node/allowJs/bar.ts ===
+import foo from "./foo.cjs"
+>foo : typeof foo
+
+foo.foo;
+>foo.foo : string
+>foo : typeof foo
+>foo : string
+

--- a/tests/baselines/reference/nodeModulesAllowJsCjsFromJs(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsCjsFromJs(module=nodenext).symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/node/allowJs/foo.cjs ===
+exports.foo = "foo"
+>exports.foo : Symbol(foo, Decl(foo.cjs, 0, 0))
+>exports : Symbol(foo, Decl(foo.cjs, 0, 0))
+>foo : Symbol(foo, Decl(foo.cjs, 0, 0))
+
+=== tests/cases/conformance/node/allowJs/bar.ts ===
+import foo from "./foo.cjs"
+>foo : Symbol(foo, Decl(bar.ts, 0, 6))
+
+foo.foo;
+>foo.foo : Symbol(foo.foo, Decl(foo.cjs, 0, 0))
+>foo : Symbol(foo, Decl(bar.ts, 0, 6))
+>foo : Symbol(foo.foo, Decl(foo.cjs, 0, 0))
+

--- a/tests/baselines/reference/nodeModulesAllowJsCjsFromJs(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesAllowJsCjsFromJs(module=nodenext).types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/node/allowJs/foo.cjs ===
+exports.foo = "foo"
+>exports.foo = "foo" : "foo"
+>exports.foo : string
+>exports : typeof import("tests/cases/conformance/node/allowJs/foo")
+>foo : string
+>"foo" : "foo"
+
+=== tests/cases/conformance/node/allowJs/bar.ts ===
+import foo from "./foo.cjs"
+>foo : typeof foo
+
+foo.foo;
+>foo.foo : string
+>foo : typeof foo
+>foo : string
+

--- a/tests/cases/conformance/node/allowJs/nodeModulesAllowJsCjsFromJs.ts
+++ b/tests/cases/conformance/node/allowJs/nodeModulesAllowJsCjsFromJs.ts
@@ -1,0 +1,8 @@
+// @module: node12,nodenext
+// @allowJs: true
+// @noEmit: true
+// @filename: foo.cjs
+exports.foo = "foo"
+// @filename: bar.ts
+import foo from "./foo.cjs"
+foo.foo;


### PR DESCRIPTION
Fixes #46185

All my prior tests have been using `export` and `import` syntax to exercise the transform pipeline and so were flagged as external modules and not commonjs-source modules - commonjs module flagging is only done in js-flagged files as determined by `ScriptKind`, and these files have been getting a `ScriptKind` of `TS` set on them rather than `JS` because of a fallthrough in the logic (y'know - maybe a flag requiring explicit switch exhaustiveness would be nice), and so haven't had cjs module indicators set, and so instead looked like global files to the checker. Just adding the missing cases to the JS branch is sufficient, but I made all the new extensions explicit for consistency.