### PR TITLE
Don't call afterEach within beforeEach

### DIFF
--- a/src/testRunner/unittests/createMapShim.ts
+++ b/src/testRunner/unittests/createMapShim.ts
@@ -130,9 +130,9 @@ namespace ts {
             }
 
             MapShim = ShimCollections.createMapShim(getIterator);
-            afterEach(() => {
-                MapShim = undefined!;
-            });
+        });
+        afterEach(() => {
+            MapShim = undefined!;
         });
 
         it("iterates values in insertion order and handles changes with string keys", () => {

--- a/src/testRunner/unittests/createSetShim.ts
+++ b/src/testRunner/unittests/createSetShim.ts
@@ -128,9 +128,9 @@ namespace ts {
             }
 
             SetShim = ShimCollections.createSetShim(getIterator);
-            afterEach(() => {
-                SetShim = undefined!;
-            });
+        });
+        afterEach(() => {
+            SetShim = undefined!;
         });
 
         it("iterates values in insertion order and handles changes with string keys", () => {

--- a/src/testRunner/unittests/debugDeprecation.ts
+++ b/src/testRunner/unittests/debugDeprecation.ts
@@ -1,10 +1,12 @@
 namespace ts {
     describe("unittests:: debugDeprecation", () => {
+        let loggingHost: LoggingHost | undefined;
         beforeEach(() => {
-            const loggingHost = Debug.loggingHost;
-            afterEach(() => {
-                Debug.loggingHost = loggingHost;
-            });
+            loggingHost = Debug.loggingHost;
+        });
+        afterEach(() => {
+            Debug.loggingHost = loggingHost;
+            loggingHost = undefined;
         });
         describe("deprecateFunction", () => {
             it("silent deprecation", () => {


### PR DESCRIPTION
Otherwise, a new afterEach handler is added for each test case and the number of handlers run grows quadratically (wrt the number of tests in the suite adding the handlers).
