### PR TITLE
No error for markdown links in @see

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -8256,8 +8256,9 @@ namespace ts {
                 }
 
                 function parseSeeTag(start: number, tagName: Identifier, indent?: number, indentText?: string): JSDocSeeTag {
-                    const isLink = lookAhead(() => nextTokenJSDoc() === SyntaxKind.AtToken && tokenIsIdentifierOrKeyword(nextTokenJSDoc()) && scanner.getTokenValue() === "link");
-                    const nameExpression = isLink ? undefined : parseJSDocNameReference();
+                    const isMarkdownOrJSDocLink = token() === SyntaxKind.OpenBracketToken
+                        || lookAhead(() => nextTokenJSDoc() === SyntaxKind.AtToken && tokenIsIdentifierOrKeyword(nextTokenJSDoc()) && scanner.getTokenValue() === "link");
+                    const nameExpression = isMarkdownOrJSDocLink ? undefined : parseJSDocNameReference();
                     const comments = indent !== undefined && indentText !== undefined ? parseTrailingTagComments(start, getNodePos(), indent, indentText) : undefined;
                     return finishNode(factory.createJSDocSeeTag(tagName, nameExpression, comments), start);
                 }

--- a/tests/baselines/reference/seeTag3.js
+++ b/tests/baselines/reference/seeTag3.js
@@ -1,0 +1,10 @@
+//// [seeTag3.js]
+/** @see [The typescript web site](https://typescriptlang.org)  */
+function theWholeThing() {
+}
+
+
+//// [seeTag3.js]
+/** @see [The typescript web site](https://typescriptlang.org)  */
+function theWholeThing() {
+}

--- a/tests/baselines/reference/seeTag3.symbols
+++ b/tests/baselines/reference/seeTag3.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/conformance/jsdoc/seeTag3.js ===
+/** @see [The typescript web site](https://typescriptlang.org)  */
+function theWholeThing() {
+>theWholeThing : Symbol(theWholeThing, Decl(seeTag3.js, 0, 0))
+}
+

--- a/tests/baselines/reference/seeTag3.types
+++ b/tests/baselines/reference/seeTag3.types
@@ -1,0 +1,6 @@
+=== tests/cases/conformance/jsdoc/seeTag3.js ===
+/** @see [The typescript web site](https://typescriptlang.org)  */
+function theWholeThing() {
+>theWholeThing : () => void
+}
+

--- a/tests/cases/conformance/jsdoc/seeTag3.ts
+++ b/tests/cases/conformance/jsdoc/seeTag3.ts
@@ -1,0 +1,7 @@
+// @outdir: out/
+// @checkJs: true
+// @filename: seeTag3.js
+
+/** @see [The typescript web site](https://typescriptlang.org)  */
+function theWholeThing() {
+}


### PR DESCRIPTION
The error only shows up in checkJS files, but should still be ignored.

Fixes #44958
