### PR TITLE
Avoid hard-wired build-tree paths

### DIFF
--- a/scripts/build/findUpDir.js
+++ b/scripts/build/findUpDir.js
@@ -1,0 +1,21 @@
+const { join, resolve, dirname } = require("path");
+const { existsSync } = require("fs");
+
+// search directories upward to avoid hard-wired paths based on the
+// build tree (same as src/harness/findUpDir.ts)
+
+function findUpFile(name) {
+    let dir = __dirname;
+    while (true) {
+        const fullPath = join(dir, name);
+        if (existsSync(fullPath)) return fullPath;
+        const up = resolve(dir, "..");
+        if (up === dir) return name; // it'll fail anyway
+        dir = up;
+    }
+}
+exports.findUpFile = findUpFile;
+
+const findUpRoot = () =>
+    findUpRoot.cached || (findUpRoot.cached = dirname(findUpFile("Gulpfile.js")));
+exports.findUpRoot = findUpRoot;

--- a/scripts/build/tests.js
+++ b/scripts/build/tests.js
@@ -9,6 +9,7 @@ const log = require("fancy-log");
 const cmdLineOptions = require("./options");
 const { CancellationToken } = require("prex");
 const { exec } = require("./utils");
+const { findUpFile } = require("./findUpDir");
 
 const mochaJs = require.resolve("mocha/bin/_mocha");
 exports.localBaseline = "tests/baselines/local/";
@@ -73,11 +74,11 @@ async function runConsoleTests(runJs, defaultReporter, runInParallel, watchMode,
     /** @type {string[]} */
     let args = [];
 
-    // timeout normally isn"t necessary but Travis-CI has been timing out on compiler baselines occasionally
+    // timeout normally isn't necessary but Travis-CI has been timing out on compiler baselines occasionally
     // default timeout is 2sec which really should be enough, but maybe we just need a small amount longer
     if (!runInParallel) {
         args.push(mochaJs);
-        args.push("-R", "scripts/failed-tests");
+        args.push("-R", findUpFile("scripts/failed-tests.js"));
         args.push("-O", '"reporter=' + reporter + (keepFailed ? ",keepFailed=true" : "") + '"');
         if (tests) {
             args.push("-g", `"${tests}"`);

--- a/src/harness/findUpDir.ts
+++ b/src/harness/findUpDir.ts
@@ -1,0 +1,21 @@
+namespace findUpDir {
+    import { join, resolve, dirname } from "path";
+    import { existsSync } from "fs";
+
+    // search directories upward to avoid hard-wired paths based on the
+    // build tree (same as scripts/build/findUpDir.js)
+
+    export function findUpFile(name: string) {
+        let dir = __dirname;
+        while (true) {
+            const fullPath = join(dir, name);
+            if (existsSync(fullPath)) return fullPath;
+            const up = resolve(dir, "..");
+            if (up === dir) return name; // it'll fail anyway
+            dir = up;
+        }
+    }
+
+    export const findUpRoot: { (): string; cached?: string; } = () =>
+        findUpRoot.cached ||= dirname(findUpFile("Gulpfile.js"));
+}


### PR DESCRIPTION
Instead, search for stuff up the directory tree, with the main
functionality being to look for `Gulpfile.js` and assume the resulting
directory is the root.

(Unfortunatley, this is implemented twice, one in `scripts` and another
in `src`.  It's not possible to use a single implementation for both
since that would require assuming a directory structure which this is
intended to avoid.)

Also, in `scripts/build/projects.js`, abstracdt common exec
functionality into a local helper, and use full paths based on the above
search instead of assuming relative paths assuming CWD being in the
project root.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #
