### PR TITLE
@link: format trailing () as part of linkName

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2290,9 +2290,9 @@ namespace ts {
         return displayPart(text, SymbolDisplayPartKind.linkText);
     }
 
-    export function linkNamePart(name: EntityName | JSDocMemberName, target: Declaration): JSDocLinkDisplayPart {
+    export function linkNamePart(text: string, target: Declaration): JSDocLinkDisplayPart {
         return {
-            text: getTextOfNode(name),
+            text,
             kind: SymbolDisplayPartKind[SymbolDisplayPartKind.linkName],
             target: {
                 fileName: getSourceFileOfNode(target).fileName,
@@ -2315,13 +2315,16 @@ namespace ts {
         }
         else {
             const symbol = checker?.getSymbolAtLocation(link.name);
+            const trailingParen = link.text.indexOf("()") === 0;
+            const name = getTextOfNode(link.name) + (trailingParen ? "()" : "");
+            const text = trailingParen ? link.text.slice(2) : link.text;
             const decl = symbol?.valueDeclaration || symbol?.declarations?.[0];
             if (decl) {
-                parts.push(linkNamePart(link.name, decl));
-                if (link.text) parts.push(linkTextPart(link.text));
+                parts.push(linkNamePart(name, decl));
+                if (text) parts.push(linkTextPart(text));
             }
             else {
-                parts.push(linkTextPart(getTextOfNode(link.name) + " " + link.text));
+                parts.push(linkTextPart(name + (trailingParen ? "" : " ") + text));
             }
         }
         parts.push(linkPart("}"));

--- a/tests/baselines/reference/jsdocLink1.baseline
+++ b/tests/baselines/reference/jsdocLink1.baseline
@@ -107,7 +107,7 @@
               "kind": "link"
             },
             {
-              "text": "C",
+              "text": "C()",
               "kind": "linkName",
               "target": {
                 "fileName": "/tests/cases/fourslash/jsdocLink1.ts",
@@ -116,10 +116,6 @@
                   "length": 11
                 }
               }
-            },
-            {
-              "text": "()",
-              "kind": "linkText"
             },
             {
               "text": "}",

--- a/tests/baselines/reference/jsdocLink2.baseline
+++ b/tests/baselines/reference/jsdocLink2.baseline
@@ -107,7 +107,7 @@
               "kind": "link"
             },
             {
-              "text": "C",
+              "text": "C()",
               "kind": "linkName",
               "target": {
                 "fileName": "/tests/cases/fourslash/jsdocLink2.ts",
@@ -116,10 +116,6 @@
                   "length": 11
                 }
               }
-            },
-            {
-              "text": "()",
-              "kind": "linkText"
             },
             {
               "text": "}",

--- a/tests/baselines/reference/jsdocLink3.baseline
+++ b/tests/baselines/reference/jsdocLink3.baseline
@@ -107,7 +107,7 @@
               "kind": "link"
             },
             {
-              "text": "C",
+              "text": "C()",
               "kind": "linkName",
               "target": {
                 "fileName": "/jsdocLink3.ts",
@@ -116,10 +116,6 @@
                   "length": 18
                 }
               }
-            },
-            {
-              "text": "()",
-              "kind": "linkText"
             },
             {
               "text": "}",

--- a/tests/baselines/reference/jsdocLink5.baseline
+++ b/tests/baselines/reference/jsdocLink5.baseline
@@ -1,0 +1,319 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsdocLink5.ts",
+      "position": 210,
+      "name": "3"
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 209,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "f",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "any",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "g()",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink5.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 16
+            }
+          }
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "g()",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink5.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 16
+            }
+          }
+        },
+        {
+          "text": " ",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "g()",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink5.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 16
+            }
+          }
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "g()",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink5.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 16
+            }
+          }
+        },
+        {
+          "text": " 0",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "g()",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink5.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 16
+            }
+          }
+        },
+        {
+          "text": "1",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "g()",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink5.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 16
+            }
+          }
+        },
+        {
+          "text": " 2",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": "\n",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "u()",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "u() ",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "u()",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "u() 0",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "u()1",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "u() 2",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/jsdocLink5.ts
+++ b/tests/cases/fourslash/jsdocLink5.ts
@@ -1,0 +1,11 @@
+///<reference path="fourslash.ts" />
+
+//// function g() { }
+//// /**
+////  * {@link g()} {@link g() } {@link g ()} {@link g () 0} {@link g()1} {@link g() 2}
+////  * {@link u()} {@link u() } {@link u ()} {@link u () 0} {@link u()1} {@link u() 2}
+////  */
+//// function f(x) {
+//// }
+//// f/*3*/()
+verify.baselineQuickInfo();


### PR DESCRIPTION
Parsing separates the identifier part of the link tag from its text, but the editor should present an identifier followed by `()` as a single identifier since people use that syntax as a function sigil.

I prefer `#'` personally, you know, xkcd 297, nudge nudge.

Fixes #44495