### PR TITLE
Set impliedNodeFormat on sourceFiles maufactured in watch mode

### DIFF
--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -560,6 +560,9 @@ namespace ts {
                         sourceFilesCache.set(path, false);
                     }
                 }
+                if (sourceFile) {
+                    sourceFile.impliedNodeFormat = getImpliedNodeFormatForFile(path, resolutionCache.getModuleResolutionCache().getPackageJsonInfoCache(), compilerHost, compilerHost.getCompilationSettings());
+                }
                 return sourceFile;
             }
             return hostSourceFile.sourceFile;

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -158,6 +158,7 @@
         "unittests/tsc/runWithoutArgs.ts",
         "unittests/tscWatch/consoleClearing.ts",
         "unittests/tscWatch/emit.ts",
+        "unittests/tscWatch/nodeNextWatch.ts",
         "unittests/tscWatch/emitAndErrorUpdates.ts",
         "unittests/tscWatch/forceConsistentCasingInFileNames.ts",
         "unittests/tscWatch/incremental.ts",

--- a/src/testRunner/unittests/tscWatch/nodeNextWatch.ts
+++ b/src/testRunner/unittests/tscWatch/nodeNextWatch.ts
@@ -1,0 +1,58 @@
+namespace ts.tscWatch {
+    describe("unittests:: tsc-watch:: nodeNextWatch:: emit when module emit is specified as nodenext", () => {
+        verifyTscWatch({
+            scenario: "nodenext watch emit",
+            subScenario: "esm-mode file is edited",
+            commandLineArgs: ["--w", "--p", "/project/tsconfig.json"],
+            sys: () => {
+                const configFile: File = {
+                    path: "/project/tsconfig.json",
+                    content: JSON.stringify({
+                        compilerOptions: {
+                            strict: true,
+                            target: "es2020",
+                            module: "nodenext",
+                            moduleResolution: "nodenext",
+                            outDir: "../dist"
+                        }
+                    })
+                };
+                const packageFile: File = {
+                    path: "/project/package.json",
+                    content: JSON.stringify({
+                        name: "some-proj",
+                        version: "1.0.0",
+                        description: "",
+                        type: "module",
+                        main: "index.js",
+                    })
+                };
+                const file1: File = {
+                    path: "/project/src/index.ts",
+                    content: Utils.dedent`
+                        import * as Thing from "thing";
+
+                        Thing.fn();`
+                };
+                const declFile: File = {
+                    path: "/project/src/deps.d.ts",
+                    content: `declare module "thing";`
+                };
+                return createWatchedSystem([configFile, file1, declFile, packageFile, { ...libFile, path: "/a/lib/lib.es2020.full.d.ts" }]);
+            },
+            changes: [
+                {
+                    caption: "Modify typescript file",
+                    change: sys => sys.modifyFile(
+                        "/project/src/index.ts",
+                        Utils.dedent`
+                            import * as Thing from "thing";
+                            Thing.fn();`,
+                        {},
+                    ),
+                    timeouts: runQueuedTimeoutCallbacks,
+                }
+            ],
+        });
+    });
+}

--- a/tests/baselines/reference/tscWatch/nodenext watch emit/esm-mode-file-is-edited.js
+++ b/tests/baselines/reference/tscWatch/nodenext watch emit/esm-mode-file-is-edited.js
@@ -1,0 +1,147 @@
+Input::
+//// [/project/tsconfig.json]
+{"compilerOptions":{"strict":true,"target":"es2020","module":"nodenext","moduleResolution":"nodenext","outDir":"../dist"}}
+
+//// [/project/src/index.ts]
+import * as Thing from "thing";
+
+Thing.fn();
+
+//// [/project/src/deps.d.ts]
+declare module "thing";
+
+//// [/project/package.json]
+{"name":"some-proj","version":"1.0.0","description":"","type":"module","main":"index.js"}
+
+//// [/a/lib/lib.es2020.full.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+
+/a/lib/tsc.js --w --p /project/tsconfig.json
+Output::
+>> Screen clear
+[[90m12:00:21 AM[0m] Starting compilation in watch mode...
+
+[[90m12:00:27 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/project/src/deps.d.ts","/project/src/index.ts"]
+Program options: {"strict":true,"target":7,"module":199,"moduleResolution":99,"outDir":"/dist","watch":true,"project":"/project/tsconfig.json","configFilePath":"/project/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.es2020.full.d.ts
+/project/src/deps.d.ts
+/project/src/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.es2020.full.d.ts
+/project/src/deps.d.ts
+/project/src/index.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.es2020.full.d.ts (used version)
+/project/src/deps.d.ts (used version)
+/project/src/index.ts (used version)
+
+WatchedFiles::
+/project/tsconfig.json:
+  {"fileName":"/project/tsconfig.json","pollingInterval":250}
+/project/src/deps.d.ts:
+  {"fileName":"/project/src/deps.d.ts","pollingInterval":250}
+/project/src/index.ts:
+  {"fileName":"/project/src/index.ts","pollingInterval":250}
+/a/lib/lib.es2020.full.d.ts:
+  {"fileName":"/a/lib/lib.es2020.full.d.ts","pollingInterval":250}
+/project/src/package.json:
+  {"fileName":"/project/src/package.json","pollingInterval":250}
+/project/package.json:
+  {"fileName":"/project/package.json","pollingInterval":250}
+/a/lib/package.json:
+  {"fileName":"/a/lib/package.json","pollingInterval":250}
+/a/package.json:
+  {"fileName":"/a/package.json","pollingInterval":250}
+/package.json:
+  {"fileName":"/package.json","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/project/node_modules/@types:
+  {"directoryName":"/project/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/project:
+  {"directoryName":"/project","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/dist/index.js]
+import * as Thing from "thing";
+Thing.fn();
+
+
+
+Change:: Modify typescript file
+
+Input::
+//// [/project/src/index.ts]
+import * as Thing from "thing";
+Thing.fn();
+
+
+Output::
+>> Screen clear
+[[90m12:00:30 AM[0m] File change detected. Starting incremental compilation...
+
+[[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/project/src/deps.d.ts","/project/src/index.ts"]
+Program options: {"strict":true,"target":7,"module":199,"moduleResolution":99,"outDir":"/dist","watch":true,"project":"/project/tsconfig.json","configFilePath":"/project/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.es2020.full.d.ts
+/project/src/deps.d.ts
+/project/src/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/project/src/index.ts
+
+Shape signatures in builder refreshed for::
+/project/src/index.ts (computed .d.ts)
+
+WatchedFiles::
+/project/tsconfig.json:
+  {"fileName":"/project/tsconfig.json","pollingInterval":250}
+/project/src/deps.d.ts:
+  {"fileName":"/project/src/deps.d.ts","pollingInterval":250}
+/project/src/index.ts:
+  {"fileName":"/project/src/index.ts","pollingInterval":250}
+/a/lib/lib.es2020.full.d.ts:
+  {"fileName":"/a/lib/lib.es2020.full.d.ts","pollingInterval":250}
+/project/src/package.json:
+  {"fileName":"/project/src/package.json","pollingInterval":250}
+/project/package.json:
+  {"fileName":"/project/package.json","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/project/node_modules/@types:
+  {"directoryName":"/project/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/project:
+  {"directoryName":"/project","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/dist/index.js] file written with same contents


### PR DESCRIPTION
Fixes #46333

I put quite a bit of effort into testing this in build/incremental mode in the initial PR (that's why `impliedNodeFormat` is serialized into the build info file already!) - I naively assumed `watch` mode would come for free from that. I was incorrect in that assumption. 😢 In any case, the fix is quite small - just setting the `impliedNodeFormat` `SourceFile` member on source files made by the watch program. (Which, as a reminder, this field has to be set by the program because you need a full module resolver host to set it, and the program is the first level at which we have one available)