### PR TITLE
fix(45907): Quick info uses JSDoc for inherited instance property with static property of same name

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -599,10 +599,11 @@ namespace ts {
     }
 
     function findBaseOfDeclaration<T>(checker: TypeChecker, declaration: Declaration, cb: (symbol: Symbol) => T[] | undefined): T[] | undefined {
+        if (hasStaticModifier(declaration)) return;
+
         const classOrInterfaceDeclaration = declaration.parent?.kind === SyntaxKind.Constructor ? declaration.parent.parent : declaration.parent;
-        if (!classOrInterfaceDeclaration) {
-            return;
-        }
+        if (!classOrInterfaceDeclaration) return;
+
         return firstDefined(getAllSuperTypeNodes(classOrInterfaceDeclaration), superTypeNode => {
             const symbol = checker.getPropertyOfType(checker.getTypeAtLocation(superTypeNode), declaration.symbol.name);
             return symbol ? cb(symbol) : undefined;

--- a/tests/cases/fourslash/jsDocInheritDoc.ts
+++ b/tests/cases/fourslash/jsDocInheritDoc.ts
@@ -17,6 +17,10 @@
 ////     * Foo#property1 documentation
 ////     */
 ////    property1: string;
+////    /**
+////     * Foo#property3 documentation
+////     */
+////    property3 = "instance prop";
 ////}
 ////interface Baz {
 ////    /** Baz#property1 documentation */
@@ -43,6 +47,8 @@
 ////     * @inheritDoc
 ////     */
 ////    property2: object;
+////
+////    static /*6*/property3 = "class prop";
 ////}
 ////const b = new Bar/*1*/(5);
 ////b.method2/*2*/();
@@ -55,3 +61,4 @@ verify.quickInfoAt("2", "(method) Bar.method2(): void", "Foo#method2 documentati
 verify.quickInfoAt("3", "(method) Bar.method1(): void", undefined); // statics aren't actually inherited
 verify.quickInfoAt("4", "(property) Bar.property1: string", "Foo#property1 documentation"); // use inherited docs only
 verify.quickInfoAt("5", "(property) Bar.property2: object", "Baz#property2 documentation\nBar#property2"); // include local and inherited docs
+verify.quickInfoAt("6", "(property) Bar.property3: string", undefined);


### PR DESCRIPTION
Fixes #45907