### PR TITLE
Import assertion: do not parse } if { is not present

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7277,19 +7277,24 @@ namespace ts {
             const pos = getNodePos();
             parseExpected(SyntaxKind.AssertKeyword);
             const openBracePosition = scanner.getTokenPos();
-            parseExpected(SyntaxKind.OpenBraceToken);
-            const multiLine = scanner.hasPrecedingLineBreak();
-            const elements = parseDelimitedList(ParsingContext.AssertEntries, parseAssertEntry, /*considerSemicolonAsDelimiter*/ true);
-            if (!parseExpected(SyntaxKind.CloseBraceToken)) {
-                const lastError = lastOrUndefined(parseDiagnostics);
-                if (lastError && lastError.code === Diagnostics._0_expected.code) {
-                    addRelatedInfo(
-                        lastError,
-                        createDetachedDiagnostic(fileName, openBracePosition, 1, Diagnostics.The_parser_expected_to_find_a_to_match_the_token_here)
-                    );
+            if (parseExpected(SyntaxKind.OpenBraceToken)) {
+                const multiLine = scanner.hasPrecedingLineBreak();
+                const elements = parseDelimitedList(ParsingContext.AssertEntries, parseAssertEntry, /*considerSemicolonAsDelimiter*/ true);
+                if (!parseExpected(SyntaxKind.CloseBraceToken)) {
+                    const lastError = lastOrUndefined(parseDiagnostics);
+                    if (lastError && lastError.code === Diagnostics._0_expected.code) {
+                        addRelatedInfo(
+                            lastError,
+                            createDetachedDiagnostic(fileName, openBracePosition, 1, Diagnostics.The_parser_expected_to_find_a_to_match_the_token_here)
+                        );
+                    }
                 }
+                return finishNode(factory.createAssertClause(elements, multiLine), pos);
             }
-            return finishNode(factory.createAssertClause(elements, multiLine), pos);
+            else {
+                const elements = createNodeArray([], getNodePos(), /*end*/ undefined, /*hasTrailingComma*/ false);
+                return finishNode(factory.createAssertClause(elements, /*multiLine*/ false), pos);
+            }
         }
 
         function tokenAfterImportDefinitelyProducesImportDeclaration() {

--- a/tests/baselines/reference/importAssertion4.errors.txt
+++ b/tests/baselines/reference/importAssertion4.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/conformance/importAssertion/importAssertion4.ts(1,20): error TS2307: Cannot find module './first' or its corresponding type declarations.
+tests/cases/conformance/importAssertion/importAssertion4.ts(2,1): error TS1005: '{' expected.
+
+
+==== tests/cases/conformance/importAssertion/importAssertion4.ts (2 errors) ====
+    import * as f from "./first" assert
+                       ~~~~~~~~~
+!!! error TS2307: Cannot find module './first' or its corresponding type declarations.
+    
+    
+!!! error TS1005: '{' expected.

--- a/tests/baselines/reference/importAssertion4.js
+++ b/tests/baselines/reference/importAssertion4.js
@@ -1,0 +1,7 @@
+//// [importAssertion4.ts]
+import * as f from "./first" assert
+
+
+//// [importAssertion4.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/importAssertion4.symbols
+++ b/tests/baselines/reference/importAssertion4.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/importAssertion/importAssertion4.ts ===
+import * as f from "./first" assert
+>f : Symbol(f, Decl(importAssertion4.ts, 0, 6))
+

--- a/tests/baselines/reference/importAssertion4.types
+++ b/tests/baselines/reference/importAssertion4.types
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/importAssertion/importAssertion4.ts ===
+import * as f from "./first" assert
+>f : any
+

--- a/tests/baselines/reference/importAssertion5.errors.txt
+++ b/tests/baselines/reference/importAssertion5.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/importAssertion/importAssertion5.ts(1,20): error TS2307: Cannot find module './first' or its corresponding type declarations.
+tests/cases/conformance/importAssertion/importAssertion5.ts(2,1): error TS1005: '}' expected.
+
+
+==== tests/cases/conformance/importAssertion/importAssertion5.ts (2 errors) ====
+    import * as f from "./first" assert {
+                       ~~~~~~~~~
+!!! error TS2307: Cannot find module './first' or its corresponding type declarations.
+    
+    
+!!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/conformance/importAssertion/importAssertion5.ts:1:37: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/importAssertion5.js
+++ b/tests/baselines/reference/importAssertion5.js
@@ -1,0 +1,7 @@
+//// [importAssertion5.ts]
+import * as f from "./first" assert {
+
+
+//// [importAssertion5.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/importAssertion5.symbols
+++ b/tests/baselines/reference/importAssertion5.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/importAssertion/importAssertion5.ts ===
+import * as f from "./first" assert {
+>f : Symbol(f, Decl(importAssertion5.ts, 0, 6))
+

--- a/tests/baselines/reference/importAssertion5.types
+++ b/tests/baselines/reference/importAssertion5.types
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/importAssertion/importAssertion5.ts ===
+import * as f from "./first" assert {
+>f : any
+

--- a/tests/cases/conformance/importAssertion/importAssertion4.ts
+++ b/tests/cases/conformance/importAssertion/importAssertion4.ts
@@ -1,0 +1,1 @@
+import * as f from "./first" assert

--- a/tests/cases/conformance/importAssertion/importAssertion5.ts
+++ b/tests/cases/conformance/importAssertion/importAssertion5.ts
@@ -1,0 +1,1 @@
+import * as f from "./first" assert {


### PR DESCRIPTION
Previously, import assertion parsing would try to parse both { and }, even if both were missing. If both were missing, the error for } could occur past the end of the file, causing an assertion. This PR changes the code to parse `{}` the same way that `parseBlock` does.

Review with whitespace ignored.

Fixes #46364