### PR TITLE
Set hasAddedOrRemovedSymlinks when discovering an existing file by its link

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1666,6 +1666,7 @@ namespace ts {
                 if (resolutionsChanged) {
                     structureIsReused = StructureIsReused.SafeModules;
                     newSourceFile.resolvedModules = zipToModeAwareCache(newSourceFile, moduleNames, resolutions);
+                    symlinks
                 }
                 else {
                     newSourceFile.resolvedModules = oldSourceFile.resolvedModules;
@@ -1674,8 +1675,8 @@ namespace ts {
                 const typesReferenceDirectives = map(newSourceFile.typeReferenceDirectives, ref => toFileNameLowerCase(ref.fileName));
                 const typeReferenceResolutions = resolveTypeReferenceDirectiveNamesWorker(typesReferenceDirectives, newSourceFile);
                 // ensure that types resolutions are still correct
-                const typeReferenceEesolutionsChanged = hasChangesInResolutions(typesReferenceDirectives, typeReferenceResolutions, oldSourceFile.resolvedTypeReferenceDirectiveNames, oldSourceFile, typeDirectiveIsEqualTo);
-                if (typeReferenceEesolutionsChanged) {
+                const typeReferenceResolutionsChanged = hasChangesInResolutions(typesReferenceDirectives, typeReferenceResolutions, oldSourceFile.resolvedTypeReferenceDirectiveNames, oldSourceFile, typeDirectiveIsEqualTo);
+                if (typeReferenceResolutionsChanged) {
                     structureIsReused = StructureIsReused.SafeModules;
                     newSourceFile.resolvedTypeReferenceDirectiveNames = zipToModeAwareCache(newSourceFile, typesReferenceDirectives, typeReferenceResolutions);
                 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1666,7 +1666,6 @@ namespace ts {
                 if (resolutionsChanged) {
                     structureIsReused = StructureIsReused.SafeModules;
                     newSourceFile.resolvedModules = zipToModeAwareCache(newSourceFile, moduleNames, resolutions);
-                    symlinks
                 }
                 else {
                     newSourceFile.resolvedModules = oldSourceFile.resolvedModules;

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -66,7 +66,7 @@ namespace ts {
         getCurrentProgram(): Program | undefined;
         fileIsOpen(filePath: Path): boolean;
         getCompilerHost?(): CompilerHost | undefined;
-        onDiscoveredSymlink(): void;
+        onDiscoveredSymlink?(): void;
     }
 
     interface DirectoryWatchesOfFailedLookup {
@@ -432,7 +432,7 @@ namespace ts {
                     else {
                         resolution = loader(name, containingFile, compilerOptions, resolutionHost.getCompilerHost?.() || resolutionHost, redirectedReference, containingSourceFile);
                         perDirectoryResolution.set(name, mode, resolution);
-                        if (resolutionIsSymlink(resolution)) {
+                        if (resolutionHost.onDiscoveredSymlink && resolutionIsSymlink(resolution)) {
                             resolutionHost.onDiscoveredSymlink();
                         }
                     }

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -66,6 +66,7 @@ namespace ts {
         getCurrentProgram(): Program | undefined;
         fileIsOpen(filePath: Path): boolean;
         getCompilerHost?(): CompilerHost | undefined;
+        onDiscoveredSymlink(): void;
     }
 
     interface DirectoryWatchesOfFailedLookup {
@@ -431,6 +432,9 @@ namespace ts {
                     else {
                         resolution = loader(name, containingFile, compilerOptions, resolutionHost.getCompilerHost?.() || resolutionHost, redirectedReference, containingSourceFile);
                         perDirectoryResolution.set(name, mode, resolution);
+                        if (resolutionIsSymlink(resolution)) {
+                            resolutionHost.onDiscoveredSymlink();
+                        }
                     }
                     resolutionsInFile.set(name, mode, resolution);
                     watchFailedLookupLocationsOfExternalModuleResolutions(name, resolution, path, getResolutionWithResolvedFileName);
@@ -964,5 +968,12 @@ namespace ts {
             const dirPath = resolutionHost.toPath(dir);
             return dirPath === rootPath || canWatchDirectory(dirPath);
         }
+    }
+
+    function resolutionIsSymlink(resolution: ResolutionWithFailedLookupLocations) {
+        return !!(
+            (resolution as ResolvedModuleWithFailedLookupLocations).resolvedModule?.originalPath ||
+            (resolution as ResolvedTypeReferenceDirectiveWithFailedLookupLocations).resolvedTypeReferenceDirective?.originalPath
+        );
     }
 }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1031,6 +1031,11 @@ namespace ts.server {
             }
         }
 
+        /* @internal */
+        onDiscoveredSymlink() {
+            this.hasAddedOrRemovedSymlinks = true;
+        }
+
         /**
          * Updates set of files that contribute to this project
          * @returns: true if set of files in the project stays the same and false - otherwise.

--- a/tests/cases/fourslash/server/completionsImport_addToNamedWithDifferentCacheValue.ts
+++ b/tests/cases/fourslash/server/completionsImport_addToNamedWithDifferentCacheValue.ts
@@ -1,0 +1,87 @@
+/// <reference path="../fourslash.ts" />
+
+// Notable lack of package.json referencing `mylib` as dependency here.
+// This is not accurate to the original repro, but I think that's a separate
+// bug, which, if fixed, would prevent the later crash.
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "commonjs" } }
+
+// @Filename: /packages/mylib/package.json
+//// { "name": "mylib", "version": "1.0.0", "main": "index.js" }
+
+// @Filename: /packages/mylib/index.ts
+//// export * from "./mySubDir";
+
+// @Filename: /packages/mylib/mySubDir/index.ts
+//// export * from "./myClass";
+//// export * from "./myClass2";
+
+// @Filename: /packages/mylib/mySubDir/myClass.ts
+//// export class MyClass {}
+
+// @Filename: /packages/mylib/mySubDir/myClass2.ts
+//// export class MyClass2 {}
+
+// @link: /packages/mylib -> /node_modules/mylib
+
+// @Filename: /src/index.ts
+//// 
+//// const a = new MyClass/*1*/();
+//// const b = new MyClass2/*2*/();
+
+goTo.marker("1");
+format.setOption("newLineCharacter", "\n");
+
+verify.completions({
+  marker: "1",
+  includes: [{
+    name: "MyClass",
+    source: "../packages/mylib",
+    sourceDisplay: "../packages/mylib",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  }
+});
+
+verify.applyCodeActionFromCompletion("1", {
+  name: "MyClass",
+  source: "../packages/mylib",
+  description: `Import 'MyClass' from module "../packages/mylib"`,
+  data: {
+    exportName: "MyClass",
+    fileName: "/packages/mylib/index.ts",
+  },
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeCompletionsWithInsertText: true,
+    allowIncompleteCompletions: true,
+  },
+  newFileContent: `import { MyClass } from "../packages/mylib";
+
+const a = new MyClass();
+const b = new MyClass2();`,
+});
+
+edit.replaceLine(0, `import { MyClass } from "mylib";`);
+
+verify.completions({
+  marker: "2",
+  includes: [{
+    name: "MyClass2",
+    source: "mylib",
+    sourceDisplay: "mylib",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  }
+});


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46564

Symlinks are such a mess... I’m pretty sure `resolutionCache.ts` is not the right place for this, but it was direct and easy... considered doing this in Program’s `tryReuseStructureFromOldProgram` or `resolveModuleNamesReusingOldState`, but would have to do an extra iteration through all its newly resolved modules (it does them in a batch, and iterates through them only enough to see if there are any changes—I would at least have to continue that iteration until seeing a resolution with a symlink change or through the end). I’m open to that approach, though I really hope there’s an even better place for this I’m not seeing.

What’s happening is actually fairly simple. We currently clear the symlink and module specifier caches in a Project during `updateGraphWorker` if we’ve added or removed any ScriptInfo for a symlinked file. However, this doesn’t cover the case where we discover a symlink that links back to a file that already _has_ a ScriptInfo (i.e., we resolve an existing file at a new, symlinked path). The test case first references `/packages/mylib/index.ts` by a relative import to its realpath, and builds a module specifier cache with that information. Then, an edit swaps `../packages/mylib` for `mylib`, which resolves to a symlink pointing at the same file. The resolution succeeds, but we fail to notice that this change has updated our knowledge of existing symlinks, which should always make us recompute those caches. My fix simply sets the flag on Project saying we need to clear those caches when the ModuleResolutionCache makes a new resolution to a symlink.