### PR TITLE
fix(46712): Add "exceptZero" for "signDisplay" option of Intl.NumberF…

### DIFF
--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -200,7 +200,7 @@ declare namespace Intl {
     interface NumberFormatOptions {
         compactDisplay?: "short" | "long" | undefined;
         notation?: "standard" | "scientific" | "engineering" | "compact" | undefined;
-        signDisplay?: "auto" | "never" | "always" | undefined;
+        signDisplay?: "auto" | "never" | "always" | "exceptZero" | undefined;
         unit?: string | undefined;
         unitDisplay?: "short" | "long" | "narrow" | undefined;
     }
@@ -208,7 +208,7 @@ declare namespace Intl {
     interface ResolvedNumberFormatOptions {
         compactDisplay?: "short" | "long";
         notation?: "standard" | "scientific" | "engineering" | "compact";
-        signDisplay?: "auto" | "never" | "always";
+        signDisplay?: "auto" | "never" | "always" | "exceptZero";
         unit?: string;
         unitDisplay?: "short" | "long" | "narrow";
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46712 

The "exceptZero" type was missing on the "signDisplay" option as it was mentioned in the issue. This PR adds it. I'm not sure whether do I have to write any test case for it. Please guide me if I have to write any.