### PR TITLE
Fix RWC missing file detection

### DIFF
--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -1438,14 +1438,15 @@ namespace Harness {
             }
 
             const referenceDir = referencePath(relativeFileBase, opts && opts.Baselinefolder, opts && opts.Subfolder);
-            let existing = IO.readDirectory(referenceDir, referencedExtensions || [extension]);
+            let existing = IO.readDirectory(referenceDir, referencedExtensions || [extension]); // always an _absolute_ path
             if (extension === ".ts" || referencedExtensions && referencedExtensions.indexOf(".ts") > -1 && referencedExtensions.indexOf(".d.ts") === -1) {
                 // special-case and filter .d.ts out of .ts results
                 existing = existing.filter(f => !ts.endsWith(f, ".d.ts"));
             }
             const missing: string[] = [];
+            const absoluteTestDir = `${process.cwd()}/${referenceDir}`;
             for (const name of existing) {
-                const localCopy = name.substring(referenceDir.length - relativeFileBase.length);
+                const localCopy = name.substring(absoluteTestDir.length - relativeFileBase.length);
                 if (!writtenFiles.has(localCopy)) {
                     missing.push(localCopy);
                 }


### PR DESCRIPTION
RWC has been failing for awhile (2 weeks); it wasn't really noticeable, since we still got normal diff PRs and merged them as needed, which seemed fine, but today I noticed that it was still failing even immediately after I merged an update PR - finding that suspect, I checked the logs and found out that pretty much every test was giving a spurious error saying it was missing every file in the test. Definitely not right. The story ended up being that #46086 made our `readDirectory` return _absolute_ paths, while the rwc harness was very much relying on relative paths to perform a simple path comparison.