### PR TITLE
Improve recursion depth checks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20359,6 +20359,13 @@ namespace ts {
         // though highly unlikely, for this test to be true in a situation where a chain of instantiations is not infinitely
         // expanding. Effectively, we will generate a false positive when two types are structurally equal to at least maxDepth
         // levels, but unequal at some level beyond that.
+        // In addition, this will also detect when an indexed access has been chained off of maxDepth more times (which is
+        // essentially the dual of the structural comparison), and likewise mark the type as deeply nested, potentially adding
+        // false positives for finite but deeply expanding indexed accesses (eg, for `Q[P1][P2][P3][P4][P5]`).
+        // It also detects when a recursive type reference has expanded maxDepth or more times, e.g. if the true branch of
+        // `type A<T> = null extends T ? [A<NonNullable<T>>] : [T]`
+        // has expanded into `[A<NonNullable<NonNullable<NonNullable<NonNullable<NonNullable<T>>>>>>]`. In such cases we need
+        // to terminate the expansion, and we do so here.
         function isDeeplyNestedType(type: Type, stack: Type[], depth: number, maxDepth = 3): boolean {
             if (depth >= maxDepth) {
                 const identity = getRecursionIdentity(type);
@@ -20409,6 +20416,13 @@ namespace ts {
             }
             if (type.flags & TypeFlags.TypeParameter) {
                 return type.symbol;
+            }
+            if (type.flags & TypeFlags.IndexedAccess) {
+                // Identity is the leftmost object type in a chain of indexed accesses, eg, in A[P][Q] it is A
+                do {
+                    type = (type as IndexedAccessType).objectType;
+                } while (type.flags & TypeFlags.IndexedAccess);
+                return type;
             }
             if (type.flags & TypeFlags.Conditional) {
                 // The root object represents the origin of the conditional type

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20366,12 +20366,14 @@ namespace ts {
                 let lastTypeId = 0;
                 for (let i = 0; i < depth; i++) {
                     const t = stack[i];
-                    // We only count occurrences with higher type ids than the previous occurrences, since higher
-                    // type ids are an indicator of newer instantiations caused by recursion.
-                    if (getRecursionIdentity(t) === identity && t.id >= lastTypeId) {
-                        count++;
-                        if (count >= maxDepth) {
-                            return true;
+                    if (getRecursionIdentity(t) === identity) {
+                        // We only count occurrences with a higher type id than the previous occurrence, since higher
+                        // type ids are an indicator of newer instantiations caused by recursion.
+                        if (t.id >= lastTypeId) {
+                            count++;
+                            if (count >= maxDepth) {
+                                return true;
+                            }
                         }
                         lastTypeId = t.id;
                     }

--- a/tests/baselines/reference/invariantGenericErrorElaboration.errors.txt
+++ b/tests/baselines/reference/invariantGenericErrorElaboration.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/invariantGenericErrorElaboration.ts(3,7): error TS2322: Type 'Num' is not assignable to type 'Runtype<any>'.
-  The types of 'constraint.constraint.constraint' are incompatible between these types.
-    Type 'Constraint<Constraint<Constraint<Num>>>' is not assignable to type 'Constraint<Constraint<Constraint<Runtype<any>>>>'.
-      Type 'Constraint<Runtype<any>>' is not assignable to type 'Constraint<Num>'.
+  The types of 'constraint.constraint' are incompatible between these types.
+    Type 'Constraint<Constraint<Num>>' is not assignable to type 'Constraint<Constraint<Runtype<any>>>'.
+      Type 'Runtype<any>' is not assignable to type 'Num'.
 tests/cases/compiler/invariantGenericErrorElaboration.ts(4,19): error TS2322: Type 'Num' is not assignable to type 'Runtype<any>'.
 
 
@@ -11,9 +11,9 @@ tests/cases/compiler/invariantGenericErrorElaboration.ts(4,19): error TS2322: Ty
     const wat: Runtype<any> = Num;
           ~~~
 !!! error TS2322: Type 'Num' is not assignable to type 'Runtype<any>'.
-!!! error TS2322:   The types of 'constraint.constraint.constraint' are incompatible between these types.
-!!! error TS2322:     Type 'Constraint<Constraint<Constraint<Num>>>' is not assignable to type 'Constraint<Constraint<Constraint<Runtype<any>>>>'.
-!!! error TS2322:       Type 'Constraint<Runtype<any>>' is not assignable to type 'Constraint<Num>'.
+!!! error TS2322:   The types of 'constraint.constraint' are incompatible between these types.
+!!! error TS2322:     Type 'Constraint<Constraint<Num>>' is not assignable to type 'Constraint<Constraint<Runtype<any>>>'.
+!!! error TS2322:       Type 'Runtype<any>' is not assignable to type 'Num'.
     const Foo = Obj({ foo: Num })
                       ~~~
 !!! error TS2322: Type 'Num' is not assignable to type 'Runtype<any>'.


### PR DESCRIPTION
This PR improves relationship checking for recursive types in a number of ways:

* When checking for potentially recursive instantiations of the same type, we now only consider types with higher type IDs. Because type IDs are monotonically increasing, newer type instantiations have higher type IDs than older type instantiations--and in a recursive type that generates an infinite series of type instantiations in some pattern, we therefore continue to see increasing type IDs. One particular advantage of this change is that manually nested type instantiations of the form `Foo<Foo<Foo<Foo<Foo<T>>>>>` are _not_ counted as recursive instantiations (because we instantiate from innermost to outermost).
* We now consider a type to be "deeply nested" when we have seen three distinct instantiations of the type with increasing type IDs. Previously the limit was five, but without the increasing type ID requirement. This change means we'll do less work to detect and stop _infinitely generated_ types, but will check _manually nested_ types to any depth. Previously we couldn't distinguish between the two.
* We improve our method of computing and checking "broadest equivalent IDs" that was introduced in #42727.

The change to computing equivalent IDs improves type checking performance by 2-5%. Our performance test suites don't contain examples of infinitely generated types, so the depth check changes show no effect there. However, several Definitely Typed packages see dramatic improvement. For example, `redux-immutable`, `react-lazylog`, and `yup` all see at least a 50% reduction in check time.