### PR TITLE
Fix ordering of module specifiers based on package.json presence

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -663,13 +663,15 @@ namespace ts.codefix {
         }
         const { allowsImportingSpecifier } = createPackageJsonImportFilter(sourceFile, preferences, host);
         return fixes.reduce((best, fix) =>
+            // Takes true branch of conditional if `fix` is better than `best`
             compareModuleSpecifiers(fix, best, sourceFile, program, allowsImportingSpecifier) === Comparison.LessThan ? fix : best
         );
     }
 
+    /** @returns `Comparison.LessThan` if `a` is better than `b`. */
     function compareModuleSpecifiers(a: ImportFix, b: ImportFix, importingFile: SourceFile, program: Program, allowsImportingSpecifier: (specifier: string) => boolean): Comparison {
         if (a.kind !== ImportFixKind.UseNamespace && b.kind !== ImportFixKind.UseNamespace) {
-            return compareBooleans(allowsImportingSpecifier(a.moduleSpecifier), allowsImportingSpecifier(b.moduleSpecifier))
+            return compareBooleans(allowsImportingSpecifier(b.moduleSpecifier), allowsImportingSpecifier(a.moduleSpecifier))
                 || compareNodeCoreModuleSpecifiers(a.moduleSpecifier, b.moduleSpecifier, importingFile, program)
                 || compareNumberOfDirectorySeparators(a.moduleSpecifier, b.moduleSpecifier);
         }

--- a/tests/cases/fourslash/completionsImport_46332.ts
+++ b/tests/cases/fourslash/completionsImport_46332.ts
@@ -77,9 +77,17 @@ verify.completions({
   },
 });
 
-// TODO
 verify.applyCodeActionFromCompletion("", {
   name: "ref",
   source: "vue",
-  description: "TODO"
+  description: `Add 'ref' to existing import declaration from "vue"`,
+  data: {
+    exportName: "ref",
+    fileName: "/node_modules/vue/dist/vue.d.ts",
+  },
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+  },
+  newFileContent: `import { ref } from "vue";\nref`
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46332

Guess I got `Comparison.GreaterThan` and `Comparison.LessThan` mixed up 9 months ago in #42614 😵
