### PR TITLE
Import chalk with import() syntax

### DIFF
--- a/scripts/browserIntegrationTest.js
+++ b/scripts/browserIntegrationTest.js
@@ -1,5 +1,4 @@
 // @ts-check
-const chalk = require("chalk");
 const { join } = require("path");
 const { readFileSync } = require("fs");
 try {
@@ -18,6 +17,7 @@ const playwright = require("playwright");
 const debugging = false;
 
 (async () => {
+  const chalk = (await import("chalk")).default;
   for (const browserType of ["chromium", "firefox"]) {
     const browser = await playwright[browserType].launch({ headless: !debugging });
     const context = await browser.newContext();

--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -8,7 +8,6 @@ const mkdirp = require("mkdirp");
 const del = require("del");
 const File = require("vinyl");
 const ts = require("../../lib/typescript");
-const chalk = require("chalk");
 const which = require("which");
 const { spawn } = require("child_process");
 const { CancellationToken, CancelError, Deferred } = require("prex");
@@ -26,7 +25,8 @@ const { Readable, Duplex } = require("stream");
  * @property {boolean} [hidePrompt]
  * @property {boolean} [waitForExit=true]
  */
-function exec(cmd, args, options = {}) {
+async function exec(cmd, args, options = {}) {
+    const chalk = (await import("chalk")).default;
     return /**@type {Promise<{exitCode: number}>}*/(new Promise((resolve, reject) => {
         const { ignoreExitCode, cancelToken = CancellationToken.none, waitForExit = true } = options;
         cancelToken.throwIfCancellationRequested();


### PR DESCRIPTION
Fixes #46930 

[chalk v5.0.0](https://github.com/chalk/chalk/releases/tag/v5.0.0) was released and we cannot build TypeScript now if we have run `npm install` after the release. :cry:

This PR changes the script so that it works with chalk v5.0.0. Fortunately, the new code is compatible with both chalk 4.x and 5.0.