### PR TITLE
Computed property names are const contexts

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33488,6 +33488,7 @@ namespace ts {
             const parent = node.parent;
             return isAssertionExpression(parent) && isConstTypeReference(parent.type) ||
                 isJSDocTypeAssertion(parent) && isConstTypeReference(getJSDocTypeAssertionType(parent)) ||
+                isComputedPropertyName(parent) ||
                 (isParenthesizedExpression(parent) || isArrayLiteralExpression(parent) || isSpreadElement(parent)) && isConstContext(parent) ||
                 (isPropertyAssignment(parent) || isShorthandPropertyAssignment(parent) || isTemplateSpan(parent)) && isConstContext(parent.parent);
         }

--- a/tests/baselines/reference/computedPropertyNames10_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames10_ES5.types
@@ -60,6 +60,6 @@ var v = {
 
     [`hello ${a} bye`]() { }
 >[`hello ${a} bye`] : () => void
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 }

--- a/tests/baselines/reference/computedPropertyNames10_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames10_ES6.types
@@ -60,6 +60,6 @@ var v = {
 
     [`hello ${a} bye`]() { }
 >[`hello ${a} bye`] : () => void
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 }

--- a/tests/baselines/reference/computedPropertyNames11_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames11_ES5.types
@@ -70,7 +70,7 @@ var v = {
 
     get [`hello ${a} bye`]() { return 0; }
 >[`hello ${a} bye`] : number
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 >0 : 0
 }

--- a/tests/baselines/reference/computedPropertyNames11_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames11_ES6.types
@@ -70,7 +70,7 @@ var v = {
 
     get [`hello ${a} bye`]() { return 0; }
 >[`hello ${a} bye`] : number
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 >0 : 0
 }

--- a/tests/baselines/reference/computedPropertyNames12_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames12_ES5.types
@@ -63,7 +63,7 @@ class C {
 
     static [`hello ${a} bye`] = 0
 >[`hello ${a} bye`] : number
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 >0 : 0
 }

--- a/tests/baselines/reference/computedPropertyNames12_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames12_ES6.types
@@ -63,7 +63,7 @@ class C {
 
     static [`hello ${a} bye`] = 0
 >[`hello ${a} bye`] : number
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 >0 : 0
 }

--- a/tests/baselines/reference/computedPropertyNames13_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames13_ES5.types
@@ -59,6 +59,6 @@ class C {
 
     static [`hello ${a} bye`]() { }
 >[`hello ${a} bye`] : () => void
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 }

--- a/tests/baselines/reference/computedPropertyNames13_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames13_ES6.types
@@ -59,6 +59,6 @@ class C {
 
     static [`hello ${a} bye`]() { }
 >[`hello ${a} bye`] : () => void
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 }

--- a/tests/baselines/reference/computedPropertyNames14_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames14_ES5.types
@@ -15,7 +15,7 @@ class C {
 
     [[]]() { }
 >[[]] : () => void
->[] : undefined[]
+>[] : readonly []
 
     static [{}]() { }
 >[{}] : () => void

--- a/tests/baselines/reference/computedPropertyNames14_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames14_ES6.types
@@ -15,7 +15,7 @@ class C {
 
     [[]]() { }
 >[[]] : () => void
->[] : undefined[]
+>[] : readonly []
 
     static [{}]() { }
 >[{}] : () => void

--- a/tests/baselines/reference/computedPropertyNames16_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames16_ES5.types
@@ -69,7 +69,7 @@ class C {
 
     get [`hello ${a} bye`]() { return 0; }
 >[`hello ${a} bye`] : number
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 >0 : 0
 }

--- a/tests/baselines/reference/computedPropertyNames16_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames16_ES6.types
@@ -69,7 +69,7 @@ class C {
 
     get [`hello ${a} bye`]() { return 0; }
 >[`hello ${a} bye`] : number
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 >0 : 0
 }

--- a/tests/baselines/reference/computedPropertyNames17_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames17_ES5.types
@@ -17,7 +17,7 @@ class C {
 
     get [[]]() { return 0; }
 >[[]] : number
->[] : undefined[]
+>[] : readonly []
 >0 : 0
 
     set [{}](v) { }

--- a/tests/baselines/reference/computedPropertyNames17_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames17_ES6.types
@@ -17,7 +17,7 @@ class C {
 
     get [[]]() { return 0; }
 >[[]] : number
->[] : undefined[]
+>[] : readonly []
 >0 : 0
 
     set [{}](v) { }

--- a/tests/baselines/reference/computedPropertyNames3_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames3_ES5.types
@@ -22,7 +22,7 @@ class C {
 
     set [[0, 1]](v) { }
 >[[0, 1]] : any
->[0, 1] : number[]
+>[0, 1] : readonly [0, 1]
 >0 : 0
 >1 : 1
 >v : any

--- a/tests/baselines/reference/computedPropertyNames3_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames3_ES6.types
@@ -22,7 +22,7 @@ class C {
 
     set [[0, 1]](v) { }
 >[[0, 1]] : any
->[0, 1] : number[]
+>[0, 1] : readonly [0, 1]
 >0 : 0
 >1 : 1
 >v : any

--- a/tests/baselines/reference/computedPropertyNames4_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames4_ES5.types
@@ -70,7 +70,7 @@ var v = {
 
     [`hello ${a} bye`]: 0
 >[`hello ${a} bye`] : number
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 >0 : 0
 }

--- a/tests/baselines/reference/computedPropertyNames4_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames4_ES6.types
@@ -70,7 +70,7 @@ var v = {
 
     [`hello ${a} bye`]: 0
 >[`hello ${a} bye`] : number
->`hello ${a} bye` : string
+>`hello ${a} bye` : `hello ${any} bye`
 >a : any
 >0 : 0
 }

--- a/tests/baselines/reference/computedPropertyNames5_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames5_ES5.types
@@ -18,7 +18,7 @@ var v = {
 
     [[]]: 0,
 >[[]] : number
->[] : undefined[]
+>[] : readonly []
 >0 : 0
 
     [{}]: 0,

--- a/tests/baselines/reference/computedPropertyNames5_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames5_ES6.types
@@ -18,7 +18,7 @@ var v = {
 
     [[]]: 0,
 >[[]] : number
->[] : undefined[]
+>[] : readonly []
 >0 : 0
 
     [{}]: 0,

--- a/tests/baselines/reference/constContextTemplateLiteral.errors.txt
+++ b/tests/baselines/reference/constContextTemplateLiteral.errors.txt
@@ -1,26 +1,13 @@
-tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(9,24): error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
-  Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
-tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(10,33): error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
+tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(3,24): error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
   Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
 
 
-==== tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts (2 errors) ====
-    interface Person {
-        id: number;
-        name: string;
-    }
-    
-    declare function key(): `person-${number}`
-    /* This only happens if index type is a template literal type */
-    const persons: Record<`person-${Person["id"]}`, { a: any }> = {
+==== tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts (1 errors) ====
+    type Person = { id: number }
+    const persons: Record<string, { a: any }> = {
         [`person-${1}`]: { b: "something" }, // ok, error
                            ~~~~~~~~~~~~~~
 !!! error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
 !!! error TS2418:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
-        [`person-${1}` as const]: { b: "something" }, // ok, error
-                                    ~~~~~~~~~~~~~~
-!!! error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
-!!! error TS2418:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
-        [key()]: { b: "something" }, // still no error, it's not a literal
     }
     

--- a/tests/baselines/reference/constContextTemplateLiteral.errors.txt
+++ b/tests/baselines/reference/constContextTemplateLiteral.errors.txt
@@ -1,0 +1,27 @@
+tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(10,24): error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
+  Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
+tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(11,33): error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
+  Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
+
+
+==== tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts (2 errors) ====
+    interface Person {
+        id: number;
+        name: string;
+    }
+    
+    declare function key(): `person-${number}`
+    /* This only happens if index type is a template literal type */
+    const persons: Record<`person-${Person["id"]}`, { a: any }> = {
+        ...{},
+        [`person-${1}`]: { b: "something" }, // ok, error
+                           ~~~~~~~~~~~~~~
+!!! error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
+!!! error TS2418:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
+        [`person-${1}` as const]: { b: "something" }, // ok, error
+                                    ~~~~~~~~~~~~~~
+!!! error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
+!!! error TS2418:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
+        [key()]: { b: "something" }, // still no error
+    }
+    

--- a/tests/baselines/reference/constContextTemplateLiteral.errors.txt
+++ b/tests/baselines/reference/constContextTemplateLiteral.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(10,24): error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
+tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(9,24): error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
   Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
-tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(11,33): error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
+tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(10,33): error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
   Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
 
 
@@ -13,7 +13,6 @@ tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(11,3
     declare function key(): `person-${number}`
     /* This only happens if index type is a template literal type */
     const persons: Record<`person-${Person["id"]}`, { a: any }> = {
-        ...{},
         [`person-${1}`]: { b: "something" }, // ok, error
                            ~~~~~~~~~~~~~~
 !!! error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
@@ -22,6 +21,6 @@ tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts(11,3
                                     ~~~~~~~~~~~~~~
 !!! error TS2418: Type of computed property's value is '{ b: string; }', which is not assignable to type '{ a: any; }'.
 !!! error TS2418:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: any; }'.
-        [key()]: { b: "something" }, // still no error
+        [key()]: { b: "something" }, // still no error, it's not a literal
     }
     

--- a/tests/baselines/reference/constContextTemplateLiteral.js
+++ b/tests/baselines/reference/constContextTemplateLiteral.js
@@ -1,23 +1,12 @@
 //// [constContextTemplateLiteral.ts]
-interface Person {
-    id: number;
-    name: string;
-}
-
-declare function key(): `person-${number}`
-/* This only happens if index type is a template literal type */
-const persons: Record<`person-${Person["id"]}`, { a: any }> = {
+type Person = { id: number }
+const persons: Record<string, { a: any }> = {
     [`person-${1}`]: { b: "something" }, // ok, error
-    [`person-${1}` as const]: { b: "something" }, // ok, error
-    [key()]: { b: "something" }, // still no error, it's not a literal
 }
 
 
 //// [constContextTemplateLiteral.js]
 var _a;
-/* This only happens if index type is a template literal type */
 var persons = (_a = {},
     _a["person-".concat(1)] = { b: "something" },
-    _a["person-".concat(1)] = { b: "something" },
-    _a[key()] = { b: "something" },
     _a);

--- a/tests/baselines/reference/constContextTemplateLiteral.js
+++ b/tests/baselines/reference/constContextTemplateLiteral.js
@@ -1,0 +1,31 @@
+//// [constContextTemplateLiteral.ts]
+interface Person {
+    id: number;
+    name: string;
+}
+
+declare function key(): `person-${number}`
+/* This only happens if index type is a template literal type */
+const persons: Record<`person-${Person["id"]}`, { a: any }> = {
+    ...{},
+    [`person-${1}`]: { b: "something" }, // ok, error
+    [`person-${1}` as const]: { b: "something" }, // ok, error
+    [key()]: { b: "something" }, // still no error
+}
+
+
+//// [constContextTemplateLiteral.js]
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var _a;
+/* This only happens if index type is a template literal type */
+var persons = __assign({}, (_a = {}, _a["person-".concat(1)] = { b: "something" }, _a["person-".concat(1)] = { b: "something" }, _a[key()] = { b: "something" }, _a));

--- a/tests/baselines/reference/constContextTemplateLiteral.js
+++ b/tests/baselines/reference/constContextTemplateLiteral.js
@@ -7,25 +7,17 @@ interface Person {
 declare function key(): `person-${number}`
 /* This only happens if index type is a template literal type */
 const persons: Record<`person-${Person["id"]}`, { a: any }> = {
-    ...{},
     [`person-${1}`]: { b: "something" }, // ok, error
     [`person-${1}` as const]: { b: "something" }, // ok, error
-    [key()]: { b: "something" }, // still no error
+    [key()]: { b: "something" }, // still no error, it's not a literal
 }
 
 
 //// [constContextTemplateLiteral.js]
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                t[p] = s[p];
-        }
-        return t;
-    };
-    return __assign.apply(this, arguments);
-};
 var _a;
 /* This only happens if index type is a template literal type */
-var persons = __assign({}, (_a = {}, _a["person-".concat(1)] = { b: "something" }, _a["person-".concat(1)] = { b: "something" }, _a[key()] = { b: "something" }, _a));
+var persons = (_a = {},
+    _a["person-".concat(1)] = { b: "something" },
+    _a["person-".concat(1)] = { b: "something" },
+    _a[key()] = { b: "something" },
+    _a);

--- a/tests/baselines/reference/constContextTemplateLiteral.symbols
+++ b/tests/baselines/reference/constContextTemplateLiteral.symbols
@@ -19,19 +19,18 @@ const persons: Record<`person-${Person["id"]}`, { a: any }> = {
 >Person : Symbol(Person, Decl(constContextTemplateLiteral.ts, 0, 0))
 >a : Symbol(a, Decl(constContextTemplateLiteral.ts, 7, 49))
 
-    ...{},
     [`person-${1}`]: { b: "something" }, // ok, error
->[`person-${1}`] : Symbol([`person-${1}`], Decl(constContextTemplateLiteral.ts, 8, 10))
->b : Symbol(b, Decl(constContextTemplateLiteral.ts, 9, 22))
+>[`person-${1}`] : Symbol([`person-${1}`], Decl(constContextTemplateLiteral.ts, 7, 63))
+>b : Symbol(b, Decl(constContextTemplateLiteral.ts, 8, 22))
 
     [`person-${1}` as const]: { b: "something" }, // ok, error
->[`person-${1}` as const] : Symbol([`person-${1}` as const], Decl(constContextTemplateLiteral.ts, 9, 40))
+>[`person-${1}` as const] : Symbol([`person-${1}` as const], Decl(constContextTemplateLiteral.ts, 8, 40))
 >const : Symbol(const)
->b : Symbol(b, Decl(constContextTemplateLiteral.ts, 10, 31))
+>b : Symbol(b, Decl(constContextTemplateLiteral.ts, 9, 31))
 
-    [key()]: { b: "something" }, // still no error
->[key()] : Symbol([key()], Decl(constContextTemplateLiteral.ts, 10, 49))
+    [key()]: { b: "something" }, // still no error, it's not a literal
+>[key()] : Symbol([key()], Decl(constContextTemplateLiteral.ts, 9, 49))
 >key : Symbol(key, Decl(constContextTemplateLiteral.ts, 3, 1))
->b : Symbol(b, Decl(constContextTemplateLiteral.ts, 11, 14))
+>b : Symbol(b, Decl(constContextTemplateLiteral.ts, 10, 14))
 }
 

--- a/tests/baselines/reference/constContextTemplateLiteral.symbols
+++ b/tests/baselines/reference/constContextTemplateLiteral.symbols
@@ -1,36 +1,15 @@
 === tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts ===
-interface Person {
+type Person = { id: number }
 >Person : Symbol(Person, Decl(constContextTemplateLiteral.ts, 0, 0))
+>id : Symbol(id, Decl(constContextTemplateLiteral.ts, 0, 15))
 
-    id: number;
->id : Symbol(Person.id, Decl(constContextTemplateLiteral.ts, 0, 18))
-
-    name: string;
->name : Symbol(Person.name, Decl(constContextTemplateLiteral.ts, 1, 15))
-}
-
-declare function key(): `person-${number}`
->key : Symbol(key, Decl(constContextTemplateLiteral.ts, 3, 1))
-
-/* This only happens if index type is a template literal type */
-const persons: Record<`person-${Person["id"]}`, { a: any }> = {
->persons : Symbol(persons, Decl(constContextTemplateLiteral.ts, 7, 5))
+const persons: Record<string, { a: any }> = {
+>persons : Symbol(persons, Decl(constContextTemplateLiteral.ts, 1, 5))
 >Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
->Person : Symbol(Person, Decl(constContextTemplateLiteral.ts, 0, 0))
->a : Symbol(a, Decl(constContextTemplateLiteral.ts, 7, 49))
+>a : Symbol(a, Decl(constContextTemplateLiteral.ts, 1, 31))
 
     [`person-${1}`]: { b: "something" }, // ok, error
->[`person-${1}`] : Symbol([`person-${1}`], Decl(constContextTemplateLiteral.ts, 7, 63))
->b : Symbol(b, Decl(constContextTemplateLiteral.ts, 8, 22))
-
-    [`person-${1}` as const]: { b: "something" }, // ok, error
->[`person-${1}` as const] : Symbol([`person-${1}` as const], Decl(constContextTemplateLiteral.ts, 8, 40))
->const : Symbol(const)
->b : Symbol(b, Decl(constContextTemplateLiteral.ts, 9, 31))
-
-    [key()]: { b: "something" }, // still no error, it's not a literal
->[key()] : Symbol([key()], Decl(constContextTemplateLiteral.ts, 9, 49))
->key : Symbol(key, Decl(constContextTemplateLiteral.ts, 3, 1))
->b : Symbol(b, Decl(constContextTemplateLiteral.ts, 10, 14))
+>[`person-${1}`] : Symbol([`person-${1}`], Decl(constContextTemplateLiteral.ts, 1, 45))
+>b : Symbol(b, Decl(constContextTemplateLiteral.ts, 2, 22))
 }
 

--- a/tests/baselines/reference/constContextTemplateLiteral.symbols
+++ b/tests/baselines/reference/constContextTemplateLiteral.symbols
@@ -1,0 +1,37 @@
+=== tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts ===
+interface Person {
+>Person : Symbol(Person, Decl(constContextTemplateLiteral.ts, 0, 0))
+
+    id: number;
+>id : Symbol(Person.id, Decl(constContextTemplateLiteral.ts, 0, 18))
+
+    name: string;
+>name : Symbol(Person.name, Decl(constContextTemplateLiteral.ts, 1, 15))
+}
+
+declare function key(): `person-${number}`
+>key : Symbol(key, Decl(constContextTemplateLiteral.ts, 3, 1))
+
+/* This only happens if index type is a template literal type */
+const persons: Record<`person-${Person["id"]}`, { a: any }> = {
+>persons : Symbol(persons, Decl(constContextTemplateLiteral.ts, 7, 5))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>Person : Symbol(Person, Decl(constContextTemplateLiteral.ts, 0, 0))
+>a : Symbol(a, Decl(constContextTemplateLiteral.ts, 7, 49))
+
+    ...{},
+    [`person-${1}`]: { b: "something" }, // ok, error
+>[`person-${1}`] : Symbol([`person-${1}`], Decl(constContextTemplateLiteral.ts, 8, 10))
+>b : Symbol(b, Decl(constContextTemplateLiteral.ts, 9, 22))
+
+    [`person-${1}` as const]: { b: "something" }, // ok, error
+>[`person-${1}` as const] : Symbol([`person-${1}` as const], Decl(constContextTemplateLiteral.ts, 9, 40))
+>const : Symbol(const)
+>b : Symbol(b, Decl(constContextTemplateLiteral.ts, 10, 31))
+
+    [key()]: { b: "something" }, // still no error
+>[key()] : Symbol([key()], Decl(constContextTemplateLiteral.ts, 10, 49))
+>key : Symbol(key, Decl(constContextTemplateLiteral.ts, 3, 1))
+>b : Symbol(b, Decl(constContextTemplateLiteral.ts, 11, 14))
+}
+

--- a/tests/baselines/reference/constContextTemplateLiteral.types
+++ b/tests/baselines/reference/constContextTemplateLiteral.types
@@ -14,10 +14,7 @@ declare function key(): `person-${number}`
 const persons: Record<`person-${Person["id"]}`, { a: any }> = {
 >persons : Record<`person-${number}`, { a: any; }>
 >a : any
->{    ...{},    [`person-${1}`]: { b: "something" }, // ok, error    [`person-${1}` as const]: { b: "something" }, // ok, error    [key()]: { b: "something" }, // still no error} : { "person-1": { b: string; }; }
-
-    ...{},
->{} : {}
+>{    [`person-${1}`]: { b: "something" }, // ok, error    [`person-${1}` as const]: { b: "something" }, // ok, error    [key()]: { b: "something" }, // still no error, it's not a literal} : { [x: string]: { b: string; }; "person-1": { b: string; }; }
 
     [`person-${1}`]: { b: "something" }, // ok, error
 >[`person-${1}`] : { b: string; }
@@ -36,7 +33,7 @@ const persons: Record<`person-${Person["id"]}`, { a: any }> = {
 >b : string
 >"something" : "something"
 
-    [key()]: { b: "something" }, // still no error
+    [key()]: { b: "something" }, // still no error, it's not a literal
 >[key()] : { b: string; }
 >key() : `person-${number}`
 >key : () => `person-${number}`

--- a/tests/baselines/reference/constContextTemplateLiteral.types
+++ b/tests/baselines/reference/constContextTemplateLiteral.types
@@ -1,42 +1,17 @@
 === tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts ===
-interface Person {
-    id: number;
+type Person = { id: number }
+>Person : Person
 >id : number
 
-    name: string;
->name : string
-}
-
-declare function key(): `person-${number}`
->key : () => `person-${number}`
-
-/* This only happens if index type is a template literal type */
-const persons: Record<`person-${Person["id"]}`, { a: any }> = {
->persons : Record<`person-${number}`, { a: any; }>
+const persons: Record<string, { a: any }> = {
+>persons : Record<string, { a: any; }>
 >a : any
->{    [`person-${1}`]: { b: "something" }, // ok, error    [`person-${1}` as const]: { b: "something" }, // ok, error    [key()]: { b: "something" }, // still no error, it's not a literal} : { [x: string]: { b: string; }; "person-1": { b: string; }; }
+>{    [`person-${1}`]: { b: "something" }, // ok, error} : { "person-1": { b: string; }; }
 
     [`person-${1}`]: { b: "something" }, // ok, error
 >[`person-${1}`] : { b: string; }
 >`person-${1}` : "person-1"
 >1 : 1
->{ b: "something" } : { b: string; }
->b : string
->"something" : "something"
-
-    [`person-${1}` as const]: { b: "something" }, // ok, error
->[`person-${1}` as const] : { b: string; }
->`person-${1}` as const : "person-1"
->`person-${1}` : "person-1"
->1 : 1
->{ b: "something" } : { b: string; }
->b : string
->"something" : "something"
-
-    [key()]: { b: "something" }, // still no error, it's not a literal
->[key()] : { b: string; }
->key() : `person-${number}`
->key : () => `person-${number}`
 >{ b: "something" } : { b: string; }
 >b : string
 >"something" : "something"

--- a/tests/baselines/reference/constContextTemplateLiteral.types
+++ b/tests/baselines/reference/constContextTemplateLiteral.types
@@ -1,0 +1,47 @@
+=== tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts ===
+interface Person {
+    id: number;
+>id : number
+
+    name: string;
+>name : string
+}
+
+declare function key(): `person-${number}`
+>key : () => `person-${number}`
+
+/* This only happens if index type is a template literal type */
+const persons: Record<`person-${Person["id"]}`, { a: any }> = {
+>persons : Record<`person-${number}`, { a: any; }>
+>a : any
+>{    ...{},    [`person-${1}`]: { b: "something" }, // ok, error    [`person-${1}` as const]: { b: "something" }, // ok, error    [key()]: { b: "something" }, // still no error} : { "person-1": { b: string; }; }
+
+    ...{},
+>{} : {}
+
+    [`person-${1}`]: { b: "something" }, // ok, error
+>[`person-${1}`] : { b: string; }
+>`person-${1}` : "person-1"
+>1 : 1
+>{ b: "something" } : { b: string; }
+>b : string
+>"something" : "something"
+
+    [`person-${1}` as const]: { b: "something" }, // ok, error
+>[`person-${1}` as const] : { b: string; }
+>`person-${1}` as const : "person-1"
+>`person-${1}` : "person-1"
+>1 : 1
+>{ b: "something" } : { b: string; }
+>b : string
+>"something" : "something"
+
+    [key()]: { b: "something" }, // still no error
+>[key()] : { b: string; }
+>key() : `person-${number}`
+>key : () => `person-${number}`
+>{ b: "something" } : { b: string; }
+>b : string
+>"something" : "something"
+}
+

--- a/tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts
+++ b/tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts
@@ -1,0 +1,13 @@
+interface Person {
+    id: number;
+    name: string;
+}
+
+declare function key(): `person-${number}`
+/* This only happens if index type is a template literal type */
+const persons: Record<`person-${Person["id"]}`, { a: any }> = {
+    ...{},
+    [`person-${1}`]: { b: "something" }, // ok, error
+    [`person-${1}` as const]: { b: "something" }, // ok, error
+    [key()]: { b: "something" }, // still no error
+}

--- a/tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts
+++ b/tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts
@@ -1,9 +1,4 @@
 type Person = { id: number }
-
-declare function key(): `person-${number}`
-/* This only happens if index type is a template literal type */
-const persons: Record<`person-${Person["id"]}`, { a: any }> = {
+const persons: Record<string, { a: any }> = {
     [`person-${1}`]: { b: "something" }, // ok, error
-    // [`person-${1}` as const]: { b: "something" }, // ok, error
-    // [key()]: { b: "something" }, // still no error, it's not a literal
 }

--- a/tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts
+++ b/tests/cases/conformance/expressions/literals/constContextTemplateLiteral.ts
@@ -1,13 +1,9 @@
-interface Person {
-    id: number;
-    name: string;
-}
+type Person = { id: number }
 
 declare function key(): `person-${number}`
 /* This only happens if index type is a template literal type */
 const persons: Record<`person-${Person["id"]}`, { a: any }> = {
-    ...{},
     [`person-${1}`]: { b: "something" }, // ok, error
-    [`person-${1}` as const]: { b: "something" }, // ok, error
-    [key()]: { b: "something" }, // still no error
+    // [`person-${1}` as const]: { b: "something" }, // ok, error
+    // [key()]: { b: "something" }, // still no error, it's not a literal
 }


### PR DESCRIPTION
By analogy with the existing rule that element access argument expressions are a const context. This is useful for template literals, which otherwise have type `string` by default.

For example, from #45798:

```ts
type Person = { id: number }
const persons: Record<`person-${Person["id"]}`, { a: any }> = {
    [`person-${1}`]: { b: "something" }, // should error with excess property check on 'b'
}
```

The problem in #45798 is that `person-${1}` is intended to be checked against the index signature `person-${Person["id"]}`. But it gets the type `string`, which makes it a late-bound property. With a template type literal, it is instantiated as a string literal and is no longer late-bound.

There are a couple of ways that seem best to fix this:

1. Make computed property names contextually typed by their index signature. But this requires choosing the index signature that matches (if any), which requires getting the template literal type even if it's later not used.
2. Make computed property names const locations. This is a new rule, but is quite similar to the existing rule for element access argument expressions.

I don't consider (3), making all template literals produce template literal types, because I still believe the common case is that both string and template literals are intended to be widened to `string`.

Fixes #45798

