### PR TITLE
Bind RHS of comma expressions too

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1365,7 +1365,7 @@ namespace ts {
         }
 
         function maybeBindExpressionFlowIfCall(node: Expression) {
-            // A top level or LHS of comma expression call expression with a dotted function name and at least one argument
+            // A top level or comma expression call expression with a dotted function name and at least one argument
             // is potentially an assertion and is therefore included in the control flow.
             if (node.kind === SyntaxKind.CallExpression) {
                 const call = node as CallExpression;

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1574,6 +1574,11 @@ namespace ts {
             function onExit(node: BinaryExpression, state: WorkArea) {
                 if (!state.skip) {
                     const operator = node.operatorToken.kind;
+
+                    if (operator === SyntaxKind.CommaToken) {
+                        maybeBindExpressionFlowIfCall(node.right);
+                    }
+
                     if (isAssignmentOperator(operator) && !isAssignmentTarget(node)) {
                         bindAssignmentTargetFlow(node.left);
                         if (operator === SyntaxKind.EqualsToken && node.left.kind === SyntaxKind.ElementAccessExpression) {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1550,35 +1550,35 @@ namespace ts {
                 return state;
             }
 
-            function onLeft(left: Expression, state: WorkArea, _node: BinaryExpression) {
+            function onLeft(left: Expression, state: WorkArea, node: BinaryExpression) {
                 if (!state.skip) {
-                    return maybeBind(left);
+                    const maybeBound = maybeBind(left);
+                    if (node.operatorToken.kind === SyntaxKind.CommaToken) {
+                        maybeBindExpressionFlowIfCall(left);
+                    }
+                    return maybeBound;
                 }
             }
 
-            function onOperator(operatorToken: BinaryOperatorToken, state: WorkArea, node: BinaryExpression) {
+            function onOperator(operatorToken: BinaryOperatorToken, state: WorkArea, _node: BinaryExpression) {
                 if (!state.skip) {
-                    if (operatorToken.kind === SyntaxKind.CommaToken) {
-                        maybeBindExpressionFlowIfCall(node.left);
-                    }
                     bind(operatorToken);
                 }
             }
 
-            function onRight(right: Expression, state: WorkArea, _node: BinaryExpression) {
+            function onRight(right: Expression, state: WorkArea, node: BinaryExpression) {
                 if (!state.skip) {
-                    return maybeBind(right);
+                    const maybeBound = maybeBind(right);
+                    if (node.operatorToken.kind === SyntaxKind.CommaToken) {
+                        maybeBindExpressionFlowIfCall(right);
+                    }
+                    return maybeBound;
                 }
             }
 
             function onExit(node: BinaryExpression, state: WorkArea) {
                 if (!state.skip) {
                     const operator = node.operatorToken.kind;
-
-                    if (operator === SyntaxKind.CommaToken) {
-                        maybeBindExpressionFlowIfCall(node.right);
-                    }
-
                     if (isAssignmentOperator(operator) && !isAssignmentTarget(node)) {
                         bindAssignmentTargetFlow(node.left);
                         if (operator === SyntaxKind.EqualsToken && node.left.kind === SyntaxKind.ElementAccessExpression) {

--- a/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.js
+++ b/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.js
@@ -1,0 +1,17 @@
+//// [controlFlowCommaExpressionAssertionMultiple.ts]
+function Narrow<T>(value: any): asserts value is T {}
+
+function func(foo: any, bar: any) {
+    Narrow<number>(foo), Narrow<string>(bar);
+    foo;
+    bar;
+}
+
+
+//// [controlFlowCommaExpressionAssertionMultiple.js]
+function Narrow(value) { }
+function func(foo, bar) {
+    Narrow(foo), Narrow(bar);
+    foo;
+    bar;
+}

--- a/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.js
+++ b/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.js
@@ -7,6 +7,13 @@ function func(foo: any, bar: any) {
     bar;
 }
 
+function func2(foo: any, bar: any, baz: any) {
+    Narrow<number>(foo), Narrow<string>(bar), Narrow<boolean>(baz);
+    foo;
+    bar;
+    baz;
+}
+
 
 //// [controlFlowCommaExpressionAssertionMultiple.js]
 function Narrow(value) { }
@@ -14,4 +21,10 @@ function func(foo, bar) {
     Narrow(foo), Narrow(bar);
     foo;
     bar;
+}
+function func2(foo, bar, baz) {
+    Narrow(foo), Narrow(bar), Narrow(baz);
+    foo;
+    bar;
+    baz;
 }

--- a/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.symbols
+++ b/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/controlFlowCommaExpressionAssertionMultiple.ts ===
+function Narrow<T>(value: any): asserts value is T {}
+>Narrow : Symbol(Narrow, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 0))
+>T : Symbol(T, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 16))
+>value : Symbol(value, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 19))
+>value : Symbol(value, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 19))
+>T : Symbol(T, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 16))
+
+function func(foo: any, bar: any) {
+>func : Symbol(func, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 53))
+>foo : Symbol(foo, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 2, 14))
+>bar : Symbol(bar, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 2, 23))
+
+    Narrow<number>(foo), Narrow<string>(bar);
+>Narrow : Symbol(Narrow, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 0))
+>foo : Symbol(foo, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 2, 14))
+>Narrow : Symbol(Narrow, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 0))
+>bar : Symbol(bar, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 2, 23))
+
+    foo;
+>foo : Symbol(foo, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 2, 14))
+
+    bar;
+>bar : Symbol(bar, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 2, 23))
+}
+

--- a/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.symbols
+++ b/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.symbols
@@ -24,3 +24,27 @@ function func(foo: any, bar: any) {
 >bar : Symbol(bar, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 2, 23))
 }
 
+function func2(foo: any, bar: any, baz: any) {
+>func2 : Symbol(func2, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 6, 1))
+>foo : Symbol(foo, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 8, 15))
+>bar : Symbol(bar, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 8, 24))
+>baz : Symbol(baz, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 8, 34))
+
+    Narrow<number>(foo), Narrow<string>(bar), Narrow<boolean>(baz);
+>Narrow : Symbol(Narrow, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 0))
+>foo : Symbol(foo, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 8, 15))
+>Narrow : Symbol(Narrow, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 0))
+>bar : Symbol(bar, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 8, 24))
+>Narrow : Symbol(Narrow, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 0, 0))
+>baz : Symbol(baz, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 8, 34))
+
+    foo;
+>foo : Symbol(foo, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 8, 15))
+
+    bar;
+>bar : Symbol(bar, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 8, 24))
+
+    baz;
+>baz : Symbol(baz, Decl(controlFlowCommaExpressionAssertionMultiple.ts, 8, 34))
+}
+

--- a/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.types
+++ b/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.types
@@ -24,3 +24,32 @@ function func(foo: any, bar: any) {
 >bar : string
 }
 
+function func2(foo: any, bar: any, baz: any) {
+>func2 : (foo: any, bar: any, baz: any) => void
+>foo : any
+>bar : any
+>baz : any
+
+    Narrow<number>(foo), Narrow<string>(bar), Narrow<boolean>(baz);
+>Narrow<number>(foo), Narrow<string>(bar), Narrow<boolean>(baz) : void
+>Narrow<number>(foo), Narrow<string>(bar) : void
+>Narrow<number>(foo) : void
+>Narrow : <T>(value: any) => asserts value is T
+>foo : any
+>Narrow<string>(bar) : void
+>Narrow : <T>(value: any) => asserts value is T
+>bar : any
+>Narrow<boolean>(baz) : void
+>Narrow : <T>(value: any) => asserts value is T
+>baz : any
+
+    foo;
+>foo : number
+
+    bar;
+>bar : string
+
+    baz;
+>baz : boolean
+}
+

--- a/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.types
+++ b/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.types
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/controlFlowCommaExpressionAssertionMultiple.ts ===
+function Narrow<T>(value: any): asserts value is T {}
+>Narrow : <T>(value: any) => asserts value is T
+>value : any
+
+function func(foo: any, bar: any) {
+>func : (foo: any, bar: any) => void
+>foo : any
+>bar : any
+
+    Narrow<number>(foo), Narrow<string>(bar);
+>Narrow<number>(foo), Narrow<string>(bar) : void
+>Narrow<number>(foo) : void
+>Narrow : <T>(value: any) => asserts value is T
+>foo : any
+>Narrow<string>(bar) : void
+>Narrow : <T>(value: any) => asserts value is T
+>bar : any
+
+    foo;
+>foo : number
+
+    bar;
+>bar : any
+}
+

--- a/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.types
+++ b/tests/baselines/reference/controlFlowCommaExpressionAssertionMultiple.types
@@ -21,6 +21,6 @@ function func(foo: any, bar: any) {
 >foo : number
 
     bar;
->bar : any
+>bar : string
 }
 

--- a/tests/cases/compiler/controlFlowCommaExpressionAssertionMultiple.ts
+++ b/tests/cases/compiler/controlFlowCommaExpressionAssertionMultiple.ts
@@ -1,0 +1,7 @@
+function Narrow<T>(value: any): asserts value is T {}
+
+function func(foo: any, bar: any) {
+    Narrow<number>(foo), Narrow<string>(bar);
+    foo;
+    bar;
+}

--- a/tests/cases/compiler/controlFlowCommaExpressionAssertionMultiple.ts
+++ b/tests/cases/compiler/controlFlowCommaExpressionAssertionMultiple.ts
@@ -5,3 +5,10 @@ function func(foo: any, bar: any) {
     foo;
     bar;
 }
+
+function func2(foo: any, bar: any, baz: any) {
+    Narrow<number>(foo), Narrow<string>(bar), Narrow<boolean>(baz);
+    foo;
+    bar;
+    baz;
+}


### PR DESCRIPTION
Fixes #44487

This is an extension of #41312, applying `maybeBindExpressionFlowIfCall` the RHS too. The argument there was:

> just like lists of statements, they generally only exist to compose lists of possibly-side-effecting actions (like, say, assertions).

I'd argue that this means that the entire chain of items in a comma expression (of any size) should have this applied, since they are being thought of here as a list of statements with potential side effects, and not just the leftmost expression.