### PR TITLE
fix(44693): Overriden properties in jsdoc annotation are not picked up in declaration file

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -39048,7 +39048,7 @@ namespace ts {
                 const properties = getPropertiesOfType(getTypeWithThisArgument(base, type.thisType));
                 for (const prop of properties) {
                     const existing = seen.get(prop.escapedName);
-                    if (existing && !isPropertyIdenticalTo(existing, prop)) {
+                    if (existing && prop.parent === existing.parent) {
                         seen.delete(prop.escapedName);
                     }
                 }

--- a/tests/baselines/reference/jsDeclarationsInheritedTypes.js
+++ b/tests/baselines/reference/jsDeclarationsInheritedTypes.js
@@ -1,0 +1,64 @@
+//// [a.js]
+/**
+ * @typedef A
+ * @property {string} a
+ */
+
+/**
+ * @typedef B
+ * @property {number} b
+ */
+
+ class C1 {
+    /**
+     * @type {A}
+     */
+    value;
+}
+
+class C2 extends C1 {
+    /**
+     * @type {A}
+     */
+    value;
+}
+
+class C3 extends C1 {
+    /**
+     * @type {A & B}
+     */
+    value;
+}
+
+
+
+
+//// [a.d.ts]
+/**
+ * @typedef A
+ * @property {string} a
+ */
+/**
+ * @typedef B
+ * @property {number} b
+ */
+declare class C1 {
+    /**
+     * @type {A}
+     */
+    value: A;
+}
+declare class C2 extends C1 {
+}
+declare class C3 extends C1 {
+    /**
+     * @type {A & B}
+     */
+    value: A & B;
+}
+type A = {
+    a: string;
+};
+type B = {
+    b: number;
+};

--- a/tests/baselines/reference/jsDeclarationsInheritedTypes.symbols
+++ b/tests/baselines/reference/jsDeclarationsInheritedTypes.symbols
@@ -1,0 +1,43 @@
+=== tests/cases/compiler/a.js ===
+/**
+ * @typedef A
+ * @property {string} a
+ */
+
+/**
+ * @typedef B
+ * @property {number} b
+ */
+
+ class C1 {
+>C1 : Symbol(C1, Decl(a.js, 0, 0))
+
+    /**
+     * @type {A}
+     */
+    value;
+>value : Symbol(C1.value, Decl(a.js, 10, 11))
+}
+
+class C2 extends C1 {
+>C2 : Symbol(C2, Decl(a.js, 15, 1))
+>C1 : Symbol(C1, Decl(a.js, 0, 0))
+
+    /**
+     * @type {A}
+     */
+    value;
+>value : Symbol(C2.value, Decl(a.js, 17, 21))
+}
+
+class C3 extends C1 {
+>C3 : Symbol(C3, Decl(a.js, 22, 1))
+>C1 : Symbol(C1, Decl(a.js, 0, 0))
+
+    /**
+     * @type {A & B}
+     */
+    value;
+>value : Symbol(C3.value, Decl(a.js, 24, 21))
+}
+

--- a/tests/baselines/reference/jsDeclarationsInheritedTypes.types
+++ b/tests/baselines/reference/jsDeclarationsInheritedTypes.types
@@ -1,0 +1,43 @@
+=== tests/cases/compiler/a.js ===
+/**
+ * @typedef A
+ * @property {string} a
+ */
+
+/**
+ * @typedef B
+ * @property {number} b
+ */
+
+ class C1 {
+>C1 : C1
+
+    /**
+     * @type {A}
+     */
+    value;
+>value : A
+}
+
+class C2 extends C1 {
+>C2 : C2
+>C1 : C1
+
+    /**
+     * @type {A}
+     */
+    value;
+>value : A
+}
+
+class C3 extends C1 {
+>C3 : C3
+>C1 : C1
+
+    /**
+     * @type {A & B}
+     */
+    value;
+>value : A & B
+}
+

--- a/tests/cases/compiler/jsDeclarationsInheritedTypes.ts
+++ b/tests/cases/compiler/jsDeclarationsInheritedTypes.ts
@@ -1,0 +1,37 @@
+// @checkJs: true
+// @allowJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @outDir: ./dist
+// @filename: a.js
+
+/**
+ * @typedef A
+ * @property {string} a
+ */
+
+/**
+ * @typedef B
+ * @property {number} b
+ */
+
+ class C1 {
+    /**
+     * @type {A}
+     */
+    value;
+}
+
+class C2 extends C1 {
+    /**
+     * @type {A}
+     */
+    value;
+}
+
+class C3 extends C1 {
+    /**
+     * @type {A & B}
+     */
+    value;
+}


### PR DESCRIPTION
Fixes #44693