### PR TITLE
Fix extract type crash on unresolvable alias references

### DIFF
--- a/src/services/refactors/extractType.ts
+++ b/src/services/refactors/extractType.ts
@@ -145,8 +145,8 @@ namespace ts.refactor {
             if (isTypeReferenceNode(node)) {
                 if (isIdentifier(node.typeName)) {
                     const symbol = checker.resolveName(node.typeName.text, node.typeName, SymbolFlags.TypeParameter, /* excludeGlobals */ true);
-                    if (symbol?.declarations) {
-                        const declaration = cast(first(symbol.declarations), isTypeParameterDeclaration);
+                    const declaration = tryCast(symbol?.declarations?.[0], isTypeParameterDeclaration);
+                    if (declaration) {
                         if (rangeContainsSkipTrivia(statement, declaration, file) && !rangeContainsSkipTrivia(selection, declaration, file)) {
                             pushIfUnique(result, declaration);
                         }

--- a/tests/cases/fourslash/extractTypeUnresolvedAlias.ts
+++ b/tests/cases/fourslash/extractTypeUnresolvedAlias.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+//// import {Renderer} from '';
+//// 
+//// export class X {
+////   constructor(renderer: /**/[|Renderer|]) {}
+//// }
+
+goTo.selectRange(test.ranges()[0]);
+verify.refactorAvailable("Extract type", "Extract to type alias");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #32860 

If you run `checker.resolveName("T", location, SymbolFlags.TypeParameter)` and it returns a Symbol, you do _not_ have a guarantee that you have a type parameter symbol. You might have an alias symbol that couldn’t be resolved.
