### PR TITLE
Process package.json exports with auto-import provider

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1643,8 +1643,7 @@ namespace ts {
 
         function loadEntrypointsFromTargetExports(target: unknown) {
             if (typeof target === "string" && startsWith(target, "./") && target.indexOf("*") === -1) {
-                const parts = getPathComponents(target).slice(1);
-                const partsAfterFirst = parts.slice(1);
+                const partsAfterFirst = getPathComponents(target).slice(2);
                 if (partsAfterFirst.indexOf("..") >= 0 || partsAfterFirst.indexOf(".") >= 0 || partsAfterFirst.indexOf("node_modules") >= 0) {
                     return;
                 }

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1205,11 +1205,6 @@ namespace ts {
     }
 
     /* @internal */
-    export function tryResolveJSModule(moduleName: string, initialDir: string, host: ModuleResolutionHost) {
-        return tryResolveJSModuleWorker(moduleName, initialDir, host).resolvedModule;
-    }
-
-    /* @internal */
     enum NodeResolutionFeatures {
         None = 0,
         // resolving `#local` names in your own package.json

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1600,15 +1600,17 @@ namespace ts {
         entrypoints = append(entrypoints, requireResolution?.path);
 
         if (features & NodeResolutionFeatures.Exports && packageJsonInfo.packageJsonContent.exports) {
-            const exportState = { ...requireState, failedLookupLocations: [], conditions: ["node", "import", "require", "types"] };
-            const exportResolutions = loadEntrypointsFromExportMap(
-                packageJsonInfo,
-                packageJsonInfo.packageJsonContent.exports,
-                exportState,
-                extensions);
-            if (exportResolutions) {
-                for (const resolution of exportResolutions) {
-                    entrypoints = appendIfUnique(entrypoints, resolution.path);
+            for (const conditions of [["node", "import", "types"], ["node", "require", "types"]]) {
+                const exportState = { ...requireState, failedLookupLocations: [], conditions };
+                const exportResolutions = loadEntrypointsFromExportMap(
+                    packageJsonInfo,
+                    packageJsonInfo.packageJsonContent.exports,
+                    exportState,
+                    extensions);
+                if (exportResolutions) {
+                    for (const resolution of exportResolutions) {
+                        entrypoints = appendIfUnique(entrypoints, resolution.path);
+                    }
                 }
             }
         }

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -59,19 +59,29 @@ namespace ts.moduleSpecifiers {
         };
     }
 
+    // `importingSourceFile` and `importingSourceFileName`? Why not just use `importingSourceFile.path`?
+    // Because when this is called by the file renamer, `importingSourceFile` is the file being renamed,
+    // while `importingSourceFileName` its *new* name. We need a source file just to get its
+    // `impliedNodeFormat` and to detect certain preferences from existing import module specifiers.
     export function updateModuleSpecifier(
         compilerOptions: CompilerOptions,
+        importingSourceFile: SourceFile,
         importingSourceFileName: Path,
         toFileName: string,
         host: ModuleSpecifierResolutionHost,
         oldImportSpecifier: string,
     ): string | undefined {
-        const res = getModuleSpecifierWorker(compilerOptions, importingSourceFileName, toFileName, host, getPreferencesForUpdate(compilerOptions, oldImportSpecifier, importingSourceFileName, host), {});
+        const res = getModuleSpecifierWorker(compilerOptions, importingSourceFile, importingSourceFile.path, toFileName, host, getPreferencesForUpdate(compilerOptions, oldImportSpecifier, importingSourceFileName, host), {});
         if (res === oldImportSpecifier) return undefined;
         return res;
     }
 
-    // Note: importingSourceFile is just for usesJsExtensionOnImports
+    // `importingSourceFile` and `importingSourceFileName`? Why not just use `importingSourceFile.path`?
+    // Because when this is called by the declaration emitter, `importingSourceFile` is the implementation
+    // file, but `importingSourceFileName` and `toFileName` refer to declaration files (the former to the
+    // one currently being produced; the latter to the one being imported). We need an implementation file
+    // just to get its `impliedNodeFormat` and to detect certain preferences from existing import module
+    // specifiers.
     export function getModuleSpecifier(
         compilerOptions: CompilerOptions,
         importingSourceFile: SourceFile,
@@ -79,24 +89,25 @@ namespace ts.moduleSpecifiers {
         toFileName: string,
         host: ModuleSpecifierResolutionHost,
     ): string {
-        return getModuleSpecifierWorker(compilerOptions, importingSourceFileName, toFileName, host, getPreferences(host, {}, compilerOptions, importingSourceFile), {});
+        return getModuleSpecifierWorker(compilerOptions, importingSourceFile, importingSourceFileName, toFileName, host, getPreferences(host, {}, compilerOptions, importingSourceFile), {});
     }
 
     export function getNodeModulesPackageName(
         compilerOptions: CompilerOptions,
-        importingSourceFileName: Path,
+        importingSourceFile: SourceFile,
         nodeModulesFileName: string,
         host: ModuleSpecifierResolutionHost,
         preferences: UserPreferences,
     ): string | undefined {
-        const info = getInfo(importingSourceFileName, host);
-        const modulePaths = getAllModulePaths(importingSourceFileName, nodeModulesFileName, host, preferences);
+        const info = getInfo(importingSourceFile.path, host);
+        const modulePaths = getAllModulePaths(importingSourceFile.path, nodeModulesFileName, host, preferences);
         return firstDefined(modulePaths,
-            modulePath => tryGetModuleNameAsNodeModule(modulePath, info, host, compilerOptions, /*packageNameOnly*/ true));
+            modulePath => tryGetModuleNameAsNodeModule(modulePath, info, importingSourceFile, host, compilerOptions, /*packageNameOnly*/ true));
     }
 
     function getModuleSpecifierWorker(
         compilerOptions: CompilerOptions,
+        importingSourceFile: SourceFile,
         importingSourceFileName: Path,
         toFileName: string,
         host: ModuleSpecifierResolutionHost,
@@ -105,7 +116,7 @@ namespace ts.moduleSpecifiers {
     ): string {
         const info = getInfo(importingSourceFileName, host);
         const modulePaths = getAllModulePaths(importingSourceFileName, toFileName, host, userPreferences);
-        return firstDefined(modulePaths, modulePath => tryGetModuleNameAsNodeModule(modulePath, info, host, compilerOptions)) ||
+        return firstDefined(modulePaths, modulePath => tryGetModuleNameAsNodeModule(modulePath, info, importingSourceFile, host, compilerOptions)) ||
             getLocalModuleSpecifier(toFileName, info, compilerOptions, host, preferences);
     }
 
@@ -222,7 +233,7 @@ namespace ts.moduleSpecifiers {
         let pathsSpecifiers: string[] | undefined;
         let relativeSpecifiers: string[] | undefined;
         for (const modulePath of modulePaths) {
-            const specifier = tryGetModuleNameAsNodeModule(modulePath, info, host, compilerOptions);
+            const specifier = tryGetModuleNameAsNodeModule(modulePath, info, importingSourceFile, host, compilerOptions);
             nodeModulesSpecifiers = append(nodeModulesSpecifiers, specifier);
             if (specifier && modulePath.isRedirect) {
                 // If we got a specifier for a redirect, it was a bare package specifier (e.g. "@foo/bar",
@@ -639,7 +650,7 @@ namespace ts.moduleSpecifiers {
             : removeFileExtension(relativePath);
     }
 
-    function tryGetModuleNameAsNodeModule({ path, isRedirect }: ModulePath, { getCanonicalFileName, sourceDirectory }: Info, host: ModuleSpecifierResolutionHost, options: CompilerOptions, packageNameOnly?: boolean): string | undefined {
+    function tryGetModuleNameAsNodeModule({ path, isRedirect }: ModulePath, { getCanonicalFileName, sourceDirectory }: Info, importingSourceFile: SourceFile , host: ModuleSpecifierResolutionHost, options: CompilerOptions, packageNameOnly?: boolean): string | undefined {
         if (!host.fileExists || !host.readFile) {
             return undefined;
         }
@@ -706,10 +717,14 @@ namespace ts.moduleSpecifiers {
             let moduleFileToTry = path;
             if (host.fileExists(packageJsonPath)) {
                 const packageJsonContent = JSON.parse(host.readFile!(packageJsonPath)!);
-                // TODO: Inject `require` or `import` condition based on the intended import mode
                 if (getEmitModuleResolutionKind(options) === ModuleResolutionKind.Node12 || getEmitModuleResolutionKind(options) === ModuleResolutionKind.NodeNext) {
+                    // `conditions` *could* be made to go against `importingSourceFile.impliedNodeFormat` if something wanted to generate
+                    // an ImportEqualsDeclaration in an ESM-implied file or an ImportCall in a CJS-implied file. But since this function is
+                    // usually called to conjure an import out of thin air, we don't have an existing usage to call `getModeForUsageAtIndex`
+                    // with, so for now we just stick with the mode of the file.
+                    const conditions = ["node", importingSourceFile.impliedNodeFormat === ModuleKind.ESNext ? "import" : "require", "types"];
                     const fromExports = packageJsonContent.exports && typeof packageJsonContent.name === "string"
-                        ? tryGetModuleNameFromExports(options, path, packageRootPath, getPackageNameFromTypesPackageName(packageJsonContent.name), packageJsonContent.exports, ["node", "types"])
+                        ? tryGetModuleNameFromExports(options, path, packageRootPath, getPackageNameFromTypesPackageName(packageJsonContent.name), packageJsonContent.exports, conditions)
                         : undefined;
                     if (fromExports) {
                         const withJsExtension = !hasTSFileExtension(fromExports.moduleFileToTry)

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -708,9 +708,13 @@ namespace ts.moduleSpecifiers {
                 const packageJsonContent = JSON.parse(host.readFile!(packageJsonPath)!);
                 // TODO: Inject `require` or `import` condition based on the intended import mode
                 if (getEmitModuleResolutionKind(options) === ModuleResolutionKind.Node12 || getEmitModuleResolutionKind(options) === ModuleResolutionKind.NodeNext) {
-                    const fromExports = packageJsonContent.exports && typeof packageJsonContent.name === "string" ? tryGetModuleNameFromExports(options, path, packageRootPath, packageJsonContent.name, packageJsonContent.exports, ["node", "types"]) : undefined;
+                    const fromExports = packageJsonContent.exports && typeof packageJsonContent.name === "string"
+                        ? tryGetModuleNameFromExports(options, path, packageRootPath, getPackageNameFromTypesPackageName(packageJsonContent.name), packageJsonContent.exports, ["node", "types"])
+                        : undefined;
                     if (fromExports) {
-                        const withJsExtension = !hasTSFileExtension(fromExports.moduleFileToTry) ? fromExports : { moduleFileToTry: removeFileExtension(fromExports.moduleFileToTry) + tryGetJSExtensionForFile(fromExports.moduleFileToTry, options) };
+                        const withJsExtension = !hasTSFileExtension(fromExports.moduleFileToTry)
+                            ? fromExports
+                            : { moduleFileToTry: removeFileExtension(fromExports.moduleFileToTry) + tryGetJSExtensionForFile(fromExports.moduleFileToTry, options) };
                         return { ...withJsExtension, verbatimFromExports: true };
                     }
                     if (packageJsonContent.exports) {

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -71,7 +71,7 @@ namespace ts.moduleSpecifiers {
         host: ModuleSpecifierResolutionHost,
         oldImportSpecifier: string,
     ): string | undefined {
-        const res = getModuleSpecifierWorker(compilerOptions, importingSourceFile, importingSourceFile.path, toFileName, host, getPreferencesForUpdate(compilerOptions, oldImportSpecifier, importingSourceFileName, host), {});
+        const res = getModuleSpecifierWorker(compilerOptions, importingSourceFile, importingSourceFileName, toFileName, host, getPreferencesForUpdate(compilerOptions, oldImportSpecifier, importingSourceFileName, host), {});
         if (res === oldImportSpecifier) return undefined;
         return res;
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6306,8 +6306,6 @@ namespace ts {
         getSymlinkedFiles(): ReadonlyESMap<Path, string> | undefined;
         setSymlinkedDirectory(symlink: string, real: SymlinkedDirectory | false): void;
         setSymlinkedFile(symlinkPath: Path, real: string): void;
-        /*@internal*/
-        setSymlinkedDirectoryFromSymlinkedFile(symlink: string, real: string): void;
         /**
          * @internal
          * Uses resolvedTypeReferenceDirectives from program instead of from files, since files
@@ -6343,16 +6341,6 @@ namespace ts {
                         (symlinkedDirectoriesByRealpath ||= createMultiMap()).add(ensureTrailingDirectorySeparator(real.realPath), symlink);
                     }
                     (symlinkedDirectories || (symlinkedDirectories = new Map())).set(symlinkPath, real);
-                }
-            },
-            setSymlinkedDirectoryFromSymlinkedFile(symlink, real) {
-                this.setSymlinkedFile(toPath(symlink, cwd, getCanonicalFileName), real);
-                const [commonResolved, commonOriginal] = guessDirectorySymlink(real, symlink, cwd, getCanonicalFileName) || emptyArray;
-                if (commonResolved && commonOriginal) {
-                    this.setSymlinkedDirectory(commonOriginal, {
-                        real: commonResolved,
-                        realPath: toPath(commonResolved, cwd, getCanonicalFileName),
-                    });
                 }
             },
             setSymlinksFromResolutions(files, typeReferenceDirectives) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1988,7 +1988,7 @@ namespace ts.server {
 
             type PackageJsonInfo = Exclude<ReturnType<typeof resolvePackageNameToPackageJson>, undefined>;
             function getRootNamesFromPackageJson(packageJson: PackageJsonInfo, program: Program, symlinkCache: SymlinkCache, resolveJs?: boolean) {
-                const entrypoints = loadEntrypointsFromPackageJsonInfo(
+                const entrypoints = getEntrypointsFromPackageJsonInfo(
                     packageJson,
                     compilerOptions,
                     moduleResolutionHost,
@@ -2005,8 +2005,8 @@ namespace ts.server {
                     }
 
                     return mapDefined(entrypoints, entrypoint => {
-                        const resolvedFileName = isSymlink ? entrypoint.path.replace(packageJson.packageDirectory, real) : entrypoint.path;
-                        if (!program.getSourceFile(resolvedFileName) && (!isSymlink || !program.getSourceFile(entrypoint.path))) {
+                        const resolvedFileName = isSymlink ? entrypoint.replace(packageJson.packageDirectory, real) : entrypoint;
+                        if (!program.getSourceFile(resolvedFileName) && (!isSymlink || !program.getSourceFile(entrypoint))) {
                             return resolvedFileName;
                         }
                     });

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1986,7 +1986,7 @@ namespace ts.server {
                 }
             }
 
-            type PackageJsonInfo = Exclude<ReturnType<typeof resolvePackageNameToPackageJson>, undefined>;
+            type PackageJsonInfo = NonNullable<ReturnType<typeof resolvePackageNameToPackageJson>>;
             function getRootNamesFromPackageJson(packageJson: PackageJsonInfo, program: Program, symlinkCache: SymlinkCache, resolveJs?: boolean) {
                 const entrypoints = getEntrypointsFromPackageJsonInfo(
                     packageJson,
@@ -2006,7 +2006,7 @@ namespace ts.server {
 
                     return mapDefined(entrypoints, entrypoint => {
                         const resolvedFileName = isSymlink ? entrypoint.replace(packageJson.packageDirectory, real) : entrypoint;
-                        if (!program.getSourceFile(resolvedFileName) && (!isSymlink || !program.getSourceFile(entrypoint))) {
+                        if (!program.getSourceFile(resolvedFileName) && !(isSymlink && program.getSourceFile(entrypoint))) {
                             return resolvedFileName;
                         }
                     });

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -156,7 +156,7 @@ namespace ts {
 
                     // Need an update if the imported file moved, or the importing file moved and was using a relative path.
                     return toImport !== undefined && (toImport.updated || (importingSourceFileMoved && pathIsRelative(importLiteral.text)))
-                        ? moduleSpecifiers.updateModuleSpecifier(program.getCompilerOptions(), getCanonicalFileName(newImportFromPath) as Path, toImport.newFileName, createModuleSpecifierResolutionHost(program, host), importLiteral.text)
+                        ? moduleSpecifiers.updateModuleSpecifier(program.getCompilerOptions(), sourceFile, getCanonicalFileName(newImportFromPath) as Path, toImport.newFileName, createModuleSpecifierResolutionHost(program, host), importLiteral.text)
                         : undefined;
                 });
         }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3085,7 +3085,7 @@ namespace ts {
             }
             const specifier = moduleSpecifiers.getNodeModulesPackageName(
                 host.getCompilationSettings(),
-                fromFile.path,
+                fromFile,
                 importedFileName,
                 moduleSpecifierResolutionHost,
                 preferences,

--- a/src/testRunner/unittests/tsserver/exportMapCache.ts
+++ b/src/testRunner/unittests/tsserver/exportMapCache.ts
@@ -19,6 +19,10 @@ namespace ts.projectSystem {
         path: "/ambient.d.ts",
         content: "declare module 'ambient' {}"
     };
+    const mobxPackageJson: File = {
+        path: "/node_modules/mobx/package.json",
+        content: `{ "name": "mobx", "version": "1.0.0" }`
+    };
     const mobxDts: File = {
         path: "/node_modules/mobx/index.d.ts",
         content: "export declare function observable(): unknown;"
@@ -118,7 +122,7 @@ namespace ts.projectSystem {
     });
 
     function setup() {
-        const host = createServerHost([aTs, bTs, ambientDeclaration, tsconfig, packageJson, mobxDts, exportEqualsMappedType]);
+        const host = createServerHost([aTs, bTs, ambientDeclaration, tsconfig, packageJson, mobxPackageJson, mobxDts, exportEqualsMappedType]);
         const session = createSession(host);
         openFilesForSession([aTs, bTs], session);
         const projectService = session.getProjectService();

--- a/src/testRunner/unittests/tsserver/moduleSpecifierCache.ts
+++ b/src/testRunner/unittests/tsserver/moduleSpecifierCache.ts
@@ -27,6 +27,10 @@ namespace ts.projectSystem {
         path: "/src/ambient.d.ts",
         content: "declare module 'ambient' {}"
     };
+    const mobxPackageJson: File = {
+        path: "/node_modules/mobx/package.json",
+        content: `{ "name": "mobx", "version": "1.0.0" }`
+    };
     const mobxDts: File = {
         path: "/node_modules/mobx/index.d.ts",
         content: "export declare function observable(): unknown;"
@@ -120,7 +124,7 @@ namespace ts.projectSystem {
     });
 
     function setup() {
-        const host = createServerHost([aTs, bTs, cTs, bSymlink, ambientDeclaration, tsconfig, packageJson, mobxDts]);
+        const host = createServerHost([aTs, bTs, cTs, bSymlink, ambientDeclaration, tsconfig, packageJson, mobxPackageJson, mobxDts]);
         const session = createSession(host);
         openFilesForSession([aTs, bTs, cTs], session);
         const projectService = session.getProjectService();

--- a/src/testRunner/unittests/tsserver/symlinkCache.ts
+++ b/src/testRunner/unittests/tsserver/symlinkCache.ts
@@ -60,7 +60,12 @@ namespace ts.projectSystem {
 
         it("works for paths close to the root", () => {
             const cache = createSymlinkCache("/", createGetCanonicalFileName(/*useCaseSensitiveFileNames*/ false));
-            cache.setSymlinkedDirectoryFromSymlinkedFile("/foo", "/one/two/foo"); // Used to crash, #44953
+            // Used to crash, #44953
+            cache.setSymlinksFromResolutions([], new Map([["foo", {
+                primary: true,
+                originalPath: "/foo",
+                resolvedFileName: "/one/two/foo",
+            }]]));
         });
     });
 

--- a/tests/cases/fourslash/server/autoImportProvider8.ts
+++ b/tests/cases/fourslash/server/autoImportProvider8.ts
@@ -1,0 +1,68 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "commonjs" } }
+
+// @Filename: /package.json
+//// { "dependencies": { "mylib": "file:packages/mylib" } }
+
+// @Filename: /packages/mylib/package.json
+//// { "name": "mylib", "version": "1.0.0" }
+
+// @Filename: /packages/mylib/index.ts
+//// export * from "./mySubDir";
+
+// @Filename: /packages/mylib/mySubDir/index.ts
+//// export * from "./myClass";
+//// export * from "./myClass2";
+
+// @Filename: /packages/mylib/mySubDir/myClass.ts
+//// export class MyClass {}
+
+// @Filename: /packages/mylib/mySubDir/myClass2.ts
+//// export class MyClass2 {}
+
+// @link: /packages/mylib -> /node_modules/mylib
+
+// @Filename: /src/index.ts
+//// 
+//// const a = new MyClass/*1*/();
+//// const b = new MyClass2/*2*/();
+
+goTo.marker("1");
+format.setOption("newLineCharacter", "\n");
+
+verify.completions({
+  marker: "1",
+  includes: [{
+    name: "MyClass",
+    source: "mylib",
+    sourceDisplay: "mylib",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  }
+});
+
+verify.applyCodeActionFromCompletion("1", {
+  name: "MyClass",
+  source: "mylib",
+  description: `Import 'MyClass' from module "mylib"`,
+  data: {
+    exportName: "MyClass",
+    fileName: "/packages/mylib/index.ts",
+  },
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeCompletionsWithInsertText: true,
+    allowIncompleteCompletions: true,
+  },
+  newFileContent: `import { MyClass } from "mylib";
+
+const a = new MyClass();
+const b = new MyClass2();`,
+});

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap1.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap1.ts
@@ -1,0 +1,64 @@
+/// <reference path="../fourslash.ts"/>
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "nodenext"
+////   }
+//// }
+
+// @Filename: /package.json
+//// {
+////   "type": "module",
+////   "dependencies": {
+////     "dependency": "^1.0.0"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/package.json
+//// {
+////   "type": "module",
+////   "name": "dependency",
+////   "version": "1.0.0",
+////   "exports": {
+////     ".": {
+////       "types": "./lib/index.d.ts"
+////     },
+////     "./lol": {
+////       "types": "./lib/lol.d.ts"
+////     }
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/lib/index.d.ts
+//// export function fooFromIndex(): void;
+
+// @Filename: /node_modules/dependency/lib/lol.d.ts
+//// export function fooFromLol(): void;
+
+// @Filename: /src/foo.ts
+//// fooFrom/**/
+
+goTo.marker("");
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "fooFromIndex",
+    source: "dependency",
+    sourceDisplay: "dependency",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }, {
+    name: "fooFromLol",
+    source: "dependency/lol",
+    sourceDisplay: "dependency/lol",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap2.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap2.ts
@@ -1,0 +1,61 @@
+/// <reference path="../fourslash.ts"/>
+
+// This one uses --module=commonjs, so the export map is not followed.
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "commonjs"
+////   }
+//// }
+
+// @Filename: /package.json
+//// {
+////   "type": "module",
+////   "dependencies": {
+////     "dependency": "^1.0.0"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/package.json
+//// {
+////   "type": "module",
+////   "name": "dependency",
+////   "version": "1.0.0",
+////   "types": "./lib/index.d.ts",
+////   "exports": {
+////     ".": {
+////       "types": "./lib/index.d.ts"
+////     },
+////     "./lol": {
+////       "types": "./lib/lol.d.ts"
+////     }
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/lib/index.d.ts
+//// export function fooFromIndex(): void;
+
+// @Filename: /node_modules/dependency/lib/lol.d.ts
+//// export function fooFromLol(): void;
+
+// @Filename: /src/foo.ts
+//// fooFrom/**/
+
+goTo.marker("");
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "fooFromIndex",
+    source: "dependency",
+    sourceDisplay: "dependency",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap3.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap3.ts
@@ -1,0 +1,53 @@
+/// <reference path="../fourslash.ts"/>
+
+// String exports
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "nodenext"
+////   }
+//// }
+
+// @Filename: /package.json
+//// {
+////   "type": "module",
+////   "dependencies": {
+////     "dependency": "^1.0.0"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/package.json
+//// {
+////   "name": "dependency",
+////   "version": "1.0.0",
+////   "main": "./lib/index.js",
+////   "exports": "./lib/lol.d.ts"
+//// }
+
+// @Filename: /node_modules/dependency/lib/index.d.ts
+//// export function fooFromIndex(): void;
+
+// @Filename: /node_modules/dependency/lib/lol.d.ts
+//// export function fooFromLol(): void;
+
+// @Filename: /src/foo.ts
+//// fooFrom/**/
+
+goTo.marker("");
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "fooFromLol",
+    source: "dependency",
+    sourceDisplay: "dependency",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap3.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap3.ts
@@ -39,6 +39,16 @@ goTo.marker("");
 verify.completions({
   marker: "",
   exact: completion.globalsPlus([{
+    // TODO: We should filter this one out due to its bad module specifier,
+    // but we don't know it's going to be filtered out until we actually
+    // resolve the module specifier, which is a problem for completions
+    // that don't have their module specifiers eagerly resolved.
+    name: "fooFromIndex",
+    source: "../node_modules/dependency/lib/index.js",
+    sourceDisplay: "../node_modules/dependency/lib/index.js",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }, {
     name: "fooFromLol",
     source: "dependency",
     sourceDisplay: "dependency",

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap4.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap4.ts
@@ -1,0 +1,56 @@
+/// <reference path="../fourslash.ts"/>
+
+// Top-level conditions
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "nodenext"
+////   }
+//// }
+
+// @Filename: /package.json
+//// {
+////   "type": "module",
+////   "dependencies": {
+////     "dependency": "^1.0.0"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/package.json
+//// {
+////   "type": "module",
+////   "name": "dependency",
+////   "version": "1.0.0",
+////   "exports": {
+////     "types": "./lib/index.d.ts",
+////     "require": "./lib/lol.js"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/lib/index.d.ts
+//// export function fooFromIndex(): void;
+
+// @Filename: /node_modules/dependency/lib/lol.d.ts
+//// export function fooFromLol(): void;
+
+// @Filename: /src/foo.ts
+//// fooFrom/**/
+
+goTo.marker("");
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "fooFromIndex",
+    source: "dependency",
+    sourceDisplay: "dependency",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap5.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap5.ts
@@ -1,0 +1,79 @@
+/// <reference path="../fourslash.ts"/>
+
+// @types package lookup
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "nodenext"
+////   }
+//// }
+
+// @Filename: /package.json
+//// {
+////   "type": "module",
+////   "dependencies": {
+////     "dependency": "^1.0.0"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/package.json
+//// {
+////   "type": "module",
+////   "name": "dependency",
+////   "version": "1.0.0",
+////   "exports": {
+////     ".": "./lib/index.js",
+////     "./lol": "./lib/lol.js"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/lib/index.js
+//// export function fooFromIndex() {}
+
+// @Filename: /node_modules/dependency/lib/lol.js
+//// export function fooFromLol() {}
+
+// @Filename: /node_modules/@types/dependency/package.json
+//// {
+////   "type": "module",
+////   "name": "@types/dependency",
+////   "version": "1.0.0",
+////   "exports": {
+////     ".": "./lib/index.d.ts",
+////     "./lol": "./lib/lol.d.ts"
+////   }
+//// }
+
+// @Filename: /node_modules/@types/dependency/lib/index.d.ts
+//// export declare function fooFromIndex(): void;
+
+// @Filename: /node_modules/@types/dependency/lib/lol.d.ts
+//// export declare function fooFromLol(): void;
+
+// @Filename: /src/foo.ts
+//// fooFrom/**/
+
+goTo.marker("");
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "fooFromIndex",
+    source: "dependency",
+    sourceDisplay: "dependency",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }, {
+    name: "fooFromLol",
+    source: "dependency/lol",
+    sourceDisplay: "dependency/lol",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap6.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap6.ts
@@ -1,0 +1,88 @@
+/// <reference path="../fourslash.ts"/>
+
+// @types package should be ignored because implementation package has types
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "nodenext"
+////   }
+//// }
+
+// @Filename: /package.json
+//// {
+////   "type": "module",
+////   "dependencies": {
+////     "dependency": "^1.0.0"
+////   },
+////   "devDependencies": {
+////     "@types/dependency": "^1.0.0"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/package.json
+//// {
+////   "type": "module",
+////   "name": "dependency",
+////   "version": "1.0.0",
+////   "exports": {
+////     ".": "./lib/index.js",
+////     "./lol": "./lib/lol.js"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/lib/index.js
+//// export function fooFromIndex() {}
+
+// @Filename: /node_modules/dependency/lib/index.d.ts
+//// export declare function fooFromIndex(): void
+
+// @Filename: /node_modules/dependency/lib/lol.js
+//// export function fooFromLol() {}
+
+// @Filename: /node_modules/dependency/lib/lol.d.ts
+//// export declare function fooFromLol(): void
+
+// @Filename: /node_modules/@types/dependency/package.json
+//// {
+////   "type": "module",
+////   "name": "@types/dependency",
+////   "version": "1.0.0",
+////   "exports": {
+////     ".": "./lib/index.d.ts",
+////     "./lol": "./lib/lol.d.ts"
+////   }
+//// }
+
+// @Filename: /node_modules/@types/dependency/lib/index.d.ts
+//// export declare function fooFromAtTypesIndex(): void;
+
+// @Filename: /node_modules/@types/dependency/lib/lol.d.ts
+//// export declare function fooFromAtTypesLol(): void;
+
+// @Filename: /src/foo.ts
+//// fooFrom/**/
+
+goTo.marker("");
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "fooFromIndex",
+    source: "dependency",
+    sourceDisplay: "dependency",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }, {
+    name: "fooFromLol",
+    source: "dependency/lol",
+    sourceDisplay: "dependency/lol",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap7.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap7.ts
@@ -1,0 +1,69 @@
+/// <reference path="../fourslash.ts"/>
+
+// Some exports are already in the main program while some are not.
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "nodenext"
+////   }
+//// }
+
+// @Filename: /package.json
+//// {
+////   "type": "module",
+////   "dependencies": {
+////     "dependency": "^1.0.0"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/package.json
+//// {
+////   "type": "module",
+////   "name": "dependency",
+////   "version": "1.0.0",
+////   "exports": {
+////     ".": {
+////       "types": "./lib/index.d.ts"
+////     },
+////     "./lol": {
+////       "types": "./lib/lol.d.ts"
+////     }
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/lib/index.d.ts
+//// export function fooFromIndex(): void;
+
+// @Filename: /node_modules/dependency/lib/lol.d.ts
+//// export function fooFromLol(): void;
+
+// @Filename: /src/bar.ts
+//// import { fooFromIndex } from "dependency";
+
+// @Filename: /src/foo.ts
+//// fooFrom/**/
+
+goTo.marker("");
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "fooFromIndex",
+    source: "dependency",
+    sourceDisplay: "dependency",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }, {
+    name: "fooFromLol",
+    source: "dependency/lol",
+    sourceDisplay: "dependency/lol",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap8.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap8.ts
@@ -1,0 +1,94 @@
+/// <reference path="../fourslash.ts"/>
+
+// Both 'import' and 'require' should be pulled in
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "nodenext"
+////   }
+//// }
+
+// @Filename: /package.json
+//// {
+////   "type": "module",
+////   "dependencies": {
+////     "dependency": "^1.0.0"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/package.json
+//// {
+////   "type": "module",
+////   "name": "dependency",
+////   "version": "1.0.0",
+////   "exports": {
+////     "./lol": {
+////       "import": "./lib/index.js",
+////       "require": "./lib/lol.js"
+////     }
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/lib/index.d.ts
+//// export function fooFromIndex(): void;
+
+// @Filename: /node_modules/dependency/lib/lol.d.ts
+//// export function fooFromLol(): void;
+
+// @Filename: /src/bar.ts
+//// import { fooFromIndex } from "dependency";
+
+// @Filename: /src/foo.cts
+//// fooFrom/*cts*/
+
+// @Filename: /src/foo.mts
+//// fooFrom/*mts*/
+
+goTo.marker("cts");
+verify.completions({
+  marker: "cts",
+  exact: completion.globalsPlus([{
+    // TODO: this one will go away (see note in ./autoImportProvider_exportMap3.ts)
+    name: "fooFromIndex",
+    source: "../node_modules/dependency/lib/index",
+    sourceDisplay: "../node_modules/dependency/lib/index",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }, {
+    name: "fooFromLol",
+    source: "dependency/lol",
+    sourceDisplay: "dependency/lol",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  },
+});
+
+// goTo.marker("mts");
+// verify.completions({
+//   marker: "mts",
+//   exact: completion.globalsPlus([{
+//     name: "fooFromIndex",
+//     source: "dependency/lol",
+//     sourceDisplay: "dependency/lol",
+//     sortText: completion.SortText.AutoImportSuggestions,
+//     hasAction: true,
+//   }, {
+//     // TODO: this one will go away (see note in ./autoImportProvider_exportMap3.ts)
+//     name: "fooFromLol",
+//     source: "../node_modules/dependency/lib/index.js",
+//     sourceDisplay: "../node_modules/dependency/lib/index.js",
+//     sortText: completion.SortText.AutoImportSuggestions,
+//     hasAction: true,
+//   }]),
+//   preferences: {
+//     includeCompletionsForModuleExports: true,
+//     includeInsertTextCompletions: true,
+//     allowIncompleteCompletions: true,
+//   },
+// });

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap8.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap8.ts
@@ -69,26 +69,26 @@ verify.completions({
   },
 });
 
-// goTo.marker("mts");
-// verify.completions({
-//   marker: "mts",
-//   exact: completion.globalsPlus([{
-//     name: "fooFromIndex",
-//     source: "dependency/lol",
-//     sourceDisplay: "dependency/lol",
-//     sortText: completion.SortText.AutoImportSuggestions,
-//     hasAction: true,
-//   }, {
-//     // TODO: this one will go away (see note in ./autoImportProvider_exportMap3.ts)
-//     name: "fooFromLol",
-//     source: "../node_modules/dependency/lib/index.js",
-//     sourceDisplay: "../node_modules/dependency/lib/index.js",
-//     sortText: completion.SortText.AutoImportSuggestions,
-//     hasAction: true,
-//   }]),
-//   preferences: {
-//     includeCompletionsForModuleExports: true,
-//     includeInsertTextCompletions: true,
-//     allowIncompleteCompletions: true,
-//   },
-// });
+goTo.marker("mts");
+verify.completions({
+  marker: "mts",
+  exact: completion.globalsPlus([{
+    name: "fooFromIndex",
+    source: "dependency/lol",
+    sourceDisplay: "dependency/lol",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }, {
+    // TODO: this one will go away (see note in ./autoImportProvider_exportMap3.ts)
+    name: "fooFromLol",
+    source: "../node_modules/dependency/lib/lol.js",
+    sourceDisplay: "../node_modules/dependency/lib/lol.js",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProvider_exportMap9.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_exportMap9.ts
@@ -1,0 +1,58 @@
+/// <reference path="../fourslash.ts"/>
+
+// Only the first resolution in an array should be used
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "nodenext"
+////   }
+//// }
+
+// @Filename: /package.json
+//// {
+////   "type": "module",
+////   "dependencies": {
+////     "dependency": "^1.0.0"
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/package.json
+//// {
+////   "type": "module",
+////   "name": "dependency",
+////   "version": "1.0.0",
+////   "exports": {
+////     "./lol": ["./lib/index.js", "./lib/lol.js"]
+////   }
+//// }
+
+// @Filename: /node_modules/dependency/lib/index.d.ts
+//// export function fooFromIndex(): void;
+
+// @Filename: /node_modules/dependency/lib/lol.d.ts
+//// export function fooFromLol(): void;
+
+// @Filename: /src/bar.ts
+//// import { fooFromIndex } from "dependency";
+
+// @Filename: /src/foo.ts
+//// fooFrom/**/
+
+
+goTo.marker("");
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "fooFromIndex",
+    source: "dependency/lol",
+    sourceDisplay: "dependency/lol",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true,
+    allowIncompleteCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/server/completionsImport_mergedReExport.ts
+++ b/tests/cases/fourslash/server/completionsImport_mergedReExport.ts
@@ -6,6 +6,9 @@
 // @Filename: /package.json
 //// { "dependencies": { "@jest/types": "*", "ts-jest": "*" } }
 
+// @Filename: /node_modules/@jest/types/package.json
+//// { "name": "@jest/types" }
+
 // @Filename: /node_modules/@jest/types/index.d.ts
 //// import type * as Config from "./Config";
 //// export type { Config };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Significantly changes the package.json auto-import provider’s resolution process. Previously it used `resolveTypeReferenceDirective` with a fallback to `tryResolveJsModule` for JS projects. Using `resolveTypeReferenceDirective` was close but not quite right, so this fixes a couple straight up bugs, and also gives us the opportunity to pull in all files specifically referenced by an export map so those can be offered as auto-imports too. (Files matching a pattern export aren’t pulled in.)

Fixes #47009
