### PR TITLE
Enable customDescriptionGenerator in launch template, update eslint setting

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -48,11 +48,7 @@
       "outFiles": [
         "${workspaceRoot}/built/local/run.js"
       ],
-
-      // NOTE: To use this, you must switch the "type" above to "pwa-node". You may also need to follow the instructions
-      // here: https://github.com/microsoft/vscode-js-debug#nightly-extension to use the js-debug nightly until
-      // this feature is shipping in insiders or to a release:
-      // "customDescriptionGenerator": "'__tsDebuggerDisplay' in this ? this.__tsDebuggerDisplay(defaultValue) : defaultValue"
+      "customDescriptionGenerator": "'__tsDebuggerDisplay' in this ? this.__tsDebuggerDisplay(defaultValue) : defaultValue",
     },
     {
       // See: https://github.com/microsoft/TypeScript/wiki/Debugging-Language-Service-in-VS-Code
@@ -60,11 +56,7 @@
       "request": "attach",
       "name": "Attach to VS Code TS Server via Port",
       "processId": "${command:PickProcess}",
-
-      // NOTE: To use this, you must switch the "type" above to "pwa-node". You may also need to follow the instructions
-      // here: https://github.com/microsoft/vscode-js-debug#nightly-extension to use the js-debug nightly until
-      // this feature is shipping in insiders or to a release:
-      // "customDescriptionGenerator": "'__tsDebuggerDisplay' in this ? this.__tsDebuggerDisplay(defaultValue) : defaultValue"
+      "customDescriptionGenerator": "'__tsDebuggerDisplay' in this ? this.__tsDebuggerDisplay(defaultValue) : defaultValue",
     }
   ]
 }

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -2,10 +2,7 @@
 // contents into your existing settings.
 {
     "eslint.validate": [
-        {
-            "language": "typescript",
-            "autoFix": true
-        }
+        "typescript"
     ],
     "eslint.options": {
         "rulePaths": ["./scripts/eslint/built/rules/"],


### PR DESCRIPTION
`customDescriptionGenerator` was added in #40308; the new debugger has been the default in VS Code for a few months now, so I think it'd be a good idea to recommend this (it's certainly helped me).

Additionally, silence a warning from the ESLint extension about an out-of-date configuration setup.
