### PR TITLE
Revert changes to matchFiles/readDirectory made since 4.3

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1266,7 +1266,6 @@ namespace ts {
             let activeSession: import("inspector").Session | "stopping" | undefined;
             let profilePath = "./profile.cpuprofile";
 
-            let hitSystemWatcherLimit = false;
 
             const Buffer: {
                 new (input: string, encoding?: string): any;
@@ -1620,12 +1619,6 @@ namespace ts {
                             options = { persistent: true };
                         }
                     }
-
-                    if (hitSystemWatcherLimit) {
-                        sysLog(`sysLog:: ${fileOrDirectory}:: Defaulting to fsWatchFile`);
-                        return watchPresentFileSystemEntryWithFsWatchFile();
-                    }
-
                     try {
                         const presentWatcher = _fs.watch(
                             fileOrDirectory,
@@ -1642,8 +1635,6 @@ namespace ts {
                         // Catch the exception and use polling instead
                         // Eg. on linux the number of watches are limited and one could easily exhaust watches and the exception ENOSPC is thrown when creating watcher at that point
                         // so instead of throwing error, use fs.watchFile
-                        hitSystemWatcherLimit ||= e.code === "ENOSPC";
-                        sysLog(`sysLog:: ${fileOrDirectory}:: Changing to fsWatchFile`);
                         return watchPresentFileSystemEntryWithFsWatchFile();
                     }
                 }
@@ -1665,6 +1656,7 @@ namespace ts {
                  * Eg. on linux the number of watches are limited and one could easily exhaust watches and the exception ENOSPC is thrown when creating watcher at that point
                  */
                 function watchPresentFileSystemEntryWithFsWatchFile(): FileWatcher {
+                    sysLog(`sysLog:: ${fileOrDirectory}:: Changing to fsWatchFile`);
                     return watchFile(
                         fileOrDirectory,
                         createFileWatcherCallback(callback),
@@ -1804,7 +1796,7 @@ namespace ts {
             }
 
             function readDirectory(path: string, extensions?: readonly string[], excludes?: readonly string[], includes?: readonly string[], depth?: number): string[] {
-                return matchFiles(path, extensions, excludes, includes, useCaseSensitiveFileNames, process.cwd(), depth, getAccessibleFileSystemEntries, realpath, directoryExists);
+                return matchFiles(path, extensions, excludes, includes, useCaseSensitiveFileNames, process.cwd(), depth, getAccessibleFileSystemEntries, realpath);
             }
 
             function fileSystemEntryExists(path: string, entryKind: FileSystemEntryKind): boolean {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6629,7 +6629,7 @@ namespace ts {
             includeFilePattern: getRegularExpressionForWildcard(includes, absolutePath, "files"),
             includeDirectoryPattern: getRegularExpressionForWildcard(includes, absolutePath, "directories"),
             excludePattern: getRegularExpressionForWildcard(excludes, absolutePath, "exclude"),
-            basePaths: getBasePaths(absolutePath, includes, useCaseSensitiveFileNames)
+            basePaths: getBasePaths(path, includes, useCaseSensitiveFileNames)
         };
     }
 
@@ -6653,22 +6653,22 @@ namespace ts {
         const results: string[][] = includeFileRegexes ? includeFileRegexes.map(() => []) : [[]];
         const visited = new Map<string, true>();
         const toCanonical = createGetCanonicalFileName(useCaseSensitiveFileNames);
-        for (const absoluteBasePath of patterns.basePaths) {
-            if (directoryExists(absoluteBasePath)) {
-                visitDirectory(absoluteBasePath, depth);
+        for (const basePath of patterns.basePaths) {
+            if (directoryExists(basePath)) {
+                visitDirectory(basePath, combinePaths(currentDirectory, basePath), depth);
             }
         }
 
         return flatten(results);
 
-        function visitDirectory(absolutePath: string, depth: number | undefined) {
+        function visitDirectory(path: string, absolutePath: string, depth: number | undefined) {
             const canonicalPath = toCanonical(realpath(absolutePath));
             if (visited.has(canonicalPath)) return;
             visited.set(canonicalPath, true);
-            const { files, directories } = getFileSystemEntries(absolutePath);
+            const { files, directories } = getFileSystemEntries(path);
 
             for (const current of sort<string>(files, compareStringsCaseSensitive)) {
-                const name = combinePaths(absolutePath, current);
+                const name = combinePaths(path, current);
                 const absoluteName = combinePaths(absolutePath, current);
                 if (extensions && !fileExtensionIsOneOf(name, extensions)) continue;
                 if (excludeRegex && excludeRegex.test(absoluteName)) continue;
@@ -6691,10 +6691,11 @@ namespace ts {
             }
 
             for (const current of sort<string>(directories, compareStringsCaseSensitive)) {
+                const name = combinePaths(path, current);
                 const absoluteName = combinePaths(absolutePath, current);
                 if ((!includeDirectoryRegex || includeDirectoryRegex.test(absoluteName)) &&
                     (!excludeRegex || !excludeRegex.test(absoluteName))) {
-                    visitDirectory(absoluteName, depth);
+                    visitDirectory(name, absoluteName, depth);
                 }
             }
         }
@@ -6702,11 +6703,10 @@ namespace ts {
 
     /**
      * Computes the unique non-wildcard base paths amongst the provided include patterns.
-     * @returns Absolute directory paths
      */
-    function getBasePaths(absoluteTsconfigPath: string, includes: readonly string[] | undefined, useCaseSensitiveFileNames: boolean): string[] {
+    function getBasePaths(path: string, includes: readonly string[] | undefined, useCaseSensitiveFileNames: boolean): string[] {
         // Storage for our results in the form of literal paths (e.g. the paths as written by the user).
-        const basePaths: string[] = [absoluteTsconfigPath];
+        const basePaths: string[] = [path];
 
         if (includes) {
             // Storage for literal base paths amongst the include patterns.
@@ -6714,9 +6714,9 @@ namespace ts {
             for (const include of includes) {
                 // We also need to check the relative paths by converting them to absolute and normalizing
                 // in case they escape the base path (e.g "..\somedirectory")
-                const absoluteIncludePath: string = isRootedDiskPath(include) ? include : normalizePath(combinePaths(absoluteTsconfigPath, include));
+                const absolute: string = isRootedDiskPath(include) ? include : normalizePath(combinePaths(path, include));
                 // Append the literal and canonical candidate base paths.
-                includeBasePaths.push(getIncludeBasePath(absoluteIncludePath));
+                includeBasePaths.push(getIncludeBasePath(absolute));
             }
 
             // Sort the offsets array using either the literal or canonical path representations.
@@ -6725,7 +6725,7 @@ namespace ts {
             // Iterate over each include base path and include unique base paths that are not a
             // subpath of an existing base path
             for (const includeBasePath of includeBasePaths) {
-                if (every(basePaths, basePath => !containsPath(basePath, includeBasePath, absoluteTsconfigPath, !useCaseSensitiveFileNames))) {
+                if (every(basePaths, basePath => !containsPath(basePath, includeBasePath, path, !useCaseSensitiveFileNames))) {
                     basePaths.push(includeBasePath);
                 }
             }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6638,7 +6638,7 @@ namespace ts {
     }
 
     /** @param path directory of the tsconfig.json */
-    export function matchFiles(path: string, extensions: readonly string[] | undefined, excludes: readonly string[] | undefined, includes: readonly string[] | undefined, useCaseSensitiveFileNames: boolean, currentDirectory: string, depth: number | undefined, getFileSystemEntries: (path: string) => FileSystemEntries, realpath: (path: string) => string, directoryExists: (path: string) => boolean): string[] {
+    export function matchFiles(path: string, extensions: readonly string[] | undefined, excludes: readonly string[] | undefined, includes: readonly string[] | undefined, useCaseSensitiveFileNames: boolean, currentDirectory: string, depth: number | undefined, getFileSystemEntries: (path: string) => FileSystemEntries, realpath: (path: string) => string): string[] {
         path = normalizePath(path);
         currentDirectory = normalizePath(currentDirectory);
 
@@ -6654,9 +6654,7 @@ namespace ts {
         const visited = new Map<string, true>();
         const toCanonical = createGetCanonicalFileName(useCaseSensitiveFileNames);
         for (const basePath of patterns.basePaths) {
-            if (directoryExists(basePath)) {
-                visitDirectory(basePath, combinePaths(currentDirectory, basePath), depth);
-            }
+            visitDirectory(basePath, combinePaths(currentDirectory, basePath), depth);
         }
 
         return flatten(results);

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -184,7 +184,7 @@ namespace ts {
             const rootResult = tryReadDirectory(rootDir, rootDirPath);
             let rootSymLinkResult: FileSystemEntries | undefined;
             if (rootResult !== undefined) {
-                return matchFiles(rootDir, extensions, excludes, includes, useCaseSensitiveFileNames, currentDirectory, depth, getFileSystemEntries, realpath, directoryExists);
+                return matchFiles(rootDir, extensions, excludes, includes, useCaseSensitiveFileNames, currentDirectory, depth, getFileSystemEntries, realpath);
             }
             return host.readDirectory!(rootDir, extensions, excludes, includes, depth);
 

--- a/src/harness/fakesHosts.ts
+++ b/src/harness/fakesHosts.ts
@@ -95,7 +95,7 @@ namespace fakes {
         }
 
         public readDirectory(path: string, extensions?: readonly string[], exclude?: readonly string[], include?: readonly string[], depth?: number): string[] {
-            return ts.matchFiles(path, extensions, exclude, include, this.useCaseSensitiveFileNames, this.getCurrentDirectory(), depth, path => this.getAccessibleFileSystemEntries(path), path => this.realpath(path), path => this.directoryExists(path));
+            return ts.matchFiles(path, extensions, exclude, include, this.useCaseSensitiveFileNames, this.getCurrentDirectory(), depth, path => this.getAccessibleFileSystemEntries(path), path => this.realpath(path));
         }
 
         public getAccessibleFileSystemEntries(path: string): ts.FileSystemEntries {

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -1438,15 +1438,14 @@ namespace Harness {
             }
 
             const referenceDir = referencePath(relativeFileBase, opts && opts.Baselinefolder, opts && opts.Subfolder);
-            let existing = IO.readDirectory(referenceDir, referencedExtensions || [extension]); // always an _absolute_ path
+            let existing = IO.readDirectory(referenceDir, referencedExtensions || [extension]);
             if (extension === ".ts" || referencedExtensions && referencedExtensions.indexOf(".ts") > -1 && referencedExtensions.indexOf(".d.ts") === -1) {
                 // special-case and filter .d.ts out of .ts results
                 existing = existing.filter(f => !ts.endsWith(f, ".d.ts"));
             }
             const missing: string[] = [];
-            const absoluteTestDir = `${process.cwd()}/${referenceDir}`;
             for (const name of existing) {
-                const localCopy = name.substring(absoluteTestDir.length - relativeFileBase.length);
+                const localCopy = name.substring(referenceDir.length - relativeFileBase.length);
                 if (!writtenFiles.has(localCopy)) {
                     missing.push(localCopy);
                 }

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -922,7 +922,7 @@ interface Array<T> { length: number; [n: number]: T; }`
                     });
                 }
                 return { directories, files };
-            }, path => this.realpath(path), path => this.directoryExists(path));
+            }, path => this.realpath(path));
         }
 
         createHash(s: string): string {

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -182,34 +182,3 @@ describe("unittests:: Public APIs:: getChild* methods on EndOfFileToken with JSD
     assert.equal(endOfFileToken.getChildCount(), 1);
     assert.notEqual(endOfFileToken.getChildAt(0), /*expected*/ undefined);
 });
-
-describe("unittests:: Public APIs:: sys", () => {
-    it("readDirectory", () => {
-        // #45990, testing passing a non-absolute path
-        // `sys.readDirectory` is just `matchFiles` plugged into the real FS
-        const read = ts.matchFiles(
-            /*path*/ "",
-            /*extensions*/ [".ts", ".tsx"],
-            /*excludes*/ ["node_modules", "dist"],
-            /*includes*/ ["**/*"],
-            /*useCaseSensitiveFileNames*/ true,
-            /*currentDirectory*/ "/",
-            /*depth*/ undefined,
-            /*getFileSystemEntries*/ path => {
-                switch (path) {
-                    case "/": return { directories: [], files: ["file.ts"] };
-                    default: return { directories: [], files: [] };
-                }
-            },
-            /*realpath*/ ts.identity,
-            /*directoryExists*/ path => {
-                switch (path) {
-                    case "/": return true;
-                    default: return false;
-                }
-            }
-        );
-
-        assert.deepEqual(read, ["/file.ts"]);
-    });
-});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Reverts #44710, #46086, and #46673.
Fixes #46577.

I have discovered that `ts.matchFiles`/`ts.sys.readDirectory` does a lot of extremely confusing things, none of which are documented and some of which are probably bugs, but nobody seemed to notice until we started messing with it, so I’m reverting back to our 4.3 state. I will post my findings of what’s weird even in 4.3 so we can decide if any of it is worth fixing (done: #46788).
