### PR TITLE
Pin chalk to ^4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1864,10 +1864,14 @@
             }
         },
         "chalk": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
-            "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
-            "dev": true
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            }
         },
         "check-error": {
             "version": "1.0.2",
@@ -5104,18 +5108,6 @@
             "requires": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "lru-cache": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "browser-resolve": "^1.11.2",
         "browserify": "latest",
         "chai": "latest",
-        "chalk": "latest",
+        "chalk": "^4.1.2",
         "convert-source-map": "latest",
         "del": "5.1.0",
         "diff": "^4.0.2",

--- a/scripts/browserIntegrationTest.js
+++ b/scripts/browserIntegrationTest.js
@@ -1,4 +1,5 @@
 // @ts-check
+const chalk = require("chalk");
 const { join } = require("path");
 const { readFileSync } = require("fs");
 try {
@@ -17,7 +18,6 @@ const playwright = require("playwright");
 const debugging = false;
 
 (async () => {
-  const chalk = (await import("chalk")).default;
   for (const browserType of ["chromium", "firefox"]) {
     const browser = await playwright[browserType].launch({ headless: !debugging });
     const context = await browser.newContext();

--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -8,6 +8,7 @@ const mkdirp = require("mkdirp");
 const del = require("del");
 const File = require("vinyl");
 const ts = require("../../lib/typescript");
+const chalk = require("chalk");
 const which = require("which");
 const { spawn } = require("child_process");
 const { CancellationToken, CancelError, Deferred } = require("prex");
@@ -26,7 +27,6 @@ const { Readable, Duplex } = require("stream");
  * @property {boolean} [waitForExit=true]
  */
 async function exec(cmd, args, options = {}) {
-    const chalk = (await import("chalk")).default;
     return /**@type {Promise<{exitCode: number}>}*/(new Promise((resolve, reject) => {
         const { ignoreExitCode, cancelToken = CancellationToken.none, waitForExit = true } = options;
         cancelToken.throwIfCancellationRequested();


### PR DESCRIPTION
This limits the version of chalk we use to `^4.1.2` since `chalk@5` is now ESM only.