### PR TITLE
Remove placeholders in class member snippets

### DIFF
--- a/tests/cases/fourslash/completionsOverridingMethod2.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod2.ts
@@ -30,7 +30,7 @@ verify.completions({
             },
             isSnippet: true,
             insertText:
-"\"\\$usd\"(${2:a}: ${3:number}): ${4:number} {\n    $1\n}\n",
+"\"\\$usd\"(a: number): number {\n    $0\n}\n",
         }
     ],
 });


### PR DESCRIPTION
Fixes #46588.
Now class member snippets only have at most one tabstop: in the body of the method.