### PR TITLE
Ignore bad typings properties in package.json files

### DIFF
--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -293,8 +293,13 @@ namespace ts.JsTyping {
                 const ownTypes = packageJson.types || packageJson.typings;
                 if (ownTypes) {
                     const absolutePath = getNormalizedAbsolutePath(ownTypes, getDirectoryPath(normalizedFileName));
-                    if (log) log(`    Package '${packageJson.name}' provides its own types.`);
-                    inferredTypings.set(packageJson.name, absolutePath);
+                    if (host.fileExists(absolutePath)) {
+                        if (log) log(`    Package '${packageJson.name}' provides its own types.`);
+                        inferredTypings.set(packageJson.name, absolutePath);
+                    }
+                    else {
+                         if (log) log(`    Package '${packageJson.name}' provides its own types but they are missing.`);
+                    }
                 }
                 else {
                     packageNames.push(packageJson.name);


### PR DESCRIPTION
Otherwise, the non-existent typings file becomes part of the project and a spurious non-existent-root-file error is reported.

This was reported by a customer using [source-map](https://unpkg.com/browse/source-map@0.7.0/package.json).

This is pretty rare, but we could go above and beyond by trying to add the file extension ourselves.