### PR TITLE
Revert change to getFalsyFlags

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20893,7 +20893,7 @@ namespace ts {
         // flags for the string, number, boolean, "", 0, false, void, undefined, or null types respectively. Returns
         // no flags for all other types (including non-falsy literal types).
         function getFalsyFlags(type: Type): TypeFlags {
-            return type.flags & TypeFlags.UnionOrIntersection ? getFalsyFlagsOfTypes((type as UnionType).types) :
+            return type.flags & TypeFlags.Union ? getFalsyFlagsOfTypes((type as UnionType).types) :
                 type.flags & TypeFlags.StringLiteral ? (type as StringLiteralType).value === "" ? TypeFlags.StringLiteral : 0 :
                 type.flags & TypeFlags.NumberLiteral ? (type as NumberLiteralType).value === 0 ? TypeFlags.NumberLiteral : 0 :
                 type.flags & TypeFlags.BigIntLiteral ? isZeroBigInt(type as BigIntLiteralType) ? TypeFlags.BigIntLiteral : 0 :

--- a/tests/baselines/reference/spreadObjectOrFalsy.errors.txt
+++ b/tests/baselines/reference/spreadObjectOrFalsy.errors.txt
@@ -40,3 +40,21 @@ tests/cases/conformance/types/spread/spreadObjectOrFalsy.ts(10,14): error TS2698
         };
     }
     
+    // Repro from #47028
+    
+    interface DatafulFoo<T> {
+        data: T;
+    }
+    
+    class Foo<T extends string> {
+        data: T | undefined;
+        bar() {
+            if (this.hasData()) {
+                this.data.toLocaleLowerCase();
+            }
+        }
+        hasData(): this is DatafulFoo<T> {
+            return true;
+        }
+    }
+    

--- a/tests/baselines/reference/spreadObjectOrFalsy.js
+++ b/tests/baselines/reference/spreadObjectOrFalsy.js
@@ -32,6 +32,24 @@ function g1<T extends {}, A extends { z: (T | undefined) & T }>(a: A) {
     };
 }
 
+// Repro from #47028
+
+interface DatafulFoo<T> {
+    data: T;
+}
+
+class Foo<T extends string> {
+    data: T | undefined;
+    bar() {
+        if (this.hasData()) {
+            this.data.toLocaleLowerCase();
+        }
+    }
+    hasData(): this is DatafulFoo<T> {
+        return true;
+    }
+}
+
 
 //// [spreadObjectOrFalsy.js]
 "use strict";
@@ -69,6 +87,19 @@ function g1(a) {
     var z = a.z;
     return __assign({}, z);
 }
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    Foo.prototype.bar = function () {
+        if (this.hasData()) {
+            this.data.toLocaleLowerCase();
+        }
+    };
+    Foo.prototype.hasData = function () {
+        return true;
+    };
+    return Foo;
+}());
 
 
 //// [spreadObjectOrFalsy.d.ts]
@@ -81,3 +112,11 @@ declare function f6<T extends object | undefined>(a: T): T;
 declare function g1<T extends {}, A extends {
     z: (T | undefined) & T;
 }>(a: A): (T | undefined) & T;
+interface DatafulFoo<T> {
+    data: T;
+}
+declare class Foo<T extends string> {
+    data: T | undefined;
+    bar(): void;
+    hasData(): this is DatafulFoo<T>;
+}

--- a/tests/baselines/reference/spreadObjectOrFalsy.symbols
+++ b/tests/baselines/reference/spreadObjectOrFalsy.symbols
@@ -85,3 +85,46 @@ function g1<T extends {}, A extends { z: (T | undefined) & T }>(a: A) {
     };
 }
 
+// Repro from #47028
+
+interface DatafulFoo<T> {
+>DatafulFoo : Symbol(DatafulFoo, Decl(spreadObjectOrFalsy.ts, 31, 1))
+>T : Symbol(T, Decl(spreadObjectOrFalsy.ts, 35, 21))
+
+    data: T;
+>data : Symbol(DatafulFoo.data, Decl(spreadObjectOrFalsy.ts, 35, 25))
+>T : Symbol(T, Decl(spreadObjectOrFalsy.ts, 35, 21))
+}
+
+class Foo<T extends string> {
+>Foo : Symbol(Foo, Decl(spreadObjectOrFalsy.ts, 37, 1))
+>T : Symbol(T, Decl(spreadObjectOrFalsy.ts, 39, 10))
+
+    data: T | undefined;
+>data : Symbol(Foo.data, Decl(spreadObjectOrFalsy.ts, 39, 29))
+>T : Symbol(T, Decl(spreadObjectOrFalsy.ts, 39, 10))
+
+    bar() {
+>bar : Symbol(Foo.bar, Decl(spreadObjectOrFalsy.ts, 40, 24))
+
+        if (this.hasData()) {
+>this.hasData : Symbol(Foo.hasData, Decl(spreadObjectOrFalsy.ts, 45, 5))
+>this : Symbol(Foo, Decl(spreadObjectOrFalsy.ts, 37, 1))
+>hasData : Symbol(Foo.hasData, Decl(spreadObjectOrFalsy.ts, 45, 5))
+
+            this.data.toLocaleLowerCase();
+>this.data.toLocaleLowerCase : Symbol(String.toLocaleLowerCase, Decl(lib.es5.d.ts, --, --))
+>this.data : Symbol(data, Decl(spreadObjectOrFalsy.ts, 39, 29), Decl(spreadObjectOrFalsy.ts, 35, 25))
+>data : Symbol(data, Decl(spreadObjectOrFalsy.ts, 39, 29), Decl(spreadObjectOrFalsy.ts, 35, 25))
+>toLocaleLowerCase : Symbol(String.toLocaleLowerCase, Decl(lib.es5.d.ts, --, --))
+        }
+    }
+    hasData(): this is DatafulFoo<T> {
+>hasData : Symbol(Foo.hasData, Decl(spreadObjectOrFalsy.ts, 45, 5))
+>DatafulFoo : Symbol(DatafulFoo, Decl(spreadObjectOrFalsy.ts, 31, 1))
+>T : Symbol(T, Decl(spreadObjectOrFalsy.ts, 39, 10))
+
+        return true;
+    }
+}
+

--- a/tests/baselines/reference/spreadObjectOrFalsy.types
+++ b/tests/baselines/reference/spreadObjectOrFalsy.types
@@ -73,3 +73,42 @@ function g1<T extends {}, A extends { z: (T | undefined) & T }>(a: A) {
     };
 }
 
+// Repro from #47028
+
+interface DatafulFoo<T> {
+    data: T;
+>data : T
+}
+
+class Foo<T extends string> {
+>Foo : Foo<T>
+
+    data: T | undefined;
+>data : T | undefined
+
+    bar() {
+>bar : () => void
+
+        if (this.hasData()) {
+>this.hasData() : boolean
+>this.hasData : () => this is DatafulFoo<T>
+>this : this
+>hasData : () => this is DatafulFoo<T>
+
+            this.data.toLocaleLowerCase();
+>this.data.toLocaleLowerCase() : string
+>this.data.toLocaleLowerCase : (locales?: string | string[] | undefined) => string
+>this.data : (T | undefined) & T
+>this : this & DatafulFoo<T>
+>data : (T | undefined) & T
+>toLocaleLowerCase : (locales?: string | string[] | undefined) => string
+        }
+    }
+    hasData(): this is DatafulFoo<T> {
+>hasData : () => this is DatafulFoo<T>
+
+        return true;
+>true : true
+    }
+}
+

--- a/tests/cases/conformance/types/spread/spreadObjectOrFalsy.ts
+++ b/tests/cases/conformance/types/spread/spreadObjectOrFalsy.ts
@@ -33,3 +33,21 @@ function g1<T extends {}, A extends { z: (T | undefined) & T }>(a: A) {
         ...z
     };
 }
+
+// Repro from #47028
+
+interface DatafulFoo<T> {
+    data: T;
+}
+
+class Foo<T extends string> {
+    data: T | undefined;
+    bar() {
+        if (this.hasData()) {
+            this.data.toLocaleLowerCase();
+        }
+    }
+    hasData(): this is DatafulFoo<T> {
+        return true;
+    }
+}


### PR DESCRIPTION
This PR reverts a change to `getFalsyFlags` made in #47010. It turns out the fix implemented in that PR didn't really need the change to `getFalsyFlags`, so we'll just keep it the way it was.

Fixes #47028.