### PR TITLE
Update symlink cache from AutoImportProvider resolution even if host project already contains the file via its realpath

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1944,14 +1944,14 @@ namespace ts.server {
                 for (const resolution of resolutions) {
                     if (!resolution.resolvedFileName) continue;
                     const { resolvedFileName, originalPath } = resolution;
+                    if (originalPath) {
+                        symlinkCache.setSymlinkedDirectoryFromSymlinkedFile(originalPath, resolvedFileName);
+                    }
                     if (!program.getSourceFile(resolvedFileName) && (!originalPath || !program.getSourceFile(originalPath))) {
                         rootNames = append(rootNames, resolvedFileName);
                         // Avoid creating a large project that would significantly slow down time to editor interactivity
                         if (dependencySelection === PackageJsonAutoImportPreference.Auto && rootNames.length > this.maxDependencies) {
                             return ts.emptyArray;
-                        }
-                        if (originalPath) {
-                            symlinkCache.setSymlinkedDirectoryFromSymlinkedFile(originalPath, resolvedFileName);
                         }
                     }
                 }

--- a/tests/cases/fourslash/server/autoImportProvider7.ts
+++ b/tests/cases/fourslash/server/autoImportProvider7.ts
@@ -1,0 +1,68 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "commonjs" } }
+
+// @Filename: /package.json
+//// { "dependencies": { "mylib": "file:packages/mylib" } }
+
+// @Filename: /packages/mylib/package.json
+//// { "name": "mylib", "version": "1.0.0", "main": "index.js", "types": "index" }
+
+// @Filename: /packages/mylib/index.ts
+//// export * from "./mySubDir";
+
+// @Filename: /packages/mylib/mySubDir/index.ts
+//// export * from "./myClass";
+//// export * from "./myClass2";
+
+// @Filename: /packages/mylib/mySubDir/myClass.ts
+//// export class MyClass {}
+
+// @Filename: /packages/mylib/mySubDir/myClass2.ts
+//// export class MyClass2 {}
+
+// @link: /packages/mylib -> /node_modules/mylib
+
+// @Filename: /src/index.ts
+//// 
+//// const a = new MyClass/*1*/();
+//// const b = new MyClass2/*2*/();
+
+goTo.marker("1");
+format.setOption("newLineCharacter", "\n");
+
+verify.completions({
+  marker: "1",
+  includes: [{
+    name: "MyClass",
+    source: "mylib",
+    sourceDisplay: "mylib",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  }
+});
+
+verify.applyCodeActionFromCompletion("1", {
+  name: "MyClass",
+  source: "mylib",
+  description: `Import 'MyClass' from module "mylib"`,
+  data: {
+    exportName: "MyClass",
+    fileName: "/packages/mylib/index.ts",
+  },
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeCompletionsWithInsertText: true,
+    allowIncompleteCompletions: true,
+  },
+  newFileContent: `import { MyClass } from "mylib";
+
+const a = new MyClass();
+const b = new MyClass2();`,
+});


### PR DESCRIPTION
This fixes part of a bug I noticed while writing #46569, mentioned in the test comment there. An AutoImportProviderProject contains only files that the host Project does not. However, it’s possible, as in the test written here, that the main project only knows about a file via its realpath, but it also exists as a symlink inside `node_modules`. Because that symlink was mentioned in the package.json dependencies, we discover it as part of spinning up an AutoImportProviderProject. However, when we see that the SourceFile we resolved to is already contained by the host Project, we skip it entirely, discarding the knowledge of the symlink we found. This PR allows the AutoImportProviderProject to add that symlink knowledge to the host project’s cache before it decides not to add the file to itself. This way, the host Project is still responsible for generating auto-imports of that SourceFile, but it can come up with the correct module specifier for it using the symlink information discovered by the AutoImportProviderProject.