### PR TITLE
Pass symbol under inspection into checkIndexConstraints

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34636,7 +34636,7 @@ namespace ts {
             forEach(node.members, checkSourceElement);
             if (produceDiagnostics) {
                 const type = getTypeFromTypeLiteralOrFunctionOrConstructorTypeNode(node);
-                checkIndexConstraints(type);
+                checkIndexConstraints(type, type.symbol);
                 checkTypeForDuplicateIndexSignatures(node);
                 checkObjectTypeForDuplicateDeclarations(node);
             }
@@ -38069,7 +38069,7 @@ namespace ts {
             }
         }
 
-        function checkIndexConstraints(type: Type, isStaticIndex?: boolean) {
+        function checkIndexConstraints(type: Type, symbol: Symbol, isStaticIndex?: boolean) {
             const indexInfos = getIndexInfosOfType(type);
             if (indexInfos.length === 0) {
                 return;
@@ -38079,7 +38079,7 @@ namespace ts {
                     checkIndexConstraintForProperty(type, prop, getLiteralTypeFromProperty(prop, TypeFlags.StringOrNumberLiteralOrUnique, /*includeNonPublic*/ true), getNonMissingTypeOfSymbol(prop));
                 }
             }
-            const typeDeclaration = type.symbol.valueDeclaration;
+            const typeDeclaration = symbol.valueDeclaration;
             if (typeDeclaration && isClassLike(typeDeclaration)) {
                 for (const member of typeDeclaration.members) {
                     // Only process instance properties with computed names here. Static properties cannot be in conflict with indexers,
@@ -38420,8 +38420,8 @@ namespace ts {
             }
 
             if (produceDiagnostics) {
-                checkIndexConstraints(type);
-                checkIndexConstraints(staticType, /*isStaticIndex*/ true);
+                checkIndexConstraints(type, symbol);
+                checkIndexConstraints(staticType, symbol, /*isStaticIndex*/ true);
                 checkTypeForDuplicateIndexSignatures(node);
                 checkPropertyInitialization(node);
             }
@@ -38848,7 +38848,7 @@ namespace ts {
                         for (const baseType of getBaseTypes(type)) {
                             checkTypeAssignableTo(typeWithThis, getTypeWithThisArgument(baseType, type.thisType), node.name, Diagnostics.Interface_0_incorrectly_extends_interface_1);
                         }
-                        checkIndexConstraints(type);
+                        checkIndexConstraints(type, symbol);
                     }
                 }
                 checkObjectTypeForDuplicateDeclarations(node);

--- a/tests/baselines/reference/mixinOverMappedTypeNoCrash.symbols
+++ b/tests/baselines/reference/mixinOverMappedTypeNoCrash.symbols
@@ -1,0 +1,58 @@
+=== tests/cases/compiler/mixinOverMappedTypeNoCrash.ts ===
+export type ClassInterface<C> = {
+>ClassInterface : Symbol(ClassInterface, Decl(mixinOverMappedTypeNoCrash.ts, 0, 0))
+>C : Symbol(C, Decl(mixinOverMappedTypeNoCrash.ts, 0, 27))
+
+    [key in keyof C]: C[key];
+>key : Symbol(key, Decl(mixinOverMappedTypeNoCrash.ts, 1, 5))
+>C : Symbol(C, Decl(mixinOverMappedTypeNoCrash.ts, 0, 27))
+>C : Symbol(C, Decl(mixinOverMappedTypeNoCrash.ts, 0, 27))
+>key : Symbol(key, Decl(mixinOverMappedTypeNoCrash.ts, 1, 5))
+}
+
+type InstanceInterface<I> = {
+>InstanceInterface : Symbol(InstanceInterface, Decl(mixinOverMappedTypeNoCrash.ts, 2, 1))
+>I : Symbol(I, Decl(mixinOverMappedTypeNoCrash.ts, 4, 23))
+
+    new(...args: any[]): I
+>args : Symbol(args, Decl(mixinOverMappedTypeNoCrash.ts, 5, 8))
+>I : Symbol(I, Decl(mixinOverMappedTypeNoCrash.ts, 4, 23))
+
+    prototype: I
+>prototype : Symbol(prototype, Decl(mixinOverMappedTypeNoCrash.ts, 5, 26))
+>I : Symbol(I, Decl(mixinOverMappedTypeNoCrash.ts, 4, 23))
+}
+
+type Constructor<I extends Object, C = any> = ClassInterface<C> & InstanceInterface<I>
+>Constructor : Symbol(Constructor, Decl(mixinOverMappedTypeNoCrash.ts, 7, 1))
+>I : Symbol(I, Decl(mixinOverMappedTypeNoCrash.ts, 9, 17))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(mixinOverMappedTypeNoCrash.ts, 9, 34))
+>ClassInterface : Symbol(ClassInterface, Decl(mixinOverMappedTypeNoCrash.ts, 0, 0))
+>C : Symbol(C, Decl(mixinOverMappedTypeNoCrash.ts, 9, 34))
+>InstanceInterface : Symbol(InstanceInterface, Decl(mixinOverMappedTypeNoCrash.ts, 2, 1))
+>I : Symbol(I, Decl(mixinOverMappedTypeNoCrash.ts, 9, 17))
+
+function cloneClass<T extends Constructor<{}>>(OriginalClass: T): T {
+>cloneClass : Symbol(cloneClass, Decl(mixinOverMappedTypeNoCrash.ts, 9, 86))
+>T : Symbol(T, Decl(mixinOverMappedTypeNoCrash.ts, 11, 20))
+>Constructor : Symbol(Constructor, Decl(mixinOverMappedTypeNoCrash.ts, 7, 1))
+>OriginalClass : Symbol(OriginalClass, Decl(mixinOverMappedTypeNoCrash.ts, 11, 47))
+>T : Symbol(T, Decl(mixinOverMappedTypeNoCrash.ts, 11, 20))
+>T : Symbol(T, Decl(mixinOverMappedTypeNoCrash.ts, 11, 20))
+
+    class AnotherOriginalClass extends OriginalClass {
+>AnotherOriginalClass : Symbol(AnotherOriginalClass, Decl(mixinOverMappedTypeNoCrash.ts, 11, 69))
+>OriginalClass : Symbol(OriginalClass, Decl(mixinOverMappedTypeNoCrash.ts, 11, 47))
+
+        constructor(...args: any[]) {
+>args : Symbol(args, Decl(mixinOverMappedTypeNoCrash.ts, 13, 20))
+
+            super(...args)
+>super : Symbol(T, Decl(mixinOverMappedTypeNoCrash.ts, 11, 20))
+>args : Symbol(args, Decl(mixinOverMappedTypeNoCrash.ts, 13, 20))
+        }
+    }
+    return AnotherOriginalClass
+>AnotherOriginalClass : Symbol(AnotherOriginalClass, Decl(mixinOverMappedTypeNoCrash.ts, 11, 69))
+}

--- a/tests/baselines/reference/mixinOverMappedTypeNoCrash.types
+++ b/tests/baselines/reference/mixinOverMappedTypeNoCrash.types
@@ -1,0 +1,41 @@
+=== tests/cases/compiler/mixinOverMappedTypeNoCrash.ts ===
+export type ClassInterface<C> = {
+>ClassInterface : ClassInterface<C>
+
+    [key in keyof C]: C[key];
+}
+
+type InstanceInterface<I> = {
+>InstanceInterface : InstanceInterface<I>
+
+    new(...args: any[]): I
+>args : any[]
+
+    prototype: I
+>prototype : I
+}
+
+type Constructor<I extends Object, C = any> = ClassInterface<C> & InstanceInterface<I>
+>Constructor : Constructor<I, C>
+
+function cloneClass<T extends Constructor<{}>>(OriginalClass: T): T {
+>cloneClass : <T extends Constructor<{}, any>>(OriginalClass: T) => T
+>OriginalClass : T
+
+    class AnotherOriginalClass extends OriginalClass {
+>AnotherOriginalClass : AnotherOriginalClass
+>OriginalClass : {}
+
+        constructor(...args: any[]) {
+>args : any[]
+
+            super(...args)
+>super(...args) : void
+>super : T
+>...args : any
+>args : any[]
+        }
+    }
+    return AnotherOriginalClass
+>AnotherOriginalClass : { new (...args: any[]): AnotherOriginalClass; prototype: cloneClass<any>.AnotherOriginalClass; } & T
+}

--- a/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts
+++ b/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts
@@ -1,0 +1,21 @@
+// @noEmit: true
+
+export type ClassInterface<C> = {
+    [key in keyof C]: C[key];
+}
+
+type InstanceInterface<I> = {
+    new(...args: any[]): I
+    prototype: I
+}
+
+type Constructor<I extends Object, C = any> = ClassInterface<C> & InstanceInterface<I>
+
+function cloneClass<T extends Constructor<{}>>(OriginalClass: T): T {
+    class AnotherOriginalClass extends OriginalClass {
+        constructor(...args: any[]) {
+            super(...args)
+        }
+    }
+    return AnotherOriginalClass
+}


### PR DESCRIPTION
Rather than relying on finding on the `type` we pass in, which may not have a symbol it it's, eg, an intersection.

Fixes #46223
