### PR TITLE
Specify parameter index for diagnostic on spread function arguments

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2535,6 +2535,10 @@
         "category": "Error",
         "code": 2598
     },
+    "Argument of type '{0}' is not assignable to parameter at position {2} of type '{1}'.": {
+        "category": "Error",
+        "code": 2599
+    },
     "JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.": {
         "category": "Error",
         "code": 2602

--- a/tests/baselines/reference/callWithSpread2.errors.txt
+++ b/tests/baselines/reference/callWithSpread2.errors.txt
@@ -2,16 +2,16 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(23,13): err
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(24,7): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(27,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(28,5): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(29,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(28,5): error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(29,13): error TS2599: Argument of type 'string | number' is not assignable to parameter at position 1 of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(30,13): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(31,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(30,13): error TS2599: Argument of type 'string' is not assignable to parameter at position 2 of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(31,11): error TS2599: Argument of type 'string | number' is not assignable to parameter at position 1 of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(32,11): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(32,11): error TS2599: Argument of type 'string' is not assignable to parameter at position 2 of type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(33,8): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(34,8): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(35,8): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(35,8): error TS2599: Argument of type 'number' is not assignable to parameter at position 0 of type 'string'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(36,14): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
 
 
@@ -52,21 +52,21 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(36,14): err
 !!! error TS2345:   Type 'string' is not assignable to type 'number'.
     all(...tuple)
         ~~~~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+!!! error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'number'.
     prefix("b", ...mixed)
                 ~~~~~~~~
-!!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-!!! error TS2345:   Type 'string' is not assignable to type 'number'.
+!!! error TS2599: Argument of type 'string | number' is not assignable to parameter at position 1 of type 'number'.
+!!! error TS2599:   Type 'string' is not assignable to type 'number'.
     prefix("c", ...tuple)
                 ~~~~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+!!! error TS2599: Argument of type 'string' is not assignable to parameter at position 2 of type 'number'.
     rest("e", ...mixed)
               ~~~~~~~~
-!!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-!!! error TS2345:   Type 'string' is not assignable to type 'number'.
+!!! error TS2599: Argument of type 'string | number' is not assignable to parameter at position 1 of type 'number'.
+!!! error TS2599:   Type 'string' is not assignable to type 'number'.
     rest("f", ...tuple)
               ~~~~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+!!! error TS2599: Argument of type 'string' is not assignable to parameter at position 2 of type 'number'.
     prefix(...ns) // required parameters are required
            ~~~~~
 !!! error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
@@ -75,7 +75,7 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(36,14): err
 !!! error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
     prefix(...tuple)
            ~~~~~~~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+!!! error TS2599: Argument of type 'number' is not assignable to parameter at position 0 of type 'string'.
     prefix2("g", ...ns);
                  ~~~~~
 !!! error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.

--- a/tests/baselines/reference/callWithSpread3.errors.txt
+++ b/tests/baselines/reference/callWithSpread3.errors.txt
@@ -8,11 +8,12 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(20,6): erro
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(21,6): error TS2599: Argument of type 'number' is not assignable to parameter at position 2 of type 'string'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(22,6): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(23,6): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
+tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(24,14): error TS2599: Argument of type 'string' is not assignable to parameter at position 2 of type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(25,7): error TS2599: Argument of type 'string' is not assignable to parameter at position 2 of type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(31,6): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
 
 
-==== tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts (12 errors) ====
+==== tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts (13 errors) ====
     declare const s2: [string, string];
     declare const s3: [string, string, string];
     declare const s2_: [string, string, ...string[]];
@@ -56,7 +57,9 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(31,6): erro
     fs2_(...s_, ...s_, ...s_); // error on ...s_
          ~~~~~
 !!! error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
-    // fs2n_(...s2, ...s_); //           FIXME: should be a type error
+    fs2n_(...s2, ...s_); // error on ...s_
+                 ~~~~~
+!!! error TS2599: Argument of type 'string' is not assignable to parameter at position 2 of type 'number'.
     fs2n_(...s2_); // error on ...s2_
           ~~~~~~
 !!! error TS2599: Argument of type 'string' is not assignable to parameter at position 2 of type 'number'.

--- a/tests/baselines/reference/callWithSpread3.errors.txt
+++ b/tests/baselines/reference/callWithSpread3.errors.txt
@@ -5,10 +5,10 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(17,15): err
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(18,12): error TS2554: Expected 2 arguments, but got 3.
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(19,5): error TS2554: Expected 2 arguments, but got 3.
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(20,6): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
-tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(21,6): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(21,6): error TS2599: Argument of type 'number' is not assignable to parameter at position 2 of type 'string'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(22,6): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(23,6): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
-tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(25,7): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(25,7): error TS2599: Argument of type 'string' is not assignable to parameter at position 2 of type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(31,6): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
 
 
@@ -49,7 +49,7 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(31,6): erro
 !!! error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
     fs2_(...s2n_); // error on ...s2n_
          ~~~~~~~
-!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+!!! error TS2599: Argument of type 'number' is not assignable to parameter at position 2 of type 'string'.
     fs2_(...s_, ...s_); // error on ...s_
          ~~~~~
 !!! error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
@@ -59,7 +59,7 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(31,6): erro
     // fs2n_(...s2, ...s_); //           FIXME: should be a type error
     fs2n_(...s2_); // error on ...s2_
           ~~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+!!! error TS2599: Argument of type 'string' is not assignable to parameter at position 2 of type 'number'.
     
     // ok
     fs2_(...s2_);

--- a/tests/baselines/reference/callWithSpread3.js
+++ b/tests/baselines/reference/callWithSpread3.js
@@ -22,7 +22,7 @@ fs2_(...s_); // error on ...s_
 fs2_(...s2n_); // error on ...s2n_
 fs2_(...s_, ...s_); // error on ...s_
 fs2_(...s_, ...s_, ...s_); // error on ...s_
-// fs2n_(...s2, ...s_); //           FIXME: should be a type error
+fs2n_(...s2, ...s_); // error on ...s_
 fs2n_(...s2_); // error on ...s2_
 
 // ok
@@ -57,7 +57,7 @@ fs2_.apply(void 0, s_); // error on ...s_
 fs2_.apply(void 0, s2n_); // error on ...s2n_
 fs2_.apply(void 0, __spreadArray(__spreadArray([], s_, false), s_, false)); // error on ...s_
 fs2_.apply(void 0, __spreadArray(__spreadArray(__spreadArray([], s_, false), s_, false), s_, false)); // error on ...s_
-// fs2n_(...s2, ...s_); //           FIXME: should be a type error
+fs2n_.apply(void 0, __spreadArray(__spreadArray([], s2, false), s_, false)); // error on ...s_
 fs2n_.apply(void 0, s2_); // error on ...s2_
 // ok
 fs2_.apply(void 0, s2_);

--- a/tests/baselines/reference/callWithSpread3.symbols
+++ b/tests/baselines/reference/callWithSpread3.symbols
@@ -86,7 +86,11 @@ fs2_(...s_, ...s_, ...s_); // error on ...s_
 >s_ : Symbol(s_, Decl(callWithSpread3.ts, 3, 13))
 >s_ : Symbol(s_, Decl(callWithSpread3.ts, 3, 13))
 
-// fs2n_(...s2, ...s_); //           FIXME: should be a type error
+fs2n_(...s2, ...s_); // error on ...s_
+>fs2n_ : Symbol(fs2n_, Decl(callWithSpread3.ts, 8, 66))
+>s2 : Symbol(s2, Decl(callWithSpread3.ts, 0, 13))
+>s_ : Symbol(s_, Decl(callWithSpread3.ts, 3, 13))
+
 fs2n_(...s2_); // error on ...s2_
 >fs2n_ : Symbol(fs2n_, Decl(callWithSpread3.ts, 8, 66))
 >s2_ : Symbol(s2_, Decl(callWithSpread3.ts, 2, 13))

--- a/tests/baselines/reference/callWithSpread3.types
+++ b/tests/baselines/reference/callWithSpread3.types
@@ -121,7 +121,14 @@ fs2_(...s_, ...s_, ...s_); // error on ...s_
 >...s_ : string
 >s_ : string[]
 
-// fs2n_(...s2, ...s_); //           FIXME: should be a type error
+fs2n_(...s2, ...s_); // error on ...s_
+>fs2n_(...s2, ...s_) : void
+>fs2n_ : (a: string, b: string, ...c: number[]) => void
+>...s2 : string
+>s2 : [string, string]
+>...s_ : string
+>s_ : string[]
+
 fs2n_(...s2_); // error on ...s2_
 >fs2n_(...s2_) : void
 >fs2n_ : (a: string, b: string, ...c: number[]) => void

--- a/tests/baselines/reference/iteratorSpreadInCall6.errors.txt
+++ b/tests/baselines/reference/iteratorSpreadInCall6.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/spread/iteratorSpreadInCall6.ts(28,28): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number | symbol'.
+tests/cases/conformance/es6/spread/iteratorSpreadInCall6.ts(28,28): error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'number | symbol'.
 
 
 ==== tests/cases/conformance/es6/spread/iteratorSpreadInCall6.ts (1 errors) ====
@@ -31,4 +31,4 @@ tests/cases/conformance/es6/spread/iteratorSpreadInCall6.ts(28,28): error TS2345
     
     foo(...new SymbolIterator, ...new _StringIterator);
                                ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number | symbol'.
+!!! error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'number | symbol'.

--- a/tests/baselines/reference/iteratorSpreadInCall7.errors.txt
+++ b/tests/baselines/reference/iteratorSpreadInCall7.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/spread/iteratorSpreadInCall7.ts(28,28): error TS2345: Argument of type 'string' is not assignable to parameter of type 'symbol'.
+tests/cases/conformance/es6/spread/iteratorSpreadInCall7.ts(28,28): error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'symbol'.
 
 
 ==== tests/cases/conformance/es6/spread/iteratorSpreadInCall7.ts (1 errors) ====
@@ -31,4 +31,4 @@ tests/cases/conformance/es6/spread/iteratorSpreadInCall7.ts(28,28): error TS2345
     
     foo(...new SymbolIterator, ...new _StringIterator);
                                ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'symbol'.
+!!! error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'symbol'.

--- a/tests/baselines/reference/iteratorSpreadInCall8.errors.txt
+++ b/tests/baselines/reference/iteratorSpreadInCall8.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/spread/iteratorSpreadInCall8.ts(31,32): error TS2345: Argument of type 'string' is not assignable to parameter of type 'symbol'.
+tests/cases/conformance/es6/spread/iteratorSpreadInCall8.ts(31,32): error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'symbol'.
 
 
 ==== tests/cases/conformance/es6/spread/iteratorSpreadInCall8.ts (1 errors) ====
@@ -34,4 +34,4 @@ tests/cases/conformance/es6/spread/iteratorSpreadInCall8.ts(31,32): error TS2345
     
     new Foo(...new SymbolIterator, ...new _StringIterator);
                                    ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'symbol'.
+!!! error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'symbol'.

--- a/tests/baselines/reference/iteratorSpreadInCall9.errors.txt
+++ b/tests/baselines/reference/iteratorSpreadInCall9.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/spread/iteratorSpreadInCall9.ts(31,32): error TS2345: Argument of type 'string' is not assignable to parameter of type 'symbol'.
+tests/cases/conformance/es6/spread/iteratorSpreadInCall9.ts(31,32): error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'symbol'.
 
 
 ==== tests/cases/conformance/es6/spread/iteratorSpreadInCall9.ts (1 errors) ====
@@ -34,5 +34,5 @@ tests/cases/conformance/es6/spread/iteratorSpreadInCall9.ts(31,32): error TS2345
     
     new Foo(...new SymbolIterator, ...[...new _StringIterator]);
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'symbol'.
+!!! error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'symbol'.
     

--- a/tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts
+++ b/tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts
@@ -21,7 +21,7 @@ fs2_(...s_); // error on ...s_
 fs2_(...s2n_); // error on ...s2n_
 fs2_(...s_, ...s_); // error on ...s_
 fs2_(...s_, ...s_, ...s_); // error on ...s_
-// fs2n_(...s2, ...s_); //           FIXME: should be a type error
+fs2n_(...s2, ...s_); // error on ...s_
 fs2n_(...s2_); // error on ...s2_
 
 // ok


### PR DESCRIPTION
Fixes #46324

```
error TS2599: Argument of type 'string' is not assignable to parameter at position 1 of type 'number'.
```

I'm very unsure on this error message... I'd originally wanted to specify the entire type of the function parameters but that got pretty noisy when there are >>2 parameters. It would have been nice to include the violating index in the tuple itself but I couldn't wordcraft a good way to phrase it. Any phrasing help would be appreciated please! :pray: 

As for the implementation, this seems to be the first diagnostic used for `checkAssignableTo` assignability complaints that would also want an additional argument beyond the two type names. Hence all the changes from `DiagnosticMessage | undefined` to `[message: DiagnosticMessage, arg?: number | string]`.