### PR TITLE
Update terminal.integrated.shell.linux config in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,13 @@
         }
     },
     "settings": {
-        "terminal.integrated.shell.linux": "/bin/bash"
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.profiles.linux": {
+            "bash": {
+                "path": "/bin/bash",
+                "icon": "terminal-bash",
+            },
+        },
     },
     "extensions": [
         "dbaeumer.vscode-eslint"


### PR DESCRIPTION
The previous `"terminal.integrated.shell.linux"` configuration is deprecated. 

This is the new way of setting this configuration



