### PR TITLE
use default type parameter rather than `unknown` when show quick help

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30243,10 +30243,11 @@ namespace ts {
         }
 
         function getTypeArgumentsFromNodes(typeArgumentNodes: readonly TypeNode[], typeParameters: readonly TypeParameter[], isJs: boolean): readonly Type[] {
-            const typeArguments = typeArgumentNodes.map(getTypeOfNode);
+            let typeArguments = typeArgumentNodes.map(getTypeOfNode);
             while (typeArguments.length > typeParameters.length) {
                 typeArguments.pop();
             }
+            typeArguments = fillMissingTypeArguments(typeArguments, typeParameters, getMinTypeArgumentCount(typeParameters), isJs);
             while (typeArguments.length < typeParameters.length) {
                 typeArguments.push(getConstraintOfTypeParameter(typeParameters[typeArguments.length]) || getDefaultTypeArgumentType(isJs));
             }

--- a/tests/cases/fourslash/signatureHelpExplicitTypeArguments.ts
+++ b/tests/cases/fourslash/signatureHelpExplicitTypeArguments.ts
@@ -9,8 +9,8 @@
 verify.signatureHelp(
     { marker: "1", text: "f(x: number, y: string): number" },
     { marker: "2", text: "f(x: boolean, y: string): boolean" },
-    // too few -- fill in rest with unknown
-    { marker: "3", text: "f(x: number, y: unknown): number" },
+    // too few -- fill in rest with default
+    { marker: "3", text: "f(x: number, y: string): number" },
     // too many -- ignore extra type arguments
     { marker: "4", text: "f(x: number, y: string): number" },
 );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46774 
