### PR TITLE
Change snippet in class member completions

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1942,6 +1942,11 @@ namespace ts {
                 case SnippetKind.TabStop:
                     emitTabStop(snippet);
                     break;
+                case SnippetKind.Sequence:
+                    emitSequence(snippet);
+                    break;
+                default:
+                    return Debug.fail("Unsupported SnippetKind.");
             }
         }
 
@@ -1954,6 +1959,12 @@ namespace ts {
 
         function emitTabStop(snippet: TabStop) {
             nonEscapingWrite(`\$${snippet.order}`);
+        }
+
+        function emitSequence(snippet: SnippetSequence) {
+            for (const s of snippet.snippets) {
+                emitTabStop(s);
+            }
         }
 
         //

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6828,7 +6828,7 @@ namespace ts {
     }
 
     /* @internal */
-    export type SnippetElement = TabStop | Placeholder;
+    export type SnippetElement = TabStop | Placeholder | SnippetSequence;
 
     /* @internal */
     export interface TabStop {
@@ -6842,6 +6842,12 @@ namespace ts {
         order: number;
     }
 
+    /* @internal */
+    export interface SnippetSequence {
+        kind: SnippetKind.Sequence;
+        snippets: TabStop[];
+    }
+
     // Reference: https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax
     /* @internal */
     export const enum SnippetKind {
@@ -6849,6 +6855,7 @@ namespace ts {
         Placeholder,                            // `${1:foo}`
         Choice,                                 // `${1|one,two,three|}`
         Variable,                               // `$name`, `${name:default}`
+        Sequence,                               // A sequence of tabstops, e.g. `$1$0`
     }
 
     export const enum EmitFlags {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -852,12 +852,19 @@ namespace ts.Completions {
         let tabstopStart = 1;
         if (preferences.includeCompletionsWithSnippetText) {
             isSnippet = true;
-            // We are adding a final tabstop (i.e. $0) in the body of the suggested member, if it has one.
+            // We are adding an initial and final tabstop (i.e. `$1$0`) in the body of the suggested member,
+            // if it has one.
             // Note: this assumes we won't have more than one body in the completion nodes, which should be the case.
-            const emptyStatement1 = factory.createExpressionStatement(factory.createIdentifier(""));
-            setSnippetElement(emptyStatement1, { kind: SnippetKind.TabStop, order: 1 });
+            const emptyStatement = factory.createExpressionStatement(factory.createIdentifier(""));
+            setSnippetElement(emptyStatement, {
+                kind: SnippetKind.Sequence,
+                snippets: [
+                    { kind: SnippetKind.TabStop, order: 1 },
+                    { kind: SnippetKind.TabStop, order: 0 },
+                ],
+            });
             tabstopStart = 2;
-            body = factory.createBlock([emptyStatement1], /* multiline */ true);
+            body = factory.createBlock([emptyStatement], /* multiline */ true);
         }
         else {
             body = factory.createBlock([], /* multiline */ true);

--- a/tests/cases/fourslash/completionsOverridingMethod2.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod2.ts
@@ -30,7 +30,7 @@ verify.completions({
             },
             isSnippet: true,
             insertText:
-"\"\\$usd\"(${2:a}: ${3:number}): ${4:number} {\n    $1\n}\n",
+"\"\\$usd\"(${2:a}: ${3:number}): ${4:number} {\n    $1$0\n}\n",
         }
     ],
 });


### PR DESCRIPTION
Partially fixes #46568. 

Whenever completions offer a method snippet, the parameter names and types, and the return type are snippet placeholders, as described in #46370. And, if the method has a body, there is a tabstop in the empty body.

We are assuming that, in most cases, the person using the method snippet won't want to change the method signature, and will instead just want to fill in the body with the implementation of the method.
For that reason, the tabstop in the body is the *first* one, so when the method snippet is inserted, the cursor is in the body, like so:

```ts
class Bar implements Foo {
    bar(a: string, b: number, c: string, d: number, e: string): void {
        | // cursor starts here
    }
}
```

This PR adds a second tabstop, namely `$0`, right next to the first tabstop, in the body of the method. `$0` is special, in that it is the last tabstop. This means that the following flow is possible:

```ts
class Bar implements Foo {
    bar(a: string, b: number, c: string, d: number, e: string): void {
        | // cursor starts here
    }
}
```
after pressing tab a few times, navigating through the method signature:
```ts
class Bar implements Foo {
    bar(a: string, b: number, c: string|, d: number, e: string): void {
        
    }
}
```
after pressing tab one last time, after going through (and possibly editing) the parameters and return type:
```ts
class Bar implements Foo {
    bar(a: string, b: number, c: |string, d: number, e: string): void {
        | // cursor ends here
    }
}
```
