### PR TITLE
Add @ts-ignore-start and @ts-ignore-end directives

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2475,6 +2475,10 @@
         "category": "Error",
         "code": 2578
     },
+    "A '@ts-ignore-end' directive must be used with a matching '@ts-ignore-start' directive": {
+        "category": "Error",
+        "code": 2579
+    },
     "Cannot find name '{0}'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.": {
         "category": "Error",
         "code": 2580
@@ -4161,7 +4165,7 @@
         "category": "Message",
         "code": 6041
     },
-    
+
     "Generates corresponding '.map' file.": {
         "category": "Message",
         "code": 6043
@@ -4941,7 +4945,7 @@
         "category": "Error",
         "code": 6258
     },
-      "Found 1 error in {1}": {
+    "Found 1 error in {1}": {
         "category": "Message",
         "code": 6259
     },
@@ -5820,7 +5824,6 @@
         "category": "Message",
         "code": 6930
     },
-
 
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2130,8 +2130,13 @@ namespace ts {
 
             const { diagnostics, directives } = getDiagnosticsWithPrecedingDirectives(sourceFile, sourceFile.commentDirectives, flatDiagnostics);
 
-            for (const errorExpectation of directives.getUnusedExpectations()) {
-                diagnostics.push(createDiagnosticForRange(sourceFile, errorExpectation.range, Diagnostics.Unused_ts_expect_error_directive));
+            for (const erroneousCommentDirectives of directives.getErroneousCommentDirectives()) {
+                if (erroneousCommentDirectives.type === CommentDirectiveType.ExpectError) {
+                    diagnostics.push(createDiagnosticForRange(sourceFile, erroneousCommentDirectives.range, Diagnostics.Unused_ts_expect_error_directive));
+                }
+                if (erroneousCommentDirectives.type === CommentDirectiveType.IgnoreEnd) {
+                    diagnostics.push(createDiagnosticForRange(sourceFile, erroneousCommentDirectives.range, Diagnostics.A_ts_ignore_end_directive_must_be_used_with_a_matching_ts_ignore_start_directive));
+                }
             }
 
             return diagnostics;

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -287,12 +287,12 @@ namespace ts {
     /**
      * Test for whether a single line comment with leading whitespace trimmed's text contains a directive.
      */
-    const commentDirectiveRegExSingleLine = /^\/\/\/?\s*@(ts-expect-error|ts-ignore)/;
+    const commentDirectiveRegExSingleLine = /^\/\/\/?\s*@(ts-ignore-start|ts-ignore-end|ts-expect-error|ts-ignore)/;
 
     /**
      * Test for whether a multi-line comment with leading whitespace trimmed's last line contains a directive.
      */
-    const commentDirectiveRegExMultiLine = /^(?:\/|\*)*\s*@(ts-expect-error|ts-ignore)/;
+    const commentDirectiveRegExMultiLine = /^(?:\/|\*)*\s*@(ts-ignore-start|ts-ignore-end|ts-expect-error|ts-ignore)/;
 
     function lookupInUnicodeMap(code: number, map: readonly number[]): boolean {
         // Bail out quickly if it couldn't possibly be in the map.
@@ -2216,6 +2216,11 @@ namespace ts {
             }
 
             switch (match[1]) {
+                case "ts-ignore-start":
+                    return CommentDirectiveType.IgnoreStart;
+
+                case "ts-ignore-end":
+                    return CommentDirectiveType.IgnoreEnd;
                 case "ts-expect-error":
                     return CommentDirectiveType.ExpectError;
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3672,6 +3672,8 @@ namespace ts {
     export const enum CommentDirectiveType {
         ExpectError,
         Ignore,
+        IgnoreStart,
+        IgnoreEnd,
     }
 
     /*@internal*/
@@ -8654,7 +8656,7 @@ namespace ts {
 
     /* @internal */
     export interface CommentDirectivesMap {
-        getUnusedExpectations(): CommentDirective[];
+        getErroneousCommentDirectives(): CommentDirective[];
         markUsed(matchedLine: number): boolean;
     }
 

--- a/tests/baselines/reference/multiline.errors.txt
+++ b/tests/baselines/reference/multiline.errors.txt
@@ -19,6 +19,16 @@ tests/cases/conformance/directives/b.tsx(32,1): error TS2578: Unused '@ts-expect
 !!! error TS2578: Unused '@ts-expect-error' directive.
     texts.push("100");
     
+    /**
+     @ts-ignore-start */
+    texts.push(100);
+    texts.push(100);
+    texts.push(100);
+    /**
+     @ts-ignore-end */
+    
+    texts.push("100");
+    
 ==== tests/cases/conformance/directives/b.tsx (1 errors) ====
     import * as React from "react";
     
@@ -55,6 +65,22 @@ tests/cases/conformance/directives/b.tsx(32,1): error TS2578: Unused '@ts-expect
     ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2578: Unused '@ts-expect-error' directive.
         <MyComponent foo={"hooray"} />
+    
+        {/* @ts-ignore-start */}
+        <MyComponent foo={100} />
+        <MyComponent foo={100} />
+        <MyComponent foo={100} />
+        {/* @ts-ignore-end */}
+        <MyComponent foo={"works!"} />
+    
+        {/*
+        @ts-ignore-start */}
+        <MyComponent foo={100} />
+        <MyComponent foo={100} />
+        <MyComponent foo={100} />
+        {/*
+        @ts-ignore-end */}
+        <MyComponent foo={"works!"} />
       </div>
     );
     

--- a/tests/baselines/reference/multiline.js
+++ b/tests/baselines/reference/multiline.js
@@ -15,6 +15,16 @@ texts.push(100);
  @ts-expect-error */
 texts.push("100");
 
+/**
+ @ts-ignore-start */
+texts.push(100);
+texts.push(100);
+texts.push(100);
+/**
+ @ts-ignore-end */
+
+texts.push("100");
+
 //// [b.tsx]
 import * as React from "react";
 
@@ -49,6 +59,22 @@ let x = (
     {/*
    @ts-expect-error */}
     <MyComponent foo={"hooray"} />
+
+    {/* @ts-ignore-start */}
+    <MyComponent foo={100} />
+    <MyComponent foo={100} />
+    <MyComponent foo={100} />
+    {/* @ts-ignore-end */}
+    <MyComponent foo={"works!"} />
+
+    {/*
+    @ts-ignore-start */}
+    <MyComponent foo={100} />
+    <MyComponent foo={100} />
+    <MyComponent foo={100} />
+    {/*
+    @ts-ignore-end */}
+    <MyComponent foo={"works!"} />
   </div>
 );
 
@@ -67,6 +93,14 @@ exports.texts.push(100);
 /**
  @ts-expect-error */
 exports.texts.push("100");
+/**
+ @ts-ignore-start */
+exports.texts.push(100);
+exports.texts.push(100);
+exports.texts.push(100);
+/**
+ @ts-ignore-end */
+exports.texts.push("100");
 //// [b.js]
 "use strict";
 exports.__esModule = true;
@@ -83,4 +117,12 @@ var x = (React.createElement("div", null,
     React.createElement(MyComponent, { foo: 100 }),
     React.createElement(MyComponent, { foo: 100 }),
     React.createElement(MyComponent, { foo: 100 }),
-    React.createElement(MyComponent, { foo: "hooray" })));
+    React.createElement(MyComponent, { foo: "hooray" }),
+    React.createElement(MyComponent, { foo: 100 }),
+    React.createElement(MyComponent, { foo: 100 }),
+    React.createElement(MyComponent, { foo: 100 }),
+    React.createElement(MyComponent, { foo: "works!" }),
+    React.createElement(MyComponent, { foo: 100 }),
+    React.createElement(MyComponent, { foo: 100 }),
+    React.createElement(MyComponent, { foo: 100 }),
+    React.createElement(MyComponent, { foo: "works!" })));

--- a/tests/baselines/reference/multiline.symbols
+++ b/tests/baselines/reference/multiline.symbols
@@ -23,6 +23,31 @@ texts.push("100");
 >texts : Symbol(texts, Decl(a.ts, 0, 12))
 >push : Symbol(Array.push, Decl(lib.d.ts, --, --))
 
+/**
+ @ts-ignore-start */
+texts.push(100);
+>texts.push : Symbol(Array.push, Decl(lib.d.ts, --, --))
+>texts : Symbol(texts, Decl(a.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.d.ts, --, --))
+
+texts.push(100);
+>texts.push : Symbol(Array.push, Decl(lib.d.ts, --, --))
+>texts : Symbol(texts, Decl(a.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.d.ts, --, --))
+
+texts.push(100);
+>texts.push : Symbol(Array.push, Decl(lib.d.ts, --, --))
+>texts : Symbol(texts, Decl(a.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.d.ts, --, --))
+
+/**
+ @ts-ignore-end */
+
+texts.push("100");
+>texts.push : Symbol(Array.push, Decl(lib.d.ts, --, --))
+>texts : Symbol(texts, Decl(a.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.d.ts, --, --))
+
 === tests/cases/conformance/directives/b.tsx ===
 import * as React from "react";
 >React : Symbol(React, Decl(b.tsx, 0, 6))
@@ -81,6 +106,44 @@ let x = (
     <MyComponent foo={"hooray"} />
 >MyComponent : Symbol(MyComponent, Decl(b.tsx, 0, 31))
 >foo : Symbol(foo, Decl(b.tsx, 32, 16))
+
+    {/* @ts-ignore-start */}
+    <MyComponent foo={100} />
+>MyComponent : Symbol(MyComponent, Decl(b.tsx, 0, 31))
+>foo : Symbol(foo, Decl(b.tsx, 35, 16))
+
+    <MyComponent foo={100} />
+>MyComponent : Symbol(MyComponent, Decl(b.tsx, 0, 31))
+>foo : Symbol(foo, Decl(b.tsx, 36, 16))
+
+    <MyComponent foo={100} />
+>MyComponent : Symbol(MyComponent, Decl(b.tsx, 0, 31))
+>foo : Symbol(foo, Decl(b.tsx, 37, 16))
+
+    {/* @ts-ignore-end */}
+    <MyComponent foo={"works!"} />
+>MyComponent : Symbol(MyComponent, Decl(b.tsx, 0, 31))
+>foo : Symbol(foo, Decl(b.tsx, 39, 16))
+
+    {/*
+    @ts-ignore-start */}
+    <MyComponent foo={100} />
+>MyComponent : Symbol(MyComponent, Decl(b.tsx, 0, 31))
+>foo : Symbol(foo, Decl(b.tsx, 43, 16))
+
+    <MyComponent foo={100} />
+>MyComponent : Symbol(MyComponent, Decl(b.tsx, 0, 31))
+>foo : Symbol(foo, Decl(b.tsx, 44, 16))
+
+    <MyComponent foo={100} />
+>MyComponent : Symbol(MyComponent, Decl(b.tsx, 0, 31))
+>foo : Symbol(foo, Decl(b.tsx, 45, 16))
+
+    {/*
+    @ts-ignore-end */}
+    <MyComponent foo={"works!"} />
+>MyComponent : Symbol(MyComponent, Decl(b.tsx, 0, 31))
+>foo : Symbol(foo, Decl(b.tsx, 48, 16))
 
   </div>
 >div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))

--- a/tests/baselines/reference/multiline.types
+++ b/tests/baselines/reference/multiline.types
@@ -30,6 +30,39 @@ texts.push("100");
 >push : (...items: string[]) => number
 >"100" : "100"
 
+/**
+ @ts-ignore-start */
+texts.push(100);
+>texts.push(100) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>100 : 100
+
+texts.push(100);
+>texts.push(100) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>100 : 100
+
+texts.push(100);
+>texts.push(100) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>100 : 100
+
+/**
+ @ts-ignore-end */
+
+texts.push("100");
+>texts.push("100") : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>"100" : "100"
+
 === tests/cases/conformance/directives/b.tsx ===
 import * as React from "react";
 >React : typeof React
@@ -46,10 +79,10 @@ export function MyComponent(props: { foo: string }) {
 
 let x = (
 >x : JSX.Element
->(  <div>    {/*   @ts-ignore */}    <MyComponent foo={100} />    {/*@ts-ignore*/}    <MyComponent foo={100} />    {/*   @ts-expect-error */}    <MyComponent foo={100} />    {/*   // @ts-expect-error */}    <MyComponent foo={100} />    {/*   * @ts-expect-error */}    <MyComponent foo={100} />    {/*@ts-expect-error*/}    <MyComponent foo={100} />    {/*   @ts-expect-error */}    <MyComponent foo={"hooray"} />  </div>) : JSX.Element
+>(  <div>    {/*   @ts-ignore */}    <MyComponent foo={100} />    {/*@ts-ignore*/}    <MyComponent foo={100} />    {/*   @ts-expect-error */}    <MyComponent foo={100} />    {/*   // @ts-expect-error */}    <MyComponent foo={100} />    {/*   * @ts-expect-error */}    <MyComponent foo={100} />    {/*@ts-expect-error*/}    <MyComponent foo={100} />    {/*   @ts-expect-error */}    <MyComponent foo={"hooray"} />    {/* @ts-ignore-start */}    <MyComponent foo={100} />    <MyComponent foo={100} />    <MyComponent foo={100} />    {/* @ts-ignore-end */}    <MyComponent foo={"works!"} />    {/*    @ts-ignore-start */}    <MyComponent foo={100} />    <MyComponent foo={100} />    <MyComponent foo={100} />    {/*    @ts-ignore-end */}    <MyComponent foo={"works!"} />  </div>) : JSX.Element
 
   <div>
-><div>    {/*   @ts-ignore */}    <MyComponent foo={100} />    {/*@ts-ignore*/}    <MyComponent foo={100} />    {/*   @ts-expect-error */}    <MyComponent foo={100} />    {/*   // @ts-expect-error */}    <MyComponent foo={100} />    {/*   * @ts-expect-error */}    <MyComponent foo={100} />    {/*@ts-expect-error*/}    <MyComponent foo={100} />    {/*   @ts-expect-error */}    <MyComponent foo={"hooray"} />  </div> : JSX.Element
+><div>    {/*   @ts-ignore */}    <MyComponent foo={100} />    {/*@ts-ignore*/}    <MyComponent foo={100} />    {/*   @ts-expect-error */}    <MyComponent foo={100} />    {/*   // @ts-expect-error */}    <MyComponent foo={100} />    {/*   * @ts-expect-error */}    <MyComponent foo={100} />    {/*@ts-expect-error*/}    <MyComponent foo={100} />    {/*   @ts-expect-error */}    <MyComponent foo={"hooray"} />    {/* @ts-ignore-start */}    <MyComponent foo={100} />    <MyComponent foo={100} />    <MyComponent foo={100} />    {/* @ts-ignore-end */}    <MyComponent foo={"works!"} />    {/*    @ts-ignore-start */}    <MyComponent foo={100} />    <MyComponent foo={100} />    <MyComponent foo={100} />    {/*    @ts-ignore-end */}    <MyComponent foo={"works!"} />  </div> : JSX.Element
 >div : any
 
     {/*
@@ -105,6 +138,60 @@ let x = (
 >MyComponent : (props: { foo: string; }) => JSX.Element
 >foo : string
 >"hooray" : "hooray"
+
+    {/* @ts-ignore-start */}
+    <MyComponent foo={100} />
+><MyComponent foo={100} /> : JSX.Element
+>MyComponent : (props: { foo: string; }) => JSX.Element
+>foo : number
+>100 : 100
+
+    <MyComponent foo={100} />
+><MyComponent foo={100} /> : JSX.Element
+>MyComponent : (props: { foo: string; }) => JSX.Element
+>foo : number
+>100 : 100
+
+    <MyComponent foo={100} />
+><MyComponent foo={100} /> : JSX.Element
+>MyComponent : (props: { foo: string; }) => JSX.Element
+>foo : number
+>100 : 100
+
+    {/* @ts-ignore-end */}
+    <MyComponent foo={"works!"} />
+><MyComponent foo={"works!"} /> : JSX.Element
+>MyComponent : (props: { foo: string; }) => JSX.Element
+>foo : string
+>"works!" : "works!"
+
+    {/*
+    @ts-ignore-start */}
+    <MyComponent foo={100} />
+><MyComponent foo={100} /> : JSX.Element
+>MyComponent : (props: { foo: string; }) => JSX.Element
+>foo : number
+>100 : 100
+
+    <MyComponent foo={100} />
+><MyComponent foo={100} /> : JSX.Element
+>MyComponent : (props: { foo: string; }) => JSX.Element
+>foo : number
+>100 : 100
+
+    <MyComponent foo={100} />
+><MyComponent foo={100} /> : JSX.Element
+>MyComponent : (props: { foo: string; }) => JSX.Element
+>foo : number
+>100 : 100
+
+    {/*
+    @ts-ignore-end */}
+    <MyComponent foo={"works!"} />
+><MyComponent foo={"works!"} /> : JSX.Element
+>MyComponent : (props: { foo: string; }) => JSX.Element
+>foo : string
+>"works!" : "works!"
 
   </div>
 >div : any

--- a/tests/baselines/reference/ts-ignore-start-ts-ignore-end.errors.txt
+++ b/tests/baselines/reference/ts-ignore-start-ts-ignore-end.errors.txt
@@ -1,0 +1,36 @@
+tests/cases/conformance/directives/ts-ignore-start-ts-ignore-end.ts(28,1): error TS2579: A '@ts-ignore-end' directive must be used with a matching '@ts-ignore-start' directive
+
+
+==== tests/cases/conformance/directives/ts-ignore-start-ts-ignore-end.ts (1 errors) ====
+    export const texts: string[] = [];
+    
+    // @ts-ignore-start
+    texts.push(1);
+    texts.push(2);
+    texts.push(3);
+    // @ts-ignore-end
+    
+    // @ts-ignore-start some comment on start
+    texts.push(4);
+    // @ts-ignore-end some comment on end
+    
+    
+    /**
+      @ts-ignore-start */
+    texts.push(4);
+    texts.push(5);
+    texts.push(6);
+    /** @ts-ignore-end */
+    
+    // @ts-ignore-start single line comment
+    texts.push(7);
+    /* @ts-ignore-end  multiline comment */
+    
+    // error
+    texts.push(8);
+    
+    // @ts-ignore-end that was not started
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2579: A '@ts-ignore-end' directive must be used with a matching '@ts-ignore-start' directive
+    texts.push(9);
+    

--- a/tests/baselines/reference/ts-ignore-start-ts-ignore-end.js
+++ b/tests/baselines/reference/ts-ignore-start-ts-ignore-end.js
@@ -1,0 +1,58 @@
+//// [ts-ignore-start-ts-ignore-end.ts]
+export const texts: string[] = [];
+
+// @ts-ignore-start
+texts.push(1);
+texts.push(2);
+texts.push(3);
+// @ts-ignore-end
+
+// @ts-ignore-start some comment on start
+texts.push(4);
+// @ts-ignore-end some comment on end
+
+
+/**
+  @ts-ignore-start */
+texts.push(4);
+texts.push(5);
+texts.push(6);
+/** @ts-ignore-end */
+
+// @ts-ignore-start single line comment
+texts.push(7);
+/* @ts-ignore-end  multiline comment */
+
+// error
+texts.push(8);
+
+// @ts-ignore-end that was not started
+texts.push(9);
+
+
+//// [ts-ignore-start-ts-ignore-end.js]
+"use strict";
+exports.__esModule = true;
+exports.texts = void 0;
+exports.texts = [];
+// @ts-ignore-start
+exports.texts.push(1);
+exports.texts.push(2);
+exports.texts.push(3);
+// @ts-ignore-end
+// @ts-ignore-start some comment on start
+exports.texts.push(4);
+// @ts-ignore-end some comment on end
+/**
+  @ts-ignore-start */
+exports.texts.push(4);
+exports.texts.push(5);
+exports.texts.push(6);
+/** @ts-ignore-end */
+// @ts-ignore-start single line comment
+exports.texts.push(7);
+/* @ts-ignore-end  multiline comment */
+// error
+exports.texts.push(8);
+// @ts-ignore-end that was not started
+exports.texts.push(9);

--- a/tests/baselines/reference/ts-ignore-start-ts-ignore-end.symbols
+++ b/tests/baselines/reference/ts-ignore-start-ts-ignore-end.symbols
@@ -1,0 +1,70 @@
+=== tests/cases/conformance/directives/ts-ignore-start-ts-ignore-end.ts ===
+export const texts: string[] = [];
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+
+// @ts-ignore-start
+texts.push(1);
+>texts.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+texts.push(2);
+>texts.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+texts.push(3);
+>texts.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+// @ts-ignore-end
+
+// @ts-ignore-start some comment on start
+texts.push(4);
+>texts.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+// @ts-ignore-end some comment on end
+
+
+/**
+  @ts-ignore-start */
+texts.push(4);
+>texts.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+texts.push(5);
+>texts.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+texts.push(6);
+>texts.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+/** @ts-ignore-end */
+
+// @ts-ignore-start single line comment
+texts.push(7);
+>texts.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+/* @ts-ignore-end  multiline comment */
+
+// error
+texts.push(8);
+>texts.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+// @ts-ignore-end that was not started
+texts.push(9);
+>texts.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>texts : Symbol(texts, Decl(ts-ignore-start-ts-ignore-end.ts, 0, 12))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/ts-ignore-start-ts-ignore-end.types
+++ b/tests/baselines/reference/ts-ignore-start-ts-ignore-end.types
@@ -1,0 +1,91 @@
+=== tests/cases/conformance/directives/ts-ignore-start-ts-ignore-end.ts ===
+export const texts: string[] = [];
+>texts : string[]
+>[] : undefined[]
+
+// @ts-ignore-start
+texts.push(1);
+>texts.push(1) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>1 : 1
+
+texts.push(2);
+>texts.push(2) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>2 : 2
+
+texts.push(3);
+>texts.push(3) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>3 : 3
+
+// @ts-ignore-end
+
+// @ts-ignore-start some comment on start
+texts.push(4);
+>texts.push(4) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>4 : 4
+
+// @ts-ignore-end some comment on end
+
+
+/**
+  @ts-ignore-start */
+texts.push(4);
+>texts.push(4) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>4 : 4
+
+texts.push(5);
+>texts.push(5) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>5 : 5
+
+texts.push(6);
+>texts.push(6) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>6 : 6
+
+/** @ts-ignore-end */
+
+// @ts-ignore-start single line comment
+texts.push(7);
+>texts.push(7) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>7 : 7
+
+/* @ts-ignore-end  multiline comment */
+
+// error
+texts.push(8);
+>texts.push(8) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>8 : 8
+
+// @ts-ignore-end that was not started
+texts.push(9);
+>texts.push(9) : number
+>texts.push : (...items: string[]) => number
+>texts : string[]
+>push : (...items: string[]) => number
+>9 : 9
+

--- a/tests/cases/conformance/directives/multiline.tsx
+++ b/tests/cases/conformance/directives/multiline.tsx
@@ -13,6 +13,16 @@ texts.push(100);
  @ts-expect-error */
 texts.push("100");
 
+/**
+ @ts-ignore-start */
+texts.push(100);
+texts.push(100);
+texts.push(100);
+/**
+ @ts-ignore-end */
+
+texts.push("100");
+
 // @filename: b.tsx
 // @jsx: react
 // @libFiles: react.d.ts,lib.d.ts
@@ -49,5 +59,21 @@ let x = (
     {/*
    @ts-expect-error */}
     <MyComponent foo={"hooray"} />
+
+    {/* @ts-ignore-start */}
+    <MyComponent foo={100} />
+    <MyComponent foo={100} />
+    <MyComponent foo={100} />
+    {/* @ts-ignore-end */}
+    <MyComponent foo={"works!"} />
+
+    {/*
+    @ts-ignore-start */}
+    <MyComponent foo={100} />
+    <MyComponent foo={100} />
+    <MyComponent foo={100} />
+    {/*
+    @ts-ignore-end */}
+    <MyComponent foo={"works!"} />
   </div>
 );

--- a/tests/cases/conformance/directives/ts-ignore-start-ts-ignore-end.ts
+++ b/tests/cases/conformance/directives/ts-ignore-start-ts-ignore-end.ts
@@ -1,0 +1,27 @@
+
+export const texts: string[] = [];
+
+// @ts-ignore-start
+texts.push(1);
+texts.push(2);
+texts.push(3);
+// @ts-ignore-end
+
+// @ts-ignore-start some comment on start
+texts.push(4);
+// @ts-ignore-end some comment on end
+
+
+/**
+  @ts-ignore-start */
+texts.push(4);
+texts.push(5);
+texts.push(6);
+/** @ts-ignore-end */
+
+// @ts-ignore-start single line comment
+texts.push(7);
+/* @ts-ignore-end  multiline comment */
+
+
+

--- a/tests/cases/conformance/directives/ts-ignore-start-ts-ignore-end.ts
+++ b/tests/cases/conformance/directives/ts-ignore-start-ts-ignore-end.ts
@@ -23,5 +23,8 @@ texts.push(6);
 texts.push(7);
 /* @ts-ignore-end  multiline comment */
 
+// error
+texts.push(8);
 
-
+// @ts-ignore-end that was not started
+texts.push(9);


### PR DESCRIPTION
## History and rationale

This is a request from the community for about 3 years now. The most concrete answer that came from the TypeScript is @weswigham's comment in https://github.com/microsoft/TypeScript/issues/19573#issuecomment-573271826:

> I cannot, for the life of me, come up with a compelling, principled example where specific ranges of code should be allowed to be unchecked (unlike files, which had a clear migration-strategy-backed reasoning), other than "writing multiple consecutive suppressions makes my eyes bleed"...

I want us to be more sympathetic with the needs of the community. Casting to `any` might be a great solution but if users don't want to do it they might have a reason for that.

*  For instance, in my example imagine `foo` being typed with only `{prop1: string; prop2: string}`. I can technically cast my argument's type to `any` to add more props but that will remove type checking for `prop1` and `prop2`. 
* There could be teams that have strong feelings around casting to `any` but take it easier with `@ts-ignore`'s. Maybe they have processes in place to address comment directives later...
* In some cases users mentioned they want to `@ts-ignore` a few imports. Casting to `any` won't work there. 

I'm sure there are other cases that `@ts-nocheck` or casting to `any` won't fit the bill. Let's give the community what it is asking for! 

### A full example

Imagine a library that is wrongly type. `foo` accepts either a string or an object. 
```ts
interface ThirdPartyLib {
   /** @param arg can also be an object but not typed */ 
   callFn(foo: string): void;
}
```

Also consider that scope of my my work doesn't allow me to change the function signiture. But in my changes I need to pass a large object to `foo`:

```ts
thirdPartyLib.callFn({
  prop1: 'abc',
  prop2: 'efg',
  // ...
  propN: 'xyx'
});
```

To get past type errors I have to put in n `@ts-ignore` or `@ts-expect-error` directives :

```ts
// @ts-ignore
thirdPartyLib.callFn({
  // @ts-ignore
  prop1: 'abc',
  // @ts-ignore
  prop2: 'efg',
  // ...
  // @ts-ignore
  propN: 'xyx'
});
```

This change allows a more gentle way of going around this issue:

```ts
// @ts-ignore-start
thirdPartyLib.callFn({
  prop1: 'abc',
  prop2: 'efg',
  // ...
  propN: 'xyx'
});
// @ts-ignore-end
```


## Implementation Notes

### A `@ts-ignore-start` without a matching `@ts-ignore-end` will ignore type-errors up to end of the file
This made sense to me. Initially I had `@ts-ignore-start` without a matching `@ts-ignore-end` being an error like an unnecessary `@ts-expect-error`. It was a poor UX because the moment you start using these directives you get errors telling you the first directive you put in is an error


### A `@ts-ignore-end` without a matching `@ts-ignore-start` is an error
For obvious reasons. This is probably due to a mistake 

### Multiple  `@ts-ignore-start` is fine

```ts
@ts-ignore-start
// some code
@ts-ignore-start
@ts-ignore-end
```
Let me know if this should be an error. I feel this is more forgiving and user friendly.

## To do
This is still work in progress but I'm open for feedback. While I'm working on these items, please let me know what I should fix! 

* [x] Add more conformance tests 
* [x] Make sure tests pass in CI
* [ ] Add autocomplete suggestion 

Fixes #19573
