### PR TITLE
Fix git remote in cherry pick script

### DIFF
--- a/scripts/open-cherry-pick-pr.ts
+++ b/scripts/open-cherry-pick-pr.ts
@@ -33,9 +33,9 @@ async function main() {
 
     const inputPR = (await gh.pulls.get({ pull_number: +process.env.SOURCE_ISSUE, owner: "microsoft", repo: "TypeScript" })).data;
     let remoteName = "origin";
-    if (inputPR.base.repo.git_url !== `git:github.com/microsoft/TypeScript`) {
+    if (inputPR.base.repo.git_url !== `git:github.com/microsoft/TypeScript` && inputPR.base.repo.git_url !== `git://github.com/microsoft/TypeScript`) {
         runSequence([
-            ["git", ["remote", "add", "nonlocal", inputPR.base.repo.git_url]]
+            ["git", ["remote", "add", "nonlocal", inputPR.base.repo.git_url.replace(/^git:(?:\/\/)?/, "https://")]]
         ]);
         remoteName = "nonlocal";
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

`git_url` is now `git://github.com/microsoft/TypeScript.git`, and fetching from `git:` protocol remotes is going away: https://github.blog/2021-09-01-improving-git-protocol-security-github/

It sounds like what's happening today is a temporary brownout, but in a few months this will be permanent.
