### PR TITLE
Make specifier generation from export map information conditional on module resolution mode

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -707,13 +707,15 @@ namespace ts.moduleSpecifiers {
             if (host.fileExists(packageJsonPath)) {
                 const packageJsonContent = JSON.parse(host.readFile!(packageJsonPath)!);
                 // TODO: Inject `require` or `import` condition based on the intended import mode
-                const fromExports = packageJsonContent.exports && typeof packageJsonContent.name === "string" ? tryGetModuleNameFromExports(options, path, packageRootPath, packageJsonContent.name, packageJsonContent.exports, ["node", "types"]) : undefined;
-                if (fromExports) {
-                    const withJsExtension = !hasTSFileExtension(fromExports.moduleFileToTry) ? fromExports : { moduleFileToTry: removeFileExtension(fromExports.moduleFileToTry) + tryGetJSExtensionForFile(fromExports.moduleFileToTry, options) };
-                    return { ...withJsExtension, verbatimFromExports: true };
-                }
-                if (packageJsonContent.exports) {
-                    return { moduleFileToTry: path, blockedByExports: true };
+                if (getEmitModuleResolutionKind(options) === ModuleResolutionKind.Node12 || getEmitModuleResolutionKind(options) === ModuleResolutionKind.NodeNext) {
+                    const fromExports = packageJsonContent.exports && typeof packageJsonContent.name === "string" ? tryGetModuleNameFromExports(options, path, packageRootPath, packageJsonContent.name, packageJsonContent.exports, ["node", "types"]) : undefined;
+                    if (fromExports) {
+                        const withJsExtension = !hasTSFileExtension(fromExports.moduleFileToTry) ? fromExports : { moduleFileToTry: removeFileExtension(fromExports.moduleFileToTry) + tryGetJSExtensionForFile(fromExports.moduleFileToTry, options) };
+                        return { ...withJsExtension, verbatimFromExports: true };
+                    }
+                    if (packageJsonContent.exports) {
+                        return { moduleFileToTry: path, blockedByExports: true };
+                    }
                 }
                 const versionPaths = packageJsonContent.typesVersions
                     ? getPackageJsonTypesVersionsPaths(packageJsonContent.typesVersions)

--- a/tests/baselines/reference/legacyNodeModulesExportsSpecifierGenerationConditions.js
+++ b/tests/baselines/reference/legacyNodeModulesExportsSpecifierGenerationConditions.js
@@ -1,0 +1,84 @@
+//// [tests/cases/conformance/node/legacyNodeModulesExportsSpecifierGenerationConditions.ts] ////
+
+//// [index.ts]
+export const a = async () => (await import("inner")).x();
+//// [index.d.ts]
+export { x } from "./other.js";
+//// [other.d.ts]
+import { Thing } from "./private.js"
+export const x: () => Thing;
+//// [private.d.ts]
+export interface Thing {} // not exported in export map, inaccessible under new module modes
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        ".": {
+            "default": "./index.js"
+        },
+        "./other": {
+            "default": "./other.js"
+        }
+    }
+}
+
+//// [index.js]
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+exports.__esModule = true;
+exports.a = void 0;
+var a = function () { return __awaiter(void 0, void 0, void 0, function () { return __generator(this, function (_a) {
+    switch (_a.label) {
+        case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require("inner"); })];
+        case 1: return [2 /*return*/, (_a.sent()).x()];
+    }
+}); }); };
+exports.a = a;
+
+
+//// [index.d.ts]
+export declare const a: () => Promise<import("inner/private").Thing>;

--- a/tests/baselines/reference/legacyNodeModulesExportsSpecifierGenerationConditions.symbols
+++ b/tests/baselines/reference/legacyNodeModulesExportsSpecifierGenerationConditions.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/node/index.ts ===
+export const a = async () => (await import("inner")).x();
+>a : Symbol(a, Decl(index.ts, 0, 12))
+>(await import("inner")).x : Symbol(x, Decl(index.d.ts, 0, 8))
+>"inner" : Symbol("tests/cases/conformance/node/node_modules/inner/index", Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(index.d.ts, 0, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+export { x } from "./other.js";
+>x : Symbol(x, Decl(index.d.ts, 0, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+import { Thing } from "./private.js"
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 8))
+
+export const x: () => Thing;
+>x : Symbol(x, Decl(other.d.ts, 1, 12))
+>Thing : Symbol(Thing, Decl(other.d.ts, 0, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/private.d.ts ===
+export interface Thing {} // not exported in export map, inaccessible under new module modes
+>Thing : Symbol(Thing, Decl(private.d.ts, 0, 0))
+

--- a/tests/baselines/reference/legacyNodeModulesExportsSpecifierGenerationConditions.types
+++ b/tests/baselines/reference/legacyNodeModulesExportsSpecifierGenerationConditions.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/node/index.ts ===
+export const a = async () => (await import("inner")).x();
+>a : () => Promise<import("tests/cases/conformance/node/node_modules/inner/private").Thing>
+>async () => (await import("inner")).x() : () => Promise<import("tests/cases/conformance/node/node_modules/inner/private").Thing>
+>(await import("inner")).x() : import("tests/cases/conformance/node/node_modules/inner/private").Thing
+>(await import("inner")).x : () => import("tests/cases/conformance/node/node_modules/inner/private").Thing
+>(await import("inner")) : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>await import("inner") : typeof import("tests/cases/conformance/node/node_modules/inner/index")
+>import("inner") : Promise<typeof import("tests/cases/conformance/node/node_modules/inner/index")>
+>"inner" : "inner"
+>x : () => import("tests/cases/conformance/node/node_modules/inner/private").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+export { x } from "./other.js";
+>x : () => import("tests/cases/conformance/node/node_modules/inner/private").Thing
+
+=== tests/cases/conformance/node/node_modules/inner/other.d.ts ===
+import { Thing } from "./private.js"
+>Thing : any
+
+export const x: () => Thing;
+>x : () => Thing
+
+=== tests/cases/conformance/node/node_modules/inner/private.d.ts ===
+export interface Thing {} // not exported in export map, inaccessible under new module modes
+No type information for this code.

--- a/tests/cases/conformance/node/legacyNodeModulesExportsSpecifierGenerationConditions.ts
+++ b/tests/cases/conformance/node/legacyNodeModulesExportsSpecifierGenerationConditions.ts
@@ -1,0 +1,33 @@
+// @module: commonjs
+// @lib: es2020
+// @declaration: true
+// @filename: index.ts
+export const a = async () => (await import("inner")).x();
+// @filename: node_modules/inner/index.d.ts
+export { x } from "./other.js";
+// @filename: node_modules/inner/other.d.ts
+import { Thing } from "./private.js"
+export const x: () => Thing;
+// @filename: node_modules/inner/private.d.ts
+export interface Thing {} // not exported in export map, inaccessible under new module modes
+// @filename: package.json
+{
+    "name": "package",
+    "private": true,
+    "type": "module",
+    "exports": "./index.js"
+}
+// @filename: node_modules/inner/package.json
+{
+    "name": "inner",
+    "private": true,
+    "type": "module",
+    "exports": {
+        ".": {
+            "default": "./index.js"
+        },
+        "./other": {
+            "default": "./other.js"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #46659

This fixes the regression on our part in `moduleResolution: node`, however `rxjs` does legitimately have the problem that their types aren't directly visible in their export map, which makes locating a valid specifier for them when export maps are respected rather difficult.