### PR TITLE
Detect usage of block-scoped variables from earlier case blocks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25258,9 +25258,14 @@ namespace ts {
             //         if (true) x; // <- bad (note: need to walk to parent)
             // }
             if (container.kind === SyntaxKind.CaseBlock) {
-                const usageCaseBlock = getAncestor(node, SyntaxKind.CaseClause);
-                if (usageCaseBlock) {
-                    if (usageCaseBlock.pos > symbol.valueDeclaration.pos) {
+                let usageCaseClause = getAncestor(node, SyntaxKind.CaseClause);
+                if (usageCaseClause) {
+                    // Walk up until we're at the same level as the declaring block
+                    while (usageCaseClause.parent !== container) {
+                        usageCaseClause = usageCaseClause!.parent;
+                    }
+
+                    if (usageCaseClause.pos > symbol.valueDeclaration.pos) {
                         error(node, Diagnostics.Variable_0_is_declared_in_a_prior_case_block, symbolToString(symbol));
                     }
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26124,6 +26124,7 @@ namespace ts {
         // Don't do this for assignment declarations unless there is a type tag on the assignment, to avoid circularity from checking the right operand.
         function getContextualTypeForAssignmentDeclaration(binaryExpression: BinaryExpression): Type | undefined {
             const kind = getAssignmentDeclarationKind(binaryExpression);
+            let valueDeclaration;
             switch (kind) {
                 case AssignmentDeclarationKind.None:
                 case AssignmentDeclarationKind.ThisProperty:
@@ -26178,7 +26179,7 @@ namespace ts {
                 case AssignmentDeclarationKind.ExportsProperty:
                 case AssignmentDeclarationKind.Prototype:
                 case AssignmentDeclarationKind.PrototypeProperty:
-                    let valueDeclaration = binaryExpression.left.symbol?.valueDeclaration;
+                    valueDeclaration = binaryExpression.left.symbol?.valueDeclaration;
                     // falls through
                 case AssignmentDeclarationKind.ModuleExports:
                     valueDeclaration ||= binaryExpression.symbol?.valueDeclaration;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25262,7 +25262,7 @@ namespace ts {
                 if (usageCaseClause) {
                     // Walk up until we're at the same level as the declaring block
                     while (usageCaseClause.parent !== container) {
-                        usageCaseClause = usageCaseClause!.parent;
+                        usageCaseClause = usageCaseClause.parent;
                     }
 
                     if (usageCaseClause.pos > symbol.valueDeclaration.pos) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3361,6 +3361,11 @@
         "category": "Error",
         "code": 2836
     },
+    "Variable '{0}' is declared in a prior case block.": {
+        "category": "Error",
+        "code": 2837
+    },
+
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/switchCaseTdz.errors.txt
+++ b/tests/baselines/reference/switchCaseTdz.errors.txt
@@ -19,9 +19,10 @@ tests/cases/compiler/switchCaseTdz.ts(46,13): error TS2837: Variable 'z' is decl
 tests/cases/compiler/switchCaseTdz.ts(50,13): error TS2837: Variable 'x' is declared in a prior case block.
 tests/cases/compiler/switchCaseTdz.ts(51,13): error TS2837: Variable 'y' is declared in a prior case block.
 tests/cases/compiler/switchCaseTdz.ts(52,13): error TS2837: Variable 'z' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(64,17): error TS2837: Variable 'x' is declared in a prior case block.
 
 
-==== tests/cases/compiler/switchCaseTdz.ts (21 errors) ====
+==== tests/cases/compiler/switchCaseTdz.ts (22 errors) ====
     switch (1 + 1) {
         case -1:
             x;
@@ -124,3 +125,14 @@ tests/cases/compiler/switchCaseTdz.ts(52,13): error TS2837: Variable 'z' is decl
     
     }
     
+    switch(2 + 2) {
+        case 0:
+            let x = 1;
+            switch(x + x) {
+                case 2:
+                    // Legal
+                    x;
+                    ~
+!!! error TS2837: Variable 'x' is declared in a prior case block.
+            }
+    }

--- a/tests/baselines/reference/switchCaseTdz.errors.txt
+++ b/tests/baselines/reference/switchCaseTdz.errors.txt
@@ -1,0 +1,126 @@
+tests/cases/compiler/switchCaseTdz.ts(3,9): error TS2448: Block-scoped variable 'x' used before its declaration.
+tests/cases/compiler/switchCaseTdz.ts(4,9): error TS2448: Block-scoped variable 'y' used before its declaration.
+tests/cases/compiler/switchCaseTdz.ts(5,9): error TS2448: Block-scoped variable 'z' used before its declaration.
+tests/cases/compiler/switchCaseTdz.ts(19,9): error TS2837: Variable 'x' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(20,9): error TS2837: Variable 'y' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(21,9): error TS2837: Variable 'z' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(24,13): error TS2837: Variable 'x' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(25,13): error TS2837: Variable 'y' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(26,13): error TS2837: Variable 'z' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(30,13): error TS2837: Variable 'x' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(31,13): error TS2837: Variable 'y' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(32,13): error TS2837: Variable 'z' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(39,9): error TS2837: Variable 'x' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(40,9): error TS2837: Variable 'y' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(41,9): error TS2837: Variable 'z' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(44,13): error TS2837: Variable 'x' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(45,13): error TS2837: Variable 'y' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(46,13): error TS2837: Variable 'z' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(50,13): error TS2837: Variable 'x' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(51,13): error TS2837: Variable 'y' is declared in a prior case block.
+tests/cases/compiler/switchCaseTdz.ts(52,13): error TS2837: Variable 'z' is declared in a prior case block.
+
+
+==== tests/cases/compiler/switchCaseTdz.ts (21 errors) ====
+    switch (1 + 1) {
+        case -1:
+            x;
+            ~
+!!! error TS2448: Block-scoped variable 'x' used before its declaration.
+!!! related TS2728 tests/cases/compiler/switchCaseTdz.ts:9:13: 'x' is declared here.
+            y;
+            ~
+!!! error TS2448: Block-scoped variable 'y' used before its declaration.
+!!! related TS2728 tests/cases/compiler/switchCaseTdz.ts:10:15: 'y' is declared here.
+            z;
+            ~
+!!! error TS2448: Block-scoped variable 'z' used before its declaration.
+!!! related TS2728 tests/cases/compiler/switchCaseTdz.ts:11:16: 'z' is declared here.
+    
+        case 0:
+            var ok = 0;
+            let x = 0;
+            const y = 0;
+            const [z] = [0];
+    
+            ok;
+            x;
+            y;
+            z;
+    
+        case 1:
+            x = 0; // <- bad
+            ~
+!!! error TS2837: Variable 'x' is declared in a prior case block.
+            y; // <- bad
+            ~
+!!! error TS2837: Variable 'y' is declared in a prior case block.
+            z; // <- bad
+            ~
+!!! error TS2837: Variable 'z' is declared in a prior case block.
+            ok;
+            if (true) {
+                x = 0; // <- bad
+                ~
+!!! error TS2837: Variable 'x' is declared in a prior case block.
+                y; // <- bad
+                ~
+!!! error TS2837: Variable 'y' is declared in a prior case block.
+                z; // <- bad
+                ~
+!!! error TS2837: Variable 'z' is declared in a prior case block.
+                ok;
+            }
+            let f1 = function () {
+                x = 0; // <- bad
+                ~
+!!! error TS2837: Variable 'x' is declared in a prior case block.
+                y; // <- bad
+                ~
+!!! error TS2837: Variable 'y' is declared in a prior case block.
+                z; // <- bad
+                ~
+!!! error TS2837: Variable 'z' is declared in a prior case block.
+                ok;
+            }
+            break;
+    
+        case 2:
+        case 3:
+            x; // <- bad
+            ~
+!!! error TS2837: Variable 'x' is declared in a prior case block.
+            y; // <- bad
+            ~
+!!! error TS2837: Variable 'y' is declared in a prior case block.
+            z; // <- bad
+            ~
+!!! error TS2837: Variable 'z' is declared in a prior case block.
+            ok;
+            if (true) {
+                x; // <- bad
+                ~
+!!! error TS2837: Variable 'x' is declared in a prior case block.
+                y; // <- bad
+                ~
+!!! error TS2837: Variable 'y' is declared in a prior case block.
+                z; // <- bad
+                ~
+!!! error TS2837: Variable 'z' is declared in a prior case block.
+                ok;
+            }
+            let f2 = function () {
+                x; // <- bad
+                ~
+!!! error TS2837: Variable 'x' is declared in a prior case block.
+                y; // <- bad
+                ~
+!!! error TS2837: Variable 'y' is declared in a prior case block.
+                z; // <- bad
+                ~
+!!! error TS2837: Variable 'z' is declared in a prior case block.
+                ok;
+            }
+    
+    }
+    

--- a/tests/baselines/reference/switchCaseTdz.errors.txt
+++ b/tests/baselines/reference/switchCaseTdz.errors.txt
@@ -19,10 +19,9 @@ tests/cases/compiler/switchCaseTdz.ts(46,13): error TS2837: Variable 'z' is decl
 tests/cases/compiler/switchCaseTdz.ts(50,13): error TS2837: Variable 'x' is declared in a prior case block.
 tests/cases/compiler/switchCaseTdz.ts(51,13): error TS2837: Variable 'y' is declared in a prior case block.
 tests/cases/compiler/switchCaseTdz.ts(52,13): error TS2837: Variable 'z' is declared in a prior case block.
-tests/cases/compiler/switchCaseTdz.ts(64,17): error TS2837: Variable 'x' is declared in a prior case block.
 
 
-==== tests/cases/compiler/switchCaseTdz.ts (22 errors) ====
+==== tests/cases/compiler/switchCaseTdz.ts (21 errors) ====
     switch (1 + 1) {
         case -1:
             x;
@@ -132,7 +131,5 @@ tests/cases/compiler/switchCaseTdz.ts(64,17): error TS2837: Variable 'x' is decl
                 case 2:
                     // Legal
                     x;
-                    ~
-!!! error TS2837: Variable 'x' is declared in a prior case block.
             }
     }

--- a/tests/baselines/reference/switchCaseTdz.js
+++ b/tests/baselines/reference/switchCaseTdz.js
@@ -1,0 +1,111 @@
+//// [switchCaseTdz.ts]
+switch (1 + 1) {
+    case -1:
+        x;
+        y;
+        z;
+
+    case 0:
+        var ok = 0;
+        let x = 0;
+        const y = 0;
+        const [z] = [0];
+
+        ok;
+        x;
+        y;
+        z;
+
+    case 1:
+        x = 0; // <- bad
+        y; // <- bad
+        z; // <- bad
+        ok;
+        if (true) {
+            x = 0; // <- bad
+            y; // <- bad
+            z; // <- bad
+            ok;
+        }
+        let f1 = function () {
+            x = 0; // <- bad
+            y; // <- bad
+            z; // <- bad
+            ok;
+        }
+        break;
+
+    case 2:
+    case 3:
+        x; // <- bad
+        y; // <- bad
+        z; // <- bad
+        ok;
+        if (true) {
+            x; // <- bad
+            y; // <- bad
+            z; // <- bad
+            ok;
+        }
+        let f2 = function () {
+            x; // <- bad
+            y; // <- bad
+            z; // <- bad
+            ok;
+        }
+
+}
+
+
+//// [switchCaseTdz.js]
+switch (1 + 1) {
+    case -1:
+        x_1;
+        y_1;
+        z_1;
+    case 0:
+        var ok = 0;
+        var x_1 = 0;
+        var y_1 = 0;
+        var z_1 = [0][0];
+        ok;
+        x_1;
+        y_1;
+        z_1;
+    case 1:
+        x_1 = 0; // <- bad
+        y_1; // <- bad
+        z_1; // <- bad
+        ok;
+        if (true) {
+            x_1 = 0; // <- bad
+            y_1; // <- bad
+            z_1; // <- bad
+            ok;
+        }
+        var f1 = function () {
+            x_1 = 0; // <- bad
+            y_1; // <- bad
+            z_1; // <- bad
+            ok;
+        };
+        break;
+    case 2:
+    case 3:
+        x_1; // <- bad
+        y_1; // <- bad
+        z_1; // <- bad
+        ok;
+        if (true) {
+            x_1; // <- bad
+            y_1; // <- bad
+            z_1; // <- bad
+            ok;
+        }
+        var f2 = function () {
+            x_1; // <- bad
+            y_1; // <- bad
+            z_1; // <- bad
+            ok;
+        };
+}

--- a/tests/baselines/reference/switchCaseTdz.js
+++ b/tests/baselines/reference/switchCaseTdz.js
@@ -56,6 +56,15 @@ switch (1 + 1) {
 
 }
 
+switch(2 + 2) {
+    case 0:
+        let x = 1;
+        switch(x + x) {
+            case 2:
+                // Legal
+                x;
+        }
+}
 
 //// [switchCaseTdz.js]
 switch (1 + 1) {
@@ -108,4 +117,13 @@ switch (1 + 1) {
             z_1; // <- bad
             ok;
         };
+}
+switch (2 + 2) {
+    case 0:
+        var x = 1;
+        switch (x + x) {
+            case 2:
+                // Legal
+                x;
+        }
 }

--- a/tests/baselines/reference/switchCaseTdz.symbols
+++ b/tests/baselines/reference/switchCaseTdz.symbols
@@ -123,3 +123,18 @@ switch (1 + 1) {
 
 }
 
+switch(2 + 2) {
+    case 0:
+        let x = 1;
+>x : Symbol(x, Decl(switchCaseTdz.ts, 59, 11))
+
+        switch(x + x) {
+>x : Symbol(x, Decl(switchCaseTdz.ts, 59, 11))
+>x : Symbol(x, Decl(switchCaseTdz.ts, 59, 11))
+
+            case 2:
+                // Legal
+                x;
+>x : Symbol(x, Decl(switchCaseTdz.ts, 59, 11))
+        }
+}

--- a/tests/baselines/reference/switchCaseTdz.symbols
+++ b/tests/baselines/reference/switchCaseTdz.symbols
@@ -1,0 +1,125 @@
+=== tests/cases/compiler/switchCaseTdz.ts ===
+switch (1 + 1) {
+    case -1:
+        x;
+>x : Symbol(x, Decl(switchCaseTdz.ts, 8, 11))
+
+        y;
+>y : Symbol(y, Decl(switchCaseTdz.ts, 9, 13))
+
+        z;
+>z : Symbol(z, Decl(switchCaseTdz.ts, 10, 15))
+
+    case 0:
+        var ok = 0;
+>ok : Symbol(ok, Decl(switchCaseTdz.ts, 7, 11))
+
+        let x = 0;
+>x : Symbol(x, Decl(switchCaseTdz.ts, 8, 11))
+
+        const y = 0;
+>y : Symbol(y, Decl(switchCaseTdz.ts, 9, 13))
+
+        const [z] = [0];
+>z : Symbol(z, Decl(switchCaseTdz.ts, 10, 15))
+
+        ok;
+>ok : Symbol(ok, Decl(switchCaseTdz.ts, 7, 11))
+
+        x;
+>x : Symbol(x, Decl(switchCaseTdz.ts, 8, 11))
+
+        y;
+>y : Symbol(y, Decl(switchCaseTdz.ts, 9, 13))
+
+        z;
+>z : Symbol(z, Decl(switchCaseTdz.ts, 10, 15))
+
+    case 1:
+        x = 0; // <- bad
+>x : Symbol(x, Decl(switchCaseTdz.ts, 8, 11))
+
+        y; // <- bad
+>y : Symbol(y, Decl(switchCaseTdz.ts, 9, 13))
+
+        z; // <- bad
+>z : Symbol(z, Decl(switchCaseTdz.ts, 10, 15))
+
+        ok;
+>ok : Symbol(ok, Decl(switchCaseTdz.ts, 7, 11))
+
+        if (true) {
+            x = 0; // <- bad
+>x : Symbol(x, Decl(switchCaseTdz.ts, 8, 11))
+
+            y; // <- bad
+>y : Symbol(y, Decl(switchCaseTdz.ts, 9, 13))
+
+            z; // <- bad
+>z : Symbol(z, Decl(switchCaseTdz.ts, 10, 15))
+
+            ok;
+>ok : Symbol(ok, Decl(switchCaseTdz.ts, 7, 11))
+        }
+        let f1 = function () {
+>f1 : Symbol(f1, Decl(switchCaseTdz.ts, 28, 11))
+
+            x = 0; // <- bad
+>x : Symbol(x, Decl(switchCaseTdz.ts, 8, 11))
+
+            y; // <- bad
+>y : Symbol(y, Decl(switchCaseTdz.ts, 9, 13))
+
+            z; // <- bad
+>z : Symbol(z, Decl(switchCaseTdz.ts, 10, 15))
+
+            ok;
+>ok : Symbol(ok, Decl(switchCaseTdz.ts, 7, 11))
+        }
+        break;
+
+    case 2:
+    case 3:
+        x; // <- bad
+>x : Symbol(x, Decl(switchCaseTdz.ts, 8, 11))
+
+        y; // <- bad
+>y : Symbol(y, Decl(switchCaseTdz.ts, 9, 13))
+
+        z; // <- bad
+>z : Symbol(z, Decl(switchCaseTdz.ts, 10, 15))
+
+        ok;
+>ok : Symbol(ok, Decl(switchCaseTdz.ts, 7, 11))
+
+        if (true) {
+            x; // <- bad
+>x : Symbol(x, Decl(switchCaseTdz.ts, 8, 11))
+
+            y; // <- bad
+>y : Symbol(y, Decl(switchCaseTdz.ts, 9, 13))
+
+            z; // <- bad
+>z : Symbol(z, Decl(switchCaseTdz.ts, 10, 15))
+
+            ok;
+>ok : Symbol(ok, Decl(switchCaseTdz.ts, 7, 11))
+        }
+        let f2 = function () {
+>f2 : Symbol(f2, Decl(switchCaseTdz.ts, 48, 11))
+
+            x; // <- bad
+>x : Symbol(x, Decl(switchCaseTdz.ts, 8, 11))
+
+            y; // <- bad
+>y : Symbol(y, Decl(switchCaseTdz.ts, 9, 13))
+
+            z; // <- bad
+>z : Symbol(z, Decl(switchCaseTdz.ts, 10, 15))
+
+            ok;
+>ok : Symbol(ok, Decl(switchCaseTdz.ts, 7, 11))
+        }
+
+}
+

--- a/tests/baselines/reference/switchCaseTdz.types
+++ b/tests/baselines/reference/switchCaseTdz.types
@@ -155,3 +155,28 @@ switch (1 + 1) {
 
 }
 
+switch(2 + 2) {
+>2 + 2 : number
+>2 : 2
+>2 : 2
+
+    case 0:
+>0 : 0
+
+        let x = 1;
+>x : number
+>1 : 1
+
+        switch(x + x) {
+>x + x : number
+>x : number
+>x : number
+
+            case 2:
+>2 : 2
+
+                // Legal
+                x;
+>x : number
+        }
+}

--- a/tests/baselines/reference/switchCaseTdz.types
+++ b/tests/baselines/reference/switchCaseTdz.types
@@ -1,0 +1,157 @@
+=== tests/cases/compiler/switchCaseTdz.ts ===
+switch (1 + 1) {
+>1 + 1 : number
+>1 : 1
+>1 : 1
+
+    case -1:
+>-1 : -1
+>1 : 1
+
+        x;
+>x : number
+
+        y;
+>y : 0
+
+        z;
+>z : number
+
+    case 0:
+>0 : 0
+
+        var ok = 0;
+>ok : number
+>0 : 0
+
+        let x = 0;
+>x : number
+>0 : 0
+
+        const y = 0;
+>y : 0
+>0 : 0
+
+        const [z] = [0];
+>z : number
+>[0] : [number]
+>0 : 0
+
+        ok;
+>ok : number
+
+        x;
+>x : number
+
+        y;
+>y : 0
+
+        z;
+>z : number
+
+    case 1:
+>1 : 1
+
+        x = 0; // <- bad
+>x = 0 : 0
+>x : number
+>0 : 0
+
+        y; // <- bad
+>y : 0
+
+        z; // <- bad
+>z : number
+
+        ok;
+>ok : number
+
+        if (true) {
+>true : true
+
+            x = 0; // <- bad
+>x = 0 : 0
+>x : number
+>0 : 0
+
+            y; // <- bad
+>y : 0
+
+            z; // <- bad
+>z : number
+
+            ok;
+>ok : number
+        }
+        let f1 = function () {
+>f1 : () => void
+>function () {            x = 0; // <- bad            y; // <- bad            z; // <- bad            ok;        } : () => void
+
+            x = 0; // <- bad
+>x = 0 : 0
+>x : number
+>0 : 0
+
+            y; // <- bad
+>y : 0
+
+            z; // <- bad
+>z : number
+
+            ok;
+>ok : number
+        }
+        break;
+
+    case 2:
+>2 : 2
+
+    case 3:
+>3 : 3
+
+        x; // <- bad
+>x : number
+
+        y; // <- bad
+>y : 0
+
+        z; // <- bad
+>z : number
+
+        ok;
+>ok : number
+
+        if (true) {
+>true : true
+
+            x; // <- bad
+>x : number
+
+            y; // <- bad
+>y : 0
+
+            z; // <- bad
+>z : number
+
+            ok;
+>ok : number
+        }
+        let f2 = function () {
+>f2 : () => void
+>function () {            x; // <- bad            y; // <- bad            z; // <- bad            ok;        } : () => void
+
+            x; // <- bad
+>x : number
+
+            y; // <- bad
+>y : 0
+
+            z; // <- bad
+>z : number
+
+            ok;
+>ok : number
+        }
+
+}
+

--- a/tests/baselines/reference/unusedSwitchStatement.errors.txt
+++ b/tests/baselines/reference/unusedSwitchStatement.errors.txt
@@ -5,9 +5,10 @@ tests/cases/compiler/unusedSwitchStatement.ts(9,13): error TS6133: 'z' is declar
 tests/cases/compiler/unusedSwitchStatement.ts(14,10): error TS2678: Type '0' is not comparable to type '2'.
 tests/cases/compiler/unusedSwitchStatement.ts(15,13): error TS6133: 'x' is declared but its value is never read.
 tests/cases/compiler/unusedSwitchStatement.ts(16,10): error TS2678: Type '1' is not comparable to type '2'.
+tests/cases/compiler/unusedSwitchStatement.ts(17,9): error TS2837: Variable 'x' is declared in a prior case block.
 
 
-==== tests/cases/compiler/unusedSwitchStatement.ts (7 errors) ====
+==== tests/cases/compiler/unusedSwitchStatement.ts (8 errors) ====
     switch (1) {
         case 0:
              ~
@@ -39,4 +40,6 @@ tests/cases/compiler/unusedSwitchStatement.ts(16,10): error TS2678: Type '1' is 
              ~
 !!! error TS2678: Type '1' is not comparable to type '2'.
             x++;
+            ~
+!!! error TS2837: Variable 'x' is declared in a prior case block.
     }

--- a/tests/cases/compiler/switchCaseTdz.ts
+++ b/tests/cases/compiler/switchCaseTdz.ts
@@ -1,0 +1,56 @@
+switch (1 + 1) {
+    case -1:
+        x;
+        y;
+        z;
+
+    case 0:
+        var ok = 0;
+        let x = 0;
+        const y = 0;
+        const [z] = [0];
+
+        ok;
+        x;
+        y;
+        z;
+
+    case 1:
+        x = 0; // <- bad
+        y; // <- bad
+        z; // <- bad
+        ok;
+        if (true) {
+            x = 0; // <- bad
+            y; // <- bad
+            z; // <- bad
+            ok;
+        }
+        let f1 = function () {
+            x = 0; // <- bad
+            y; // <- bad
+            z; // <- bad
+            ok;
+        }
+        break;
+
+    case 2:
+    case 3:
+        x; // <- bad
+        y; // <- bad
+        z; // <- bad
+        ok;
+        if (true) {
+            x; // <- bad
+            y; // <- bad
+            z; // <- bad
+            ok;
+        }
+        let f2 = function () {
+            x; // <- bad
+            y; // <- bad
+            z; // <- bad
+            ok;
+        }
+
+}

--- a/tests/cases/compiler/switchCaseTdz.ts
+++ b/tests/cases/compiler/switchCaseTdz.ts
@@ -54,3 +54,13 @@ switch (1 + 1) {
         }
 
 }
+
+switch(2 + 2) {
+    case 0:
+        let x = 1;
+        switch(x + x) {
+            case 2:
+                // Legal
+                x;
+        }
+}


### PR DESCRIPTION
Fixes #19503

Note that this has the possibility to incur a false positive:
```ts
let sHasBeenSet = false;
switch (n) {
    case 0:
        let s = "ok";
        sHasBeenSet = true;
    case 1:
        if (sHasBeenSet) {
            s; // ok by construction
        }
        break;
}
```