### PR TITLE
fix(46305): Keep spread syntax instead of generating Object.assign for ReactJSX and es2018+

### DIFF
--- a/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2015).js
+++ b/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2015).js
@@ -1,0 +1,56 @@
+//// [test.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+
+export function T1(a: any) {
+    return <div className={"T1"} { ...a }>T1</div>;
+}
+
+export function T2(a: any, b: any) {
+    return <div className={"T2"} { ...a } { ...b }>T2</div>;
+}
+
+export function T3(a: any, b: any) {
+    return <div { ...a } className={"T3"} { ...b }>T3</div>;
+}
+
+export function T4(a: any, b: any) {
+    return <div className={"T4"} { ...{ ...a, ...b } }>T4</div>;
+}
+
+export function T5(a: any, b: any, c: any, d: any) {
+    return <div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div>;
+}
+
+export function T6(a: any, b: any, c: any, d: any) {
+    return <div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div>;
+}
+
+export function T7(a: any, b: any, c: any, d: any) {
+    return <div>T7</div>;
+}
+
+
+//// [test.js]
+import { jsx as _jsx } from "react/jsx-runtime";
+/// <reference path="react16.d.ts" />
+export function T1(a) {
+    return _jsx("div", Object.assign({ className: "T1" }, a, { children: "T1" }), void 0);
+}
+export function T2(a, b) {
+    return _jsx("div", Object.assign({ className: "T2" }, a, b, { children: "T2" }), void 0);
+}
+export function T3(a, b) {
+    return _jsx("div", Object.assign({}, a, { className: "T3" }, b, { children: "T3" }), void 0);
+}
+export function T4(a, b) {
+    return _jsx("div", Object.assign({ className: "T4" }, Object.assign(Object.assign({}, a), b), { children: "T4" }), void 0);
+}
+export function T5(a, b, c, d) {
+    return _jsx("div", Object.assign({ className: "T5" }, Object.assign(Object.assign(Object.assign({}, a), b), { c, d }), { children: "T5" }), void 0);
+}
+export function T6(a, b, c, d) {
+    return _jsx("div", Object.assign({ className: "T6" }, Object.assign(Object.assign(Object.assign({}, a), b), Object.assign(Object.assign({}, c), d)), { children: "T6" }), void 0);
+}
+export function T7(a, b, c, d) {
+    return _jsx("div", { children: "T7" }, void 0);
+}

--- a/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2015).symbols
+++ b/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2015).symbols
@@ -1,0 +1,99 @@
+=== tests/cases/conformance/jsx/test.tsx ===
+/// <reference path="react16.d.ts" />
+
+export function T1(a: any) {
+>T1 : Symbol(T1, Decl(test.tsx, 0, 0))
+>a : Symbol(a, Decl(test.tsx, 2, 19))
+
+    return <div className={"T1"} { ...a }>T1</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 3, 15))
+>a : Symbol(a, Decl(test.tsx, 2, 19))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T2(a: any, b: any) {
+>T2 : Symbol(T2, Decl(test.tsx, 4, 1))
+>a : Symbol(a, Decl(test.tsx, 6, 19))
+>b : Symbol(b, Decl(test.tsx, 6, 26))
+
+    return <div className={"T2"} { ...a } { ...b }>T2</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 7, 15))
+>a : Symbol(a, Decl(test.tsx, 6, 19))
+>b : Symbol(b, Decl(test.tsx, 6, 26))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T3(a: any, b: any) {
+>T3 : Symbol(T3, Decl(test.tsx, 8, 1))
+>a : Symbol(a, Decl(test.tsx, 10, 19))
+>b : Symbol(b, Decl(test.tsx, 10, 26))
+
+    return <div { ...a } className={"T3"} { ...b }>T3</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>a : Symbol(a, Decl(test.tsx, 10, 19))
+>className : Symbol(className, Decl(test.tsx, 11, 24))
+>b : Symbol(b, Decl(test.tsx, 10, 26))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T4(a: any, b: any) {
+>T4 : Symbol(T4, Decl(test.tsx, 12, 1))
+>a : Symbol(a, Decl(test.tsx, 14, 19))
+>b : Symbol(b, Decl(test.tsx, 14, 26))
+
+    return <div className={"T4"} { ...{ ...a, ...b } }>T4</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 15, 15))
+>a : Symbol(a, Decl(test.tsx, 14, 19))
+>b : Symbol(b, Decl(test.tsx, 14, 26))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T5(a: any, b: any, c: any, d: any) {
+>T5 : Symbol(T5, Decl(test.tsx, 16, 1))
+>a : Symbol(a, Decl(test.tsx, 18, 19))
+>b : Symbol(b, Decl(test.tsx, 18, 26))
+>c : Symbol(c, Decl(test.tsx, 18, 34))
+>d : Symbol(d, Decl(test.tsx, 18, 42))
+
+    return <div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 19, 15))
+>a : Symbol(a, Decl(test.tsx, 18, 19))
+>b : Symbol(b, Decl(test.tsx, 18, 26))
+>c : Symbol(c, Decl(test.tsx, 19, 56))
+>d : Symbol(d, Decl(test.tsx, 19, 59))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T6(a: any, b: any, c: any, d: any) {
+>T6 : Symbol(T6, Decl(test.tsx, 20, 1))
+>a : Symbol(a, Decl(test.tsx, 22, 19))
+>b : Symbol(b, Decl(test.tsx, 22, 26))
+>c : Symbol(c, Decl(test.tsx, 22, 34))
+>d : Symbol(d, Decl(test.tsx, 22, 42))
+
+    return <div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 23, 15))
+>a : Symbol(a, Decl(test.tsx, 22, 19))
+>b : Symbol(b, Decl(test.tsx, 22, 26))
+>c : Symbol(c, Decl(test.tsx, 22, 34))
+>d : Symbol(d, Decl(test.tsx, 22, 42))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T7(a: any, b: any, c: any, d: any) {
+>T7 : Symbol(T7, Decl(test.tsx, 24, 1))
+>a : Symbol(a, Decl(test.tsx, 26, 19))
+>b : Symbol(b, Decl(test.tsx, 26, 26))
+>c : Symbol(c, Decl(test.tsx, 26, 34))
+>d : Symbol(d, Decl(test.tsx, 26, 42))
+
+    return <div>T7</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+

--- a/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2015).types
+++ b/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2015).types
@@ -1,0 +1,117 @@
+=== tests/cases/conformance/jsx/test.tsx ===
+/// <reference path="react16.d.ts" />
+
+export function T1(a: any) {
+>T1 : (a: any) => JSX.Element
+>a : any
+
+    return <div className={"T1"} { ...a }>T1</div>;
+><div className={"T1"} { ...a }>T1</div> : JSX.Element
+>div : any
+>className : string
+>"T1" : "T1"
+>a : any
+>div : any
+}
+
+export function T2(a: any, b: any) {
+>T2 : (a: any, b: any) => JSX.Element
+>a : any
+>b : any
+
+    return <div className={"T2"} { ...a } { ...b }>T2</div>;
+><div className={"T2"} { ...a } { ...b }>T2</div> : JSX.Element
+>div : any
+>className : string
+>"T2" : "T2"
+>a : any
+>b : any
+>div : any
+}
+
+export function T3(a: any, b: any) {
+>T3 : (a: any, b: any) => JSX.Element
+>a : any
+>b : any
+
+    return <div { ...a } className={"T3"} { ...b }>T3</div>;
+><div { ...a } className={"T3"} { ...b }>T3</div> : JSX.Element
+>div : any
+>a : any
+>className : string
+>"T3" : "T3"
+>b : any
+>div : any
+}
+
+export function T4(a: any, b: any) {
+>T4 : (a: any, b: any) => JSX.Element
+>a : any
+>b : any
+
+    return <div className={"T4"} { ...{ ...a, ...b } }>T4</div>;
+><div className={"T4"} { ...{ ...a, ...b } }>T4</div> : JSX.Element
+>div : any
+>className : string
+>"T4" : "T4"
+>{ ...a, ...b } : any
+>a : any
+>b : any
+>div : any
+}
+
+export function T5(a: any, b: any, c: any, d: any) {
+>T5 : (a: any, b: any, c: any, d: any) => JSX.Element
+>a : any
+>b : any
+>c : any
+>d : any
+
+    return <div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div>;
+><div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div> : JSX.Element
+>div : any
+>className : string
+>"T5" : "T5"
+>{ ...a, ...b, ...{ c, d } } : any
+>a : any
+>b : any
+>{ c, d } : { c: any; d: any; }
+>c : any
+>d : any
+>div : any
+}
+
+export function T6(a: any, b: any, c: any, d: any) {
+>T6 : (a: any, b: any, c: any, d: any) => JSX.Element
+>a : any
+>b : any
+>c : any
+>d : any
+
+    return <div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div>;
+><div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div> : JSX.Element
+>div : any
+>className : string
+>"T6" : "T6"
+>{ ...a, ...b, ...{ ...c, ...d } } : any
+>a : any
+>b : any
+>{ ...c, ...d } : any
+>c : any
+>d : any
+>div : any
+}
+
+export function T7(a: any, b: any, c: any, d: any) {
+>T7 : (a: any, b: any, c: any, d: any) => JSX.Element
+>a : any
+>b : any
+>c : any
+>d : any
+
+    return <div>T7</div>;
+><div>T7</div> : JSX.Element
+>div : any
+>div : any
+}
+

--- a/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2018).js
+++ b/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2018).js
@@ -1,0 +1,56 @@
+//// [test.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+
+export function T1(a: any) {
+    return <div className={"T1"} { ...a }>T1</div>;
+}
+
+export function T2(a: any, b: any) {
+    return <div className={"T2"} { ...a } { ...b }>T2</div>;
+}
+
+export function T3(a: any, b: any) {
+    return <div { ...a } className={"T3"} { ...b }>T3</div>;
+}
+
+export function T4(a: any, b: any) {
+    return <div className={"T4"} { ...{ ...a, ...b } }>T4</div>;
+}
+
+export function T5(a: any, b: any, c: any, d: any) {
+    return <div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div>;
+}
+
+export function T6(a: any, b: any, c: any, d: any) {
+    return <div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div>;
+}
+
+export function T7(a: any, b: any, c: any, d: any) {
+    return <div>T7</div>;
+}
+
+
+//// [test.js]
+import { jsx as _jsx } from "react/jsx-runtime";
+/// <reference path="react16.d.ts" />
+export function T1(a) {
+    return _jsx("div", { className: "T1", ...a, children: "T1" }, void 0);
+}
+export function T2(a, b) {
+    return _jsx("div", { className: "T2", ...a, ...b, children: "T2" }, void 0);
+}
+export function T3(a, b) {
+    return _jsx("div", { ...a, className: "T3", ...b, children: "T3" }, void 0);
+}
+export function T4(a, b) {
+    return _jsx("div", { className: "T4", ...{ ...a, ...b }, children: "T4" }, void 0);
+}
+export function T5(a, b, c, d) {
+    return _jsx("div", { className: "T5", ...{ ...a, ...b, ...{ c, d } }, children: "T5" }, void 0);
+}
+export function T6(a, b, c, d) {
+    return _jsx("div", { className: "T6", ...{ ...a, ...b, ...{ ...c, ...d } }, children: "T6" }, void 0);
+}
+export function T7(a, b, c, d) {
+    return _jsx("div", { children: "T7" }, void 0);
+}

--- a/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2018).symbols
+++ b/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2018).symbols
@@ -1,0 +1,99 @@
+=== tests/cases/conformance/jsx/test.tsx ===
+/// <reference path="react16.d.ts" />
+
+export function T1(a: any) {
+>T1 : Symbol(T1, Decl(test.tsx, 0, 0))
+>a : Symbol(a, Decl(test.tsx, 2, 19))
+
+    return <div className={"T1"} { ...a }>T1</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 3, 15))
+>a : Symbol(a, Decl(test.tsx, 2, 19))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T2(a: any, b: any) {
+>T2 : Symbol(T2, Decl(test.tsx, 4, 1))
+>a : Symbol(a, Decl(test.tsx, 6, 19))
+>b : Symbol(b, Decl(test.tsx, 6, 26))
+
+    return <div className={"T2"} { ...a } { ...b }>T2</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 7, 15))
+>a : Symbol(a, Decl(test.tsx, 6, 19))
+>b : Symbol(b, Decl(test.tsx, 6, 26))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T3(a: any, b: any) {
+>T3 : Symbol(T3, Decl(test.tsx, 8, 1))
+>a : Symbol(a, Decl(test.tsx, 10, 19))
+>b : Symbol(b, Decl(test.tsx, 10, 26))
+
+    return <div { ...a } className={"T3"} { ...b }>T3</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>a : Symbol(a, Decl(test.tsx, 10, 19))
+>className : Symbol(className, Decl(test.tsx, 11, 24))
+>b : Symbol(b, Decl(test.tsx, 10, 26))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T4(a: any, b: any) {
+>T4 : Symbol(T4, Decl(test.tsx, 12, 1))
+>a : Symbol(a, Decl(test.tsx, 14, 19))
+>b : Symbol(b, Decl(test.tsx, 14, 26))
+
+    return <div className={"T4"} { ...{ ...a, ...b } }>T4</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 15, 15))
+>a : Symbol(a, Decl(test.tsx, 14, 19))
+>b : Symbol(b, Decl(test.tsx, 14, 26))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T5(a: any, b: any, c: any, d: any) {
+>T5 : Symbol(T5, Decl(test.tsx, 16, 1))
+>a : Symbol(a, Decl(test.tsx, 18, 19))
+>b : Symbol(b, Decl(test.tsx, 18, 26))
+>c : Symbol(c, Decl(test.tsx, 18, 34))
+>d : Symbol(d, Decl(test.tsx, 18, 42))
+
+    return <div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 19, 15))
+>a : Symbol(a, Decl(test.tsx, 18, 19))
+>b : Symbol(b, Decl(test.tsx, 18, 26))
+>c : Symbol(c, Decl(test.tsx, 19, 56))
+>d : Symbol(d, Decl(test.tsx, 19, 59))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T6(a: any, b: any, c: any, d: any) {
+>T6 : Symbol(T6, Decl(test.tsx, 20, 1))
+>a : Symbol(a, Decl(test.tsx, 22, 19))
+>b : Symbol(b, Decl(test.tsx, 22, 26))
+>c : Symbol(c, Decl(test.tsx, 22, 34))
+>d : Symbol(d, Decl(test.tsx, 22, 42))
+
+    return <div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 23, 15))
+>a : Symbol(a, Decl(test.tsx, 22, 19))
+>b : Symbol(b, Decl(test.tsx, 22, 26))
+>c : Symbol(c, Decl(test.tsx, 22, 34))
+>d : Symbol(d, Decl(test.tsx, 22, 42))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T7(a: any, b: any, c: any, d: any) {
+>T7 : Symbol(T7, Decl(test.tsx, 24, 1))
+>a : Symbol(a, Decl(test.tsx, 26, 19))
+>b : Symbol(b, Decl(test.tsx, 26, 26))
+>c : Symbol(c, Decl(test.tsx, 26, 34))
+>d : Symbol(d, Decl(test.tsx, 26, 42))
+
+    return <div>T7</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+

--- a/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2018).types
+++ b/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=es2018).types
@@ -1,0 +1,117 @@
+=== tests/cases/conformance/jsx/test.tsx ===
+/// <reference path="react16.d.ts" />
+
+export function T1(a: any) {
+>T1 : (a: any) => JSX.Element
+>a : any
+
+    return <div className={"T1"} { ...a }>T1</div>;
+><div className={"T1"} { ...a }>T1</div> : JSX.Element
+>div : any
+>className : string
+>"T1" : "T1"
+>a : any
+>div : any
+}
+
+export function T2(a: any, b: any) {
+>T2 : (a: any, b: any) => JSX.Element
+>a : any
+>b : any
+
+    return <div className={"T2"} { ...a } { ...b }>T2</div>;
+><div className={"T2"} { ...a } { ...b }>T2</div> : JSX.Element
+>div : any
+>className : string
+>"T2" : "T2"
+>a : any
+>b : any
+>div : any
+}
+
+export function T3(a: any, b: any) {
+>T3 : (a: any, b: any) => JSX.Element
+>a : any
+>b : any
+
+    return <div { ...a } className={"T3"} { ...b }>T3</div>;
+><div { ...a } className={"T3"} { ...b }>T3</div> : JSX.Element
+>div : any
+>a : any
+>className : string
+>"T3" : "T3"
+>b : any
+>div : any
+}
+
+export function T4(a: any, b: any) {
+>T4 : (a: any, b: any) => JSX.Element
+>a : any
+>b : any
+
+    return <div className={"T4"} { ...{ ...a, ...b } }>T4</div>;
+><div className={"T4"} { ...{ ...a, ...b } }>T4</div> : JSX.Element
+>div : any
+>className : string
+>"T4" : "T4"
+>{ ...a, ...b } : any
+>a : any
+>b : any
+>div : any
+}
+
+export function T5(a: any, b: any, c: any, d: any) {
+>T5 : (a: any, b: any, c: any, d: any) => JSX.Element
+>a : any
+>b : any
+>c : any
+>d : any
+
+    return <div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div>;
+><div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div> : JSX.Element
+>div : any
+>className : string
+>"T5" : "T5"
+>{ ...a, ...b, ...{ c, d } } : any
+>a : any
+>b : any
+>{ c, d } : { c: any; d: any; }
+>c : any
+>d : any
+>div : any
+}
+
+export function T6(a: any, b: any, c: any, d: any) {
+>T6 : (a: any, b: any, c: any, d: any) => JSX.Element
+>a : any
+>b : any
+>c : any
+>d : any
+
+    return <div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div>;
+><div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div> : JSX.Element
+>div : any
+>className : string
+>"T6" : "T6"
+>{ ...a, ...b, ...{ ...c, ...d } } : any
+>a : any
+>b : any
+>{ ...c, ...d } : any
+>c : any
+>d : any
+>div : any
+}
+
+export function T7(a: any, b: any, c: any, d: any) {
+>T7 : (a: any, b: any, c: any, d: any) => JSX.Element
+>a : any
+>b : any
+>c : any
+>d : any
+
+    return <div>T7</div>;
+><div>T7</div> : JSX.Element
+>div : any
+>div : any
+}
+

--- a/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=esnext).js
+++ b/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=esnext).js
@@ -1,0 +1,56 @@
+//// [test.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+
+export function T1(a: any) {
+    return <div className={"T1"} { ...a }>T1</div>;
+}
+
+export function T2(a: any, b: any) {
+    return <div className={"T2"} { ...a } { ...b }>T2</div>;
+}
+
+export function T3(a: any, b: any) {
+    return <div { ...a } className={"T3"} { ...b }>T3</div>;
+}
+
+export function T4(a: any, b: any) {
+    return <div className={"T4"} { ...{ ...a, ...b } }>T4</div>;
+}
+
+export function T5(a: any, b: any, c: any, d: any) {
+    return <div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div>;
+}
+
+export function T6(a: any, b: any, c: any, d: any) {
+    return <div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div>;
+}
+
+export function T7(a: any, b: any, c: any, d: any) {
+    return <div>T7</div>;
+}
+
+
+//// [test.js]
+import { jsx as _jsx } from "react/jsx-runtime";
+/// <reference path="react16.d.ts" />
+export function T1(a) {
+    return _jsx("div", { className: "T1", ...a, children: "T1" }, void 0);
+}
+export function T2(a, b) {
+    return _jsx("div", { className: "T2", ...a, ...b, children: "T2" }, void 0);
+}
+export function T3(a, b) {
+    return _jsx("div", { ...a, className: "T3", ...b, children: "T3" }, void 0);
+}
+export function T4(a, b) {
+    return _jsx("div", { className: "T4", ...{ ...a, ...b }, children: "T4" }, void 0);
+}
+export function T5(a, b, c, d) {
+    return _jsx("div", { className: "T5", ...{ ...a, ...b, ...{ c, d } }, children: "T5" }, void 0);
+}
+export function T6(a, b, c, d) {
+    return _jsx("div", { className: "T6", ...{ ...a, ...b, ...{ ...c, ...d } }, children: "T6" }, void 0);
+}
+export function T7(a, b, c, d) {
+    return _jsx("div", { children: "T7" }, void 0);
+}

--- a/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=esnext).symbols
+++ b/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=esnext).symbols
@@ -1,0 +1,99 @@
+=== tests/cases/conformance/jsx/test.tsx ===
+/// <reference path="react16.d.ts" />
+
+export function T1(a: any) {
+>T1 : Symbol(T1, Decl(test.tsx, 0, 0))
+>a : Symbol(a, Decl(test.tsx, 2, 19))
+
+    return <div className={"T1"} { ...a }>T1</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 3, 15))
+>a : Symbol(a, Decl(test.tsx, 2, 19))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T2(a: any, b: any) {
+>T2 : Symbol(T2, Decl(test.tsx, 4, 1))
+>a : Symbol(a, Decl(test.tsx, 6, 19))
+>b : Symbol(b, Decl(test.tsx, 6, 26))
+
+    return <div className={"T2"} { ...a } { ...b }>T2</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 7, 15))
+>a : Symbol(a, Decl(test.tsx, 6, 19))
+>b : Symbol(b, Decl(test.tsx, 6, 26))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T3(a: any, b: any) {
+>T3 : Symbol(T3, Decl(test.tsx, 8, 1))
+>a : Symbol(a, Decl(test.tsx, 10, 19))
+>b : Symbol(b, Decl(test.tsx, 10, 26))
+
+    return <div { ...a } className={"T3"} { ...b }>T3</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>a : Symbol(a, Decl(test.tsx, 10, 19))
+>className : Symbol(className, Decl(test.tsx, 11, 24))
+>b : Symbol(b, Decl(test.tsx, 10, 26))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T4(a: any, b: any) {
+>T4 : Symbol(T4, Decl(test.tsx, 12, 1))
+>a : Symbol(a, Decl(test.tsx, 14, 19))
+>b : Symbol(b, Decl(test.tsx, 14, 26))
+
+    return <div className={"T4"} { ...{ ...a, ...b } }>T4</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 15, 15))
+>a : Symbol(a, Decl(test.tsx, 14, 19))
+>b : Symbol(b, Decl(test.tsx, 14, 26))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T5(a: any, b: any, c: any, d: any) {
+>T5 : Symbol(T5, Decl(test.tsx, 16, 1))
+>a : Symbol(a, Decl(test.tsx, 18, 19))
+>b : Symbol(b, Decl(test.tsx, 18, 26))
+>c : Symbol(c, Decl(test.tsx, 18, 34))
+>d : Symbol(d, Decl(test.tsx, 18, 42))
+
+    return <div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 19, 15))
+>a : Symbol(a, Decl(test.tsx, 18, 19))
+>b : Symbol(b, Decl(test.tsx, 18, 26))
+>c : Symbol(c, Decl(test.tsx, 19, 56))
+>d : Symbol(d, Decl(test.tsx, 19, 59))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T6(a: any, b: any, c: any, d: any) {
+>T6 : Symbol(T6, Decl(test.tsx, 20, 1))
+>a : Symbol(a, Decl(test.tsx, 22, 19))
+>b : Symbol(b, Decl(test.tsx, 22, 26))
+>c : Symbol(c, Decl(test.tsx, 22, 34))
+>d : Symbol(d, Decl(test.tsx, 22, 42))
+
+    return <div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>className : Symbol(className, Decl(test.tsx, 23, 15))
+>a : Symbol(a, Decl(test.tsx, 22, 19))
+>b : Symbol(b, Decl(test.tsx, 22, 26))
+>c : Symbol(c, Decl(test.tsx, 22, 34))
+>d : Symbol(d, Decl(test.tsx, 22, 42))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+
+export function T7(a: any, b: any, c: any, d: any) {
+>T7 : Symbol(T7, Decl(test.tsx, 24, 1))
+>a : Symbol(a, Decl(test.tsx, 26, 19))
+>b : Symbol(b, Decl(test.tsx, 26, 26))
+>c : Symbol(c, Decl(test.tsx, 26, 34))
+>d : Symbol(d, Decl(test.tsx, 26, 42))
+
+    return <div>T7</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+}
+

--- a/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=esnext).types
+++ b/tests/baselines/reference/tsxReactEmitSpreadAttribute(target=esnext).types
@@ -1,0 +1,117 @@
+=== tests/cases/conformance/jsx/test.tsx ===
+/// <reference path="react16.d.ts" />
+
+export function T1(a: any) {
+>T1 : (a: any) => JSX.Element
+>a : any
+
+    return <div className={"T1"} { ...a }>T1</div>;
+><div className={"T1"} { ...a }>T1</div> : JSX.Element
+>div : any
+>className : string
+>"T1" : "T1"
+>a : any
+>div : any
+}
+
+export function T2(a: any, b: any) {
+>T2 : (a: any, b: any) => JSX.Element
+>a : any
+>b : any
+
+    return <div className={"T2"} { ...a } { ...b }>T2</div>;
+><div className={"T2"} { ...a } { ...b }>T2</div> : JSX.Element
+>div : any
+>className : string
+>"T2" : "T2"
+>a : any
+>b : any
+>div : any
+}
+
+export function T3(a: any, b: any) {
+>T3 : (a: any, b: any) => JSX.Element
+>a : any
+>b : any
+
+    return <div { ...a } className={"T3"} { ...b }>T3</div>;
+><div { ...a } className={"T3"} { ...b }>T3</div> : JSX.Element
+>div : any
+>a : any
+>className : string
+>"T3" : "T3"
+>b : any
+>div : any
+}
+
+export function T4(a: any, b: any) {
+>T4 : (a: any, b: any) => JSX.Element
+>a : any
+>b : any
+
+    return <div className={"T4"} { ...{ ...a, ...b } }>T4</div>;
+><div className={"T4"} { ...{ ...a, ...b } }>T4</div> : JSX.Element
+>div : any
+>className : string
+>"T4" : "T4"
+>{ ...a, ...b } : any
+>a : any
+>b : any
+>div : any
+}
+
+export function T5(a: any, b: any, c: any, d: any) {
+>T5 : (a: any, b: any, c: any, d: any) => JSX.Element
+>a : any
+>b : any
+>c : any
+>d : any
+
+    return <div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div>;
+><div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div> : JSX.Element
+>div : any
+>className : string
+>"T5" : "T5"
+>{ ...a, ...b, ...{ c, d } } : any
+>a : any
+>b : any
+>{ c, d } : { c: any; d: any; }
+>c : any
+>d : any
+>div : any
+}
+
+export function T6(a: any, b: any, c: any, d: any) {
+>T6 : (a: any, b: any, c: any, d: any) => JSX.Element
+>a : any
+>b : any
+>c : any
+>d : any
+
+    return <div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div>;
+><div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div> : JSX.Element
+>div : any
+>className : string
+>"T6" : "T6"
+>{ ...a, ...b, ...{ ...c, ...d } } : any
+>a : any
+>b : any
+>{ ...c, ...d } : any
+>c : any
+>d : any
+>div : any
+}
+
+export function T7(a: any, b: any, c: any, d: any) {
+>T7 : (a: any, b: any, c: any, d: any) => JSX.Element
+>a : any
+>b : any
+>c : any
+>d : any
+
+    return <div>T7</div>;
+><div>T7</div> : JSX.Element
+>div : any
+>div : any
+}
+

--- a/tests/cases/conformance/jsx/tsxReactEmitSpreadAttribute.ts
+++ b/tests/cases/conformance/jsx/tsxReactEmitSpreadAttribute.ts
@@ -1,0 +1,32 @@
+// @jsx: react-jsx
+// @target: es2015,es2018,esnext
+// @filename: test.tsx
+/// <reference path="/.lib/react16.d.ts" />
+
+export function T1(a: any) {
+    return <div className={"T1"} { ...a }>T1</div>;
+}
+
+export function T2(a: any, b: any) {
+    return <div className={"T2"} { ...a } { ...b }>T2</div>;
+}
+
+export function T3(a: any, b: any) {
+    return <div { ...a } className={"T3"} { ...b }>T3</div>;
+}
+
+export function T4(a: any, b: any) {
+    return <div className={"T4"} { ...{ ...a, ...b } }>T4</div>;
+}
+
+export function T5(a: any, b: any, c: any, d: any) {
+    return <div className={"T5"} { ...{ ...a, ...b, ...{ c, d } } }>T5</div>;
+}
+
+export function T6(a: any, b: any, c: any, d: any) {
+    return <div className={"T6"} { ...{ ...a, ...b, ...{ ...c, ...d } } }>T6</div>;
+}
+
+export function T7(a: any, b: any, c: any, d: any) {
+    return <div>T7</div>;
+}


### PR DESCRIPTION
Fixes #46305