### PR TITLE
fix: update types for RTF.p.formatToParts() result

### DIFF
--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -31,6 +31,25 @@ declare namespace Intl {
         | "seconds";
 
     /**
+     * Value of the `unit` property in objects returned by
+     * `Intl.RelativeTimeFormat.prototype.formatToParts()`. `formatToParts` and
+     * `format` methods accept either singular or plural unit names as input,
+     * but `formatToParts` only outputs singular (e.g. "day") not plural (e.g.
+     * "days").
+     *
+     * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/formatToParts#Using_formatToParts).
+     */
+     type RelativeTimeFormatUnitSingular =
+        | "year"
+        | "quarter"
+        | "month"
+        | "week"
+        | "day"
+        | "hour"
+        | "minute"
+        | "second";
+
+    /**
      * The locale matching algorithm to use.
      *
      * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_negotiation).
@@ -93,11 +112,16 @@ declare namespace Intl {
      *
      * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/formatToParts#Using_formatToParts).
      */
-    interface RelativeTimeFormatPart {
-        type: string;
-        value: string;
-        unit?: RelativeTimeFormatUnit;
-    }
+    type RelativeTimeFormatPart =
+        | {
+              type: "literal";
+              value: string;
+          }
+        | {
+              type: Exclude<NumberFormatPartTypes, "literal">;
+              value: string;
+              unit: RelativeTimeFormatUnitSingular;
+          };
 
     interface RelativeTimeFormat {
         /**


### PR DESCRIPTION
This PR: 
* updates the type of `RelativeTimeFormatPart` to clarify that the `unit` prop is always singular in the result's array elements, unlike the plural or singular values that are accepted as inputs. Spec: https://tc39.es/ecma402/#sec-PartitionRelativeTimePattern step 5
* changes `RelativeTimeFormatPart` to be a discriminated union type because the `unit` prop is only present if the `type` prop's value is not "literal". Spec: https://tc39.es/ecma402/#sec-makepartslist step 3

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46245

@orta - what are the right tests to add for this kind of change?  
