### PR TITLE
Only print "file change detected" if program changed

### DIFF
--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -665,8 +665,19 @@ namespace ts {
 
         function updateProgramWithWatchStatus() {
             timerToUpdateProgram = undefined;
-            reportWatchDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation);
+
+            const oldProgram = getCurrentBuilderProgram();
             updateProgram();
+            const newProgram = getCurrentBuilderProgram();
+
+            // This event may not have actually changed anything; avoid
+            // printing this message if the program didn't change, as
+            // host.afterProgramCreate will not be called to print out
+            // "Watching for file changes", potentially confusing external
+            // tools into thinking the compilation is hanging.
+            if (newProgram !== oldProgram) {
+                reportWatchDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation);
+            }
         }
 
         function updateProgram() {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #46949

Testing on a few projects, `updateProgram` is cheap (a couple of milliseconds), so I don't think this will have a negative impact. I'm not sure if this is generically true, though, or just specific to my Linux machine and what I tested.

I have no idea how to test this, though, except manually.