### PR TITLE
Fix parsing of parenthesized functions in conditional expressions

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4539,9 +4539,10 @@ namespace ts {
             //  - "(x,y)" is a comma expression parsed as a signature with two parameters.
             //  - "a ? (b): c" will have "(b):" parsed as a signature with a return type annotation.
             //  - "a ? (b): function() {}" will too, since function() is a valid JSDoc function type.
+            //  - "a ? (b): (function() {})" as well, but inside of a parenthesized type.
             //
             // So we need just a bit of lookahead to ensure that it can only be a signature.
-            const hasJSDocFunctionType = type && isJSDocFunctionType(type);
+            const hasJSDocFunctionType = type && (isJSDocFunctionType(type) || isParenthesizedTypeNode(type) && isJSDocFunctionType(type.type));
             if (!allowAmbiguity && token() !== SyntaxKind.EqualsGreaterThanToken && (hasJSDocFunctionType || token() !== SyntaxKind.OpenBraceToken)) {
                 // Returning undefined here will cause our caller to rewind to where we started from.
                     return undefined;

--- a/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.js
+++ b/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.js
@@ -1,0 +1,8 @@
+//// [parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts]
+let a: any;
+const c = true ? (a) : (function() {});
+
+
+//// [parserParenthesizedVariableAndParenthesizedFunctionInTernary.js]
+var a;
+var c = true ? (a) : (function () { });

--- a/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.symbols
+++ b/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts ===
+let a: any;
+>a : Symbol(a, Decl(parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts, 0, 3))
+
+const c = true ? (a) : (function() {});
+>c : Symbol(c, Decl(parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts, 1, 5))
+>a : Symbol(a, Decl(parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts, 0, 3))
+

--- a/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.types
+++ b/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.types
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts ===
+let a: any;
+>a : any
+
+const c = true ? (a) : (function() {});
+>c : any
+>true ? (a) : (function() {}) : any
+>true : true
+>(a) : any
+>a : any
+>(function() {}) : () => void
+>function() {} : () => void
+

--- a/tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts
+++ b/tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts
@@ -1,0 +1,2 @@
+let a: any;
+const c = true ? (a) : (function() {});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46933

When we speculatively parse after `?`, `function() {}` may be within parens and appear as a parenthesized JSDoc function type.