### PR TITLE
fix(47062): support generic arrow function with default type parameter in tsx

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4433,7 +4433,7 @@ namespace ts {
                                     return true;
                             }
                         }
-                        else if (third === SyntaxKind.CommaToken) {
+                        else if (third === SyntaxKind.CommaToken || third === SyntaxKind.EqualsToken) {
                             return true;
                         }
                         return false;

--- a/tests/baselines/reference/tsxGenericArrowFunctionParsing.errors.txt
+++ b/tests/baselines/reference/tsxGenericArrowFunctionParsing.errors.txt
@@ -36,4 +36,7 @@ tests/cases/conformance/jsx/file.tsx(24,25): error TS1382: Unexpected token. Did
 !!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
     x5.isElement;
     
+    // This is a generic function
+    var x6 = <T = string,>() => {};
+    x6();
     

--- a/tests/baselines/reference/tsxGenericArrowFunctionParsing.js
+++ b/tests/baselines/reference/tsxGenericArrowFunctionParsing.js
@@ -25,6 +25,9 @@ x4.isElement;
 var x5 = <T extends>() => {}</T>;
 x5.isElement;
 
+// This is a generic function
+var x6 = <T = string,>() => {};
+x6();
 
 
 //// [file.jsx]
@@ -44,3 +47,6 @@ x4.isElement;
 // This is an element
 var x5 = <T extends>() => </T>;
 x5.isElement;
+// This is a generic function
+var x6 = function () { };
+x6();

--- a/tests/baselines/reference/tsxGenericArrowFunctionParsing.symbols
+++ b/tests/baselines/reference/tsxGenericArrowFunctionParsing.symbols
@@ -64,4 +64,11 @@ x5.isElement;
 >x5 : Symbol(x5, Decl(file.tsx, 23, 3))
 >isElement : Symbol(JSX.Element.isElement, Decl(file.tsx, 1, 20))
 
+// This is a generic function
+var x6 = <T = string,>() => {};
+>x6 : Symbol(x6, Decl(file.tsx, 27, 3))
+>T : Symbol(T, Decl(file.tsx, 27, 10))
+
+x6();
+>x6 : Symbol(x6, Decl(file.tsx, 27, 3))
 

--- a/tests/baselines/reference/tsxGenericArrowFunctionParsing.types
+++ b/tests/baselines/reference/tsxGenericArrowFunctionParsing.types
@@ -66,4 +66,12 @@ x5.isElement;
 >x5 : JSX.Element
 >isElement : any
 
+// This is a generic function
+var x6 = <T = string,>() => {};
+>x6 : <T = string>() => void
+><T = string,>() => {} : <T = string>() => void
+
+x6();
+>x6() : void
+>x6 : <T = string>() => void
 

--- a/tests/cases/conformance/jsx/tsxGenericArrowFunctionParsing.tsx
+++ b/tests/cases/conformance/jsx/tsxGenericArrowFunctionParsing.tsx
@@ -26,3 +26,6 @@ x4.isElement;
 var x5 = <T extends>() => {}</T>;
 x5.isElement;
 
+// This is a generic function
+var x6 = <T = string,>() => {};
+x6();

--- a/tests/cases/fourslash/completionListIsGlobalCompletion.ts
+++ b/tests/cases/fourslash/completionListIsGlobalCompletion.ts
@@ -47,7 +47,7 @@ verify.completions(
     { marker: "7", exact: completion.globalsInsideFunction(x), isGlobalCompletion: true },
     { marker: "9", exact: ["x", "y"], isGlobalCompletion: false },
     { marker: "10", exact: completion.classElementKeywords, isGlobalCompletion: false, isNewIdentifierLocation: true },
-    { marker: "13", exact: globals.filter(name => name !== 'z'), isGlobalCompletion: false },
+    { marker: "13", exact: globals, isGlobalCompletion: false },
     { marker: "15", exact: globals.filter(name => name !== 'x'), isGlobalCompletion: true, isNewIdentifierLocation: true },
     { marker: "16", unsorted: [...x, completion.globalThisEntry, ...completion.globalsVars, completion.undefinedVarEntry].filter(name => name !== 'user'), isGlobalCompletion: false },
     { marker: "17", exact: completion.globalKeywords, isGlobalCompletion: false },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes https://github.com/microsoft/TypeScript/issues/47062 (based on the suggestion   https://github.com/microsoft/TypeScript/issues/47062#issuecomment-988997288)
