### PR TITLE
Discourage typo fixes in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,11 @@ Refer to CONTRIBUTING.MD for more details.
   https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
 
 ** Please don't send typo fixes! **
-We understand that typo fixes are generally nice, but these fixes don't help
-with code quality and add work to the core team. If you're interested in
-sending a PR, the issue tracker has many issues marked `help wanted`.
+Please don't send a PR solely for the purpose of fixing a typo, unless that
+typo truly hurts understanding of the text. Each PR represents work for the
+maintainers, and that work should provide commensurate value.
+
+If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
 -->
 
 Fixes #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,9 +12,8 @@ Refer to CONTRIBUTING.MD for more details.
 
 ** Please don't send typo fixes! **
 We understand that typo fixes are generally nice, but these fixes don't help
-with code quality and add work to the core team. The same generally applies
-to other projects. If you're interested in sending a PR, the issue tracker
-has many issues marked `help wanted`.
+with code quality and add work to the core team. If you're interested in
+sending a PR, the issue tracker has many issues marked `help wanted`.
 -->
 
 Fixes #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,12 @@ Please verify that:
 
 Refer to CONTRIBUTING.MD for more details.
   https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
+
+** Please don't send typo fixes! **
+We understand that typo fixes are generally nice, but these fixes don't help
+with code quality and add work to the core team. The same generally applies
+to other projects. If you're interested in sending a PR, the issue tracker
+has many issues marked `help wanted`.
 -->
 
 Fixes #


### PR DESCRIPTION
Wording taken from [this comment](https://github.com/microsoft/TypeScript/pull/45834#issuecomment-919606286).

There have been a number of rejected typo fix PRs lately; hopefully this can reduce the amount of typo-fix-rejecting work for the team.