### PR TITLE
Check for undefined globalObjectType in getPropertyOfObjectType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12360,7 +12360,9 @@ namespace ts {
                         return symbol;
                     }
                 }
-                return globalObjectType === undefined ? undefined : getPropertyOfObjectType(globalObjectType, name);
+                // TODO: In some cases, the containing function may be called before global types have been initialized.
+                // This simple guard avoids issues with those cases, but in the future we may need to reconsider how these steps are ordered.
+                return globalObjectType && getPropertyOfObjectType(globalObjectType, name);
             }
             if (type.flags & TypeFlags.UnionOrIntersection) {
                 return getPropertyOfUnionOrIntersectionType(type as UnionOrIntersectionType, name, skipObjectFunctionPropertyAugment);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12360,7 +12360,7 @@ namespace ts {
                         return symbol;
                     }
                 }
-                return getPropertyOfObjectType(globalObjectType, name);
+                return globalObjectType === undefined ? undefined : getPropertyOfObjectType(globalObjectType, name);
             }
             if (type.flags & TypeFlags.UnionOrIntersection) {
                 return getPropertyOfUnionOrIntersectionType(type as UnionOrIntersectionType, name, skipObjectFunctionPropertyAugment);


### PR DESCRIPTION
This can happen during symbol merging when initialising the checker, because global types aren't set until after symbols are merged.

May stop the crashes in #47179, #47181, #47180.
Does not address the underlying problem of needing to resolve aliases, and therefore names, during symbol merging when initialising the checker.

I created this PR so it would be easier for others to see if this is actually fixes their crashes.