### PR TITLE
Unwrap parens when checking for JSDocFunctionType in conditional expression

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4549,7 +4549,6 @@ namespace ts {
             }
 
             const hasJSDocFunctionType = unwrappedType && isJSDocFunctionType(unwrappedType);
-            // const hasJSDocFunctionType = type && isJSDocFunctionType(skipParentheses(type));
             if (!allowAmbiguity && token() !== SyntaxKind.EqualsGreaterThanToken && (hasJSDocFunctionType || token() !== SyntaxKind.OpenBraceToken)) {
                 // Returning undefined here will cause our caller to rewind to where we started from.
                     return undefined;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4543,12 +4543,12 @@ namespace ts {
             //
             // So we need just a bit of lookahead to ensure that it can only be a signature.
 
-            let maybeJSDocFunctionType = type;
-            while (maybeJSDocFunctionType && isParenthesizedTypeNode(maybeJSDocFunctionType)) {
-                maybeJSDocFunctionType = maybeJSDocFunctionType.type;  // Skip parens if need be
+            let unwrappedType = type;
+            while (unwrappedType?.kind === SyntaxKind.ParenthesizedType) {
+                unwrappedType = (unwrappedType as ParenthesizedTypeNode).type;  // Skip parens if need be
             }
 
-            const hasJSDocFunctionType = maybeJSDocFunctionType && isJSDocFunctionType(maybeJSDocFunctionType);
+            const hasJSDocFunctionType = unwrappedType && isJSDocFunctionType(unwrappedType);
             // const hasJSDocFunctionType = type && isJSDocFunctionType(skipParentheses(type));
             if (!allowAmbiguity && token() !== SyntaxKind.EqualsGreaterThanToken && (hasJSDocFunctionType || token() !== SyntaxKind.OpenBraceToken)) {
                 // Returning undefined here will cause our caller to rewind to where we started from.

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4539,10 +4539,17 @@ namespace ts {
             //  - "(x,y)" is a comma expression parsed as a signature with two parameters.
             //  - "a ? (b): c" will have "(b):" parsed as a signature with a return type annotation.
             //  - "a ? (b): function() {}" will too, since function() is a valid JSDoc function type.
-            //  - "a ? (b): (function() {})" as well, but inside of a parenthesized type.
+            //  - "a ? (b): (function() {})" as well, but inside of a parenthesized type with an arbitrary amount of nesting.
             //
             // So we need just a bit of lookahead to ensure that it can only be a signature.
-            const hasJSDocFunctionType = type && (isJSDocFunctionType(type) || isParenthesizedTypeNode(type) && isJSDocFunctionType(type.type));
+
+            let maybeJSDocFunctionType = type;
+            while (maybeJSDocFunctionType && isParenthesizedTypeNode(maybeJSDocFunctionType)) {
+                maybeJSDocFunctionType = maybeJSDocFunctionType.type;  // Skip parens if need be
+            }
+
+            const hasJSDocFunctionType = maybeJSDocFunctionType && isJSDocFunctionType(maybeJSDocFunctionType);
+            // const hasJSDocFunctionType = type && isJSDocFunctionType(skipParentheses(type));
             if (!allowAmbiguity && token() !== SyntaxKind.EqualsGreaterThanToken && (hasJSDocFunctionType || token() !== SyntaxKind.OpenBraceToken)) {
                 // Returning undefined here will cause our caller to rewind to where we started from.
                     return undefined;

--- a/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.js
+++ b/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.js
@@ -1,8 +1,10 @@
 //// [parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts]
 let a: any;
 const c = true ? (a) : (function() {});
+const d = true ? (a) : ((function() {}));
 
 
 //// [parserParenthesizedVariableAndParenthesizedFunctionInTernary.js]
 var a;
 var c = true ? (a) : (function () { });
+var d = true ? (a) : ((function () { }));

--- a/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.symbols
+++ b/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.symbols
@@ -6,3 +6,7 @@ const c = true ? (a) : (function() {});
 >c : Symbol(c, Decl(parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts, 1, 5))
 >a : Symbol(a, Decl(parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts, 0, 3))
 
+const d = true ? (a) : ((function() {}));
+>d : Symbol(d, Decl(parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts, 2, 5))
+>a : Symbol(a, Decl(parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts, 0, 3))
+

--- a/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.types
+++ b/tests/baselines/reference/parserParenthesizedVariableAndParenthesizedFunctionInTernary.types
@@ -11,3 +11,13 @@ const c = true ? (a) : (function() {});
 >(function() {}) : () => void
 >function() {} : () => void
 
+const d = true ? (a) : ((function() {}));
+>d : any
+>true ? (a) : ((function() {})) : any
+>true : true
+>(a) : any
+>a : any
+>((function() {})) : () => void
+>(function() {}) : () => void
+>function() {} : () => void
+

--- a/tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts
+++ b/tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndParenthesizedFunctionInTernary.ts
@@ -1,2 +1,3 @@
 let a: any;
 const c = true ? (a) : (function() {});
+const d = true ? (a) : ((function() {}));


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46933

This is a followup to #46960; I realized that these could be nested after merging.

`skipParentheses` is for `Expression` and doesn't work here. Other places do this loop, so I've copied the same pattern as other places and removed my use of `isParenthesizedTypeNode`. Seems like it'd be a good helper, but it's only two other places, somehow.