### PR TITLE
fix(47134): Inconsistent QuickInfo on type-only imported symbols

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -99,13 +99,6 @@ namespace ts {
             || isImportSpecifier(parent)
             || isImportClause(parent)
             || isImportEqualsDeclaration(parent) && node === parent.name) {
-            let decl: Node = parent;
-            while (decl) {
-                if (isImportEqualsDeclaration(decl) || isImportClause(decl) || isExportDeclaration(decl)) {
-                    return decl.isTypeOnly ? SemanticMeaning.Type : SemanticMeaning.All;
-                }
-                decl = decl.parent;
-            }
             return SemanticMeaning.All;
         }
         else if (isInRightSideOfInternalImportEqualsDeclaration(node)) {

--- a/tests/cases/fourslash/documentHighlightInTypeExport.ts
+++ b/tests/cases/fourslash/documentHighlightInTypeExport.ts
@@ -30,12 +30,12 @@
 //// let [|A|]: [|A|] = 1;
 //// export type { [|A|] as [|B|] };
 
-{ // properly handle type only
+{ // type-only exports may still export values to be imported and used in type contexts
     const [AType, ALet, ADecl, AExport, asB] = test.rangesInFile("/3.ts");
     verify.documentHighlightsOf(AType, [AType, ADecl, AExport, asB]);
     verify.documentHighlightsOf(ADecl, [AType, ADecl, AExport, asB]);
-    verify.documentHighlightsOf(AExport, [AType, ADecl, AExport, asB]);
-    verify.documentHighlightsOf(ALet, [ALet]);
+    verify.documentHighlightsOf(AExport, [AType, ALet, ADecl, AExport, asB]);
+    verify.documentHighlightsOf(ALet, [ALet, AExport, asB]);
     verify.documentHighlightsOf(asB, [asB]);
 }
 

--- a/tests/cases/fourslash/quickInfoTypeOnlyImportExport.ts
+++ b/tests/cases/fourslash/quickInfoTypeOnlyImportExport.ts
@@ -1,0 +1,71 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.ts
+////export type A = number;
+////export const A = 42;
+////export type B = number;
+////export const B = 42;
+////
+////type C = number;
+////const C = 42;
+////export type { C };
+////type D = number;
+////const D = 42;
+////export { type D ];
+
+// @Filename: /b.ts
+////import type { A/*1*/ } from './a';
+////import { type B/*2*/ } from './a';
+////import { C/*3*/, D/*4*/ } from './a';
+////export type { A/*5*/ } from './a';
+////export { type B/*6*/ } from './a';
+////export { C/*7*/, D/*8*/ } from './a';
+
+verify.quickInfoAt("1", [
+  "(alias) type A = number",
+  "(alias) const A: 42",
+  "import A",
+].join("\n"));
+
+verify.quickInfoAt("2", [
+  "(alias) type B = number",
+  "(alias) const B: 42",
+  "import B",
+].join("\n"));
+
+verify.quickInfoAt("3", [
+  "(alias) type C = number",
+  "(alias) const C: 42",
+  "import C",
+].join("\n"));
+
+verify.quickInfoAt("4", [
+  "(alias) type D = number",
+  "(alias) const D: 42",
+  "import D",
+].join("\n"));
+
+verify.quickInfoAt("5", [
+  "(alias) type A = number",
+  "(alias) const A: 42",
+  "export A",
+].join("\n"));
+
+verify.quickInfoAt("6", [
+  "(alias) type B = number",
+  "(alias) const B: 42",
+  "export B",
+].join("\n"));
+
+verify.quickInfoAt("7", [
+  "(alias) type C = number",
+  "(alias) const C: 42",
+  "export C",
+].join("\n"));
+
+verify.quickInfoAt("8", [
+  "(alias) type D = number",
+  "(alias) const D: 42",
+  "export D",
+].join("\n"));
+


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #47134 

I think type-only (re)exports should behave the same so included the fix for that, but I can revert it if it's not desirable.