### PR TITLE
Fix JsDocTags inheritage and setter/getter quickInfo

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1393,11 +1393,11 @@ namespace FourSlash {
             }));
         }
 
-        public verifyQuickInfoAt(markerName: string | Range, expectedText: string, expectedDocumentation?: string) {
+        public verifyQuickInfoAt(markerName: string | Range, expectedText: string, expectedDocumentation?: string, expectedTags?: {name: string; text: string;}[]) {
             if (typeof markerName === "string") this.goToMarker(markerName);
             else this.goToRangeStart(markerName);
 
-            this.verifyQuickInfoString(expectedText, expectedDocumentation);
+            this.verifyQuickInfoString(expectedText, expectedDocumentation, expectedTags);
         }
 
         public verifyQuickInfos(namesAndTexts: { [name: string]: string | [string, string] }) {
@@ -1416,16 +1416,29 @@ namespace FourSlash {
             }
         }
 
-        public verifyQuickInfoString(expectedText: string, expectedDocumentation?: string) {
+        public verifyQuickInfoString(expectedText: string, expectedDocumentation?: string, expectedTags?: { name: string; text: string; }[]) {
             if (expectedDocumentation === "") {
-                throw new Error("Use 'undefined' instead");
+                throw new Error("Use 'undefined' instead of empty string for `expectedDocumentation`");
             }
             const actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
-            const actualQuickInfoText = actualQuickInfo ? ts.displayPartsToString(actualQuickInfo.displayParts) : "";
-            const actualQuickInfoDocumentation = actualQuickInfo ? ts.displayPartsToString(actualQuickInfo.documentation) : "";
+            const actualQuickInfoText = ts.displayPartsToString(actualQuickInfo?.displayParts);
+            const actualQuickInfoDocumentation = ts.displayPartsToString(actualQuickInfo?.documentation);
+            const actualQuickInfoTags = actualQuickInfo?.tags?.map(tag => ({ name: tag.name, text: ts.displayPartsToString(tag.text) }));
 
             assert.equal(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
             assert.equal(actualQuickInfoDocumentation, expectedDocumentation || "", this.assertionMessageAtLastKnownMarker("quick info doc"));
+            if (!expectedTags) {
+                // Skip if `expectedTags` is not given
+            }
+            else if (!actualQuickInfoTags) {
+                assert.equal(actualQuickInfoTags, expectedTags, this.messageAtLastKnownMarker("QuickInfo tags"));
+            }
+            else {
+                ts.zipWith(expectedTags, actualQuickInfoTags, (expectedTag, actualTag) => {
+                    assert.equal(expectedTag.name, actualTag.name);
+                    assert.equal(expectedTag.text, actualTag.text, this.messageAtLastKnownMarker("QuickInfo tag " + actualTag.name));
+                });
+            }
         }
 
         public verifyQuickInfoDisplayParts(kind: string, kindModifiers: string, textSpan: TextSpan,

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -259,12 +259,12 @@ namespace FourSlashInterface {
             this.state.verifyInlayHints(expected, span, preference);
         }
 
-        public quickInfoIs(expectedText: string, expectedDocumentation?: string) {
-            this.state.verifyQuickInfoString(expectedText, expectedDocumentation);
+        public quickInfoIs(expectedText: string, expectedDocumentation?: string, expectedTags?: { name: string; text: string; }[]) {
+            this.state.verifyQuickInfoString(expectedText, expectedDocumentation, expectedTags);
         }
 
-        public quickInfoAt(markerName: string | FourSlash.Range, expectedText: string, expectedDocumentation?: string) {
-            this.state.verifyQuickInfoAt(markerName, expectedText, expectedDocumentation);
+        public quickInfoAt(markerName: string | FourSlash.Range, expectedText: string, expectedDocumentation?: string, expectedTags?: { name: string; text: string; }[]) {
+            this.state.verifyQuickInfoAt(markerName, expectedText, expectedDocumentation, expectedTags);
         }
 
         public quickInfos(namesAndTexts: { [name: string]: string }) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -346,13 +346,11 @@ namespace ts {
             switch (context?.kind) {
                 case SyntaxKind.GetAccessor:
                     if (!this.contextualGetAccessorDocumentationComment) {
-                        this.contextualGetAccessorDocumentationComment = emptyArray;
                         this.contextualGetAccessorDocumentationComment = getDocumentationComment(filter(this.declarations, isGetAccessor), checker);
                     }
                     return this.contextualGetAccessorDocumentationComment;
                 case SyntaxKind.SetAccessor:
                     if (!this.contextualSetAccessorDocumentationComment) {
-                        this.contextualSetAccessorDocumentationComment = emptyArray;
                         this.contextualSetAccessorDocumentationComment = getDocumentationComment(filter(this.declarations, isSetAccessor), checker);
                     }
                     return this.contextualSetAccessorDocumentationComment;
@@ -373,13 +371,11 @@ namespace ts {
             switch (context?.kind) {
                 case SyntaxKind.GetAccessor:
                     if (!this.contextualGetAccessorTags) {
-                        this.contextualGetAccessorTags = emptyArray;
                         this.contextualGetAccessorTags = getJsDocTagsOfDeclarations(filter(this.declarations, isGetAccessor), checker);
                     }
                     return this.contextualGetAccessorTags;
                 case SyntaxKind.SetAccessor:
                     if (!this.contextualSetAccessorTags) {
-                        this.contextualSetAccessorTags = emptyArray;
                         this.contextualSetAccessorTags = getJsDocTagsOfDeclarations(filter(this.declarations, isSetAccessor), checker);
                     }
                     return this.contextualSetAccessorTags;

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -169,7 +169,7 @@ namespace ts.SymbolDisplay {
             // If symbol is accessor, they are allowed only if location is at declaration identifier of the accessor
             if (symbolKind === ScriptElementKind.memberGetAccessorElement || symbolKind === ScriptElementKind.memberSetAccessorElement) {
                 const declaration = find(symbol.declarations as ((GetAccessorDeclaration | SetAccessorDeclaration)[]), declaration => declaration.name === location);
-                if (!!declaration) {
+                if (declaration) {
                     switch(declaration.kind){
                         case SyntaxKind.GetAccessor:
                             symbolKind = ScriptElementKind.memberGetAccessorElement;

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -593,7 +593,7 @@ namespace ts.SymbolDisplay {
         }
 
         if (tags.length === 0 && !hasMultipleSignatures) {
-            tags = symbol.getJsDocTags(typeChecker);
+            tags = symbol.getContextualJsDocTags(enclosingDeclaration, typeChecker);
         }
 
         if (documentation.length === 0 && documentationFromAlias) {

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -519,6 +519,8 @@ namespace ts.SymbolDisplay {
 
                     // For properties, variables and local vars: show the type
                     if (symbolKind === ScriptElementKind.memberVariableElement ||
+                        symbolKind === ScriptElementKind.memberGetAccessorElement ||
+                        symbolKind === ScriptElementKind.memberSetAccessorElement ||
                         symbolKind === ScriptElementKind.jsxAttribute ||
                         symbolFlags & SymbolFlags.Variable ||
                         symbolKind === ScriptElementKind.localVariableElement ||

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -44,6 +44,8 @@ namespace ts {
         /* @internal */
         getContextualDocumentationComment(context: Node | undefined, checker: TypeChecker | undefined): SymbolDisplayPart[]
         getJsDocTags(checker?: TypeChecker): JSDocTagInfo[];
+        /* @internal */
+        getContextualJsDocTags(context: Node | undefined, checker: TypeChecker | undefined): JSDocTagInfo[];
     }
 
     export interface Type {

--- a/tests/baselines/reference/quickInfoCommentsClassMembers.baseline
+++ b/tests/baselines/reference/quickInfoCommentsClassMembers.baseline
@@ -191,7 +191,7 @@
       "name": "6"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "public",
       "textSpan": {
         "start": 245,
@@ -203,7 +203,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -341,7 +341,7 @@
       "name": "10"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "public",
       "textSpan": {
         "start": 334,
@@ -353,7 +353,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {
@@ -641,7 +641,7 @@
       "name": "18"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "private",
       "textSpan": {
         "start": 624,
@@ -653,7 +653,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -791,7 +791,7 @@
       "name": "22"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "private",
       "textSpan": {
         "start": 717,
@@ -803,7 +803,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {
@@ -1146,7 +1146,7 @@
       "name": "32"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "static",
       "textSpan": {
         "start": 1077,
@@ -1158,7 +1158,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -1296,7 +1296,7 @@
       "name": "37"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "static",
       "textSpan": {
         "start": 1162,
@@ -1308,7 +1308,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {
@@ -1586,7 +1586,7 @@
       "name": "46"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "public",
       "textSpan": {
         "start": 1346,
@@ -1598,7 +1598,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -1726,7 +1726,7 @@
       "name": "48"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "public",
       "textSpan": {
         "start": 1416,
@@ -1738,7 +1738,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {
@@ -2006,7 +2006,7 @@
       "name": "53"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "private",
       "textSpan": {
         "start": 1599,
@@ -2018,7 +2018,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -2146,7 +2146,7 @@
       "name": "55"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "private",
       "textSpan": {
         "start": 1673,
@@ -2158,7 +2158,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {
@@ -2426,7 +2426,7 @@
       "name": "60"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "static",
       "textSpan": {
         "start": 1851,
@@ -2438,7 +2438,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -2566,7 +2566,7 @@
       "name": "62"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "static",
       "textSpan": {
         "start": 1917,
@@ -2578,7 +2578,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {

--- a/tests/baselines/reference/quickInfoDisplayPartsClassAccessors.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsClassAccessors.baseline
@@ -6,7 +6,7 @@
       "name": "1"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "public",
       "textSpan": {
         "start": 25,
@@ -18,7 +18,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -64,7 +64,7 @@
       "name": "1s"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "public",
       "textSpan": {
         "start": 72,
@@ -76,7 +76,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {
@@ -122,7 +122,7 @@
       "name": "2"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "private",
       "textSpan": {
         "start": 118,
@@ -134,7 +134,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -180,7 +180,7 @@
       "name": "2s"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "private",
       "textSpan": {
         "start": 167,
@@ -192,7 +192,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {
@@ -238,7 +238,7 @@
       "name": "21"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "protected",
       "textSpan": {
         "start": 216,
@@ -250,7 +250,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -296,7 +296,7 @@
       "name": "21s"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "protected",
       "textSpan": {
         "start": 269,
@@ -308,7 +308,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {
@@ -354,7 +354,7 @@
       "name": "3"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "static",
       "textSpan": {
         "start": 317,
@@ -366,7 +366,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -412,7 +412,7 @@
       "name": "3s"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "static",
       "textSpan": {
         "start": 364,
@@ -424,7 +424,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {
@@ -470,7 +470,7 @@
       "name": "4"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "private,static",
       "textSpan": {
         "start": 418,
@@ -482,7 +482,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -528,7 +528,7 @@
       "name": "4s"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "private,static",
       "textSpan": {
         "start": 480,
@@ -540,7 +540,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {
@@ -586,7 +586,7 @@
       "name": "41"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "getter",
       "kindModifiers": "protected,static",
       "textSpan": {
         "start": 542,
@@ -598,7 +598,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "getter",
           "kind": "text"
         },
         {
@@ -644,7 +644,7 @@
       "name": "41s"
     },
     "quickInfo": {
-      "kind": "property",
+      "kind": "setter",
       "kindModifiers": "protected,static",
       "textSpan": {
         "start": 608,
@@ -656,7 +656,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "property",
+          "text": "setter",
           "kind": "text"
         },
         {

--- a/tests/baselines/reference/quickInfoJsDocGetterSetter.baseline
+++ b/tests/baselines/reference/quickInfoJsDocGetterSetter.baseline
@@ -1,0 +1,802 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts",
+      "position": 75,
+      "name": "1"
+    },
+    "quickInfo": {
+      "kind": "getter",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 75,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "getter",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "A",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "getter A",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "return A",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts",
+      "position": 205,
+      "name": "2"
+    },
+    "quickInfo": {
+      "kind": "setter",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 205,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "setter",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "A",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "setter A",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "foo A",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "todo",
+          "text": [
+            {
+              "text": "empty jsdoc",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts",
+      "position": 340,
+      "name": "3"
+    },
+    "quickInfo": {
+      "kind": "getter",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 340,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "getter",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "B",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "getter B",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "return B",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts",
+      "position": 445,
+      "name": "4"
+    },
+    "quickInfo": {
+      "kind": "setter",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 445,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "setter",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "B",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "setter B",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "foo B",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts",
+      "position": 607,
+      "name": "5"
+    },
+    "quickInfo": {
+      "kind": "setter",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 607,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "setter",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "D",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "setter D",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "foo D",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts",
+      "position": 636,
+      "name": "6"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 636,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "A",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "getter A",
+          "kind": "text"
+        },
+        {
+          "text": "\n",
+          "kind": "lineBreak"
+        },
+        {
+          "text": "setter A",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "return A",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "foo A",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "todo",
+          "text": [
+            {
+              "text": "empty jsdoc",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts",
+      "position": 653,
+      "name": "7"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 653,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "B",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "getter B",
+          "kind": "text"
+        },
+        {
+          "text": "\n",
+          "kind": "lineBreak"
+        },
+        {
+          "text": "setter B",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "return B",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "foo B",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts",
+      "position": 670,
+      "name": "8"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 670,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "A",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "getter A",
+          "kind": "text"
+        },
+        {
+          "text": "\n",
+          "kind": "lineBreak"
+        },
+        {
+          "text": "setter A",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "return A",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "foo A",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "todo",
+          "text": [
+            {
+              "text": "empty jsdoc",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts",
+      "position": 687,
+      "name": "9"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 687,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "D",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "setter D",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "foo D",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/quickInfoJsDocInheritage.baseline
+++ b/tests/baselines/reference/quickInfoJsDocInheritage.baseline
@@ -338,14 +338,350 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
-      "position": 1012,
+      "position": 666,
       "name": "5"
     },
     "quickInfo": {
       "kind": "property",
       "kindModifiers": "",
       "textSpan": {
-        "start": 1012,
+        "start": 666,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "C",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "A.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 680,
+      "name": "6"
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 680,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "C",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "q",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "A.foo2",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 694,
+      "name": "7"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 694,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "D",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "A.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 708,
+      "name": "8"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 708,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "D",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "q",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "A.foo2",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1069,
+      "name": "9"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1069,
         "length": 4
       },
       "displayParts": [
@@ -407,14 +743,14 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
-      "position": 1034,
-      "name": "6"
+      "position": 1091,
+      "name": "10"
     },
     "quickInfo": {
       "kind": "method",
       "kindModifiers": "",
       "textSpan": {
-        "start": 1034,
+        "start": 1091,
         "length": 4
       },
       "displayParts": [
@@ -517,14 +853,14 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
-      "position": 1206,
-      "name": "7"
+      "position": 1263,
+      "name": "11"
     },
     "quickInfo": {
       "kind": "property",
       "kindModifiers": "",
       "textSpan": {
-        "start": 1206,
+        "start": 1263,
         "length": 4
       },
       "displayParts": [
@@ -586,14 +922,14 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
-      "position": 1228,
-      "name": "8"
+      "position": 1285,
+      "name": "12"
     },
     "quickInfo": {
       "kind": "property",
       "kindModifiers": "",
       "textSpan": {
-        "start": 1228,
+        "start": 1285,
         "length": 4
       },
       "displayParts": [
@@ -708,14 +1044,14 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
-      "position": 1624,
-      "name": "9"
+      "position": 1681,
+      "name": "13"
     },
     "quickInfo": {
       "kind": "property",
       "kindModifiers": "",
       "textSpan": {
-        "start": 1624,
+        "start": 1681,
         "length": 4
       },
       "displayParts": [
@@ -777,14 +1113,14 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
-      "position": 1646,
-      "name": "10"
+      "position": 1703,
+      "name": "14"
     },
     "quickInfo": {
       "kind": "method",
       "kindModifiers": "",
       "textSpan": {
-        "start": 1646,
+        "start": 1703,
         "length": 4
       },
       "displayParts": [
@@ -887,14 +1223,14 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
-      "position": 1818,
-      "name": "11"
+      "position": 1875,
+      "name": "15"
     },
     "quickInfo": {
       "kind": "property",
       "kindModifiers": "",
       "textSpan": {
-        "start": 1818,
+        "start": 1875,
         "length": 4
       },
       "displayParts": [
@@ -956,14 +1292,754 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
-      "position": 1840,
-      "name": "12"
+      "position": 1897,
+      "name": "16"
     },
     "quickInfo": {
       "kind": "property",
       "kindModifiers": "",
       "textSpan": {
-        "start": 1840,
+        "start": 1897,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived4",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "para1",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "q",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Base2.foo2 parameter",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "Base2.foo2 return",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1955,
+      "name": "17"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1955,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived1",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "Base1.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1975,
+      "name": "18"
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1975,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived1",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "para1",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "q",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Base1.foo2 parameter",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "Base1.foo2 return",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1995,
+      "name": "19"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1995,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived2",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "Base1.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 2015,
+      "name": "20"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 2015,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived2",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "para1",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "q",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Base1.foo2 parameter",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "Base1.foo2 return",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 2035,
+      "name": "21"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 2035,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived3",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "Base2.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 2055,
+      "name": "22"
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 2055,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived3",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "para1",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "q",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Base2.foo2 parameter",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "Base2.foo2 return",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 2075,
+      "name": "23"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 2075,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived4",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "Base2.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 2095,
+      "name": "24"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 2095,
         "length": 4
       },
       "displayParts": [

--- a/tests/baselines/reference/quickInfoJsDocInheritage.baseline
+++ b/tests/baselines/reference/quickInfoJsDocInheritage.baseline
@@ -1,0 +1,1078 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 429,
+      "name": "1"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 429,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "C",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "A.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 451,
+      "name": "2"
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 451,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "C",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "q",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "A.foo2",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 598,
+      "name": "3"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 598,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "D",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "A.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 620,
+      "name": "4"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 620,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "D",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "q",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "A.foo2",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1012,
+      "name": "5"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1012,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived1",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "Base1.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1034,
+      "name": "6"
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1034,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived1",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "para1",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "q",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Base1.foo2 parameter",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "Base1.foo2 return",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1206,
+      "name": "7"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1206,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived2",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "Base1.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1228,
+      "name": "8"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1228,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived2",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "para1",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "q",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Base1.foo2 parameter",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "Base1.foo2 return",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1624,
+      "name": "9"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1624,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived3",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "Base2.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1646,
+      "name": "10"
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1646,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived3",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "para1",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "q",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Base2.foo2 parameter",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "Base2.foo2 return",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1818,
+      "name": "11"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1818,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived4",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "description",
+          "text": [
+            {
+              "text": "Base2.foo1",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocInheritage.ts",
+      "position": 1840,
+      "name": "12"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1840,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Drived4",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo2",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "para1",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "q",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Base2.foo2 parameter",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "returns",
+          "text": [
+            {
+              "text": "Base2.foo2 return",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/quickInfoOnParameterProperties.baseline
+++ b/tests/baselines/reference/quickInfoOnParameterProperties.baseline
@@ -59,6 +59,17 @@
           "text": "this is the name of blabla \n- use blabla",
           "kind": "text"
         }
+      ],
+      "tags": [
+        {
+          "name": "example",
+          "text": [
+            {
+              "text": "blabla",
+              "kind": "text"
+            }
+          ]
+        }
       ]
     }
   },
@@ -121,6 +132,17 @@
         {
           "text": "this is the name of blabla \n- use blabla",
           "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "example",
+          "text": [
+            {
+              "text": "blabla",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/cases/fourslash/findAllRefsDestructureGetter2.ts
+++ b/tests/cases/fourslash/findAllRefsDestructureGetter2.ts
@@ -11,6 +11,6 @@
 ////[|const { /*g1*/[|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 4 |}g|], /*s1*/[|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 4 |}s|] } = new C();|]
 
 const [g0Def, g0, s0Def, s0, gs1Def, g1, s1] = test.ranges();
-verify.quickInfoAt(g0, "(property) C.g: number");
-verify.quickInfoAt(s0, "(property) C.s: number");
+verify.quickInfoAt(g0, "(getter) C.g: number");
+verify.quickInfoAt(s0, "(setter) C.s: number");
 verify.baselineFindAllReferences('g0', 'g1', 's0', 's1')

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -399,9 +399,9 @@ declare namespace FourSlashInterface {
         baselineRename(marker: string, options: RenameOptions): void;
 
         /** Verify the quick info available at the current marker. */
-        quickInfoIs(expectedText: string, expectedDocumentation?: string): void;
+        quickInfoIs(expectedText: string, expectedDocumentation?: string, expectedTags?: { name: string; text: string; }[]): void;
         /** Goto a marker and call `quickInfoIs`. */
-        quickInfoAt(markerName: string | Range, expectedText?: string, expectedDocumentation?: string): void;
+        quickInfoAt(markerName: string | Range, expectedText?: string, expectedDocumentation?: string, expectedTags?: { name: string; text: string; }[]): void;
         /**
          * Call `quickInfoAt` for each pair in the object.
          * (If the value is an array, it is [expectedText, expectedDocumentation].)

--- a/tests/cases/fourslash/quickInfoForGetterAndSetter.ts
+++ b/tests/cases/fourslash/quickInfoForGetterAndSetter.ts
@@ -17,7 +17,7 @@
 //// }
 
 goTo.marker("1");
-verify.quickInfoIs("(property) Test.value: any", "Getter text");
+verify.quickInfoIs("(getter) Test.value: any", "Getter text");
 
 goTo.marker("2");
-verify.quickInfoIs("(property) Test.value: any", "Setter text");
+verify.quickInfoIs("(setter) Test.value: any", "Setter text");

--- a/tests/cases/fourslash/quickInfoGetterSetter.ts
+++ b/tests/cases/fourslash/quickInfoGetterSetter.ts
@@ -15,6 +15,6 @@
 //// instance./*setterUse*/myValue = instance./*getterUse*/myValue;
 
 verify.quickInfoAt("getterUse", "(property) C.myValue: Promise<string>");
-verify.quickInfoAt("getterDef", "(property) C.myValue: Promise<string>");
+verify.quickInfoAt("getterDef", "(getter) C.myValue: Promise<string>");
 verify.quickInfoAt("setterUse", "(property) C.myValue: string | Promise<string>");
-verify.quickInfoAt("setterDef", "(property) C.myValue: string | Promise<string>");
+verify.quickInfoAt("setterDef", "(setter) C.myValue: string | Promise<string>");

--- a/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts
+++ b/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts
@@ -1,0 +1,68 @@
+/// <reference path='fourslash.ts' />
+
+//// class A {
+////     /**
+////      * getter A
+////      * @returns return A
+////      */
+////     get /*1*/x(): string {
+////         return "";
+////     }
+////     /**
+////      * setter A
+////      * @param value foo A
+////      * @todo empty jsdoc
+////      */
+////     set /*2*/x(value) { }
+//// }
+//// // override both getter and setter
+//// class B extends A {
+////     /**
+////      * getter B
+////      * @returns return B
+////      */
+////     get /*3*/x(): string {
+////         return "";
+////     }
+////     /**
+////      * setter B
+////      * @param value foo B
+////      */
+////     set /*4*/x(vale) { }
+//// }
+//// // not override
+//// class C extends A { }
+//// // only override setter
+//// class D extends A {
+////     /**
+////      * setter D
+////      * @param value foo D
+////      */
+////     set /*5*/x(val: string) { }
+//// }
+//// new A()./*6*/x = "1";
+//// new B()./*7*/x = "1";
+//// new C()./*8*/x = "1";
+//// new D()./*9*/x = "1";
+
+verify.quickInfoAt("1", "(getter) A.x", 'getter A', [{ name: "returns", text: "return A" }]);
+verify.quickInfoAt("2", "(setter) A.x", 'setter A', [{ name: "param", text: "value foo A" }, { name: "todo", text: "empty jsdoc" }]);
+verify.quickInfoAt("3", "(getter) B.x", 'getter B', [{ name: "returns", text: "return B" }]);
+verify.quickInfoAt("4", "(setter) B.x", 'setter B', [{ name: "param", text: "value foo B" }]);
+verify.quickInfoAt("5", "(setter) D.x", 'setter D', [{ name: "param", text: "value foo D" }]);
+
+verify.quickInfoAt("6", "(property) A.x: string", 'getter A\nsetter A', [
+    { name: "returns", text: "return A" },
+    { name: "param", text: "value foo A" },
+    { name: "todo", text: "empty jsdoc" },
+]);
+verify.quickInfoAt("7", "(property) B.x: string", 'getter B\nsetter B', [
+    { name: "returns", text: "return B" },
+    { name: "param", text: "value foo B" },
+]);
+verify.quickInfoAt("8", "(property) A.x: string", 'getter A\nsetter A', [
+    { name: "returns", text: "return A" },
+    { name: "param", text: "value foo A" },
+    { name: "todo", text: "empty jsdoc" },
+]);
+verify.quickInfoAt("9", "(property) D.x: string", 'setter D', [{ name: "param", text: "value foo D" }]);

--- a/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts
+++ b/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts
@@ -45,24 +45,4 @@
 //// new C()./*8*/x = "1";
 //// new D()./*9*/x = "1";
 
-verify.quickInfoAt("1", "(getter) A.x: string", 'getter A', [{ name: "returns", text: "return A" }]);
-verify.quickInfoAt("2", "(setter) A.x: string", 'setter A', [{ name: "param", text: "value foo A" }, { name: "todo", text: "empty jsdoc" }]);
-verify.quickInfoAt("3", "(getter) B.x: string", 'getter B', [{ name: "returns", text: "return B" }]);
-verify.quickInfoAt("4", "(setter) B.x: string", 'setter B', [{ name: "param", text: "value foo B" }]);
-verify.quickInfoAt("5", "(setter) D.x: string", 'setter D', [{ name: "param", text: "value foo D" }]);
-
-verify.quickInfoAt("6", "(property) A.x: string", 'getter A\nsetter A', [
-    { name: "returns", text: "return A" },
-    { name: "param", text: "value foo A" },
-    { name: "todo", text: "empty jsdoc" },
-]);
-verify.quickInfoAt("7", "(property) B.x: string", 'getter B\nsetter B', [
-    { name: "returns", text: "return B" },
-    { name: "param", text: "value foo B" },
-]);
-verify.quickInfoAt("8", "(property) A.x: string", 'getter A\nsetter A', [
-    { name: "returns", text: "return A" },
-    { name: "param", text: "value foo A" },
-    { name: "todo", text: "empty jsdoc" },
-]);
-verify.quickInfoAt("9", "(property) D.x: string", 'setter D', [{ name: "param", text: "value foo D" }]);
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts
+++ b/tests/cases/fourslash/quickInfoJsDocGetterSetter.ts
@@ -45,11 +45,11 @@
 //// new C()./*8*/x = "1";
 //// new D()./*9*/x = "1";
 
-verify.quickInfoAt("1", "(getter) A.x", 'getter A', [{ name: "returns", text: "return A" }]);
-verify.quickInfoAt("2", "(setter) A.x", 'setter A', [{ name: "param", text: "value foo A" }, { name: "todo", text: "empty jsdoc" }]);
-verify.quickInfoAt("3", "(getter) B.x", 'getter B', [{ name: "returns", text: "return B" }]);
-verify.quickInfoAt("4", "(setter) B.x", 'setter B', [{ name: "param", text: "value foo B" }]);
-verify.quickInfoAt("5", "(setter) D.x", 'setter D', [{ name: "param", text: "value foo D" }]);
+verify.quickInfoAt("1", "(getter) A.x: string", 'getter A', [{ name: "returns", text: "return A" }]);
+verify.quickInfoAt("2", "(setter) A.x: string", 'setter A', [{ name: "param", text: "value foo A" }, { name: "todo", text: "empty jsdoc" }]);
+verify.quickInfoAt("3", "(getter) B.x: string", 'getter B', [{ name: "returns", text: "return B" }]);
+verify.quickInfoAt("4", "(setter) B.x: string", 'setter B', [{ name: "param", text: "value foo B" }]);
+verify.quickInfoAt("5", "(setter) D.x: string", 'setter D', [{ name: "param", text: "value foo D" }]);
 
 verify.quickInfoAt("6", "(property) A.x: string", 'getter A\nsetter A', [
     { name: "returns", text: "return A" },

--- a/tests/cases/fourslash/quickInfoJsDocInheritage.ts
+++ b/tests/cases/fourslash/quickInfoJsDocInheritage.ts
@@ -1,0 +1,94 @@
+/// <reference path='fourslash.ts' />
+
+//// interface A {
+////     /**
+////      * @description A.foo1
+////      */
+////     foo1: number;
+////     /**
+////      * @description A.foo2
+////      */
+////     foo2: (para1: string) => number;
+//// }
+//// 
+//// interface B {
+////     /**
+////      * @description B.foo1
+////      */
+////     foo1: number;
+////     /**
+////      * @description B.foo2
+////      */
+////     foo2: (para2: string) => number;
+//// }
+//// 
+//// // implement multi interfaces with duplicate name
+//// // method for function signature
+//// class C implements A, B {
+////     /*1*/foo1: number = 1;
+////     /*2*/foo2(q: string) { return 1 }
+//// }
+//// 
+//// // implement multi interfaces with duplicate name
+//// // property for function signature
+//// class D implements A, B {
+////     /*3*/foo1: number = 1;
+////     /*4*/foo2 = (q: string) => { return 1 }
+//// }
+//// 
+//// class Base1 {
+////     /**
+////      * @description Base1.foo1 
+////      */
+////     foo1: number = 1;
+//// 
+////     /**
+////      * 
+////      * @param q Base1.foo2 parameter
+////      * @returns Base1.foo2 return
+////      */
+////      foo2(q: string) { return 1 }
+//// }
+//// 
+//// // extends class and implement interfaces with duplicate name
+//// // property override method
+//// class Drived1 extends Base1 implements A {
+////     /*5*/foo1: number = 1;
+////     /*6*/foo2(para1: string) { return 1 };
+//// }
+//// 
+//// // extends class and implement interfaces with duplicate name
+//// // method override method
+//// class Drived2 extends Base1 implements B {
+////     /*7*/foo1: number = 1;
+////     /*8*/foo2 = (para1: string) => { return 1; };
+//// }
+//// 
+//// class Base2 {
+////     /**
+////      * @description Base2.foo1 
+////      */
+////     foo1: number = 1;
+////     /**
+////      * 
+////      * @param q Base2.foo2 parameter
+////      * @returns Base2.foo2 return
+////      */
+////     foo2(q: string) { return 1 }
+//// }
+//// 
+//// // extends class and implement interfaces with duplicate name
+//// // property override method
+//// class Drived3 extends Base2 implements A {
+////     /*9*/foo1: number = 1;
+////     /*10*/foo2(para1: string) { return 1 };
+//// }
+//// 
+//// // extends class and implement interfaces with duplicate name
+//// // method override method
+//// class Drived4 extends Base2 implements B {
+////     /*11*/foo1: number = 1;
+////     /*12*/foo2 = (para1: string) => { return 1; };
+//// }
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/quickInfoJsDocInheritage.ts
+++ b/tests/cases/fourslash/quickInfoJsDocInheritage.ts
@@ -36,6 +36,11 @@
 ////     /*4*/foo2 = (q: string) => { return 1 }
 //// }
 //// 
+//// new C()./*5*/foo1;
+//// new C()./*6*/foo2;
+//// new D()./*7*/foo1;
+//// new D()./*8*/foo2;
+//// 
 //// class Base1 {
 ////     /**
 ////      * @description Base1.foo1 
@@ -53,15 +58,15 @@
 //// // extends class and implement interfaces with duplicate name
 //// // property override method
 //// class Drived1 extends Base1 implements A {
-////     /*5*/foo1: number = 1;
-////     /*6*/foo2(para1: string) { return 1 };
+////     /*9*/foo1: number = 1;
+////     /*10*/foo2(para1: string) { return 1 };
 //// }
 //// 
 //// // extends class and implement interfaces with duplicate name
 //// // method override method
 //// class Drived2 extends Base1 implements B {
-////     /*7*/foo1: number = 1;
-////     /*8*/foo2 = (para1: string) => { return 1; };
+////     /*11*/foo1: number = 1;
+////     /*12*/foo2 = (para1: string) => { return 1; };
 //// }
 //// 
 //// class Base2 {
@@ -80,15 +85,24 @@
 //// // extends class and implement interfaces with duplicate name
 //// // property override method
 //// class Drived3 extends Base2 implements A {
-////     /*9*/foo1: number = 1;
-////     /*10*/foo2(para1: string) { return 1 };
+////     /*13*/foo1: number = 1;
+////     /*14*/foo2(para1: string) { return 1 };
 //// }
 //// 
 //// // extends class and implement interfaces with duplicate name
 //// // method override method
 //// class Drived4 extends Base2 implements B {
-////     /*11*/foo1: number = 1;
-////     /*12*/foo2 = (para1: string) => { return 1; };
+////     /*15*/foo1: number = 1;
+////     /*16*/foo2 = (para1: string) => { return 1; };
 //// }
+//// 
+//// new Drived1()./*17*/foo1;
+//// new Drived1()./*18*/foo2;
+//// new Drived2()./*19*/foo1;
+//// new Drived2()./*20*/foo2;
+//// new Drived3()./*21*/foo1;
+//// new Drived3()./*22*/foo2;
+//// new Drived4()./*23*/foo1;
+//// new Drived4()./*24*/foo2;
 
 verify.baselineQuickInfo();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #45508 
Fixes #46572

1. property and getter/setter could inherit jsDoc tags
2. the quick info of getter/setter in the class shows "(getter/setter)" rather than "property", but for property access of getter/setter, it still shows "property".
3. getter/setter inherits correspond getter/setter if none of getter/setter is overridden, or nothing if one of getter/setter is overridden. And for property access of getter/setter, it inherit its getter and setter JsDoc tags
4. add JsDocTags parameter to fourslash `quickInfoAt` and `quickInfoIs`. Note that if this parameter is not given, the check is skipped now. Maybe we should create one issue to always compare JsDocTags?
