### PR TITLE
fix(46345): declare on computed class field with decorator makes invalid code that crashes due to missing _a

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1189,7 +1189,7 @@ namespace ts {
             //
 
             const prefix = getClassMemberPrefix(node, member);
-            const memberName = getExpressionForPropertyName(member, /*generateNameForComputedPropertyName*/ true);
+            const memberName = getExpressionForPropertyName(member, /*generateNameForComputedPropertyName*/ !hasSyntacticModifier(member, ModifierFlags.Ambient));
             const descriptor = languageVersion > ScriptTarget.ES3
                 ? member.kind === SyntaxKind.PropertyDeclaration
                     // We emit `void 0` here to indicate to `__decorate` that it can invoke `Object.defineProperty` directly, but that it

--- a/tests/baselines/reference/decoratorInAmbientContext.js
+++ b/tests/baselines/reference/decoratorInAmbientContext.js
@@ -1,0 +1,26 @@
+//// [decoratorInAmbientContext.ts]
+declare function decorator(target: any, key: any): any;
+
+const b = Symbol('b');
+class Foo {
+    @decorator declare a: number;
+    @decorator declare [b]: number;
+}
+
+
+//// [decoratorInAmbientContext.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+const b = Symbol('b');
+class Foo {
+}
+__decorate([
+    decorator
+], Foo.prototype, "a", void 0);
+__decorate([
+    decorator
+], Foo.prototype, b, void 0);

--- a/tests/baselines/reference/decoratorInAmbientContext.symbols
+++ b/tests/baselines/reference/decoratorInAmbientContext.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/decorators/decoratorInAmbientContext.ts ===
+declare function decorator(target: any, key: any): any;
+>decorator : Symbol(decorator, Decl(decoratorInAmbientContext.ts, 0, 0))
+>target : Symbol(target, Decl(decoratorInAmbientContext.ts, 0, 27))
+>key : Symbol(key, Decl(decoratorInAmbientContext.ts, 0, 39))
+
+const b = Symbol('b');
+>b : Symbol(b, Decl(decoratorInAmbientContext.ts, 2, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+class Foo {
+>Foo : Symbol(Foo, Decl(decoratorInAmbientContext.ts, 2, 22))
+
+    @decorator declare a: number;
+>decorator : Symbol(decorator, Decl(decoratorInAmbientContext.ts, 0, 0))
+>a : Symbol(Foo.a, Decl(decoratorInAmbientContext.ts, 3, 11))
+
+    @decorator declare [b]: number;
+>decorator : Symbol(decorator, Decl(decoratorInAmbientContext.ts, 0, 0))
+>[b] : Symbol(Foo[b], Decl(decoratorInAmbientContext.ts, 4, 33))
+>b : Symbol(b, Decl(decoratorInAmbientContext.ts, 2, 5))
+}
+

--- a/tests/baselines/reference/decoratorInAmbientContext.types
+++ b/tests/baselines/reference/decoratorInAmbientContext.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/decorators/decoratorInAmbientContext.ts ===
+declare function decorator(target: any, key: any): any;
+>decorator : (target: any, key: any) => any
+>target : any
+>key : any
+
+const b = Symbol('b');
+>b : unique symbol
+>Symbol('b') : unique symbol
+>Symbol : SymbolConstructor
+>'b' : "b"
+
+class Foo {
+>Foo : Foo
+
+    @decorator declare a: number;
+>decorator : (target: any, key: any) => any
+>a : number
+
+    @decorator declare [b]: number;
+>decorator : (target: any, key: any) => any
+>[b] : number
+>b : unique symbol
+}
+

--- a/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
+++ b/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
@@ -1,0 +1,10 @@
+// @target: esnext
+// @experimentalDecorators: true
+
+declare function decorator(target: any, key: any): any;
+
+const b = Symbol('b');
+class Foo {
+    @decorator declare a: number;
+    @decorator declare [b]: number;
+}


### PR DESCRIPTION
Fixes #46345