### PR TITLE
Ensure distributive constraints of restrictive instantiations of type parameters don't exist

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11775,7 +11775,7 @@ namespace ts {
             if (type.root.isDistributive && type.restrictiveInstantiation !== type) {
                 const simplified = getSimplifiedType(type.checkType, /*writing*/ false);
                 const constraint = simplified === type.checkType ? getConstraintOfType(simplified) : simplified;
-                if (constraint && constraint !== type.checkType) {
+                if (constraint && constraint !== type.checkType && simplified.restrictiveInstantiation !== simplified) {
                     const instantiated = getConditionalTypeInstantiation(type, prependTypeMapping(type.root.checkType, constraint, type.mapper));
                     if (!(instantiated.flags & TypeFlags.Never)) {
                         return instantiated;
@@ -16436,6 +16436,7 @@ namespace ts {
             return tp.constraint === unknownType ? tp : tp.restrictiveInstantiation || (
                 tp.restrictiveInstantiation = createTypeParameter(tp.symbol),
                 (tp.restrictiveInstantiation as TypeParameter).constraint = unknownType,
+                (tp.restrictiveInstantiation as TypeParameter).restrictiveInstantiation = tp.restrictiveInstantiation,
                 tp.restrictiveInstantiation
             );
         }

--- a/tests/baselines/reference/conditionalTypesCheckingConditionalTypes.js
+++ b/tests/baselines/reference/conditionalTypesCheckingConditionalTypes.js
@@ -1,0 +1,10 @@
+//// [conditionalTypesCheckingConditionalTypes.ts]
+type Bit = 0 | 1;
+type And<A extends Bit, B extends Bit> = [A, B] extends [1, 1] ? 1 : 0;
+
+type Test<A extends Bit, B extends Bit> = And<A extends 1 ? 0 : 1, B extends 1 ? 0 : 1>;
+//    ^? type Test<I1 extends Bit, I2 extends Bit> = 1
+
+type a = Test<1, 1>; // 1, should be 0
+
+//// [conditionalTypesCheckingConditionalTypes.js]

--- a/tests/baselines/reference/conditionalTypesCheckingConditionalTypes.symbols
+++ b/tests/baselines/reference/conditionalTypesCheckingConditionalTypes.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/conditionalTypesCheckingConditionalTypes.ts ===
+type Bit = 0 | 1;
+>Bit : Symbol(Bit, Decl(conditionalTypesCheckingConditionalTypes.ts, 0, 0))
+
+type And<A extends Bit, B extends Bit> = [A, B] extends [1, 1] ? 1 : 0;
+>And : Symbol(And, Decl(conditionalTypesCheckingConditionalTypes.ts, 0, 17))
+>A : Symbol(A, Decl(conditionalTypesCheckingConditionalTypes.ts, 1, 9))
+>Bit : Symbol(Bit, Decl(conditionalTypesCheckingConditionalTypes.ts, 0, 0))
+>B : Symbol(B, Decl(conditionalTypesCheckingConditionalTypes.ts, 1, 23))
+>Bit : Symbol(Bit, Decl(conditionalTypesCheckingConditionalTypes.ts, 0, 0))
+>A : Symbol(A, Decl(conditionalTypesCheckingConditionalTypes.ts, 1, 9))
+>B : Symbol(B, Decl(conditionalTypesCheckingConditionalTypes.ts, 1, 23))
+
+type Test<A extends Bit, B extends Bit> = And<A extends 1 ? 0 : 1, B extends 1 ? 0 : 1>;
+>Test : Symbol(Test, Decl(conditionalTypesCheckingConditionalTypes.ts, 1, 71))
+>A : Symbol(A, Decl(conditionalTypesCheckingConditionalTypes.ts, 3, 10))
+>Bit : Symbol(Bit, Decl(conditionalTypesCheckingConditionalTypes.ts, 0, 0))
+>B : Symbol(B, Decl(conditionalTypesCheckingConditionalTypes.ts, 3, 24))
+>Bit : Symbol(Bit, Decl(conditionalTypesCheckingConditionalTypes.ts, 0, 0))
+>And : Symbol(And, Decl(conditionalTypesCheckingConditionalTypes.ts, 0, 17))
+>A : Symbol(A, Decl(conditionalTypesCheckingConditionalTypes.ts, 3, 10))
+>B : Symbol(B, Decl(conditionalTypesCheckingConditionalTypes.ts, 3, 24))
+
+//    ^? type Test<I1 extends Bit, I2 extends Bit> = 1
+
+type a = Test<1, 1>; // 1, should be 0
+>a : Symbol(a, Decl(conditionalTypesCheckingConditionalTypes.ts, 3, 88))
+>Test : Symbol(Test, Decl(conditionalTypesCheckingConditionalTypes.ts, 1, 71))
+

--- a/tests/baselines/reference/conditionalTypesCheckingConditionalTypes.types
+++ b/tests/baselines/reference/conditionalTypesCheckingConditionalTypes.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/conditionalTypesCheckingConditionalTypes.ts ===
+type Bit = 0 | 1;
+>Bit : Bit
+
+type And<A extends Bit, B extends Bit> = [A, B] extends [1, 1] ? 1 : 0;
+>And : And<A, B>
+
+type Test<A extends Bit, B extends Bit> = And<A extends 1 ? 0 : 1, B extends 1 ? 0 : 1>;
+>Test : Test<A, B>
+
+//    ^? type Test<I1 extends Bit, I2 extends Bit> = 1
+
+type a = Test<1, 1>; // 1, should be 0
+>a : 0
+

--- a/tests/baselines/reference/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.errors.txt
+++ b/tests/baselines/reference/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.errors.txt
@@ -8,8 +8,7 @@ tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcre
               Type 'ReturnType<T[string]>' is not assignable to type 'A'.
                 Type 'unknown' is not assignable to type 'A'.
                   Type 'ReturnType<FunctionsObj<T>[string]>' is not assignable to type 'A'.
-                    Type 'unknown' is not assignable to type 'A'.
-                      Property 'x' is missing in type '{}' but required in type 'A'.
+                    Property 'x' is missing in type '{}' but required in type 'A'.
 
 
 ==== tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.ts (1 errors) ====
@@ -37,8 +36,7 @@ tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcre
 !!! error TS2322:               Type 'ReturnType<T[string]>' is not assignable to type 'A'.
 !!! error TS2322:                 Type 'unknown' is not assignable to type 'A'.
 !!! error TS2322:                   Type 'ReturnType<FunctionsObj<T>[string]>' is not assignable to type 'A'.
-!!! error TS2322:                     Type 'unknown' is not assignable to type 'A'.
-!!! error TS2322:                       Property 'x' is missing in type '{}' but required in type 'A'.
+!!! error TS2322:                     Property 'x' is missing in type '{}' but required in type 'A'.
 !!! related TS2728 tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.ts:1:15: 'x' is declared here.
     }
     

--- a/tests/cases/compiler/conditionalTypesCheckingConditionalTypes.ts
+++ b/tests/cases/compiler/conditionalTypesCheckingConditionalTypes.ts
@@ -1,0 +1,7 @@
+type Bit = 0 | 1;
+type And<A extends Bit, B extends Bit> = [A, B] extends [1, 1] ? 1 : 0;
+
+type Test<A extends Bit, B extends Bit> = And<A extends 1 ? 0 : 1, B extends 1 ? 0 : 1>;
+//    ^? type Test<I1 extends Bit, I2 extends Bit> = 1
+
+type a = Test<1, 1>; // 1, should be 0


### PR DESCRIPTION
Since restrictive instantiations replace type parameter constraints with `unknown`, if we use them to calculate a distributive constraint, we produce _very_ wrong results. So we try to see if we're looking at such an instantiation when calculating a distributive constraint now, and choose to not yield a constraint if that is the case.

Fixes #46761
