### PR TITLE
Bail on 0- and 1-length lists in `removeSubtypes` to avoid spurious circularity problems

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14200,7 +14200,7 @@ namespace ts {
         function removeSubtypes(types: Type[], hasObjectTypes: boolean): Type[] | undefined {
             // [] and [T] immediately reduce to [] and [T] respectively
             if (types.length < 2) {
-                // return types;
+                return types;
             }
 
             const id = getTypeListId(types);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14198,14 +14198,15 @@ namespace ts {
         }
 
         function removeSubtypes(types: Type[], hasObjectTypes: boolean): Type[] | undefined {
+            // [] and [T] immediately reduce to [] and [T] respectively
+            if (types.length < 2) {
+                // return types;
+            }
+
             const id = getTypeListId(types);
             const match = subtypeReductionCache.get(id);
             if (match) {
                 return match;
-            }
-            // [] and [T] immediately reduce to [] and [T] respectively
-            if (types.length < 2) {
-                return types;
             }
 
             // We assume that redundant primitive types have already been removed from the types array and that there

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14333,7 +14333,6 @@ namespace ts {
             if (types.length === 1) {
                 return types[0];
             }
-
             let typeSet: Type[] | undefined = [];
             const includes = addTypesToUnion(typeSet, 0, types);
             if (unionReduction !== UnionReduction.None) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14203,6 +14203,11 @@ namespace ts {
             if (match) {
                 return match;
             }
+            // [] and [T] immediately reduce to [] and [T] respectively
+            if (types.length < 2) {
+                return types;
+            }
+
             // We assume that redundant primitive types have already been removed from the types array and that there
             // are no any and unknown types in the array. Thus, the only possible supertypes for primitive types are empty
             // object types, and if none of those are present we can exclude primitive types from the subtype check.
@@ -14328,6 +14333,7 @@ namespace ts {
             if (types.length === 1) {
                 return types[0];
             }
+
             let typeSet: Type[] | undefined = [];
             const includes = addTypesToUnion(typeSet, 0, types);
             if (unionReduction !== UnionReduction.None) {

--- a/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck.errors.txt
+++ b/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck.errors.txt
@@ -1,0 +1,19 @@
+tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck.ts(3,7): error TS7023: 'steps' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+
+
+==== tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck.ts (1 errors) ====
+    declare const props: WizardStepProps;
+    export class Wizard {
+      get steps() {
+          ~~~~~
+!!! error TS7023: 'steps' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+        return {
+          wizard: this,
+          ...props,
+        } as WizardStepProps;
+      }
+    }
+    
+    export interface WizardStepProps {
+      wizard?: Wizard;
+    }

--- a/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck.js
+++ b/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck.js
@@ -1,0 +1,43 @@
+//// [trivialSubtypeReductionNoStructuralCheck.ts]
+declare const props: WizardStepProps;
+export class Wizard {
+  get steps() {
+    return {
+      wizard: this,
+      ...props,
+    } as WizardStepProps;
+  }
+}
+
+export interface WizardStepProps {
+  wizard?: Wizard;
+}
+
+//// [trivialSubtypeReductionNoStructuralCheck.js]
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Wizard = void 0;
+var Wizard = /** @class */ (function () {
+    function Wizard() {
+    }
+    Object.defineProperty(Wizard.prototype, "steps", {
+        get: function () {
+            return __assign({ wizard: this }, props);
+        },
+        enumerable: false,
+        configurable: true
+    });
+    return Wizard;
+}());
+exports.Wizard = Wizard;

--- a/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck.symbols
+++ b/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck.symbols
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck.ts ===
+declare const props: WizardStepProps;
+>props : Symbol(props, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 0, 13))
+>WizardStepProps : Symbol(WizardStepProps, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 8, 1))
+
+export class Wizard {
+>Wizard : Symbol(Wizard, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 0, 37))
+
+  get steps() {
+>steps : Symbol(Wizard.steps, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 1, 21))
+
+    return {
+      wizard: this,
+>wizard : Symbol(wizard, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 3, 12))
+>this : Symbol(Wizard, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 0, 37))
+
+      ...props,
+>props : Symbol(props, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 0, 13))
+
+    } as WizardStepProps;
+>WizardStepProps : Symbol(WizardStepProps, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 8, 1))
+  }
+}
+
+export interface WizardStepProps {
+>WizardStepProps : Symbol(WizardStepProps, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 8, 1))
+
+  wizard?: Wizard;
+>wizard : Symbol(WizardStepProps.wizard, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 10, 34))
+>Wizard : Symbol(Wizard, Decl(trivialSubtypeReductionNoStructuralCheck.ts, 0, 37))
+}

--- a/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck.types
+++ b/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck.types
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck.ts ===
+declare const props: WizardStepProps;
+>props : WizardStepProps
+
+export class Wizard {
+>Wizard : Wizard
+
+  get steps() {
+>steps : any
+
+    return {
+>{      wizard: this,      ...props,    } as WizardStepProps : WizardStepProps
+>{      wizard: this,      ...props,    } : { wizard: Wizard; }
+
+      wizard: this,
+>wizard : this
+>this : this
+
+      ...props,
+>props : WizardStepProps
+
+    } as WizardStepProps;
+  }
+}
+
+export interface WizardStepProps {
+  wizard?: Wizard;
+>wizard : Wizard | undefined
+}

--- a/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck2.js
+++ b/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck2.js
@@ -1,0 +1,43 @@
+//// [trivialSubtypeReductionNoStructuralCheck2.ts]
+declare const props: WizardStepProps;
+export class Wizard {
+  get steps() {
+    return {
+      wizard: this as Wizard,
+      ...props,
+    } as WizardStepProps;
+  }
+}
+
+export interface WizardStepProps {
+  wizard?: Wizard;
+}
+
+//// [trivialSubtypeReductionNoStructuralCheck2.js]
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Wizard = void 0;
+var Wizard = /** @class */ (function () {
+    function Wizard() {
+    }
+    Object.defineProperty(Wizard.prototype, "steps", {
+        get: function () {
+            return __assign({ wizard: this }, props);
+        },
+        enumerable: false,
+        configurable: true
+    });
+    return Wizard;
+}());
+exports.Wizard = Wizard;

--- a/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck2.symbols
+++ b/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck2.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck2.ts ===
+declare const props: WizardStepProps;
+>props : Symbol(props, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 0, 13))
+>WizardStepProps : Symbol(WizardStepProps, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 8, 1))
+
+export class Wizard {
+>Wizard : Symbol(Wizard, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 0, 37))
+
+  get steps() {
+>steps : Symbol(Wizard.steps, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 1, 21))
+
+    return {
+      wizard: this as Wizard,
+>wizard : Symbol(wizard, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 3, 12))
+>this : Symbol(Wizard, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 0, 37))
+>Wizard : Symbol(Wizard, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 0, 37))
+
+      ...props,
+>props : Symbol(props, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 0, 13))
+
+    } as WizardStepProps;
+>WizardStepProps : Symbol(WizardStepProps, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 8, 1))
+  }
+}
+
+export interface WizardStepProps {
+>WizardStepProps : Symbol(WizardStepProps, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 8, 1))
+
+  wizard?: Wizard;
+>wizard : Symbol(WizardStepProps.wizard, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 10, 34))
+>Wizard : Symbol(Wizard, Decl(trivialSubtypeReductionNoStructuralCheck2.ts, 0, 37))
+}

--- a/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck2.types
+++ b/tests/baselines/reference/trivialSubtypeReductionNoStructuralCheck2.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck2.ts ===
+declare const props: WizardStepProps;
+>props : WizardStepProps
+
+export class Wizard {
+>Wizard : Wizard
+
+  get steps() {
+>steps : WizardStepProps
+
+    return {
+>{      wizard: this as Wizard,      ...props,    } as WizardStepProps : WizardStepProps
+>{      wizard: this as Wizard,      ...props,    } : { wizard: Wizard; }
+
+      wizard: this as Wizard,
+>wizard : Wizard
+>this as Wizard : Wizard
+>this : this
+
+      ...props,
+>props : WizardStepProps
+
+    } as WizardStepProps;
+  }
+}
+
+export interface WizardStepProps {
+  wizard?: Wizard;
+>wizard : Wizard | undefined
+}

--- a/tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck.ts
+++ b/tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck.ts
@@ -1,0 +1,16 @@
+// @strict: true
+// @target: es5
+
+declare const props: WizardStepProps;
+export class Wizard {
+  get steps() {
+    return {
+      wizard: this,
+      ...props,
+    } as WizardStepProps;
+  }
+}
+
+export interface WizardStepProps {
+  wizard?: Wizard;
+}

--- a/tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck2.ts
+++ b/tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck2.ts
@@ -1,0 +1,16 @@
+// @strict: true
+// @target: es5
+
+declare const props: WizardStepProps;
+export class Wizard {
+  get steps() {
+    return {
+      wizard: this as Wizard,
+      ...props,
+    } as WizardStepProps;
+  }
+}
+
+export interface WizardStepProps {
+  wizard?: Wizard;
+}


### PR DESCRIPTION
Creates a reasonable workaround for #46939

Another example for illustration:
```ts
type Box = {
  content?: Foo
};
declare const b: Box;
class Foo {
  get foo() {
    return {
      content: this as Foo,
      ...b
    };
  }
}
```
When resolving the type of `Foo#foo`, we need to compute the type of the object literal in the return position. This has two parts: the `content` from the `content: ` property (type `Foo`), and the `content` property from type `Box` (which is `Foo | missing`).

We want the type of `content` here to be subtype-reduced when creating the union of the two possible constituents, `Foo` and `Foo`. That list gets deduped in `getUnionType` to just `[Foo]`, *then passed to `removeSubTypes`*, which computes this value ahead of the `while` loop below it which in reality runs zero iterations:
```ts
            const hasEmptyObject = hasObjectTypes && some(types, t => !!(t.flags & TypeFlags.Object) && !isGenericMappedType(t) && isEmptyResolvedType(resolveStructuredTypeMembers(t as ObjectType)));
```
That call to `resolveStructuredTypeMembers` attempts to resolve the type of `Foo#foo`, triggering a circularity even though none actually exists.

Instead we can just bail out earlier in the function, saving time (I hope?) and avoiding this computation until later when doing so won't introduce a circularity.