### PR TITLE
Fix `isNewIdentifierLocation` after `*` generator

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2258,6 +2258,9 @@ namespace ts.Completions {
                     case SyntaxKind.AsyncKeyword:
                         return containingNodeKind === SyntaxKind.MethodDeclaration            // const obj = { async c|()
                             || containingNodeKind === SyntaxKind.ShorthandPropertyAssignment; // const obj = { async c|
+
+                    case SyntaxKind.AsteriskToken:
+                        return containingNodeKind === SyntaxKind.MethodDeclaration;           // const obj = { * c|
                 }
 
                 if (isClassMemberCompletionKeyword(tokenKind)) {

--- a/tests/cases/fourslash/completionsGeneratorMethodDeclaration.ts
+++ b/tests/cases/fourslash/completionsGeneratorMethodDeclaration.ts
@@ -1,0 +1,28 @@
+/// <reference path="fourslash.ts" />
+
+//// const obj = {
+////   a() {},
+////   * b/*1*/
+//// };
+//// const obj2 = {
+////   * /*2*/
+//// };
+//// const obj3 = {
+////   async * /*3*/
+//// };
+//// class Foo {
+////   * b/*4*/
+//// }
+//// class Foo2 {
+////   * /*5*/
+//// }
+//// class Bar {
+////   static * b/*6*/
+//// }
+
+test.markerNames().forEach(marker => {
+  verify.completions({
+    marker,
+    isNewIdentifierLocation: true
+  });
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**): mostly a yes
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes the other half of #46470 which concerns generator methods
(this is basically a copy paste with slight mods of #46485)
Also tests `async *`
