### PR TITLE
Describe jsxFragmentFactory option default value

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -938,7 +938,8 @@ namespace ts {
             name: "jsxFragmentFactory",
             type: "string",
             category: Diagnostics.Language_and_Environment,
-            description: Diagnostics.Specify_the_JSX_Fragment_reference_used_for_fragments_when_targeting_React_JSX_emit_e_g_React_Fragment_or_Fragment
+            description: Diagnostics.Specify_the_JSX_Fragment_reference_used_for_fragments_when_targeting_React_JSX_emit_e_g_React_Fragment_or_Fragment,
+            defaultValueDescription: "React.Fragment",
         },
         {
             name: "jsxImportSource",


### PR DESCRIPTION
Adds `defaultValueDescription` to the `jsxFragmentFactory` option: Defaults to `React.Fragment`, I think?
```ts
            // by default, jsx:'react' will use jsxFactory = React.createElement and jsxFragmentFactory = React.Fragment
```
https://github.com/microsoft/TypeScript/blob/719ab0b47721c7dfe72708d8771f6778f2de58c3/src/compiler/checker.ts#L27312
https://github.com/microsoft/TypeScript/blob/e160bc8c0df502dcf415f0cd625c6680ff089512/src/compiler/factory/utilities.ts#L59-L64

/cc @orta