### PR TITLE
fix(46605): Template literal autocomplete not working for parameter objects

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -3526,6 +3526,7 @@ namespace ts.Completions {
         // function f<T>(x: T) {}
         // f({ abc/**/: "" }) // `abc` is a member of `T` but only because it declares itself
         function hasDeclarationOtherThanSelf(member: Symbol) {
+            if (!length(member.declarations)) return true;
             return some(member.declarations, decl => decl.parent !== obj);
         }
     }

--- a/tests/cases/fourslash/completionListInObjectLiteral6.ts
+++ b/tests/cases/fourslash/completionListInObjectLiteral6.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts'/>
+
+////const foo = {
+////    a: "a",
+////    b: "b"
+////};
+////function fn<T extends { [key: string]: any }>(obj: T, events: { [Key in `on_${string & keyof T}`]?: Key }) {}
+////
+////fn(foo, {
+////    /*1*/
+////})
+////fn({ a: "a", b: "b" }, {
+////    /*2*/
+////})
+
+verify.completions({
+    marker: ["1", "2"],
+    exact: [
+        { name: "on_a", sortText: completion.SortText.OptionalMember },
+        { name: "on_b", sortText: completion.SortText.OptionalMember }
+    ]
+});


### PR DESCRIPTION
Fixes #46605