### PR TITLE
Correctly check computed property names in type-space get/set accessors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27000,7 +27000,8 @@ namespace ts {
             const links = getNodeLinks(node.expression);
             if (!links.resolvedType) {
                 if ((isTypeLiteralNode(node.parent.parent) || isClassLike(node.parent.parent) || isInterfaceDeclaration(node.parent.parent))
-                    && isBinaryExpression(node.expression) && node.expression.operatorToken.kind === SyntaxKind.InKeyword) {
+                    && isBinaryExpression(node.expression) && node.expression.operatorToken.kind === SyntaxKind.InKeyword
+                    && node.parent.kind !== SyntaxKind.GetAccessor && node.parent.kind !== SyntaxKind.SetAccessor) {
                     return links.resolvedType = errorType;
                 }
                 links.resolvedType = checkExpression(node.expression);

--- a/tests/baselines/reference/noMappedGetSet.errors.txt
+++ b/tests/baselines/reference/noMappedGetSet.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/compiler/noMappedGetSet.ts(2,9): error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.
+tests/cases/compiler/noMappedGetSet.ts(2,10): error TS2304: Cannot find name 'K'.
+tests/cases/compiler/noMappedGetSet.ts(2,15): error TS2304: Cannot find name 'WAT'.
+
+
+==== tests/cases/compiler/noMappedGetSet.ts (3 errors) ====
+    type OH_NO = {
+        get [K in WAT](): string
+            ~~~~~~~~~~
+!!! error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.
+             ~
+!!! error TS2304: Cannot find name 'K'.
+                  ~~~
+!!! error TS2304: Cannot find name 'WAT'.
+    };
+    

--- a/tests/baselines/reference/noMappedGetSet.js
+++ b/tests/baselines/reference/noMappedGetSet.js
@@ -1,0 +1,7 @@
+//// [noMappedGetSet.ts]
+type OH_NO = {
+    get [K in WAT](): string
+};
+
+
+//// [noMappedGetSet.js]

--- a/tests/baselines/reference/noMappedGetSet.symbols
+++ b/tests/baselines/reference/noMappedGetSet.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/noMappedGetSet.ts ===
+type OH_NO = {
+>OH_NO : Symbol(OH_NO, Decl(noMappedGetSet.ts, 0, 0))
+
+    get [K in WAT](): string
+>[K in WAT] : Symbol([K in WAT], Decl(noMappedGetSet.ts, 0, 14))
+
+};
+

--- a/tests/baselines/reference/noMappedGetSet.types
+++ b/tests/baselines/reference/noMappedGetSet.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/noMappedGetSet.ts ===
+type OH_NO = {
+>OH_NO : OH_NO
+
+    get [K in WAT](): string
+>[K in WAT] : string
+>K in WAT : boolean
+>K : error
+>WAT : error
+
+};
+

--- a/tests/baselines/reference/noMappedGetSet.types
+++ b/tests/baselines/reference/noMappedGetSet.types
@@ -5,8 +5,8 @@ type OH_NO = {
     get [K in WAT](): string
 >[K in WAT] : string
 >K in WAT : boolean
->K : error
->WAT : error
+>K : any
+>WAT : any
 
 };
 

--- a/tests/cases/compiler/noMappedGetSet.ts
+++ b/tests/cases/compiler/noMappedGetSet.ts
@@ -1,0 +1,3 @@
+type OH_NO = {
+    get [K in WAT](): string
+};


### PR DESCRIPTION
Fixes #47146 (introduced by #42425 which enabled this syntax)

Previously this code ran without error:
```ts
type OH_NO = {
  get [K in WAT](): string
};
```
because we incorrectly swallowed the errors in `checkComputedPropertyName` under the assumption that we were looking at a `{ [K in T]: U }` declaration. The code path where the error would have been detected -- in the mapped checking logic -- obviously does not run because this is not actually a mapped type.

Thankfully the computed type was completely useless (see comments in linked issue), so it isn't feasible that anyone took a dependency on this.