### PR TITLE
Duplicate GDPR fragment from VS Code repo

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3199,6 +3199,14 @@ namespace ts.server.protocol {
         payload: TypingsInstalledTelemetryEventPayload;
     }
 
+    // VS Code adds this on our behalf, but the tooling won't pick up the __GDPR__FRAGMENT__ from another codebase.
+    // Keep in sync with https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/utils/telemetry.ts
+    /* __GDPR__FRAGMENT__
+        "TypeScriptCommonProperties" : {
+            "version" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+        }
+    */
+
     /* __GDPR__
         "typingsinstalled" : {
             "${include}": ["${TypeScriptCommonProperties}"],

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3199,8 +3199,19 @@ namespace ts.server.protocol {
         payload: TypingsInstalledTelemetryEventPayload;
     }
 
-    // VS Code adds this on our behalf, but the tooling won't pick up the __GDPR__FRAGMENT__ from another codebase.
-    // Keep in sync with https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/utils/telemetry.ts
+    // A __GDPR__FRAGMENT__ has no meaning until it is ${include}d by a __GDPR__ comment, at which point
+    // the included properties are effectively inlined into the __GDPR__ declaration.  In this case, for
+    // example, any __GDPR__ comment including the TypeScriptCommonProperties will be updated with an
+    // additional version property with the classification below.  Obviously, the purpose of such a construct
+    // is to reduce duplication and keep multiple use sites consistent (e.g. by making sure that all reflect
+    // any newly added TypeScriptCommonProperties).  Unfortunately, the system has limits - in particular,
+    // these reusable __GDPR__FRAGMENT__s are not accessible across repo boundaries.  Therefore, even though
+    // the code for adding the common properties (i.e. version), along with the corresponding __GDPR__FRAGMENT__,
+    // lives in the VS Code repo (see https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/utils/telemetry.ts)
+    // we have to duplicate it here.  It would be nice to keep them in sync, but the only likely failure mode
+    // is adding a property to the VS Code repro but not here and the only consequence would be having that
+    // property suppressed on the events (i.e. __GDPT__ comments) in this repo that reference the out-of-date
+    // local __GDPR__FRAGMENT__.
     /* __GDPR__FRAGMENT__
         "TypeScriptCommonProperties" : {
             "version" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }


### PR DESCRIPTION
...because the tool doesn't handle cross-repro references.

Follow up to #46585.