### PR TITLE
Fix #38482

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -300,7 +300,7 @@ declare var Function: FunctionConstructor;
 /**
  * Extracts the type of the 'this' parameter of a function type, or 'unknown' if the function type has no 'this' parameter.
  */
-type ThisParameterType<T> = T extends (this: infer U, ...args: any[]) => any ? U : unknown;
+type ThisParameterType<T> = T extends (this: infer U, ...args: never) => any ? U : unknown;
 
 /**
  * Removes the 'this' parameter from a function type.

--- a/tests/baselines/reference/strictBindCallApply1.errors.txt
+++ b/tests/baselines/reference/strictBindCallApply1.errors.txt
@@ -58,9 +58,24 @@ tests/cases/conformance/functions/strictBindCallApply1.ts(70,12): error TS2345: 
 tests/cases/conformance/functions/strictBindCallApply1.ts(71,17): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/functions/strictBindCallApply1.ts(72,12): error TS2345: Argument of type '[number, string, number]' is not assignable to parameter of type '[a: number, b: string]'.
   Source has 3 element(s) but target allows only 2.
+tests/cases/conformance/functions/strictBindCallApply1.ts(76,5): error TS2769: No overload matches this call.
+  Overload 1 of 6, '(this: (this: 1, ...args: T) => void, thisArg: 1): (...args: T) => void', gave the following error.
+    Argument of type '2' is not assignable to parameter of type '1'.
+  Overload 2 of 6, '(this: (this: 1, ...args: unknown[]) => void, thisArg: 1, ...args: unknown[]): (...args: unknown[]) => void', gave the following error.
+    The 'this' context of type '(this: 1, ...args: T) => void' is not assignable to method's 'this' of type '(this: 1, ...args: unknown[]) => void'.
+      Types of parameters 'args' and 'args' are incompatible.
+        Type 'unknown[]' is not assignable to type 'T'.
+          'unknown[]' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'unknown[]'.
+tests/cases/conformance/functions/strictBindCallApply1.ts(81,5): error TS2769: No overload matches this call.
+  Overload 1 of 6, '(this: (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void, thisArg: 1): (...args: T extends 1 ? [unknown] : [unknown, unknown]) => void', gave the following error.
+    Argument of type '2' is not assignable to parameter of type '1'.
+  Overload 2 of 6, '(this: (this: 1, ...args: unknown[]) => void, thisArg: 1, ...args: unknown[]): (...args: unknown[]) => void', gave the following error.
+    The 'this' context of type '(this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void' is not assignable to method's 'this' of type '(this: 1, ...args: unknown[]) => void'.
+      Types of parameters 'args' and 'args' are incompatible.
+        Type 'unknown[]' is not assignable to type 'T extends 1 ? [unknown] : [unknown, unknown]'.
 
 
-==== tests/cases/conformance/functions/strictBindCallApply1.ts (24 errors) ====
+==== tests/cases/conformance/functions/strictBindCallApply1.ts (26 errors) ====
     declare function foo(a: number, b: string): string;
     
     declare function overloaded(s: string): number;
@@ -217,4 +232,48 @@ tests/cases/conformance/functions/strictBindCallApply1.ts(72,12): error TS2345: 
                ~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '[number, string, number]' is not assignable to parameter of type '[a: number, b: string]'.
 !!! error TS2345:   Source has 3 element(s) but target allows only 2.
+    
+    function bar<T extends unknown[]>(callback: (this: 1, ...args: T) => void) {
+        callback.bind(1);
+        callback.bind(2); // Error
+        ~~~~~~~~~~~~~~~~
+!!! error TS2769: No overload matches this call.
+!!! error TS2769:   Overload 1 of 6, '(this: (this: 1, ...args: T) => void, thisArg: 1): (...args: T) => void', gave the following error.
+!!! error TS2769:     Argument of type '2' is not assignable to parameter of type '1'.
+!!! error TS2769:   Overload 2 of 6, '(this: (this: 1, ...args: unknown[]) => void, thisArg: 1, ...args: unknown[]): (...args: unknown[]) => void', gave the following error.
+!!! error TS2769:     The 'this' context of type '(this: 1, ...args: T) => void' is not assignable to method's 'this' of type '(this: 1, ...args: unknown[]) => void'.
+!!! error TS2769:       Types of parameters 'args' and 'args' are incompatible.
+!!! error TS2769:         Type 'unknown[]' is not assignable to type 'T'.
+!!! error TS2769:           'unknown[]' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'unknown[]'.
+    }
+    
+    function baz<T extends 1 | 2>(callback: (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void) {
+        callback.bind(1);
+        callback.bind(2); // Error
+        ~~~~~~~~~~~~~~~~
+!!! error TS2769: No overload matches this call.
+!!! error TS2769:   Overload 1 of 6, '(this: (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void, thisArg: 1): (...args: T extends 1 ? [unknown] : [unknown, unknown]) => void', gave the following error.
+!!! error TS2769:     Argument of type '2' is not assignable to parameter of type '1'.
+!!! error TS2769:   Overload 2 of 6, '(this: (this: 1, ...args: unknown[]) => void, thisArg: 1, ...args: unknown[]): (...args: unknown[]) => void', gave the following error.
+!!! error TS2769:     The 'this' context of type '(this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void' is not assignable to method's 'this' of type '(this: 1, ...args: unknown[]) => void'.
+!!! error TS2769:       Types of parameters 'args' and 'args' are incompatible.
+!!! error TS2769:         Type 'unknown[]' is not assignable to type 'T extends 1 ? [unknown] : [unknown, unknown]'.
+    }
+    
+    // Repro from #32964
+    class Foo<T extends unknown[]> {
+        constructor() {
+            this.fn.bind(this);
+        }
+    
+        fn(...args: T): void {}
+    }
+    
+    class Bar<T extends 1 | 2> {
+        constructor() {
+            this.fn.bind(this);
+        }
+    
+        fn(...args: T extends 1 ? [unknown] : [unknown, unknown]) {}
+    }
     

--- a/tests/baselines/reference/strictBindCallApply1.js
+++ b/tests/baselines/reference/strictBindCallApply1.js
@@ -72,6 +72,33 @@ C.apply(c, [10]);  // Error
 C.apply(c, [10, 20]);  // Error
 C.apply(c, [10, "hello", 30]);  // Error
 
+function bar<T extends unknown[]>(callback: (this: 1, ...args: T) => void) {
+    callback.bind(1);
+    callback.bind(2); // Error
+}
+
+function baz<T extends 1 | 2>(callback: (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void) {
+    callback.bind(1);
+    callback.bind(2); // Error
+}
+
+// Repro from #32964
+class Foo<T extends unknown[]> {
+    constructor() {
+        this.fn.bind(this);
+    }
+
+    fn(...args: T): void {}
+}
+
+class Bar<T extends 1 | 2> {
+    constructor() {
+        this.fn.bind(this);
+    }
+
+    fn(...args: T extends 1 ? [unknown] : [unknown, unknown]) {}
+}
+
 
 //// [strictBindCallApply1.js]
 "use strict";
@@ -126,3 +153,36 @@ C.apply(c, [10, "hello"]);
 C.apply(c, [10]); // Error
 C.apply(c, [10, 20]); // Error
 C.apply(c, [10, "hello", 30]); // Error
+function bar(callback) {
+    callback.bind(1);
+    callback.bind(2); // Error
+}
+function baz(callback) {
+    callback.bind(1);
+    callback.bind(2); // Error
+}
+// Repro from #32964
+var Foo = /** @class */ (function () {
+    function Foo() {
+        this.fn.bind(this);
+    }
+    Foo.prototype.fn = function () {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+    };
+    return Foo;
+}());
+var Bar = /** @class */ (function () {
+    function Bar() {
+        this.fn.bind(this);
+    }
+    Bar.prototype.fn = function () {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+    };
+    return Bar;
+}());

--- a/tests/baselines/reference/strictBindCallApply1.symbols
+++ b/tests/baselines/reference/strictBindCallApply1.symbols
@@ -388,3 +388,82 @@ C.apply(c, [10, "hello", 30]);  // Error
 >apply : Symbol(NewableFunction.apply, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >c : Symbol(c, Decl(strictBindCallApply1.ts, 34, 11))
 
+function bar<T extends unknown[]>(callback: (this: 1, ...args: T) => void) {
+>bar : Symbol(bar, Decl(strictBindCallApply1.ts, 71, 30))
+>T : Symbol(T, Decl(strictBindCallApply1.ts, 73, 13))
+>callback : Symbol(callback, Decl(strictBindCallApply1.ts, 73, 34))
+>this : Symbol(this, Decl(strictBindCallApply1.ts, 73, 45))
+>args : Symbol(args, Decl(strictBindCallApply1.ts, 73, 53))
+>T : Symbol(T, Decl(strictBindCallApply1.ts, 73, 13))
+
+    callback.bind(1);
+>callback.bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+>callback : Symbol(callback, Decl(strictBindCallApply1.ts, 73, 34))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+
+    callback.bind(2); // Error
+>callback.bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+>callback : Symbol(callback, Decl(strictBindCallApply1.ts, 73, 34))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+}
+
+function baz<T extends 1 | 2>(callback: (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void) {
+>baz : Symbol(baz, Decl(strictBindCallApply1.ts, 76, 1))
+>T : Symbol(T, Decl(strictBindCallApply1.ts, 78, 13))
+>callback : Symbol(callback, Decl(strictBindCallApply1.ts, 78, 30))
+>this : Symbol(this, Decl(strictBindCallApply1.ts, 78, 41))
+>args : Symbol(args, Decl(strictBindCallApply1.ts, 78, 49))
+>T : Symbol(T, Decl(strictBindCallApply1.ts, 78, 13))
+
+    callback.bind(1);
+>callback.bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+>callback : Symbol(callback, Decl(strictBindCallApply1.ts, 78, 30))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+
+    callback.bind(2); // Error
+>callback.bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+>callback : Symbol(callback, Decl(strictBindCallApply1.ts, 78, 30))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+}
+
+// Repro from #32964
+class Foo<T extends unknown[]> {
+>Foo : Symbol(Foo, Decl(strictBindCallApply1.ts, 81, 1))
+>T : Symbol(T, Decl(strictBindCallApply1.ts, 84, 10))
+
+    constructor() {
+        this.fn.bind(this);
+>this.fn.bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+>this.fn : Symbol(Foo.fn, Decl(strictBindCallApply1.ts, 87, 5))
+>this : Symbol(Foo, Decl(strictBindCallApply1.ts, 81, 1))
+>fn : Symbol(Foo.fn, Decl(strictBindCallApply1.ts, 87, 5))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+>this : Symbol(Foo, Decl(strictBindCallApply1.ts, 81, 1))
+    }
+
+    fn(...args: T): void {}
+>fn : Symbol(Foo.fn, Decl(strictBindCallApply1.ts, 87, 5))
+>args : Symbol(args, Decl(strictBindCallApply1.ts, 89, 7))
+>T : Symbol(T, Decl(strictBindCallApply1.ts, 84, 10))
+}
+
+class Bar<T extends 1 | 2> {
+>Bar : Symbol(Bar, Decl(strictBindCallApply1.ts, 90, 1))
+>T : Symbol(T, Decl(strictBindCallApply1.ts, 92, 10))
+
+    constructor() {
+        this.fn.bind(this);
+>this.fn.bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+>this.fn : Symbol(Bar.fn, Decl(strictBindCallApply1.ts, 95, 5))
+>this : Symbol(Bar, Decl(strictBindCallApply1.ts, 90, 1))
+>fn : Symbol(Bar.fn, Decl(strictBindCallApply1.ts, 95, 5))
+>bind : Symbol(CallableFunction.bind, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 1 more)
+>this : Symbol(Bar, Decl(strictBindCallApply1.ts, 90, 1))
+    }
+
+    fn(...args: T extends 1 ? [unknown] : [unknown, unknown]) {}
+>fn : Symbol(Bar.fn, Decl(strictBindCallApply1.ts, 95, 5))
+>args : Symbol(args, Decl(strictBindCallApply1.ts, 97, 7))
+>T : Symbol(T, Decl(strictBindCallApply1.ts, 92, 10))
+}
+

--- a/tests/baselines/reference/strictBindCallApply1.types
+++ b/tests/baselines/reference/strictBindCallApply1.types
@@ -506,3 +506,84 @@ C.apply(c, [10, "hello", 30]);  // Error
 >"hello" : "hello"
 >30 : 30
 
+function bar<T extends unknown[]>(callback: (this: 1, ...args: T) => void) {
+>bar : <T extends unknown[]>(callback: (this: 1, ...args: T) => void) => void
+>callback : (this: 1, ...args: T) => void
+>this : 1
+>args : T
+
+    callback.bind(1);
+>callback.bind(1) : (...args: T) => void
+>callback.bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>callback : (this: 1, ...args: T) => void
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>1 : 1
+
+    callback.bind(2); // Error
+>callback.bind(2) : (...args: T) => void
+>callback.bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>callback : (this: 1, ...args: T) => void
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>2 : 2
+}
+
+function baz<T extends 1 | 2>(callback: (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void) {
+>baz : <T extends 2 | 1>(callback: (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void) => void
+>callback : (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void
+>this : 1
+>args : T extends 1 ? [unknown] : [unknown, unknown]
+
+    callback.bind(1);
+>callback.bind(1) : (...args: T extends 1 ? [unknown] : [unknown, unknown]) => void
+>callback.bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>callback : (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>1 : 1
+
+    callback.bind(2); // Error
+>callback.bind(2) : (...args: T extends 1 ? [unknown] : [unknown, unknown]) => void
+>callback.bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>callback : (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>2 : 2
+}
+
+// Repro from #32964
+class Foo<T extends unknown[]> {
+>Foo : Foo<T>
+
+    constructor() {
+        this.fn.bind(this);
+>this.fn.bind(this) : (...args: T) => void
+>this.fn.bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>this.fn : (...args: T) => void
+>this : this
+>fn : (...args: T) => void
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>this : this
+    }
+
+    fn(...args: T): void {}
+>fn : (...args: T) => void
+>args : T
+}
+
+class Bar<T extends 1 | 2> {
+>Bar : Bar<T>
+
+    constructor() {
+        this.fn.bind(this);
+>this.fn.bind(this) : (...args: T extends 1 ? [unknown] : [unknown, unknown]) => void
+>this.fn.bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>this.fn : (...args: T extends 1 ? [unknown] : [unknown, unknown]) => void
+>this : this
+>fn : (...args: T extends 1 ? [unknown] : [unknown, unknown]) => void
+>bind : { <T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>; <T, A0, A extends any[], R>(this: (this: T, arg0: A0, ...args: A) => R, thisArg: T, arg0: A0): (...args: A) => R; <T, A0, A1, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1): (...args: A) => R; <T, A0, A1, A2, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2): (...args: A) => R; <T, A0, A1, A2, A3, A extends any[], R>(this: (this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R, thisArg: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3): (...args: A) => R; <T, AX, R>(this: (this: T, ...args: AX[]) => R, thisArg: T, ...args: AX[]): (...args: AX[]) => R; }
+>this : this
+    }
+
+    fn(...args: T extends 1 ? [unknown] : [unknown, unknown]) {}
+>fn : (...args: T extends 1 ? [unknown] : [unknown, unknown]) => void
+>args : T extends 1 ? [unknown] : [unknown, unknown]
+}
+

--- a/tests/cases/conformance/functions/strictBindCallApply1.ts
+++ b/tests/cases/conformance/functions/strictBindCallApply1.ts
@@ -72,3 +72,30 @@ C.apply(c, [10, "hello"]);
 C.apply(c, [10]);  // Error
 C.apply(c, [10, 20]);  // Error
 C.apply(c, [10, "hello", 30]);  // Error
+
+function bar<T extends unknown[]>(callback: (this: 1, ...args: T) => void) {
+    callback.bind(1);
+    callback.bind(2); // Error
+}
+
+function baz<T extends 1 | 2>(callback: (this: 1, ...args: T extends 1 ? [unknown] : [unknown, unknown]) => void) {
+    callback.bind(1);
+    callback.bind(2); // Error
+}
+
+// Repro from #32964
+class Foo<T extends unknown[]> {
+    constructor() {
+        this.fn.bind(this);
+    }
+
+    fn(...args: T): void {}
+}
+
+class Bar<T extends 1 | 2> {
+    constructor() {
+        this.fn.bind(this);
+    }
+
+    fn(...args: T extends 1 ? [unknown] : [unknown, unknown]) {}
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #38482 by making `ThisParameterType<T>` more general.

The issue is that `ThisParameterType<(...args: X) => void>` expands to 
```ts
((...args: X) => void) extends (this: infer U, ...args: any[]) => any ? U : never
```

When `X` is an unresolved type parameter it is not possible to determine that `any[]` is assignable to `X`, `X` may not be an array type. However `never` is always assignable to `X`, so we use that instead.
