### PR TITLE
fix(22682): Fail on class declaration in statement position for ES2015 or higher

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -39276,6 +39276,14 @@ namespace ts {
             registerForUnusedIdentifiersCheck(node);
         }
 
+        function checkGrammarClassDeclaration(node: ClassDeclaration) {
+            if (node.parent) {
+                if (!isBlockLike(node.parent) && !isLabeledStatement(node.parent)) {
+                    grammarErrorOnNode(node, Diagnostics.A_class_declaration_can_only_be_used_in_a_scope_where_other_statements_can_reference_it);
+                }
+            }
+        }
+
         function checkClassDeclaration(node: ClassDeclaration) {
             if (some(node.decorators) && some(node.members, p => hasStaticModifier(p) && isPrivateIdentifierClassElementDeclaration(p))) {
                 grammarErrorOnNode(node.decorators[0], Diagnostics.Class_decorators_can_t_be_used_with_static_private_identifier_Consider_removing_the_experimental_decorator);
@@ -39283,6 +39291,7 @@ namespace ts {
             if (!node.name && !hasSyntacticModifier(node, ModifierFlags.Default)) {
                 grammarErrorOnFirstToken(node, Diagnostics.A_class_declaration_without_the_default_modifier_must_have_a_name);
             }
+            checkGrammarClassDeclaration(node);
             checkClassLikeDeclaration(node);
             forEach(node.members, checkSourceElement);
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1469,7 +1469,10 @@
         "category": "Message",
         "code": 1476
     },
-
+    "A class declaration can only be used in a scope where other statements can reference it." : {
+        "category": "Error",
+        "code": 1477
+    },
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",
         "code": 2200

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -734,6 +734,19 @@ namespace ts {
         return getBaseFileName(moduleName).replace(/^(\d)/, "_$1").replace(/\W/g, "_");
     }
 
+    export function isBlockLike(node: Node): node is BlockLike {
+        switch (node.kind) {
+            case SyntaxKind.Block:
+            case SyntaxKind.SourceFile:
+            case SyntaxKind.ModuleBlock:
+            case SyntaxKind.CaseClause:
+            case SyntaxKind.DefaultClause:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     export function isBlockOrCatchScoped(declaration: Declaration) {
         return (getCombinedNodeFlags(declaration) & NodeFlags.BlockScoped) !== 0 ||
             isCatchClauseVariableDeclarationOrBindingElement(declaration);

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1990,18 +1990,6 @@ namespace ts.refactor.extractSymbol {
         return true;
     }
 
-    function isBlockLike(node: Node): node is BlockLike {
-        switch (node.kind) {
-            case SyntaxKind.Block:
-            case SyntaxKind.SourceFile:
-            case SyntaxKind.ModuleBlock:
-            case SyntaxKind.CaseClause:
-                return true;
-            default:
-                return false;
-        }
-    }
-
     function isInJSXContent(node: Node) {
         return isStringLiteralJsxAttribute(node) ||
             (isJsxElement(node) || isJsxSelfClosingElement(node) || isJsxFragment(node)) && (isJsxElement(node.parent) || isJsxFragment(node.parent));

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1514,7 +1514,7 @@ namespace ts.refactor.extractSymbol {
                     prevStatement = statement;
                 }
 
-                if (!prevStatement && isCaseClause(curr)) {
+                if (!prevStatement && (isCaseClause(curr) || isDefaultClause(curr))) {
                     // We must have been in the expression of the case clause.
                     Debug.assert(isSwitchStatement(curr.parent.parent), "Grandparent isn't a switch statement");
                     return curr.parent.parent;

--- a/tests/baselines/reference/scopeClassDeclarations.errors.txt
+++ b/tests/baselines/reference/scopeClassDeclarations.errors.txt
@@ -1,0 +1,42 @@
+tests/cases/compiler/scopeClassDeclarations.ts(4,11): error TS1477: A class declaration can only be used in a scope where other statements can reference it.
+tests/cases/compiler/scopeClassDeclarations.ts(11,11): error TS1477: A class declaration can only be used in a scope where other statements can reference it.
+
+
+==== tests/cases/compiler/scopeClassDeclarations.ts (2 errors) ====
+    declare const condition: boolean;
+    
+    if (condition)
+        class C {} // runtime error if transpiled to ES2015 or above: Unexpected token class.
+              ~
+!!! error TS1477: A class declaration can only be used in a scope where other statements can reference it.
+    
+    new C(); // runtime error if transpiled to ES5, because 'C' is undefined.
+    
+    if (condition) 
+        console.log(); 
+    else
+        class X {}
+              ~
+!!! error TS1477: A class declaration can only be used in a scope where other statements can reference it.
+    
+    function foo() {
+    	return class X {}; // Not an error.
+    }
+    
+    while (class C {}) {  // Not an error.
+        break;
+    }
+    
+    switch (condition) {
+        case true:
+            class C {} // Not an error.
+            break;
+        case false: {
+            class C {} // Not an error.
+            break;
+        }
+        default:
+            class X {} // Not an error.
+            break;
+    }
+    

--- a/tests/baselines/reference/scopeClassDeclarations.js
+++ b/tests/baselines/reference/scopeClassDeclarations.js
@@ -1,0 +1,91 @@
+//// [scopeClassDeclarations.ts]
+declare const condition: boolean;
+
+if (condition)
+    class C {} // runtime error if transpiled to ES2015 or above: Unexpected token class.
+
+new C(); // runtime error if transpiled to ES5, because 'C' is undefined.
+
+if (condition) 
+    console.log(); 
+else
+    class X {}
+
+function foo() {
+	return class X {}; // Not an error.
+}
+
+while (class C {}) {  // Not an error.
+    break;
+}
+
+switch (condition) {
+    case true:
+        class C {} // Not an error.
+        break;
+    case false: {
+        class C {} // Not an error.
+        break;
+    }
+    default:
+        class X {} // Not an error.
+        break;
+}
+
+
+//// [scopeClassDeclarations.js]
+if (condition) {
+    var C = /** @class */ (function () {
+        function C() {
+        }
+        return C;
+    }());
+} // runtime error if transpiled to ES2015 or above: Unexpected token class.
+new C(); // runtime error if transpiled to ES5, because 'C' is undefined.
+if (condition)
+    console.log();
+else {
+    var X = /** @class */ (function () {
+        function X() {
+        }
+        return X;
+    }());
+}
+function foo() {
+    return /** @class */ (function () {
+        function X() {
+        }
+        return X;
+    }()); // Not an error.
+}
+while (/** @class */ (function () {
+    function C() {
+    }
+    return C;
+}())) { // Not an error.
+    break;
+}
+switch (condition) {
+    case true:
+        var C_1 = /** @class */ (function () {
+            function C() {
+            }
+            return C;
+        }()); // Not an error.
+        break;
+    case false: {
+        var C_2 = /** @class */ (function () {
+            function C() {
+            }
+            return C;
+        }()); // Not an error.
+        break;
+    }
+    default:
+        var X_1 = /** @class */ (function () {
+            function X() {
+            }
+            return X;
+        }()); // Not an error.
+        break;
+}

--- a/tests/baselines/reference/scopeClassDeclarations.symbols
+++ b/tests/baselines/reference/scopeClassDeclarations.symbols
@@ -1,0 +1,59 @@
+=== tests/cases/compiler/scopeClassDeclarations.ts ===
+declare const condition: boolean;
+>condition : Symbol(condition, Decl(scopeClassDeclarations.ts, 0, 13))
+
+if (condition)
+>condition : Symbol(condition, Decl(scopeClassDeclarations.ts, 0, 13))
+
+    class C {} // runtime error if transpiled to ES2015 or above: Unexpected token class.
+>C : Symbol(C, Decl(scopeClassDeclarations.ts, 2, 14))
+
+new C(); // runtime error if transpiled to ES5, because 'C' is undefined.
+>C : Symbol(C, Decl(scopeClassDeclarations.ts, 2, 14))
+
+if (condition) 
+>condition : Symbol(condition, Decl(scopeClassDeclarations.ts, 0, 13))
+
+    console.log(); 
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+
+else
+    class X {}
+>X : Symbol(X, Decl(scopeClassDeclarations.ts, 9, 4))
+
+function foo() {
+>foo : Symbol(foo, Decl(scopeClassDeclarations.ts, 10, 14))
+
+	return class X {}; // Not an error.
+>X : Symbol(X, Decl(scopeClassDeclarations.ts, 13, 7))
+}
+
+while (class C {}) {  // Not an error.
+>C : Symbol(C, Decl(scopeClassDeclarations.ts, 16, 7))
+
+    break;
+}
+
+switch (condition) {
+>condition : Symbol(condition, Decl(scopeClassDeclarations.ts, 0, 13))
+
+    case true:
+        class C {} // Not an error.
+>C : Symbol(C, Decl(scopeClassDeclarations.ts, 21, 14))
+
+        break;
+    case false: {
+        class C {} // Not an error.
+>C : Symbol(C, Decl(scopeClassDeclarations.ts, 24, 17))
+
+        break;
+    }
+    default:
+        class X {} // Not an error.
+>X : Symbol(X, Decl(scopeClassDeclarations.ts, 28, 12))
+
+        break;
+}
+

--- a/tests/baselines/reference/scopeClassDeclarations.types
+++ b/tests/baselines/reference/scopeClassDeclarations.types
@@ -1,0 +1,67 @@
+=== tests/cases/compiler/scopeClassDeclarations.ts ===
+declare const condition: boolean;
+>condition : boolean
+
+if (condition)
+>condition : boolean
+
+    class C {} // runtime error if transpiled to ES2015 or above: Unexpected token class.
+>C : C
+
+new C(); // runtime error if transpiled to ES5, because 'C' is undefined.
+>new C() : C
+>C : typeof C
+
+if (condition) 
+>condition : boolean
+
+    console.log(); 
+>console.log() : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+
+else
+    class X {}
+>X : X
+
+function foo() {
+>foo : () => typeof X
+
+	return class X {}; // Not an error.
+>class X {} : typeof X
+>X : typeof X
+}
+
+while (class C {}) {  // Not an error.
+>class C {} : typeof C
+>C : typeof C
+
+    break;
+}
+
+switch (condition) {
+>condition : boolean
+
+    case true:
+>true : true
+
+        class C {} // Not an error.
+>C : C
+
+        break;
+    case false: {
+>false : false
+
+        class C {} // Not an error.
+>C : C
+
+        break;
+    }
+    default:
+        class X {} // Not an error.
+>X : X
+
+        break;
+}
+

--- a/tests/cases/compiler/scopeClassDeclarations.ts
+++ b/tests/cases/compiler/scopeClassDeclarations.ts
@@ -1,0 +1,32 @@
+declare const condition: boolean;
+
+if (condition)
+    class C {} // runtime error if transpiled to ES2015 or above: Unexpected token class.
+
+new C(); // runtime error if transpiled to ES5, because 'C' is undefined.
+
+if (condition) 
+    console.log(); 
+else
+    class X {}
+
+function foo() {
+	return class X {}; // Not an error.
+}
+
+while (class C {}) {  // Not an error.
+    break;
+}
+
+switch (condition) {
+    case true:
+        class C {} // Not an error.
+        break;
+    case false: {
+        class C {} // Not an error.
+        break;
+    }
+    default:
+        class X {} // Not an error.
+        break;
+}


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Fixes #22682 

The error should be reported only in ES2015 or higher, therefore I changed the `binder` instead of the `parser` which needs still to parse this sequence to allow older standards.

In this PR I am checking only class declarations, since I am not sure from the conversation in the issue which is the required behaviour for enums.

Since this is my first contribution, I am not sure about the test coverage. In particular, I am not sure on how to generate the `.error.txt` file which I need to generate by running directly (calling tsc) the updated version of the compiler against the newly created `scopeClassDeclaration.ts` test file. 
