### PR TITLE
Use webworker typings for webServer.ts

### DIFF
--- a/src/tsserver/webServer.ts
+++ b/src/tsserver/webServer.ts
@@ -1,12 +1,8 @@
 /*@internal*/
-namespace ts.server {
-    declare const addEventListener: any;
-    declare const postMessage: any;
-    declare const close: any;
-    declare const location: any;
-    declare const XMLHttpRequest: any;
-    declare const self: any;
 
+/// <reference lib="webworker" />
+
+namespace ts.server {
     const nullLogger: Logger = {
         close: noop,
         hasLevel: returnFalse,
@@ -86,7 +82,7 @@ namespace ts.server {
     }
 
     function hrtime(previous?: [number, number]) {
-        const now = self.performance.now(performance) * 1e-3;
+        const now = self.performance.now() * 1e-3;
         let seconds = Math.floor(now);
         let nanoseconds = Math.floor((now % 1) * 1e9);
         if (previous) {
@@ -109,7 +105,7 @@ namespace ts.server {
             exit() {
                 this.logger.info("Exiting...");
                 this.projectService.closeLog();
-                close(0);
+                close();
             }
 
             listen() {


### PR DESCRIPTION
Updates `webServer.ts` to include the webworker typings. This means we don't have to redeclare the web globals we use in this file

