### PR TITLE
ATA for tsserver on web

### DIFF
--- a/src/tsserver/webServer.ts
+++ b/src/tsserver/webServer.ts
@@ -44,7 +44,7 @@ namespace ts.server {
             logger: createLogger(),
             cancellationToken: nullCancellationToken,
             // Webserver defaults to partial semantic mode
-            serverMode: serverMode ?? LanguageServiceMode.PartialSemantic,
+            serverMode: serverMode ?? LanguageServiceMode.Semantic,
             unknownServerMode,
             startSession: startWebSession
         };

--- a/src/webServer/webServer.ts
+++ b/src/webServer/webServer.ts
@@ -1,5 +1,7 @@
 /*@internal*/
 namespace ts.server {
+    declare const fetch: any;
+
     export interface HostWithWriteMessage {
         writeMessage(s: any): void;
     }
@@ -177,13 +179,285 @@ namespace ts.server {
         syntaxOnly: SessionOptions["syntaxOnly"];
         serverMode: SessionOptions["serverMode"];
     }
+
+    interface ATADownload {
+        readonly moduleName: string
+        readonly moduleVersion: string
+        readonly vfsPath: string
+        readonly path: string
+    };
+
+    interface NPMTreeMeta {
+        readonly default: string;
+        readonly files: readonly { readonly name: string }[];
+        readonly moduleName: string;
+        readonly version: string;
+    };
+
+    /**
+     * Typings installer that runs in browsers. Stores typings files in memory.
+     *
+     * Code modified from: https://www.npmjs.com/package/@typescript/ata
+     */
+    class WebTypingsInstaller implements ITypingsInstaller {
+
+        private projectService?: ProjectService;
+
+        private readonly fsMap = new Map<string, string>();
+
+        constructor(
+            private readonly logger: Logger
+        ) { }
+
+        //#region ITypingsInstaller
+
+        // TODO: What should this be?
+        public readonly globalTypingsCacheLocation: string | undefined;
+
+        public isKnownTypesPackageName(name: string): boolean {
+            // TODO
+            this.logger.info(`isKnownTypesPackageName ${name}`);
+            return false;
+        }
+
+        public async installPackage(options: InstallPackageOptionsWithProject): Promise<ApplyCodeActionCommandResult> {
+            if (!this.projectService) {
+                throw new Error("No project service");
+            }
+
+            // TODO: Can this be implemented on web?
+
+            console.log("install", options.projectName);
+
+            return {
+                successMessage: "test",
+            };
+        }
+
+        public async enqueueInstallTypingsRequest(p: Project, _typeAcquisition: TypeAcquisition, unresolvedImports: SortedReadonlyArray<string> | undefined): Promise<void> {
+            if (!unresolvedImports?.length) {
+                return;
+            }
+
+            const allDeps = unresolvedImports.map(x => ({ module: x, version: undefined }));
+            await this.installDeps(p, allDeps);
+
+            // TODO: proper response
+            const response: PackageInstalledResponse = {
+                kind: "action::packageInstalled",
+                success: true,
+                message: "",
+                projectName: ""
+            };
+
+            this.projectService!.updateTypingsForProject(response);
+        }
+
+        public attach(projectService: ProjectService): void {
+            this.projectService = projectService;
+        }
+
+        public onProjectClosed(_p: Project): void {
+            // noop
+        }
+
+        // #endregion
+
+        private async installDeps(p: Project, depsToGet: readonly { module: string; version: undefined; }[]) {
+            // Grab the module trees which gives us a list of files to download
+            const trees = await Promise.all(depsToGet.map(f => this.getFileTreeForModuleWithTag(f.module, f.version)));
+            const treesOnly = trees.filter(t => !("error" in t)) as NPMTreeMeta[];
+
+            // These are the modules which we can grab directly
+            const hasDTS = treesOnly.filter(t => t.files.find(f => f.name.endsWith(".d.ts")));
+            const dtsFilesFromNPM = hasDTS.map(t => this.treeToDTSFiles(t, `/node_modules/${t.moduleName}`));
+
+            // These are ones we need to look on DT for (which may not be there, who knows)
+            const mightBeOnDT = treesOnly.filter(t => !hasDTS.includes(t));
+            const dtTrees = await Promise.all(
+                // TODO: Switch from 'latest' to the version from the original tree which is user-controlled
+                mightBeOnDT.map(f => this.getFileTreeForModuleWithTag(`@types/${this.getDTName(f.moduleName)}`, "latest"))
+            );
+
+            const dtTreesOnly = dtTrees.filter(t => !("error" in t)) as NPMTreeMeta[];
+            const dtsFilesFromDT = dtTreesOnly.map(t => this.treeToDTSFiles(t, `/node_modules/@types/${this.getDTName(t.moduleName).replace("types__", "")}`));
+
+            // Collect all the npm and DT DTS requests and flatten their arrays
+            const allDTSFiles = dtsFilesFromNPM.concat(dtsFilesFromDT).reduce((p, c) => p.concat(c), []);
+
+            // Grab the package.jsons for each dependency
+            for (const tree of treesOnly) {
+                let prefix = `/node_modules/${tree.moduleName}`;
+                if (dtTreesOnly.includes(tree)) {
+                    prefix = `/node_modules/@types/${this.getDTName(tree.moduleName).replace("types__", "")}`;
+                }
+
+                const path = prefix + "/package.json";
+                const pkgJSON = await this.getDTSFileForModuleWithVersion(tree.moduleName, tree.version, "/package.json");
+
+                if (typeof pkgJSON === "string") {
+                    this.fsMap.set(path, pkgJSON);
+                }
+                else {
+                    this.logger.info(`Could not download package.json for ${tree.moduleName}`);
+                }
+            }
+
+            // Grab all dts files
+            await Promise.all(
+                allDTSFiles.map(async (dts) => {
+                    const dtsCode = await this.getDTSFileForModuleWithVersion(dts.moduleName, dts.moduleVersion, dts.path);
+                    if (dtsCode instanceof Error) {
+                        this.logger.info(`Had an issue getting ${dts.path} for ${dts.moduleName}`);
+                    }
+                    else {
+                        const root = p.getRootFiles();
+
+                        // TODO: Not sure how to get the d.ts into the project correctly.
+                        const path = root[0].replace(/\/\w+.js/, dts.vfsPath);
+                        this.projectService!.openClientFile(path, dtsCode, ScriptKind.TS, "/sample-folder");
+
+                        this.fsMap.set(dts.vfsPath, dtsCode);
+                    }
+                })
+            );
+        }
+
+        private async getDTSFileForModuleWithVersion(moduleName: string, version: string, file: string) {
+            // file comes with a prefix /
+            const url = `https://cdn.jsdelivr.net/npm/${moduleName}@${version}${file}`;
+            const f = fetch;
+            const res = await f(url);
+            if (res.ok) {
+                return res.text();
+            }
+            else {
+                return new Error("OK");
+            }
+        }
+
+        private api<T>(url: string, init?: any /*RequestInit*/): Promise<T | Error> {
+            const f = fetch;
+
+            return f(url, init).then((res: any) => {
+                if (res.ok) {
+                    return res.json().then((f: any) => f as T);
+                }
+                else {
+                    return new Error("OK");
+                }
+            });
+        }
+
+        // Taken from dts-gen: https://github.com/microsoft/dts-gen/blob/master/lib/names.ts
+        private getDTName(s: string) {
+            if (s.indexOf("@") === 0 && s.indexOf("/") !== -1) {
+                // we have a scoped module, e.g. @bla/foo
+                // which should be converted to   bla__foo
+                s = s.substr(1).replace("/", "__");
+            }
+            return s;
+        }
+
+        private async getFileTreeForModuleWithTag(moduleName: string, tag: string | undefined
+        ) {
+            let toDownload = tag || "latest";
+
+            // I think having at least 2 dots is a reasonable approx for being a semver and not a tag,
+            // we can skip an API request, TBH this is probably rare
+            if (toDownload.split(".").length < 2) {
+                // The jsdelivr API needs a _version_ not a tag. So, we need to switch out
+                // the tag to the version via an API request.
+                const response = await this.getNPMVersionForModuleReference(moduleName, toDownload);
+                if (response instanceof Error) {
+                    return {
+                        error: response,
+                        userFacingMessage: `Could not go from a tag to version on npm for ${moduleName} - possible typo?`,
+                    };
+                }
+
+                const neededVersion = response.version;
+                if (!neededVersion) {
+                    const versions = await this.getNPMVersionsForModule(moduleName);
+                    if (versions instanceof Error) {
+                        return {
+                            error: response,
+                            userFacingMessage: `Could not get versions on npm for ${moduleName} - possible typo?`,
+                        };
+                    }
+
+                    const tags = Object.entries(versions.tags).join(", ");
+                    return {
+                        error: new Error("Could not find tag for module"),
+                        userFacingMessage: `Could not find a tag for ${moduleName} called ${tag}. Did find ${tags}`,
+                    };
+                }
+
+                toDownload = neededVersion;
+            }
+
+            const res = await this.getFiletreeForModuleWithVersion(moduleName, toDownload);
+            if (res instanceof Error) {
+                return {
+                    error: res,
+                    userFacingMessage: `Could not get the files for ${moduleName}@${toDownload}. Is it possibly a typo?`,
+                };
+            }
+
+            return res;
+        }
+
+        private async getFiletreeForModuleWithVersion(moduleName: string, version: string) {
+            const url = `https://data.jsdelivr.com/v1/package/npm/${moduleName}@${version}/flat`;
+            const res = await this.api<NPMTreeMeta>(url);
+            if (res instanceof Error) {
+                return res;
+            }
+            else {
+                return {
+                    ...res,
+                    moduleName,
+                    version,
+                };
+            }
+        }
+
+        private treeToDTSFiles(tree: NPMTreeMeta, vfsPrefix: string) {
+            const dtsRefs: ATADownload[] = [];
+
+            for (const file of tree.files) {
+                if (file.name.endsWith(".d.ts")) {
+                    dtsRefs.push({
+                        moduleName: tree.moduleName,
+                        moduleVersion: tree.version,
+                        vfsPath: `${vfsPrefix}${file.name}`,
+                        path: file.name,
+                    });
+                }
+            }
+            return dtsRefs;
+        }
+
+        //  https://github.com/jsdelivr/data.jsdelivr.com
+
+        private getNPMVersionsForModule(moduleName: string) {
+            const url = `https://data.jsdelivr.com/v1/package/npm/${moduleName}`;
+            return this.api<{ tags: Record<string, string>; versions: string[] }>(url, { cache: "no-store" });
+        }
+
+        private getNPMVersionForModuleReference(moduleName: string, reference: string) {
+            const url = `https://data.jsdelivr.com/v1/package/resolve/npm/${moduleName}@${reference}`;
+            return this.api<{ version: string | null }>(url);
+        }
+    }
+
     export class WorkerSession extends Session<{}> {
         constructor(host: ServerHost, private webHost: HostWithWriteMessage, options: StartSessionOptions, logger: Logger, cancellationToken: ServerCancellationToken, hrtime: SessionOptions["hrtime"]) {
             super({
                 host,
                 cancellationToken,
                 ...options,
-                typingsInstaller: nullTypingsInstaller,
+                typingsInstaller: new WebTypingsInstaller(logger),
                 byteLength: notImplemented, // Formats the message text in send of Session which is overriden in this class so not needed
                 hrtime,
                 logger,

--- a/src/webServer/webServer.ts
+++ b/src/webServer/webServer.ts
@@ -1,7 +1,8 @@
 /*@internal*/
-namespace ts.server {
-    declare const fetch: any;
 
+/// <reference lib="webworker" />
+
+namespace ts.server {
     export interface HostWithWriteMessage {
         writeMessage(s: any): void;
     }
@@ -215,7 +216,7 @@ namespace ts.server {
         public readonly globalTypingsCacheLocation: string | undefined;
 
         public isKnownTypesPackageName(name: string): boolean {
-            // TODO
+            // TODO: implement this
             this.logger.info(`isKnownTypesPackageName ${name}`);
             return false;
         }
@@ -225,7 +226,7 @@ namespace ts.server {
                 throw new Error("No project service");
             }
 
-            // TODO: Can this be implemented on web?
+            // TODO: Can this be implemented on web? Probably not but is throwing an error ok here?
 
             console.log("install", options.projectName);
 


### PR DESCRIPTION
For microsoft/vscode#172887

This prototypes ATA for the web version of TypeScript. The logic is copied from the `@typescript/ata` project

The current implementation is not complete, mainly because I don't understand how to get the d.ts files into the TS project correctly

/cc @orta @DanielRosenwasser 