### PR TITLE
Use node ipc for TS Server

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -940,6 +940,10 @@ namespace ts.server {
                 }
                 return;
             }
+            this.writeMessage(msg);
+        }
+
+        protected writeMessage(msg: protocol.Message) {
             const msgText = formatMessage(msg, this.logger, this.byteLength, this.host.newLine);
             perfLogger.logEvent(`Response message size: ${msgText.length}`);
             this.host.write(msgText);

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -233,7 +233,7 @@ namespace ts.server {
 
         // Override sys.write because fs.writeSync is not reliable on Node 4
         sys.write = (s: string) => writeMessage(sys.bufferFrom!(s, "utf8") as globalThis.Buffer);
-         // REVIEW: for now this implementation uses polling.
+        // REVIEW: for now this implementation uses polling.
         // The advantage of polling is that it works reliably
         // on all os and with network mounted files.
         // For 90 referenced files, the average time to detect
@@ -723,9 +723,13 @@ namespace ts.server {
                         }
                         return;
                     }
-                    // TODO: Do we need any perf stuff here?
-                    // const msgText = formatMessage(msg, this.logger, this.byteLength, this.host.newLine);
-                    // perfLogger.logEvent(`Response message size: ${msgText.length}`);
+
+                    const verboseLogging = logger.hasLevel(LogLevel.verbose);
+                    if (verboseLogging) {
+                        const json = JSON.stringify(msg);
+                        logger.info(`${msg.type}:${indent(json)}`);
+                    }
+
                     process.send!(msg);
                 }
                 else {
@@ -781,7 +785,7 @@ namespace ts.server {
 
             listen() {
                 if (useNodeIpc) {
-                    process.on('message', (e: any) => {
+                    process.on("message", (e: any) => {
                         this.onMessage(e);
                     });
                 }
@@ -804,7 +808,7 @@ namespace ts.server {
         const npmLocation = findArgument(Arguments.NpmLocation);
         const validateDefaultNpmLocation = hasArgument(Arguments.ValidateDefaultNpmLocation);
         const disableAutomaticTypingAcquisition = hasArgument("--disableAutomaticTypingAcquisition");
-        const useNodeIpc = hasArgument('--useNodeIpc');
+        const useNodeIpc = hasArgument("--useNodeIpc");
         const telemetryEnabled = hasArgument(Arguments.EnableTelemetry);
         const commandLineTraceDir = findArgument("--traceDirectory");
         const traceDir = commandLineTraceDir

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -761,14 +761,7 @@ namespace ts.server {
 
         class IpcIOSession extends IOSession {
 
-            public send(msg: protocol.Message) {
-                if (msg.type === "event" && !this.canUseEvents) {
-                    if (this.logger.hasLevel(LogLevel.verbose)) {
-                        this.logger.info(`Session does not support events: ignored event: ${JSON.stringify(msg)}`);
-                    }
-                    return;
-                }
-
+            protected writeMessage(msg: protocol.Message): void {
                 const verboseLogging = logger.hasLevel(LogLevel.verbose);
                 if (verboseLogging) {
                     const json = JSON.stringify(msg);
@@ -786,7 +779,7 @@ namespace ts.server {
                 return JSON.stringify(message, undefined, 2);
             }
 
-            listen() {
+            public listen() {
                 process.on("message", (e: any) => {
                     this.onMessage(e);
                 });

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -733,6 +733,20 @@ namespace ts.server {
                 }
             }
 
+            protected parseMessage(message: any): protocol.Request {
+                if (useNodeIpc) {
+                    return message as protocol.Request;
+                }
+                return super.parseMessage(message);
+            }
+
+            protected toStringMessage(message: any) {
+                if (useNodeIpc) {
+                    return JSON.stringify(message, undefined, 2);
+                }
+                return super.toStringMessage(message);
+            }
+
             event<T extends object>(body: T, eventName: string): void {
                 Debug.assert(!!this.constructed, "Should only call `IOSession.prototype.event` on an initialized IOSession");
 
@@ -768,7 +782,7 @@ namespace ts.server {
             listen() {
                 if (useNodeIpc) {
                     process.on('message', (e: any) => {
-                        this.onMessage(JSON.stringify(e)); // TODO: should not convert to back to a string just to parse again :)
+                        this.onMessage(e);
                     });
                 }
                 else {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -10470,6 +10470,7 @@ declare namespace ts.server {
         logError(err: Error, cmd: string): void;
         private logErrorWorker;
         send(msg: protocol.Message): void;
+        protected writeMessage(msg: protocol.Message): void;
         event<T extends object>(body: T, eventName: string): void;
         /** @deprecated */
         output(info: any, cmdName: string, reqSeq?: number, errorMsg?: string): void;


### PR DESCRIPTION
For #46417

This lets us use Node's built-in ipc for passing messages to/from the typescript server instead of using stdio

Needs review from the TS team because there are still a few todo comments and I'm pretty sure I've overlooked some things 
