### PR TITLE
Remove defaultValueDescription: "n/a" from options

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1,6 +1,6 @@
 namespace ts {
     /* @internal */
-    export const compileOnSaveCommandLineOption: CommandLineOption = { name: "compileOnSave", type: "boolean" };
+    export const compileOnSaveCommandLineOption: CommandLineOption = { name: "compileOnSave", type: "boolean", defaultValueDescription: "false" };
 
     const jsxOptionMap = new Map(getEntries({
         "preserve": JsxEmit.Preserve,
@@ -140,6 +140,7 @@ namespace ts {
             type: "boolean",
             category: Diagnostics.Watch_and_Build_Modes,
             description: Diagnostics.Synchronously_call_callbacks_and_update_the_state_of_directory_watchers_on_platforms_that_don_t_support_recursive_watching_natively,
+            defaultValueDescription: "false",
         },
         {
             name: "excludeDirectories",
@@ -176,11 +177,13 @@ namespace ts {
             showInSimplifiedHelpView: true,
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Print_this_message,
+            defaultValueDescription: "false",
         },
         {
             name: "help",
             shortName: "?",
-            type: "boolean"
+            type: "boolean",
+            defaultValueDescription: "false",
         },
         {
             name: "watch",
@@ -190,6 +193,7 @@ namespace ts {
             isCommandLineOnly: true,
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Watch_input_files,
+            defaultValueDescription: "false",
         },
         {
             name: "preserveWatchOutput",
@@ -197,6 +201,7 @@ namespace ts {
             showInSimplifiedHelpView: false,
             category: Diagnostics.Output_Formatting,
             description: Diagnostics.Disable_wiping_the_console_in_watch_mode,
+            defaultValueDescription: "false",
         },
         {
             name: "listFiles",
@@ -209,7 +214,8 @@ namespace ts {
             name: "explainFiles",
             type: "boolean",
             category: Diagnostics.Compiler_Diagnostics,
-            description: Diagnostics.Print_files_read_during_the_compilation_including_why_it_was_included
+            description: Diagnostics.Print_files_read_during_the_compilation_including_why_it_was_included,
+            defaultValueDescription: "false",
         },
         {
             name: "listEmittedFiles",
@@ -280,7 +286,8 @@ namespace ts {
             affectsSemanticDiagnostics: true,
             affectsEmit: true,
             category: Diagnostics.Watch_and_Build_Modes,
-            description: Diagnostics.Have_recompiles_in_projects_that_use_incremental_and_watch_mode_assume_that_changes_within_a_file_will_only_affect_files_directly_depending_on_it
+            description: Diagnostics.Have_recompiles_in_projects_that_use_incremental_and_watch_mode_assume_that_changes_within_a_file_will_only_affect_files_directly_depending_on_it,
+            defaultValueDescription: "false",
         },
         {
             name: "locale",
@@ -327,6 +334,7 @@ namespace ts {
             showInSimplifiedHelpView: true,
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Show_all_compiler_options,
+            defaultValueDescription: "false",
         },
         {
             name: "version",
@@ -335,6 +343,7 @@ namespace ts {
             showInSimplifiedHelpView: true,
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Print_the_compiler_s_version,
+            defaultValueDescription: "false",
         },
         {
             name: "init",
@@ -342,6 +351,7 @@ namespace ts {
             showInSimplifiedHelpView: true,
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Initializes_a_TypeScript_project_and_creates_a_tsconfig_json_file,
+            defaultValueDescription: "false",
         },
         {
             name: "project",
@@ -359,7 +369,8 @@ namespace ts {
             shortName: "b",
             showInSimplifiedHelpView: true,
             category: Diagnostics.Command_line_Options,
-            description: Diagnostics.Build_one_or_more_projects_and_their_dependencies_if_out_of_date
+            description: Diagnostics.Build_one_or_more_projects_and_their_dependencies_if_out_of_date,
+            defaultValueDescription: "false",
         },
         {
             name: "showConfig",
@@ -367,7 +378,8 @@ namespace ts {
             showInSimplifiedHelpView: true,
             category: Diagnostics.Command_line_Options,
             isCommandLineOnly: true,
-            description: Diagnostics.Print_the_final_configuration_instead_of_building
+            description: Diagnostics.Print_the_final_configuration_instead_of_building,
+            defaultValueDescription: "false",
         },
         {
             name: "listFilesOnly",
@@ -376,7 +388,8 @@ namespace ts {
             affectsSemanticDiagnostics: true,
             affectsEmit: true,
             isCommandLineOnly: true,
-            description: Diagnostics.Print_names_of_files_that_are_part_of_the_compilation_and_then_stop_processing
+            description: Diagnostics.Print_names_of_files_that_are_part_of_the_compilation_and_then_stop_processing,
+            defaultValueDescription: "false",
         },
 
         // Basic
@@ -665,6 +678,7 @@ namespace ts {
             strictFlag: true,
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Type_catch_clause_variables_as_unknown_instead_of_any,
+            defaultValueDescription: "false",
         },
         {
             name: "alwaysStrict",
@@ -698,7 +712,8 @@ namespace ts {
             type: "boolean",
             affectsSemanticDiagnostics: true,
             category: Diagnostics.Type_Checking,
-            description: Diagnostics.Interpret_optional_property_types_as_written_rather_than_adding_undefined
+            description: Diagnostics.Interpret_optional_property_types_as_written_rather_than_adding_undefined,
+            defaultValueDescription: "false",
         },
         {
             name: "noImplicitReturns",
@@ -714,21 +729,24 @@ namespace ts {
             affectsBindDiagnostics: true,
             affectsSemanticDiagnostics: true,
             category: Diagnostics.Type_Checking,
-            description: Diagnostics.Enable_error_reporting_for_fallthrough_cases_in_switch_statements
+            description: Diagnostics.Enable_error_reporting_for_fallthrough_cases_in_switch_statements,
+            defaultValueDescription: "false",
         },
         {
             name: "noUncheckedIndexedAccess",
             type: "boolean",
             affectsSemanticDiagnostics: true,
             category: Diagnostics.Type_Checking,
-            description: Diagnostics.Include_undefined_in_index_signature_results
+            description: Diagnostics.Include_undefined_in_index_signature_results,
+            defaultValueDescription: "false",
         },
         {
             name: "noImplicitOverride",
             type: "boolean",
             affectsSemanticDiagnostics: true,
             category: Diagnostics.Type_Checking,
-            description: Diagnostics.Ensure_overriding_members_in_derived_classes_are_marked_with_an_override_modifier
+            description: Diagnostics.Ensure_overriding_members_in_derived_classes_are_marked_with_an_override_modifier,
+            defaultValueDescription: "false",
         },
         {
             name: "noPropertyAccessFromIndexSignature",
@@ -838,6 +856,7 @@ namespace ts {
             type: "boolean",
             category: Diagnostics.Interop_Constraints,
             description: Diagnostics.Disable_resolving_symlinks_to_their_realpath_This_correlates_to_the_same_flag_in_node,
+            defaultValueDescription: "false",
         },
         {
             name: "allowUmdGlobalAccess",
@@ -888,7 +907,8 @@ namespace ts {
             type: "boolean",
             affectsSemanticDiagnostics: true,
             category: Diagnostics.Language_and_Environment,
-            description: Diagnostics.Enable_experimental_support_for_TC39_stage_2_draft_decorators
+            description: Diagnostics.Enable_experimental_support_for_TC39_stage_2_draft_decorators,
+            defaultValueDescription: "false",
         },
         {
             name: "emitDecoratorMetadata",
@@ -896,7 +916,8 @@ namespace ts {
             affectsSemanticDiagnostics: true,
             affectsEmit: true,
             category: Diagnostics.Language_and_Environment,
-            description: Diagnostics.Emit_design_type_metadata_for_decorated_declarations_in_source_files
+            description: Diagnostics.Emit_design_type_metadata_for_decorated_declarations_in_source_files,
+            defaultValueDescription: "false",
         },
 
         // Advanced
@@ -1021,6 +1042,7 @@ namespace ts {
             affectsEmit: true,
             category: Diagnostics.Emit,
             description: Diagnostics.Disable_emitting_declarations_that_have_internal_in_their_JSDoc_comments,
+            defaultValueDescription: "false",
         },
         {
             name: "disableSizeLimit",
@@ -1035,21 +1057,24 @@ namespace ts {
             type: "boolean",
             isTSConfigOnly: true,
             category: Diagnostics.Projects,
-            description: Diagnostics.Disable_preferring_source_files_instead_of_declaration_files_when_referencing_composite_projects
+            description: Diagnostics.Disable_preferring_source_files_instead_of_declaration_files_when_referencing_composite_projects,
+            defaultValueDescription: "false",
         },
         {
             name: "disableSolutionSearching",
             type: "boolean",
             isTSConfigOnly: true,
             category: Diagnostics.Projects,
-            description: Diagnostics.Opt_a_project_out_of_multi_project_reference_checking_when_editing
+            description: Diagnostics.Opt_a_project_out_of_multi_project_reference_checking_when_editing,
+            defaultValueDescription: "false",
         },
         {
             name: "disableReferencedProjectLoad",
             type: "boolean",
             isTSConfigOnly: true,
             category: Diagnostics.Projects,
-            description: Diagnostics.Reduce_the_number_of_projects_loaded_automatically_by_TypeScript
+            description: Diagnostics.Reduce_the_number_of_projects_loaded_automatically_by_TypeScript,
+            defaultValueDescription: "false",
         },
         {
             name: "noImplicitUseStrict",
@@ -1082,6 +1107,7 @@ namespace ts {
             affectsEmit: true,
             category: Diagnostics.Emit,
             description: Diagnostics.Disable_erasing_const_enum_declarations_in_generated_code,
+            defaultValueDescription: "false",
         },
         {
             name: "declarationDir",
@@ -1173,6 +1199,7 @@ namespace ts {
             affectsEmit: true,
             category: Diagnostics.Emit,
             description: Diagnostics.Preserve_unused_imported_values_in_the_JavaScript_output_that_would_otherwise_be_removed,
+            defaultValueDescription: "false",
         },
 
         {
@@ -1235,27 +1262,31 @@ namespace ts {
             shortName: "v",
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Enable_verbose_logging,
-            type: "boolean"
+            type: "boolean",
+            defaultValueDescription: "false",
         },
         {
             name: "dry",
             shortName: "d",
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Show_what_would_be_built_or_deleted_if_specified_with_clean,
-            type: "boolean"
+            type: "boolean",
+            defaultValueDescription: "false",
         },
         {
             name: "force",
             shortName: "f",
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Build_all_projects_including_those_that_appear_to_be_up_to_date,
-            type: "boolean"
+            type: "boolean",
+            defaultValueDescription: "false",
         },
         {
             name: "clean",
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Delete_the_outputs_of_all_projects,
-            type: "boolean"
+            type: "boolean",
+            defaultValueDescription: "false",
         }
     ];
 
@@ -1273,10 +1304,12 @@ namespace ts {
              */
             name: "enableAutoDiscovery",
             type: "boolean",
+            defaultValueDescription: "false",
         },
         {
             name: "enable",
             type: "boolean",
+            defaultValueDescription: "false",
         },
         {
             name: "include",
@@ -1297,6 +1330,7 @@ namespace ts {
         {
             name: "disableFilenameBasedTypeAcquisition",
             type: "boolean",
+            defaultValueDescription: "false",
         },
     ];
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6345,13 +6345,13 @@ namespace ts {
     /* @internal */
     export interface CommandLineOptionOfNumberType extends CommandLineOptionBase {
         type: "number";
-        defaultValueDescription?: `${number | undefined}` | DiagnosticMessage;
+        defaultValueDescription: `${number | undefined}` | DiagnosticMessage;
     }
 
     /* @internal */
     export interface CommandLineOptionOfBooleanType extends CommandLineOptionBase {
         type: "boolean";
-        defaultValueDescription?: `${boolean | undefined}` | DiagnosticMessage;
+        defaultValueDescription: `${boolean | undefined}` | DiagnosticMessage;
     }
 
     /* @internal */

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -303,21 +303,21 @@ namespace Harness {
 
         // Additional options not already in ts.optionDeclarations
         const harnessOptionDeclarations: ts.CommandLineOption[] = [
-            { name: "allowNonTsExtensions", type: "boolean" },
-            { name: "useCaseSensitiveFileNames", type: "boolean" },
+            { name: "allowNonTsExtensions", type: "boolean", defaultValueDescription: "false" },
+            { name: "useCaseSensitiveFileNames", type: "boolean", defaultValueDescription: "false" },
             { name: "baselineFile", type: "string" },
             { name: "includeBuiltFile", type: "string" },
             { name: "fileName", type: "string" },
             { name: "libFiles", type: "string" },
-            { name: "noErrorTruncation", type: "boolean" },
-            { name: "suppressOutputPathCheck", type: "boolean" },
-            { name: "noImplicitReferences", type: "boolean" },
+            { name: "noErrorTruncation", type: "boolean", defaultValueDescription: "false" },
+            { name: "suppressOutputPathCheck", type: "boolean", defaultValueDescription: "false" },
+            { name: "noImplicitReferences", type: "boolean", defaultValueDescription: "false" },
             { name: "currentDirectory", type: "string" },
             { name: "symlink", type: "string" },
             { name: "link", type: "string" },
-            { name: "noTypesAndSymbols", type: "boolean" },
+            { name: "noTypesAndSymbols", type: "boolean", defaultValueDescription: "false" },
             // Emitted js baseline will print full paths for every output file
-            { name: "fullEmitPaths", type: "boolean" }
+            { name: "fullEmitPaths", type: "boolean", defaultValueDescription: "false" }
         ];
 
         let optionsIndex: ts.ESMap<string, ts.CommandLineOption>;

--- a/src/testRunner/unittests/config/commandLineParsing.ts
+++ b/src/testRunner/unittests/config/commandLineParsing.ts
@@ -526,7 +526,7 @@ namespace ts {
                     nonNullValue,
                     diagnosticMessage: Diagnostics.Option_0_can_only_be_specified_in_tsconfig_json_file_or_set_to_null_on_command_line,
                     workerDiagnostic: () => {
-                        const optionDeclarations = [
+                        const optionDeclarations: CommandLineOption[] = [
                             ...compilerOptionsDidYouMeanDiagnostics.optionDeclarations,
                             {
                                 name: "optionName",
@@ -534,6 +534,7 @@ namespace ts {
                                 isTSConfigOnly: true,
                                 category: Diagnostics.Backwards_Compatibility,
                                 description: Diagnostics.Enable_project_compilation,
+                                defaultValueDescription: "undefined",
                             }
                         ];
                         return {


### PR DESCRIPTION
Are there different meanings to `defaultValueDescription: "n/a"` and omitting `defaultValueDescription`?

/cc @orta