### PR TITLE
Fix strict/es5+ octal literal 2x error #46810

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2341,7 +2341,7 @@ namespace ts {
         }
 
         function checkStrictModeNumericLiteral(node: NumericLiteral) {
-            if (inStrictMode && node.numericLiteralFlags & TokenFlags.Octal) {
+            if (languageVersion < ScriptTarget.ES5 && inStrictMode && node.numericLiteralFlags & TokenFlags.Octal) {
                 file.bindDiagnostics.push(createDiagnosticForNode(node, Diagnostics.Octal_literals_are_not_allowed_in_strict_mode));
             }
         }

--- a/tests/baselines/reference/jsFileCompilationBindStrictModeErrors.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationBindStrictModeErrors.errors.txt
@@ -11,7 +11,6 @@ tests/cases/compiler/b.js(3,7): error TS1210: Code contained in a class is evalu
 tests/cases/compiler/b.js(6,13): error TS1213: Identifier expected. 'let' is a reserved word in strict mode. Class definitions are automatically in strict mode.
 tests/cases/compiler/c.js(1,12): error TS1214: Identifier expected. 'let' is a reserved word in strict mode. Modules are automatically in strict mode.
 tests/cases/compiler/c.js(2,5): error TS1215: Invalid use of 'eval'. Modules are automatically in strict mode.
-tests/cases/compiler/d.js(2,9): error TS1121: Octal literals are not allowed in strict mode.
 tests/cases/compiler/d.js(2,11): error TS1005: ',' expected.
 
 
@@ -75,10 +74,8 @@ tests/cases/compiler/d.js(2,11): error TS1005: ',' expected.
 !!! error TS1215: Invalid use of 'eval'. Modules are automatically in strict mode.
     };
     
-==== tests/cases/compiler/d.js (2 errors) ====
+==== tests/cases/compiler/d.js (1 errors) ====
     "use strict";
     var x = 009; // error
-            ~~
-!!! error TS1121: Octal literals are not allowed in strict mode.
               ~
 !!! error TS1005: ',' expected.

--- a/tests/baselines/reference/plainJSBinderErrors.errors.txt
+++ b/tests/baselines/reference/plainJSBinderErrors.errors.txt
@@ -10,14 +10,13 @@ tests/cases/conformance/salsa/plainJSBinderErrors.js(18,16): error TS1102: 'dele
 tests/cases/conformance/salsa/plainJSBinderErrors.js(19,16): error TS1102: 'delete' cannot be called on an identifier in strict mode.
 tests/cases/conformance/salsa/plainJSBinderErrors.js(22,15): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'eval'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 tests/cases/conformance/salsa/plainJSBinderErrors.js(23,15): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
-tests/cases/conformance/salsa/plainJSBinderErrors.js(26,27): error TS1121: Octal literals are not allowed in strict mode.
 tests/cases/conformance/salsa/plainJSBinderErrors.js(27,9): error TS1101: 'with' statements are not allowed in strict mode.
 tests/cases/conformance/salsa/plainJSBinderErrors.js(33,13): error TS1344: 'A label is not allowed here.
 tests/cases/conformance/salsa/plainJSBinderErrors.js(39,7): error TS1215: Invalid use of 'eval'. Modules are automatically in strict mode.
 tests/cases/conformance/salsa/plainJSBinderErrors.js(40,7): error TS1215: Invalid use of 'arguments'. Modules are automatically in strict mode.
 
 
-==== tests/cases/conformance/salsa/plainJSBinderErrors.js (17 errors) ====
+==== tests/cases/conformance/salsa/plainJSBinderErrors.js (16 errors) ====
     export default 12
     ~~~~~~~~~~~~~~~~~
 !!! error TS2528: A module cannot have multiple default exports.
@@ -70,8 +69,6 @@ tests/cases/conformance/salsa/plainJSBinderErrors.js(40,7): error TS1215: Invali
         }
         withOctal() {
             const redundant = 010
-                              ~~~
-!!! error TS1121: Octal literals are not allowed in strict mode.
             with (redundant) {
             ~~~~
 !!! error TS1101: 'with' statements are not allowed in strict mode.

--- a/tests/baselines/reference/strictModeOctalLiterals.errors.txt
+++ b/tests/baselines/reference/strictModeOctalLiterals.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/conformance/expressions/literals/strictModeOctalLiterals.ts(2,14): error TS1085: Octal literals are not available when targeting ECMAScript 5 and higher. Use the syntax '0o1'.
+tests/cases/conformance/expressions/literals/strictModeOctalLiterals.ts(4,16): error TS1085: Octal literals are not available when targeting ECMAScript 5 and higher. Use the syntax '0o1'.
+tests/cases/conformance/expressions/literals/strictModeOctalLiterals.ts(4,21): error TS1085: Octal literals are not available when targeting ECMAScript 5 and higher. Use the syntax '0o1'.
+
+
+==== tests/cases/conformance/expressions/literals/strictModeOctalLiterals.ts (3 errors) ====
+    export enum E {
+        A = 12 + 01
+                 ~~
+!!! error TS1085: Octal literals are not available when targeting ECMAScript 5 and higher. Use the syntax '0o1'.
+    }
+    const orbitol: 01 = 01
+                   ~~
+!!! error TS1085: Octal literals are not available when targeting ECMAScript 5 and higher. Use the syntax '0o1'.
+                        ~~
+!!! error TS1085: Octal literals are not available when targeting ECMAScript 5 and higher. Use the syntax '0o1'.
+    

--- a/tests/baselines/reference/strictModeOctalLiterals.js
+++ b/tests/baselines/reference/strictModeOctalLiterals.js
@@ -1,0 +1,13 @@
+//// [strictModeOctalLiterals.ts]
+export enum E {
+    A = 12 + 01
+}
+const orbitol: 01 = 01
+
+
+//// [strictModeOctalLiterals.js]
+export var E;
+(function (E) {
+    E[E["A"] = 13] = "A";
+})(E || (E = {}));
+const orbitol = 01;

--- a/tests/baselines/reference/strictModeOctalLiterals.symbols
+++ b/tests/baselines/reference/strictModeOctalLiterals.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/expressions/literals/strictModeOctalLiterals.ts ===
+export enum E {
+>E : Symbol(E, Decl(strictModeOctalLiterals.ts, 0, 0))
+
+    A = 12 + 01
+>A : Symbol(E.A, Decl(strictModeOctalLiterals.ts, 0, 15))
+}
+const orbitol: 01 = 01
+>orbitol : Symbol(orbitol, Decl(strictModeOctalLiterals.ts, 3, 5))
+

--- a/tests/baselines/reference/strictModeOctalLiterals.types
+++ b/tests/baselines/reference/strictModeOctalLiterals.types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/expressions/literals/strictModeOctalLiterals.ts ===
+export enum E {
+>E : E
+
+    A = 12 + 01
+>A : E
+>12 + 01 : number
+>12 : 12
+>01 : 1
+}
+const orbitol: 01 = 01
+>orbitol : 1
+>01 : 1
+

--- a/tests/cases/conformance/expressions/literals/strictModeOctalLiterals.ts
+++ b/tests/cases/conformance/expressions/literals/strictModeOctalLiterals.ts
@@ -1,0 +1,5 @@
+// @target: es2018
+export enum E {
+    A = 12 + 01
+}
+const orbitol: 01 = 01


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Partially fixes #46810 

Fixes the conditional in the binder to only issue an error for octal literals in strict mode if the target is before es5. (If es5 or after, this error becomes redundant.) Also fixes the same issue in tsserver.js

Please verify that:
* [X] There is an associated issue in the `Backlog` milestone (**required**)
* [X] Code is up-to-date with the `main` branch
* [X] You've successfully run `gulp runtests` locally
* [X] There are new or updated unit tests validating the change