### PR TITLE
Enable auto imports in member snippet completions

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6433,6 +6433,11 @@
         "category": "Message",
         "code": 90053
     },
+    "Includes imports of types referenced by '{0}'": {
+        "category": "Message",
+        "code": 90054
+    },
+
     "Convert function to an ES2015 class": {
         "category": "Message",
         "code": 95001

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -942,7 +942,7 @@ namespace FourSlash {
             expected = typeof expected === "string" ? { name: expected } : expected;
 
             if (actual.insertText !== expected.insertText) {
-                this.raiseError(`Expected completion insert text to be ${expected.insertText}, got ${actual.insertText}`);
+                this.raiseError(`Completion insert text did not match: ${showTextDiff(expected.insertText || "", actual.insertText || "")}`);
             }
             const convertedReplacementSpan = expected.replacementSpan && ts.createTextSpanFromRange(expected.replacementSpan);
             if (convertedReplacementSpan?.length) {

--- a/src/services/codeFixProvider.ts
+++ b/src/services/codeFixProvider.ts
@@ -3,13 +3,6 @@ namespace ts.codefix {
     const errorCodeToFixes = createMultiMap<CodeFixRegistration>();
     const fixIdToRegistration = new Map<string, CodeFixRegistration>();
 
-    export type DiagnosticAndArguments = DiagnosticMessage | [DiagnosticMessage, string] | [DiagnosticMessage, string, string];
-    function diagnosticToString(diag: DiagnosticAndArguments): string {
-        return isArray(diag)
-            ? formatStringFromArgs(getLocaleSpecificMessage(diag[0]), diag.slice(1) as readonly string[])
-            : getLocaleSpecificMessage(diag);
-    }
-
     export function createCodeFixActionWithoutFixAll(fixName: string, changes: FileTextChanges[], description: DiagnosticAndArguments) {
         return createCodeFixActionWorker(fixName, diagnosticToString(description), changes, /*fixId*/ undefined, /*fixAllDescription*/ undefined);
     }

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -33,6 +33,7 @@ namespace ts.codefix {
     });
 
     export interface ImportAdder {
+        hasFixes(): boolean;
         addImportFromDiagnostic: (diagnostic: DiagnosticWithLocation, context: CodeFixContextBase) => void;
         addImportFromExportedSymbol: (exportedSymbol: Symbol, isValidTypeOnlyUseSite?: boolean) => void;
         writeFixes: (changeTracker: textChanges.ChangeTracker) => void;
@@ -59,7 +60,7 @@ namespace ts.codefix {
         type NewImportsKey = `${0 | 1}|${string}`;
         /** Use `getNewImportEntry` for access */
         const newImports = new Map<NewImportsKey, Mutable<ImportsCollection & { useRequire: boolean }>>();
-        return { addImportFromDiagnostic, addImportFromExportedSymbol, writeFixes };
+        return { addImportFromDiagnostic, addImportFromExportedSymbol, writeFixes, hasFixes };
 
         function addImportFromDiagnostic(diagnostic: DiagnosticWithLocation, context: CodeFixContextBase) {
             const info = getFixesInfo(context, diagnostic.code, diagnostic.start, useAutoImportProvider);
@@ -216,6 +217,10 @@ namespace ts.codefix {
             if (newDeclarations) {
                 insertImports(changeTracker, sourceFile, newDeclarations, /*blankLineBetween*/ true);
             }
+        }
+
+        function hasFixes() {
+            return addToNamespace.length > 0 || importType.length > 0 || addToExisting.size > 0 || newImports.size > 0;
         }
     }
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3283,5 +3283,12 @@ namespace ts {
         return newLineCharacter === "\n" ? NewLineKind.LineFeed : NewLineKind.CarriageReturnLineFeed;
     }
 
+    export type DiagnosticAndArguments = DiagnosticMessage | [DiagnosticMessage, string] | [DiagnosticMessage, string, string];
+    export function diagnosticToString(diag: DiagnosticAndArguments): string {
+        return isArray(diag)
+            ? formatStringFromArgs(getLocaleSpecificMessage(diag[0]), diag.slice(1) as readonly string[])
+            : getLocaleSpecificMessage(diag);
+    }
+
     // #endregion
 }

--- a/tests/cases/fourslash/completionsOverridingMethod8.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod8.ts
@@ -1,0 +1,56 @@
+/// <reference path="fourslash.ts" />
+
+// @newline: LF
+
+// @Filename: /types1.ts
+//// export interface I { foo: string }
+
+// @Filename: /types2.ts
+//// import { I } from "./types1";
+//// export interface Base { method(p: I): void }
+
+// @Filename: /index.ts
+//// import { Base } from "./types2";
+//// export class C implements Base {
+////   /**/
+//// }
+
+goTo.marker("");
+verify.completions({
+  marker: "",
+  isNewIdentifierLocation: true,
+  preferences: {
+    includeCompletionsWithInsertText: true,
+    includeCompletionsWithSnippetText: false,
+    includeCompletionsWithClassMemberSnippets: true,
+  },
+  includes: [{
+    name: "method",
+    sortText: completion.SortText.LocationPriority,
+    replacementSpan: {
+      fileName: "",
+      pos: 0,
+      end: 0,
+    },
+    insertText: "method(p: I): void {\n}\n",
+    hasAction: true,
+    source: completion.CompletionSource.ClassMemberSnippet,
+  }],
+});
+
+verify.applyCodeActionFromCompletion("", {
+  preferences: {
+    includeCompletionsWithInsertText: true,
+    includeCompletionsWithSnippetText: false,
+    includeCompletionsWithClassMemberSnippets: true,
+  },
+  name: "method",
+  source: completion.CompletionSource.ClassMemberSnippet,
+  description: "Includes imports of types referenced by 'method'",
+  newFileContent:
+`import { I } from "./types1";
+import { Base } from "./types2";
+export class C implements Base {
+  
+}`
+});

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -850,7 +850,8 @@ declare namespace completion {
         DeprecatedAutoImportSuggestions = "24"
     }
     export const enum CompletionSource {
-        ThisProperty = "ThisProperty/"
+        ThisProperty = "ThisProperty/",
+        ClassMemberSnippet = "ClassMemberSnippet/",
     }
     export const globalThisEntry: Entry;
     export const undefinedVarEntry: Entry;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes part of #46568 

This duplicates the work of calculating auto-imports between `CompletionInfo` and `CompletionDetails` in order to support this without a last-minute protocol change and VS Code update. During 4.6, we can actually just update the protocol and leverage the work done in `CompletionInfo`, removing the `CompletionDetails` work, but I think this is alright for the moment.


https://user-images.githubusercontent.com/3277153/139499129-9296369e-d25f-4071-805b-bc705cc6f0a4.mp4


