### PR TITLE
fix(46366): Escaped notation in an enum's computed property shows as non-escaped on hover

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6127,12 +6127,8 @@ namespace ts {
                             firstChar = symbolName.charCodeAt(0);
                         }
                         let expression: Expression | undefined;
-                        if (isSingleOrDoubleQuote(firstChar)) {
-                            expression = factory.createStringLiteral(
-                                symbolName
-                                    .substring(1, symbolName.length - 1)
-                                    .replace(/\\./g, s => s.substring(1)),
-                                firstChar === CharacterCodes.singleQuote);
+                        if (isSingleOrDoubleQuote(firstChar) && !(symbol.flags & SymbolFlags.EnumMember)) {
+                           expression = factory.createStringLiteral(stripQuotes(symbolName).replace(/\\./g, s => s.substring(1)), firstChar === CharacterCodes.singleQuote);
                         }
                         else if (("" + +symbolName) === symbolName) {
                             expression = factory.createNumericLiteral(+symbolName);

--- a/tests/baselines/reference/enumWithUnicodeEscape1.symbols
+++ b/tests/baselines/reference/enumWithUnicodeEscape1.symbols
@@ -3,6 +3,6 @@ enum E {
 >E : Symbol(E, Decl(enumWithUnicodeEscape1.ts, 0, 0))
 
   'gold \u2730'
->'gold \u2730' : Symbol(E['gold u2730'], Decl(enumWithUnicodeEscape1.ts, 0, 8))
+>'gold \u2730' : Symbol(E['gold \u2730'], Decl(enumWithUnicodeEscape1.ts, 0, 8))
 }
 

--- a/tests/baselines/reference/quickInfoDisplayPartsEnum2.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsEnum2.baseline
@@ -69,7 +69,7 @@
         },
         {
           "text": "\"e1\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -135,7 +135,7 @@
         },
         {
           "text": "'e2'",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -201,7 +201,7 @@
         },
         {
           "text": "\"e3\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -411,7 +411,7 @@
         },
         {
           "text": "\"e1\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -549,7 +549,7 @@
         },
         {
           "text": "'e2'",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -687,7 +687,7 @@
         },
         {
           "text": "\"e3\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -791,7 +791,7 @@
         },
         {
           "text": "\"e1\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -857,7 +857,7 @@
         },
         {
           "text": "'e2'",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -923,7 +923,7 @@
         },
         {
           "text": "\"e3\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -1149,7 +1149,7 @@
         },
         {
           "text": "\"e1\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -1295,7 +1295,7 @@
         },
         {
           "text": "'e2'",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -1441,7 +1441,7 @@
         },
         {
           "text": "\"e3\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",

--- a/tests/baselines/reference/quickInfoDisplayPartsEnum3.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsEnum3.baseline
@@ -69,7 +69,7 @@
         },
         {
           "text": "\"e1\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -135,7 +135,7 @@
         },
         {
           "text": "'e2'",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -201,7 +201,7 @@
         },
         {
           "text": "\"e3\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -411,7 +411,7 @@
         },
         {
           "text": "\"e1\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -549,7 +549,7 @@
         },
         {
           "text": "'e2'",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -687,7 +687,7 @@
         },
         {
           "text": "\"e3\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -791,7 +791,7 @@
         },
         {
           "text": "\"e1\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -857,7 +857,7 @@
         },
         {
           "text": "'e2'",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -923,7 +923,7 @@
         },
         {
           "text": "\"e3\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -1149,7 +1149,7 @@
         },
         {
           "text": "\"e1\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -1295,7 +1295,7 @@
         },
         {
           "text": "'e2'",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",
@@ -1441,7 +1441,7 @@
         },
         {
           "text": "\"e3\"",
-          "kind": "stringLiteral"
+          "kind": "enumMemberName"
         },
         {
           "text": "]",

--- a/tests/baselines/reference/quickInfoDisplayPartsEnum4.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsEnum4.baseline
@@ -1,0 +1,134 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsEnum4.ts",
+      "position": 51,
+      "name": "1"
+    },
+    "quickInfo": {
+      "kind": "enum member",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 51,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "enum member",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Foo",
+          "kind": "enumName"
+        },
+        {
+          "text": "[",
+          "kind": "punctuation"
+        },
+        {
+          "text": "\"\\t\"",
+          "kind": "enumMemberName"
+        },
+        {
+          "text": "]",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=",
+          "kind": "operator"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "9",
+          "kind": "numericLiteral"
+        }
+      ],
+      "documentation": []
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsEnum4.ts",
+      "position": 61,
+      "name": "2"
+    },
+    "quickInfo": {
+      "kind": "enum member",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 61,
+        "length": 8
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "enum member",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Foo",
+          "kind": "enumName"
+        },
+        {
+          "text": "[",
+          "kind": "punctuation"
+        },
+        {
+          "text": "\"\\u007f\"",
+          "kind": "enumMemberName"
+        },
+        {
+          "text": "]",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=",
+          "kind": "operator"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "127",
+          "kind": "numericLiteral"
+        }
+      ],
+      "documentation": []
+    }
+  }
+]

--- a/tests/cases/fourslash/quickInfoDisplayPartsEnum4.ts
+++ b/tests/cases/fourslash/quickInfoDisplayPartsEnum4.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts'/>
+
+////const enum Foo {
+////	"\t" = 9,
+////	"\u007f" = 127,
+////}
+////Foo[/*1*/"\t"]
+////Foo[/*2*/"\u007f"]
+
+verify.baselineQuickInfo();


### PR DESCRIPTION
Fixes #46366