### PR TITLE
Adds a github actions workflow which pings related repos with a blank commit

### DIFF
--- a/.github/workflows/ensure-related-repos-run-crons.yml
+++ b/.github/workflows/ensure-related-repos-run-crons.yml
@@ -1,0 +1,44 @@
+# Ensures that repos which are related to TypeScript but may not have regular commits
+# have their GitHub Actions scheduled jobs still active due to the 6 week timeout
+# on OSS repos. This has already triggered a few times with microsoft/TypeScript-Make-Monaco-Builds
+# so, better to automate keeping on top of it.
+
+name: Related Repo Commit Bumps
+
+on:
+    schedule:
+        # Monthly, https://crontab.guru/#0_0_*_1-12_*
+        - cron: '0 0 * 1-12 *'
+    workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Configure git and update package-lock.json
+      run: |
+        git config user.email "typescriptbot@microsoft.com"
+        git config user.name "TypeScript Bot"
+
+    - uses: actions/checkout@v2
+      with: 
+        repository: 'microsoft/TypeScript-Website'
+        path: 'ts-site'
+
+    - name: Push Commit to TS Website
+      run:  |
+        cd ts-site
+        git commit --allow-empty -m "Monthly Bump"
+        git push https://${{ secrets.TS_BOT_GITHUB_TOKEN }}@github.com/microsoft/TypeScript-Website.git
+
+    - uses: actions/checkout@v2
+      with: 
+        repository: 'microsoft/TypeScript-Make-Monaco-Builds'
+        path: 'monaco-builds'
+
+    - name: Push Commit to TS Make Monaco Builds
+      run:  |
+        cd monaco-builds
+        git commit --allow-empty -m "Monthly Bump"
+        git push https://${{ secrets.TS_BOT_GITHUB_TOKEN }}@github.com/microsoft/TypeScript-Make-Monaco-Builds.git


### PR DESCRIPTION
… once a month to ensure their automation stays running.

GitHub has the scheduled actions like:

```yml
on:
    schedule:
        # Monthly, https://crontab.guru/#0_0_*_1-12_*
        - cron: '0 0 * 1-12 *'
    workflow_dispatch: {}
```

Which only keep running if there has been a commit in the last 6 weeks. Given that the playground and website auto-update based on TypeScript releases, we really want to be sure that those repos don't timeout and unexpectedly don't ship updates to the site or the versions in the Playground. Which happened during the 4.4 betas.

I'm like 90% sure this should work, but may need to faff around a bit with the actions once I can test it properly