### PR TITLE
Fix broken module resolution after large/rapid edits in nodenext

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1577,6 +1577,7 @@ namespace ts {
                 newSourceFile.originalFileName = oldSourceFile.originalFileName;
                 newSourceFile.resolvedPath = oldSourceFile.resolvedPath;
                 newSourceFile.fileName = oldSourceFile.fileName;
+                newSourceFile.impliedNodeFormat = oldSourceFile.impliedNodeFormat;
 
                 const packageName = oldProgram.sourceFileToPackageName.get(oldSourceFile.path);
                 if (packageName !== undefined) {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -637,7 +637,8 @@ namespace FourSlash {
             ts.forEachKey(this.inputFiles, fileName => {
                 if (!ts.isAnySupportedFileExtension(fileName)
                     || Harness.getConfigNameFromFileName(fileName)
-                    || !ts.getAllowJSCompilerOption(this.getProgram().getCompilerOptions()) && !ts.resolutionExtensionIsTSOrJson(ts.extensionFromPath(fileName))
+                    // Can't get a Program in Server tests
+                    || this.testType !== FourSlashTestType.Server && !ts.getAllowJSCompilerOption(this.getProgram().getCompilerOptions()) && !ts.resolutionExtensionIsTSOrJson(ts.extensionFromPath(fileName))
                     || ts.getBaseFileName(fileName) === "package.json") return;
                 const errors = this.getDiagnostics(fileName).filter(e => e.category !== ts.DiagnosticCategory.Suggestion);
                 if (errors.length) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1124,9 +1124,7 @@ namespace ts {
         }
 
         // Otherwise, just create a new source file.
-        const newSourceFile = createLanguageServiceSourceFile(sourceFile.fileName, scriptSnapshot, sourceFile.languageVersion, version, /*setNodeParents*/ true, sourceFile.scriptKind);
-        newSourceFile.impliedNodeFormat = sourceFile.impliedNodeFormat;
-        return newSourceFile;
+        return createLanguageServiceSourceFile(sourceFile.fileName, scriptSnapshot, sourceFile.languageVersion, version, /*setNodeParents*/ true, sourceFile.scriptKind);
     }
 
     const NoopCancellationToken: CancellationToken = {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1124,7 +1124,9 @@ namespace ts {
         }
 
         // Otherwise, just create a new source file.
-        return createLanguageServiceSourceFile(sourceFile.fileName, scriptSnapshot, sourceFile.languageVersion, version, /*setNodeParents*/ true, sourceFile.scriptKind);
+        const newSourceFile = createLanguageServiceSourceFile(sourceFile.fileName, scriptSnapshot, sourceFile.languageVersion, version, /*setNodeParents*/ true, sourceFile.scriptKind);
+        newSourceFile.impliedNodeFormat = sourceFile.impliedNodeFormat;
+        return newSourceFile;
     }
 
     const NoopCancellationToken: CancellationToken = {

--- a/tests/cases/fourslash/server/impliedNodeFormat.ts
+++ b/tests/cases/fourslash/server/impliedNodeFormat.ts
@@ -1,0 +1,20 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "nodenext" } }
+
+// @Filename: /package.json
+//// { "name": "foo", "type": "module", "exports": { ".": "./main.js" } }
+
+// @Filename: /main.ts
+//// export {};
+
+// @Filename: /index.ts
+//// import {} from "foo";
+
+goTo.file("/index.ts");
+verify.noErrors();
+
+edit.paste(`\n"${"a".repeat(256)}";`);
+
+verify.noErrors();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46396

When updating a SourceFile, the incremental parser copies the old SourceFile’s `impliedNodeFormat` to the new one. Reusing module resolution from the old Program later expects that field to already be set on the updated SourceFile. However, the incremental parser is skipped when the language service gets overwhelmed by changes—specifically, when there are 8 or more changes logged against the snapshot before the language service asks for an updated SourceFile, or when the length of a text change is greater than 256 characters. In these cases, the SourceFile is re-parsed from scratch, and so it lacks its `impliedNodeFormat` field.
