### PR TITLE
Big[U]Int64Array.at returns bigint, not number

### DIFF
--- a/src/lib/es2022.array.d.ts
+++ b/src/lib/es2022.array.d.ts
@@ -91,7 +91,7 @@ interface BigInt64Array {
      * Returns the item located at the specified index.
      * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
      */
-    at(index: number): number | undefined;
+    at(index: number): bigint | undefined;
 }
 
 interface BigUint64Array {
@@ -99,5 +99,5 @@ interface BigUint64Array {
      * Returns the item located at the specified index.
      * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
      */
-    at(index: number): number | undefined;
+    at(index: number): bigint | undefined;
 }

--- a/tests/baselines/reference/indexAt(target=es2022).types
+++ b/tests/baselines/reference/indexAt(target=es2022).types
@@ -87,18 +87,18 @@ new Float64Array().at(0);
 >0 : 0
 
 new BigInt64Array().at(0);
->new BigInt64Array().at(0) : number
->new BigInt64Array().at : (index: number) => number
+>new BigInt64Array().at(0) : bigint
+>new BigInt64Array().at : (index: number) => bigint
 >new BigInt64Array() : BigInt64Array
 >BigInt64Array : BigInt64ArrayConstructor
->at : (index: number) => number
+>at : (index: number) => bigint
 >0 : 0
 
 new BigUint64Array().at(0);
->new BigUint64Array().at(0) : number
->new BigUint64Array().at : (index: number) => number
+>new BigUint64Array().at(0) : bigint
+>new BigUint64Array().at : (index: number) => bigint
 >new BigUint64Array() : BigUint64Array
 >BigUint64Array : BigUint64ArrayConstructor
->at : (index: number) => number
+>at : (index: number) => bigint
 >0 : 0
 

--- a/tests/baselines/reference/indexAt(target=esnext).types
+++ b/tests/baselines/reference/indexAt(target=esnext).types
@@ -87,18 +87,18 @@ new Float64Array().at(0);
 >0 : 0
 
 new BigInt64Array().at(0);
->new BigInt64Array().at(0) : number
->new BigInt64Array().at : (index: number) => number
+>new BigInt64Array().at(0) : bigint
+>new BigInt64Array().at : (index: number) => bigint
 >new BigInt64Array() : BigInt64Array
 >BigInt64Array : BigInt64ArrayConstructor
->at : (index: number) => number
+>at : (index: number) => bigint
 >0 : 0
 
 new BigUint64Array().at(0);
->new BigUint64Array().at(0) : number
->new BigUint64Array().at : (index: number) => number
+>new BigUint64Array().at(0) : bigint
+>new BigUint64Array().at : (index: number) => bigint
 >new BigUint64Array() : BigUint64Array
 >BigUint64Array : BigUint64ArrayConstructor
->at : (index: number) => number
+>at : (index: number) => bigint
 >0 : 0
 


### PR DESCRIPTION
bigint is needed to represent all 64-bit ints that these arrays could contain.

Breaks jsdom and jsreport-core on DT, and any package that depends on es2022 and `@types/node`