### PR TITLE
Use features for selected module resolution rather than all features …

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -340,7 +340,11 @@ namespace ts {
         }
 
         const failedLookupLocations: string[] = [];
-        const moduleResolutionState: ModuleResolutionState = { compilerOptions: options, host, traceEnabled, failedLookupLocations, packageJsonInfoCache: cache, features: NodeResolutionFeatures.AllFeatures, conditions: ["node", "require", "types"] };
+        const features =
+            getEmitModuleResolutionKind(options) === ModuleResolutionKind.Node12 ? NodeResolutionFeatures.Node12Default :
+            getEmitModuleResolutionKind(options) === ModuleResolutionKind.NodeNext ? NodeResolutionFeatures.NodeNextDefault :
+            NodeResolutionFeatures.None;
+        const moduleResolutionState: ModuleResolutionState = { compilerOptions: options, host, traceEnabled, failedLookupLocations, packageJsonInfoCache: cache, features, conditions: ["node", "require", "types"] };
         let resolved = primaryLookup();
         let primary = true;
         if (!resolved) {
@@ -1186,6 +1190,10 @@ namespace ts {
         ExportsPatternTrailers = 1 << 4,
         AllFeatures = Imports | SelfName | Exports | ExportsPatternTrailers,
 
+        Node12Default = Imports | SelfName | Exports,
+
+        NodeNextDefault = AllFeatures,
+
         EsmMode = 1 << 5,
     }
 
@@ -1193,7 +1201,7 @@ namespace ts {
             host: ModuleResolutionHost, cache?: ModuleResolutionCache, redirectedReference?: ResolvedProjectReference,
             resolutionMode?: ModuleKind.CommonJS | ModuleKind.ESNext): ResolvedModuleWithFailedLookupLocations {
         return nodeNextModuleNameResolverWorker(
-            NodeResolutionFeatures.Imports | NodeResolutionFeatures.SelfName | NodeResolutionFeatures.Exports,
+            NodeResolutionFeatures.Node12Default,
             moduleName,
             containingFile,
             compilerOptions,
@@ -1208,7 +1216,7 @@ namespace ts {
             host: ModuleResolutionHost, cache?: ModuleResolutionCache, redirectedReference?: ResolvedProjectReference,
             resolutionMode?: ModuleKind.CommonJS | ModuleKind.ESNext): ResolvedModuleWithFailedLookupLocations {
         return nodeNextModuleNameResolverWorker(
-            NodeResolutionFeatures.AllFeatures,
+            NodeResolutionFeatures.NodeNextDefault,
             moduleName,
             containingFile,
             compilerOptions,

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=commonjs).js
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=commonjs).js
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/tripleSlashTypesReferenceWithMissingExports.ts] ////
+
+//// [index.d.ts]
+interface GlobalThing { a: number }
+//// [package.json]
+{
+    "name": "pkg",
+    "types": "index.d.ts",
+    "exports": "some-other-thing.js"
+}
+//// [usage.ts]
+/// <reference types="pkg" />
+
+const a: GlobalThing = { a: 0 };
+
+//// [usage.js]
+/// <reference types="pkg" />
+var a = { a: 0 };

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=commonjs).symbols
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=commonjs).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/node_modules/pkg/index.d.ts ===
+interface GlobalThing { a: number }
+>GlobalThing : Symbol(GlobalThing, Decl(index.d.ts, 0, 0))
+>a : Symbol(GlobalThing.a, Decl(index.d.ts, 0, 23))
+
+=== tests/cases/compiler/usage.ts ===
+/// <reference types="pkg" />
+
+const a: GlobalThing = { a: 0 };
+>a : Symbol(a, Decl(usage.ts, 2, 5))
+>GlobalThing : Symbol(GlobalThing, Decl(index.d.ts, 0, 0))
+>a : Symbol(a, Decl(usage.ts, 2, 24))
+

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=commonjs).types
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=commonjs).types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/node_modules/pkg/index.d.ts ===
+interface GlobalThing { a: number }
+>a : number
+
+=== tests/cases/compiler/usage.ts ===
+/// <reference types="pkg" />
+
+const a: GlobalThing = { a: 0 };
+>a : GlobalThing
+>{ a: 0 } : { a: number; }
+>a : number
+>0 : 0
+

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=node12).errors.txt
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=node12).errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/usage.ts(1,23): error TS2688: Cannot find type definition file for 'pkg'.
+
+
+==== tests/cases/compiler/node_modules/pkg/index.d.ts (0 errors) ====
+    interface GlobalThing { a: number }
+==== tests/cases/compiler/node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "types": "index.d.ts",
+        "exports": "some-other-thing.js"
+    }
+==== tests/cases/compiler/usage.ts (1 errors) ====
+    /// <reference types="pkg" />
+                          ~~~
+!!! error TS2688: Cannot find type definition file for 'pkg'.
+    
+    const a: GlobalThing = { a: 0 };

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=node12).js
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=node12).js
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/tripleSlashTypesReferenceWithMissingExports.ts] ////
+
+//// [index.d.ts]
+interface GlobalThing { a: number }
+//// [package.json]
+{
+    "name": "pkg",
+    "types": "index.d.ts",
+    "exports": "some-other-thing.js"
+}
+//// [usage.ts]
+/// <reference types="pkg" />
+
+const a: GlobalThing = { a: 0 };
+
+//// [usage.js]
+/// <reference types="pkg" />
+const a = { a: 0 };

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=node12).symbols
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=node12).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/node_modules/pkg/index.d.ts ===
+interface GlobalThing { a: number }
+>GlobalThing : Symbol(GlobalThing, Decl(index.d.ts, 0, 0))
+>a : Symbol(GlobalThing.a, Decl(index.d.ts, 0, 23))
+
+=== tests/cases/compiler/usage.ts ===
+/// <reference types="pkg" />
+
+const a: GlobalThing = { a: 0 };
+>a : Symbol(a, Decl(usage.ts, 2, 5))
+>GlobalThing : Symbol(GlobalThing, Decl(index.d.ts, 0, 0))
+>a : Symbol(a, Decl(usage.ts, 2, 24))
+

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=node12).types
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=node12).types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/node_modules/pkg/index.d.ts ===
+interface GlobalThing { a: number }
+>a : number
+
+=== tests/cases/compiler/usage.ts ===
+/// <reference types="pkg" />
+
+const a: GlobalThing = { a: 0 };
+>a : GlobalThing
+>{ a: 0 } : { a: number; }
+>a : number
+>0 : 0
+

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=nodenext).errors.txt
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=nodenext).errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/usage.ts(1,23): error TS2688: Cannot find type definition file for 'pkg'.
+
+
+==== tests/cases/compiler/node_modules/pkg/index.d.ts (0 errors) ====
+    interface GlobalThing { a: number }
+==== tests/cases/compiler/node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "types": "index.d.ts",
+        "exports": "some-other-thing.js"
+    }
+==== tests/cases/compiler/usage.ts (1 errors) ====
+    /// <reference types="pkg" />
+                          ~~~
+!!! error TS2688: Cannot find type definition file for 'pkg'.
+    
+    const a: GlobalThing = { a: 0 };

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=nodenext).js
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=nodenext).js
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/tripleSlashTypesReferenceWithMissingExports.ts] ////
+
+//// [index.d.ts]
+interface GlobalThing { a: number }
+//// [package.json]
+{
+    "name": "pkg",
+    "types": "index.d.ts",
+    "exports": "some-other-thing.js"
+}
+//// [usage.ts]
+/// <reference types="pkg" />
+
+const a: GlobalThing = { a: 0 };
+
+//// [usage.js]
+/// <reference types="pkg" />
+const a = { a: 0 };

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=nodenext).symbols
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=nodenext).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/node_modules/pkg/index.d.ts ===
+interface GlobalThing { a: number }
+>GlobalThing : Symbol(GlobalThing, Decl(index.d.ts, 0, 0))
+>a : Symbol(GlobalThing.a, Decl(index.d.ts, 0, 23))
+
+=== tests/cases/compiler/usage.ts ===
+/// <reference types="pkg" />
+
+const a: GlobalThing = { a: 0 };
+>a : Symbol(a, Decl(usage.ts, 2, 5))
+>GlobalThing : Symbol(GlobalThing, Decl(index.d.ts, 0, 0))
+>a : Symbol(a, Decl(usage.ts, 2, 24))
+

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=nodenext).types
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=nodenext).types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/node_modules/pkg/index.d.ts ===
+interface GlobalThing { a: number }
+>a : number
+
+=== tests/cases/compiler/usage.ts ===
+/// <reference types="pkg" />
+
+const a: GlobalThing = { a: 0 };
+>a : GlobalThing
+>{ a: 0 } : { a: number; }
+>a : number
+>0 : 0
+

--- a/tests/cases/compiler/tripleSlashTypesReferenceWithMissingExports.ts
+++ b/tests/cases/compiler/tripleSlashTypesReferenceWithMissingExports.ts
@@ -1,0 +1,13 @@
+// @module: commonjs,node12,nodenext
+// @filename: node_modules/pkg/index.d.ts
+interface GlobalThing { a: number }
+// @filename: node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "types": "index.d.ts",
+    "exports": "some-other-thing.js"
+}
+// @filename: usage.ts
+/// <reference types="pkg" />
+
+const a: GlobalThing = { a: 0 };


### PR DESCRIPTION
…for type reference directives, since they can add restrictions to resolutions (eg, `exports` that don't contain a `types` resolution and no adjacent declaration files to the js ones blocking use of a top-level `types` field). This should prevent the new module resolution features from affecting people who don't opt-in to them via the new module modes (though I'm pleased with how quickly it seems some of the affected packages reacted to add a `types` entry to their exports!).

Fixes #46860

cc @DanielRosenwasser because I imagine you'll want to backport this to 4.5
