### PR TITLE
Add generic type parameter to startsWith/endsWith

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -401,6 +401,7 @@ interface String {
      * same as the corresponding elements of this object (converted to a String) starting at
      * endPosition – length(this). Otherwise returns false.
      */
+    endsWith<T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`;
     endsWith(searchString: string, endPosition?: number): boolean;
 
     /**
@@ -431,6 +432,7 @@ interface String {
      * same as the corresponding elements of this object (converted to a String) starting at
      * position. Otherwise returns false.
      */
+    startsWith<T extends string>(searchString: T, position?: 0): this is `${T}${string}`;
     startsWith(searchString: string, position?: number): boolean;
 
     /**

--- a/tests/baselines/reference/stringEndsWith.errors.txt
+++ b/tests/baselines/reference/stringEndsWith.errors.txt
@@ -1,0 +1,28 @@
+tests/cases/compiler/stringEndsWith.ts(9,46): error TS2345: Argument of type 'string' is not assignable to parameter of type '`${string}test`'.
+tests/cases/compiler/stringEndsWith.ts(10,46): error TS2345: Argument of type 'string' is not assignable to parameter of type '`${string}test`'.
+tests/cases/compiler/stringEndsWith.ts(11,56): error TS2345: Argument of type 'string' is not assignable to parameter of type '`${string}test`'.
+tests/cases/compiler/stringEndsWith.ts(12,56): error TS2345: Argument of type 'string' is not assignable to parameter of type '`${string}test`'.
+
+
+==== tests/cases/compiler/stringEndsWith.ts (4 errors) ====
+    declare var test: string;
+    declare function requirePostfix(input: `${string}test`): void;
+    
+    // works
+    if (test.endsWith('test')) requirePostfix(test);
+    if (test.endsWith('test', undefined)) requirePostfix(test);
+    
+    // errors
+    if (test.endsWith('test', 0)) requirePostfix(test);
+                                                 ~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type '`${string}test`'.
+    if (test.endsWith('test', 1)) requirePostfix(test);
+                                                 ~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type '`${string}test`'.
+    if (test.endsWith('test', 0 as number)) requirePostfix(test);
+                                                           ~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type '`${string}test`'.
+    if (test.endsWith('test', 1 as number)) requirePostfix(test);
+                                                           ~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type '`${string}test`'.
+    

--- a/tests/baselines/reference/stringEndsWith.js
+++ b/tests/baselines/reference/stringEndsWith.js
@@ -1,0 +1,30 @@
+//// [stringEndsWith.ts]
+declare var test: string;
+declare function requirePostfix(input: `${string}test`): void;
+
+// works
+if (test.endsWith('test')) requirePostfix(test);
+if (test.endsWith('test', undefined)) requirePostfix(test);
+
+// errors
+if (test.endsWith('test', 0)) requirePostfix(test);
+if (test.endsWith('test', 1)) requirePostfix(test);
+if (test.endsWith('test', 0 as number)) requirePostfix(test);
+if (test.endsWith('test', 1 as number)) requirePostfix(test);
+
+
+//// [stringEndsWith.js]
+// works
+if (test.endsWith('test'))
+    requirePostfix(test);
+if (test.endsWith('test', undefined))
+    requirePostfix(test);
+// errors
+if (test.endsWith('test', 0))
+    requirePostfix(test);
+if (test.endsWith('test', 1))
+    requirePostfix(test);
+if (test.endsWith('test', 0))
+    requirePostfix(test);
+if (test.endsWith('test', 1))
+    requirePostfix(test);

--- a/tests/baselines/reference/stringEndsWith.symbols
+++ b/tests/baselines/reference/stringEndsWith.symbols
@@ -1,0 +1,53 @@
+=== tests/cases/compiler/stringEndsWith.ts ===
+declare var test: string;
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+
+declare function requirePostfix(input: `${string}test`): void;
+>requirePostfix : Symbol(requirePostfix, Decl(stringEndsWith.ts, 0, 25))
+>input : Symbol(input, Decl(stringEndsWith.ts, 1, 32))
+
+// works
+if (test.endsWith('test')) requirePostfix(test);
+>test.endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+>endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>requirePostfix : Symbol(requirePostfix, Decl(stringEndsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+
+if (test.endsWith('test', undefined)) requirePostfix(test);
+>test.endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+>endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>undefined : Symbol(undefined)
+>requirePostfix : Symbol(requirePostfix, Decl(stringEndsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+
+// errors
+if (test.endsWith('test', 0)) requirePostfix(test);
+>test.endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+>endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>requirePostfix : Symbol(requirePostfix, Decl(stringEndsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+
+if (test.endsWith('test', 1)) requirePostfix(test);
+>test.endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+>endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>requirePostfix : Symbol(requirePostfix, Decl(stringEndsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+
+if (test.endsWith('test', 0 as number)) requirePostfix(test);
+>test.endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+>endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>requirePostfix : Symbol(requirePostfix, Decl(stringEndsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+
+if (test.endsWith('test', 1 as number)) requirePostfix(test);
+>test.endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+>endsWith : Symbol(String.endsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>requirePostfix : Symbol(requirePostfix, Decl(stringEndsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringEndsWith.ts, 0, 11))
+

--- a/tests/baselines/reference/stringEndsWith.types
+++ b/tests/baselines/reference/stringEndsWith.types
@@ -1,0 +1,77 @@
+=== tests/cases/compiler/stringEndsWith.ts ===
+declare var test: string;
+>test : string
+
+declare function requirePostfix(input: `${string}test`): void;
+>requirePostfix : (input: `${string}test`) => void
+>input : `${string}test`
+
+// works
+if (test.endsWith('test')) requirePostfix(test);
+>test.endsWith('test') : boolean
+>test.endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>test : string
+>endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>'test' : "test"
+>requirePostfix(test) : void
+>requirePostfix : (input: `${string}test`) => void
+>test : `${string}test`
+
+if (test.endsWith('test', undefined)) requirePostfix(test);
+>test.endsWith('test', undefined) : boolean
+>test.endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>test : string
+>endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>'test' : "test"
+>undefined : undefined
+>requirePostfix(test) : void
+>requirePostfix : (input: `${string}test`) => void
+>test : `${string}test`
+
+// errors
+if (test.endsWith('test', 0)) requirePostfix(test);
+>test.endsWith('test', 0) : boolean
+>test.endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>test : string
+>endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>'test' : "test"
+>0 : 0
+>requirePostfix(test) : void
+>requirePostfix : (input: `${string}test`) => void
+>test : string
+
+if (test.endsWith('test', 1)) requirePostfix(test);
+>test.endsWith('test', 1) : boolean
+>test.endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>test : string
+>endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>'test' : "test"
+>1 : 1
+>requirePostfix(test) : void
+>requirePostfix : (input: `${string}test`) => void
+>test : string
+
+if (test.endsWith('test', 0 as number)) requirePostfix(test);
+>test.endsWith('test', 0 as number) : boolean
+>test.endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>test : string
+>endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>'test' : "test"
+>0 as number : number
+>0 : 0
+>requirePostfix(test) : void
+>requirePostfix : (input: `${string}test`) => void
+>test : string
+
+if (test.endsWith('test', 1 as number)) requirePostfix(test);
+>test.endsWith('test', 1 as number) : boolean
+>test.endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>test : string
+>endsWith : { <T extends string>(searchString: T, endPosition?: undefined): this is `${string}${T}`; (searchString: string, endPosition?: number): boolean; }
+>'test' : "test"
+>1 as number : number
+>1 : 1
+>requirePostfix(test) : void
+>requirePostfix : (input: `${string}test`) => void
+>test : string
+

--- a/tests/baselines/reference/stringStartsWith.errors.txt
+++ b/tests/baselines/reference/stringStartsWith.errors.txt
@@ -1,0 +1,25 @@
+tests/cases/compiler/stringStartsWith.ts(10,47): error TS2345: Argument of type 'string' is not assignable to parameter of type '`test${string}`'.
+tests/cases/compiler/stringStartsWith.ts(11,57): error TS2345: Argument of type 'string' is not assignable to parameter of type '`test${string}`'.
+tests/cases/compiler/stringStartsWith.ts(12,57): error TS2345: Argument of type 'string' is not assignable to parameter of type '`test${string}`'.
+
+
+==== tests/cases/compiler/stringStartsWith.ts (3 errors) ====
+    declare var test: string;
+    declare function requirePrefix(input: `test${string}`): void;
+    
+    // works
+    if (test.startsWith('test')) requirePrefix(test);
+    if (test.startsWith('test', undefined)) requirePrefix(test);
+    if (test.startsWith('test', 0)) requirePrefix(test);
+    
+    // errors
+    if (test.startsWith('test', 1)) requirePrefix(test);
+                                                  ~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type '`test${string}`'.
+    if (test.startsWith('test', 0 as number)) requirePrefix(test);
+                                                            ~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type '`test${string}`'.
+    if (test.startsWith('test', 1 as number)) requirePrefix(test);
+                                                            ~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type '`test${string}`'.
+    

--- a/tests/baselines/reference/stringStartsWith.js
+++ b/tests/baselines/reference/stringStartsWith.js
@@ -1,0 +1,30 @@
+//// [stringStartsWith.ts]
+declare var test: string;
+declare function requirePrefix(input: `test${string}`): void;
+
+// works
+if (test.startsWith('test')) requirePrefix(test);
+if (test.startsWith('test', undefined)) requirePrefix(test);
+if (test.startsWith('test', 0)) requirePrefix(test);
+
+// errors
+if (test.startsWith('test', 1)) requirePrefix(test);
+if (test.startsWith('test', 0 as number)) requirePrefix(test);
+if (test.startsWith('test', 1 as number)) requirePrefix(test);
+
+
+//// [stringStartsWith.js]
+// works
+if (test.startsWith('test'))
+    requirePrefix(test);
+if (test.startsWith('test', undefined))
+    requirePrefix(test);
+if (test.startsWith('test', 0))
+    requirePrefix(test);
+// errors
+if (test.startsWith('test', 1))
+    requirePrefix(test);
+if (test.startsWith('test', 0))
+    requirePrefix(test);
+if (test.startsWith('test', 1))
+    requirePrefix(test);

--- a/tests/baselines/reference/stringStartsWith.symbols
+++ b/tests/baselines/reference/stringStartsWith.symbols
@@ -1,0 +1,53 @@
+=== tests/cases/compiler/stringStartsWith.ts ===
+declare var test: string;
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+
+declare function requirePrefix(input: `test${string}`): void;
+>requirePrefix : Symbol(requirePrefix, Decl(stringStartsWith.ts, 0, 25))
+>input : Symbol(input, Decl(stringStartsWith.ts, 1, 31))
+
+// works
+if (test.startsWith('test')) requirePrefix(test);
+>test.startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+>startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>requirePrefix : Symbol(requirePrefix, Decl(stringStartsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+
+if (test.startsWith('test', undefined)) requirePrefix(test);
+>test.startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+>startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>undefined : Symbol(undefined)
+>requirePrefix : Symbol(requirePrefix, Decl(stringStartsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+
+if (test.startsWith('test', 0)) requirePrefix(test);
+>test.startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+>startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>requirePrefix : Symbol(requirePrefix, Decl(stringStartsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+
+// errors
+if (test.startsWith('test', 1)) requirePrefix(test);
+>test.startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+>startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>requirePrefix : Symbol(requirePrefix, Decl(stringStartsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+
+if (test.startsWith('test', 0 as number)) requirePrefix(test);
+>test.startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+>startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>requirePrefix : Symbol(requirePrefix, Decl(stringStartsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+
+if (test.startsWith('test', 1 as number)) requirePrefix(test);
+>test.startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+>startsWith : Symbol(String.startsWith, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>requirePrefix : Symbol(requirePrefix, Decl(stringStartsWith.ts, 0, 25))
+>test : Symbol(test, Decl(stringStartsWith.ts, 0, 11))
+

--- a/tests/baselines/reference/stringStartsWith.types
+++ b/tests/baselines/reference/stringStartsWith.types
@@ -1,0 +1,77 @@
+=== tests/cases/compiler/stringStartsWith.ts ===
+declare var test: string;
+>test : string
+
+declare function requirePrefix(input: `test${string}`): void;
+>requirePrefix : (input: `test${string}`) => void
+>input : `test${string}`
+
+// works
+if (test.startsWith('test')) requirePrefix(test);
+>test.startsWith('test') : boolean
+>test.startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>test : string
+>startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>'test' : "test"
+>requirePrefix(test) : void
+>requirePrefix : (input: `test${string}`) => void
+>test : `test${string}`
+
+if (test.startsWith('test', undefined)) requirePrefix(test);
+>test.startsWith('test', undefined) : boolean
+>test.startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>test : string
+>startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>'test' : "test"
+>undefined : undefined
+>requirePrefix(test) : void
+>requirePrefix : (input: `test${string}`) => void
+>test : `test${string}`
+
+if (test.startsWith('test', 0)) requirePrefix(test);
+>test.startsWith('test', 0) : boolean
+>test.startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>test : string
+>startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>'test' : "test"
+>0 : 0
+>requirePrefix(test) : void
+>requirePrefix : (input: `test${string}`) => void
+>test : `test${string}`
+
+// errors
+if (test.startsWith('test', 1)) requirePrefix(test);
+>test.startsWith('test', 1) : boolean
+>test.startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>test : string
+>startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>'test' : "test"
+>1 : 1
+>requirePrefix(test) : void
+>requirePrefix : (input: `test${string}`) => void
+>test : string
+
+if (test.startsWith('test', 0 as number)) requirePrefix(test);
+>test.startsWith('test', 0 as number) : boolean
+>test.startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>test : string
+>startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>'test' : "test"
+>0 as number : number
+>0 : 0
+>requirePrefix(test) : void
+>requirePrefix : (input: `test${string}`) => void
+>test : string
+
+if (test.startsWith('test', 1 as number)) requirePrefix(test);
+>test.startsWith('test', 1 as number) : boolean
+>test.startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>test : string
+>startsWith : { <T extends string>(searchString: T, position?: 0): this is `${T}${string}`; (searchString: string, position?: number): boolean; }
+>'test' : "test"
+>1 as number : number
+>1 : 1
+>requirePrefix(test) : void
+>requirePrefix : (input: `test${string}`) => void
+>test : string
+

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3_ES6.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3_ES6.errors.txt
@@ -113,7 +113,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     fn5 `${ (n) => n.toFixed() }`; // will error; 'n' should have type 'string'.
                      ~~~~~~~
 !!! error TS2551: Property 'toFixed' does not exist on type 'string'. Did you mean 'fixed'?
-!!! related TS2728 /.ts/lib.es2015.core.d.ts:485:5: 'fixed' is declared here.
+!!! related TS2728 /.ts/lib.es2015.core.d.ts:487:5: 'fixed' is declared here.
     fn5 `${ (n) => n.substr(0) }`;
     
     

--- a/tests/cases/compiler/stringEndsWith.ts
+++ b/tests/cases/compiler/stringEndsWith.ts
@@ -1,0 +1,14 @@
+// @target: es2015
+
+declare var test: string;
+declare function requirePostfix(input: `${string}test`): void;
+
+// works
+if (test.endsWith('test')) requirePostfix(test);
+if (test.endsWith('test', undefined)) requirePostfix(test);
+
+// errors
+if (test.endsWith('test', 0)) requirePostfix(test);
+if (test.endsWith('test', 1)) requirePostfix(test);
+if (test.endsWith('test', 0 as number)) requirePostfix(test);
+if (test.endsWith('test', 1 as number)) requirePostfix(test);

--- a/tests/cases/compiler/stringStartsWith.ts
+++ b/tests/cases/compiler/stringStartsWith.ts
@@ -1,0 +1,14 @@
+// @target: es2015
+
+declare var test: string;
+declare function requirePrefix(input: `test${string}`): void;
+
+// works
+if (test.startsWith('test')) requirePrefix(test);
+if (test.startsWith('test', undefined)) requirePrefix(test);
+if (test.startsWith('test', 0)) requirePrefix(test);
+
+// errors
+if (test.startsWith('test', 1)) requirePrefix(test);
+if (test.startsWith('test', 0 as number)) requirePrefix(test);
+if (test.startsWith('test', 1 as number)) requirePrefix(test);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46958

Sorry for being a bit quick to open this PR, I started by editing the code and then later found out about the proper process. I figured it would be good to open this one anyways a suggestion on how to fix the issue I opened.

I also had a hard time figuring out _where_ to add tests for this. It's not under ["Contributing lib.d.ts fixes"](https://github.com/microsoft/TypeScript/blob/main/CONTRIBUTING.md#contributing-libdts-fixes) and ["Adding a Test"](https://github.com/microsoft/TypeScript/blob/main/CONTRIBUTING.md#adding-a-test) seems to be for compiler tests cases. Any help appreciated!