### PR TITLE
fix(46845): Add missing "locale" field to Intl.DisplayNamesOptions

### DIFF
--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -277,6 +277,7 @@ declare namespace Intl {
     };
 
      interface DisplayNamesOptions {
+        locale: UnicodeBCP47LocaleIdentifier;
         localeMatcher: RelativeTimeFormatLocaleMatcher;
         style: RelativeTimeFormatStyle;
         type: "language" | "region" | "script" | "currency";


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/46845

Not sure what tests, if any, are needed similar to https://github.com/microsoft/TypeScript/pull/46740