### PR TITLE
chore: add packageManager field to support corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "engines": {
         "node": ">=4.2.0"
     },
+    "packageManager": "npm@6.14.15",
     "devDependencies": {
         "@octokit/rest": "latest",
         "@types/browserify": "latest",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Corepack is a new package manager manager that default ships in Node 16.9.0.

It will select the correct NPM version based on the "packageManager" field in the package.json

I added this field and set it to 6.14.15. It's the current latest NPM version that uses NPM lockfile version 1.
