### PR TITLE
enable go-to-type-definition on type nodes

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -206,11 +206,9 @@ namespace ts.GoToDefinition {
         const fromReturnType = returnType && definitionFromType(returnType, typeChecker, node);
         // If a function returns 'void' or some other type with no definition, just return the function definition.
         const typeDefinitions = fromReturnType && fromReturnType.length !== 0 ? fromReturnType : definitionFromType(typeAtLocation, typeChecker, node);
-        return typeDefinitions.length
-            ? typeDefinitions
-            : !(symbol.flags & SymbolFlags.Value) && symbol.flags & SymbolFlags.Type
-                ? getDefinitionFromSymbol(typeChecker, skipAlias(symbol, typeChecker), node)
-                : undefined;
+        return typeDefinitions.length ? typeDefinitions
+            : !(symbol.flags & SymbolFlags.Value) && symbol.flags & SymbolFlags.Type ? getDefinitionFromSymbol(typeChecker, skipAlias(symbol, typeChecker), node)
+            : undefined;
     }
 
     function definitionFromType(type: Type, checker: TypeChecker, node: Node): readonly DefinitionInfo[] {

--- a/tests/cases/fourslash/goToTypeDefinition3.ts
+++ b/tests/cases/fourslash/goToTypeDefinition3.ts
@@ -1,0 +1,6 @@
+/// <reference path='fourslash.ts' />
+
+////type /*definition*/T = string;
+////const x: /*reference*/T;
+
+verify.goToType("reference", "definition");

--- a/tests/cases/fourslash/goToTypeDefinition4.ts
+++ b/tests/cases/fourslash/goToTypeDefinition4.ts
@@ -8,5 +8,5 @@
 ////import { T } from "./foo";
 ////let x: [|/*reference*/T|];
 
-verify.goToType("reference", ["def0", "def1"]);
+verify.goToType("reference", []);
 verify.goToDefinition("reference", ["def0", "def1"]);

--- a/tests/cases/fourslash/goToTypeDefinition4.ts
+++ b/tests/cases/fourslash/goToTypeDefinition4.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: foo.ts
+////export type /*def0*/T = string;
+////export const /*def1*/T = "";
+
+// @Filename: bar.ts
+////import { T } from "./foo";
+////let x: [|/*reference*/T|];
+
+verify.goToType("reference", ["def0", "def1"]);
+verify.goToDefinition("reference", ["def0", "def1"]);

--- a/tests/cases/fourslash/goToTypeDefinition5.ts
+++ b/tests/cases/fourslash/goToTypeDefinition5.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: foo.ts
+////let Foo: /*definition*/unresolved;
+////type Foo = { x: string };
+
+/////*reference*/Foo;
+
+
+verify.goToType("reference", []);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46627
