### PR TITLE
more precise type facts for intersection

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -180,7 +180,7 @@ namespace ts {
         SymbolAlwaysFalse = TypeofEQString | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
         SymbolStrictAlwaysFalse = SymbolAlwaysFalse | TypeofNESymbol | EQUndefined | EQNull | EQUndefinedOrNull,
         // Function
-        FunctionAlwaysFalse = TypeofEQSymbol | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject,
+        FunctionAlwaysFalse = TypeofEQSymbol | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject | TypeofEQHostObject,
         FunctionStrictAlwaysFalse = FunctionAlwaysFalse | TypeofNEFunction | EQUndefined | EQNull | EQUndefinedOrNull | Falsy,
         // Object
         ObjectAlwaysFalse = TypeofEQSymbol | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23023,7 +23023,10 @@ namespace ts {
                     (type === falseType || type === regularFalseType) ? TypeFacts.FalseStrictFacts : TypeFacts.TrueStrictFacts :
                     (type === falseType || type === regularFalseType) ? TypeFacts.FalseFacts : TypeFacts.TrueFacts;
             }
-            if (flags & TypeFlags.Object && !ignoreObjects) {
+            if (flags & TypeFlags.Object) {
+                if (ignoreObjects) {
+                    return TypeFacts.None;
+                }
                 return getObjectFlags(type) & ObjectFlags.Anonymous && isEmptyObjectType(type as ObjectType) ?
                     strictNullChecks ? TypeFacts.EmptyObjectStrictFacts : TypeFacts.EmptyObjectFacts :
                     isFunctionObjectType(type as ObjectType) ?
@@ -23055,21 +23058,13 @@ namespace ts {
             if (flags & TypeFlags.Intersection) {
                 // // When an intersection contains a primitive type we ignore object type constituents as they are
                 // // presumably type tags. For example, in string & { __kind__: "name" } we ignore the object type.
-                // const hasPrimitive = maybeTypeOfKind(type, TypeFlags.Primitive);
-                // ignoreObjects ||= hasPrimitive;
-                // if (hasPrimitive) {
-                //     return reduceLeft((type as IntersectionType).types, (facts, t) => facts & getTypeFacts(t, ignoreObjects), TypeFacts.All);
-                // }
-                // else {
-                //     return reduceLeft((type as IntersectionType).types, (facts, t) => facts | getTypeFacts(t, ignoreObjects), TypeFacts.None);
-                // }
+                ignoreObjects ||= maybeTypeOfKind(type, TypeFlags.Primitive);
                 return getIntersectionTypeFacts(type as IntersectionType, ignoreObjects);
             }
             return TypeFacts.All;
         }
 
         function getIntersectionTypeFacts(type: IntersectionType, ignoreObjects: boolean): TypeFacts {
-            ignoreObjects ||= maybeTypeOfKind(type, TypeFlags.Primitive);
             let alwaysTrue = TypeFacts.None;
             let alwaysFalse = TypeFacts.None;
             let facts = TypeFacts.None;
@@ -23155,7 +23150,13 @@ namespace ts {
                         ? { alwaysTrue: TypeFacts.FalseAlwaysTrue, alwaysFalse: TypeFacts.FalseAlwaysFalse }
                         : { alwaysTrue: TypeFacts.TrueAlwaysTrue, alwaysFalse: TypeFacts.TrueAlwaysFalse };
             }
-            if (flags & TypeFlags.Object && !ignoreObjects) {
+            if (flags & TypeFlags.Object) {
+                if (ignoreObjects) {
+                    return {
+                        alwaysTrue: TypeFacts.None,
+                        alwaysFalse: TypeFacts.None,
+                    };
+                }
                 return getObjectFlags(type) & ObjectFlags.Anonymous && isEmptyObjectType(type as ObjectType)
                     ? strictNullChecks
                         ? { alwaysTrue: TypeFacts.EmptyObjectStrictAlwaysTrue, alwaysFalse: TypeFacts.EmptyObjectStrictAlwaysFalse }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -74,7 +74,7 @@ namespace ts {
         TypeofNEString = 1 << 8,      // typeof x !== "string"
         TypeofNENumber = 1 << 9,      // typeof x !== "number"
         TypeofNEBigInt = 1 << 10,     // typeof x !== "bigint"
-        TypeofNEBoolean = 1 << 11,     // typeof x !== "boolean"
+        TypeofNEBoolean = 1 << 11,    // typeof x !== "boolean"
         TypeofNESymbol = 1 << 12,     // typeof x !== "symbol"
         TypeofNEObject = 1 << 13,     // typeof x !== "object"
         TypeofNEFunction = 1 << 14,   // typeof x !== "function"
@@ -134,92 +134,58 @@ namespace ts {
         EmptyObjectStrictFacts = All & ~(EQUndefined | EQNull | EQUndefinedOrNull),
         AllTypeofNE = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | NEUndefined,
         EmptyObjectFacts = All,
-        // Facts that are always true or always false (i.e. for all values of that type), to be used in `getIntersectionTypeFacts`.
+        // Facts that are always false (i.e. false for all values of that type), to be used in `getIntersectionTypeFacts`.
         // String
-        StringAlwaysTrue = TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject,
-        StringStrictAlwaysTrue = StringAlwaysTrue | TypeofEQString | NEUndefined | NENull | NEUndefinedOrNull,
         StringAlwaysFalse = TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
         StringStrictAlwaysFalse = StringAlwaysFalse | TypeofNEString | EQUndefined | EQNull | EQUndefinedOrNull,
         // Empty string
-        EmptyStringAlwaysTrue = StringAlwaysTrue,
-        EmptyStringStrictAlwaysTrue = StringStrictAlwaysTrue | Falsy,
         EmptyStringAlwaysFalse = StringAlwaysFalse,
         EmptyStringStrictAlwaysFalse = StringStrictAlwaysFalse | Truthy,
         // Non-empty string
-        NonEmptyStringAlwaysTrue = StringAlwaysTrue,
-        NonEmptyStringStrictAlwaysTrue = StringStrictAlwaysTrue | Truthy,
         NonEmptyStringAlwaysFalse = StringAlwaysFalse,
         NonEmptyStringStrictAlwaysFalse = StringStrictAlwaysFalse | Falsy,
         // Number
-        NumberAlwaysTrue = TypeofNEString | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject,
-        NumberStrictAlwaysTrue = NumberAlwaysTrue | TypeofEQNumber | NEUndefined | NENull | NEUndefinedOrNull,
         NumberAlwaysFalse = TypeofEQString | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
         NumberStrictAlwaysFalse = NumberAlwaysFalse | TypeofNENumber | EQUndefined | EQNull | EQUndefinedOrNull,
         // Zero number
-        ZeroNumberAlwaysTrue = NumberAlwaysTrue,
-        ZeroNumberStrictAlwaysTrue = NumberStrictAlwaysTrue | Falsy,
         ZeroNumberAlwaysFalse = NumberAlwaysFalse,
         ZeroNumberStrictAlwaysFalse = NumberStrictAlwaysFalse | Truthy,
         // Non-zero number
-        NonZeroNumberAlwaysTrue = NumberAlwaysTrue,
-        NonZeroNumberStrictAlwaysTrue = NumberStrictAlwaysTrue | Truthy,
         NonZeroNumberAlwaysFalse = NumberAlwaysFalse,
         NonZeroNumberStrictAlwaysFalse = NumberStrictAlwaysFalse | Falsy,
         // Big int
-        BigIntAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject,
-        BigIntStrictAlwaysTrue = BigIntAlwaysTrue | TypeofEQBigInt | NEUndefined | NENull | NEUndefinedOrNull,
         BigIntAlwaysFalse = TypeofEQString | TypeofEQNumber | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
         BigIntStrictAlwaysFalse = BigIntAlwaysFalse | TypeofNEBigInt | EQUndefined | EQNull | EQUndefinedOrNull,
         // Zero big int
-        ZeroBigIntAlwaysTrue = BigIntAlwaysTrue,
-        ZeroBigIntStrictAlwaysTrue = BigIntStrictAlwaysTrue | Falsy,
         ZeroBigIntAlwaysFalse = BigIntAlwaysFalse,
         ZeroBigIntStrictAlwaysFalse = BigIntStrictAlwaysFalse | Truthy,
         // Non-zero big int
-        NonZeroBigIntAlwaysTrue = BigIntAlwaysTrue,
-        NonZeroBigIntStrictAlwaysTrue = BigIntStrictAlwaysTrue | Truthy,
         NonZeroBigIntAlwaysFalse = BigIntAlwaysFalse,
         NonZeroBigIntStrictAlwaysFalse = BigIntStrictAlwaysFalse | Falsy,
         // Boolean
-        BooleanAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject,
-        BooleanStrictAlwaysTrue = BooleanAlwaysTrue | TypeofEQBoolean | NEUndefined | NENull | NEUndefinedOrNull,
         BooleanAlwaysFalse = TypeofEQString | TypeofEQNumber | TypeofEQBigInt | TypeofEQSymbol | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
         BooleanStrictAlwaysFalse = BooleanAlwaysFalse | TypeofNEBoolean | EQUndefined | EQNull | EQUndefinedOrNull,
         // Boolean-like
         // False
-        FalseAlwaysTrue = BooleanAlwaysTrue,
-        FalseStrictAlwaysTrue = BooleanStrictAlwaysTrue | Falsy,
         FalseAlwaysFalse = BooleanAlwaysFalse,
         FalseStrictAlwaysFalse = BooleanStrictAlwaysFalse | Truthy,
         // True
-        TrueAlwaysTrue = BooleanAlwaysTrue,
-        TrueStrictAlwaysTrue = BooleanStrictAlwaysTrue | Truthy,
         TrueAlwaysFalse = BooleanAlwaysFalse,
         TrueStrictAlwaysFalse = BooleanStrictAlwaysFalse | Falsy,
         // Undefined
-        UndefinedAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject | EQUndefined | EQUndefinedOrNull | NENull | Falsy,
         UndefinedAlwaysFalse = TypeofEQSymbol | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject | NEUndefined | NEUndefinedOrNull | EQNull | Truthy,
         // Null
-        NullAlwaysTrue = TypeofEQObject | TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEFunction | TypeofNEHostObject | EQNull | EQUndefinedOrNull | NEUndefined | Falsy,
         NullAlwaysFalse = TypeofNEObject | TypeofEQString | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQFunction | TypeofEQHostObject | NENull | NEUndefinedOrNull | EQUndefined | Truthy,
         // Symbol
-        SymbolAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject,
-        SymbolStrictAlwaysTrue = SymbolAlwaysTrue | TypeofEQSymbol | NEUndefined | NENull | NEUndefinedOrNull | Truthy,
         SymbolAlwaysFalse = TypeofEQString | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
         SymbolStrictAlwaysFalse = SymbolAlwaysFalse | TypeofNESymbol | EQUndefined | EQNull | EQUndefinedOrNull,
         // Function
-        FunctionAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject,
-        FunctionStrictAlwaysTrue = FunctionAlwaysTrue | TypeofEQFunction | NEUndefined | NENull | NEUndefinedOrNull | Truthy, // >> TODO: what about `TypeofEQHostObject`?
         FunctionAlwaysFalse = TypeofEQSymbol | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject,
         FunctionStrictAlwaysFalse = FunctionAlwaysFalse | TypeofNEFunction | EQUndefined | EQNull | EQUndefinedOrNull | Falsy,
         // Object
-        ObjectAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol, // could it still be e.g. a symbol?
-        ObjectStrictAlwaysTrue = ObjectAlwaysTrue | NEUndefined | NENull | NEUndefinedOrNull | Truthy, // >> TODO: what about `TypeofEQHostObject`
         ObjectAlwaysFalse = TypeofEQSymbol | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol,
         ObjectStrictAlwaysFalse = ObjectAlwaysFalse | EQUndefined | EQNull | EQUndefinedOrNull | Falsy,
         // Empty object
-        EmptyObjectAlwaysTrue = None,
-        EmptyObjectStrictAlwaysTrue = NEUndefined | NENull | NEUndefinedOrNull,
         EmptyObjectAlwaysFalse = None,
         EmptyObjectStrictAlwaysFalse = EQUndefined | EQNull | EQUndefinedOrNull,
     }
@@ -23065,167 +23031,122 @@ namespace ts {
         }
 
         function getIntersectionTypeFacts(type: IntersectionType, ignoreObjects: boolean): TypeFacts {
-            let alwaysTrue = TypeFacts.None;
             let alwaysFalse = TypeFacts.None;
             let facts = TypeFacts.None;
             for (const t of type.types) {
                 facts |= getTypeFacts(t, ignoreObjects);
-                const { alwaysTrue: tTrue, alwaysFalse: tFalse } = getAlwaysTypeFacts(t, ignoreObjects);
-                alwaysTrue |= tTrue;
-                alwaysFalse |= tFalse;
+                alwaysFalse |= getAlwaysFalseTypeFacts(t, ignoreObjects);
             }
 
-            if (alwaysTrue & alwaysFalse) {
-                // Contradiction
-                return TypeFacts.None;
-            }
-
-            return (facts | alwaysTrue) & (~alwaysFalse);
+            return facts & ~alwaysFalse;
         }
 
-        function getAlwaysTypeFacts(type: Type, ignoreObjects: boolean): { alwaysTrue: TypeFacts, alwaysFalse: TypeFacts } {
+        function getAlwaysFalseTypeFacts(type: Type, ignoreObjects: boolean): TypeFacts {
             const flags = type.flags;
             if (flags & TypeFlags.String) {
-                return {
-                    alwaysTrue: strictNullChecks ? TypeFacts.StringStrictAlwaysTrue : TypeFacts.StringAlwaysTrue,
-                    alwaysFalse: strictNullChecks ?
-                        TypeFacts.StringStrictAlwaysFalse : TypeFacts.StringAlwaysFalse,
-                };
+                return strictNullChecks ? TypeFacts.StringStrictAlwaysFalse : TypeFacts.StringAlwaysFalse;
             }
             if (flags & TypeFlags.StringLiteral) {
                 const isEmpty = (type as StringLiteralType).value === "";
                 return strictNullChecks
                     ? isEmpty
-                        ? { alwaysTrue: TypeFacts.EmptyStringStrictAlwaysTrue, alwaysFalse: TypeFacts.EmptyStringStrictAlwaysFalse }
-                        : { alwaysTrue: TypeFacts.NonEmptyStringStrictAlwaysTrue, alwaysFalse: TypeFacts.NonEmptyStringStrictAlwaysFalse }
+                        ? TypeFacts.EmptyStringStrictAlwaysFalse
+                        : TypeFacts.NonEmptyStringStrictAlwaysFalse
                     : isEmpty
-                    ? { alwaysTrue: TypeFacts.EmptyStringAlwaysTrue, alwaysFalse: TypeFacts.EmptyStringAlwaysFalse }
-                    : { alwaysTrue: TypeFacts.NonEmptyStringAlwaysTrue, alwaysFalse: TypeFacts.NonEmptyStringAlwaysFalse };
+                    ? TypeFacts.EmptyStringAlwaysFalse
+                    : TypeFacts.NonEmptyStringAlwaysFalse;
             }
             if (flags & (TypeFlags.Number | TypeFlags.Enum)) {
-                return {
-                    alwaysTrue: strictNullChecks ? TypeFacts.NumberStrictAlwaysTrue : TypeFacts.NumberAlwaysTrue,
-                    alwaysFalse: strictNullChecks ? TypeFacts.NumberStrictAlwaysFalse : TypeFacts.NumberAlwaysFalse,
-                };
+                return strictNullChecks ? TypeFacts.NumberStrictAlwaysFalse : TypeFacts.NumberAlwaysFalse;
             }
             if (flags & TypeFlags.NumberLiteral) {
                 const isZero = (type as NumberLiteralType).value === 0;
                 return strictNullChecks
                     ? isZero
-                        ? { alwaysTrue: TypeFacts.ZeroNumberStrictAlwaysTrue, alwaysFalse: TypeFacts.ZeroNumberStrictAlwaysFalse }
-                        : { alwaysTrue: TypeFacts.NonZeroNumberStrictAlwaysTrue, alwaysFalse: TypeFacts.NonZeroNumberStrictAlwaysFalse }
+                        ? TypeFacts.ZeroNumberStrictAlwaysFalse
+                        : TypeFacts.NonZeroNumberStrictAlwaysFalse
                     : isZero
-                        ? { alwaysTrue: TypeFacts.ZeroNumberAlwaysTrue, alwaysFalse: TypeFacts.ZeroNumberAlwaysFalse }
-                        : { alwaysTrue: TypeFacts.NonZeroNumberAlwaysTrue, alwaysFalse: TypeFacts.NonZeroNumberAlwaysFalse };
+                        ? TypeFacts.ZeroNumberAlwaysFalse
+                        : TypeFacts.NonZeroNumberAlwaysFalse;
             }
             if (flags & TypeFlags.BigInt) {
-                return {
-                    alwaysTrue: strictNullChecks ? TypeFacts.BigIntStrictAlwaysTrue : TypeFacts.BigIntAlwaysTrue,
-                    alwaysFalse: strictNullChecks ? TypeFacts.BigIntStrictAlwaysFalse : TypeFacts.BigIntAlwaysFalse,
-                };
+                return strictNullChecks ? TypeFacts.BigIntStrictAlwaysFalse : TypeFacts.BigIntAlwaysFalse;
             }
             if (flags & TypeFlags.BigIntLiteral) {
                 const isZero = isZeroBigInt(type as BigIntLiteralType);
                  return strictNullChecks
                     ? isZero
-                        ? { alwaysTrue: TypeFacts.ZeroBigIntStrictAlwaysTrue, alwaysFalse: TypeFacts.ZeroBigIntStrictAlwaysFalse }
-                        : { alwaysTrue: TypeFacts.NonZeroBigIntStrictAlwaysTrue, alwaysFalse: TypeFacts.NonZeroBigIntStrictAlwaysFalse }
+                        ? TypeFacts.ZeroBigIntStrictAlwaysFalse
+                        : TypeFacts.NonZeroBigIntStrictAlwaysFalse
                     : isZero
-                        ? { alwaysTrue: TypeFacts.ZeroBigIntAlwaysTrue, alwaysFalse: TypeFacts.ZeroBigIntAlwaysFalse }
-                        : { alwaysTrue: TypeFacts.NonZeroBigIntAlwaysTrue, alwaysFalse: TypeFacts.NonZeroBigIntAlwaysFalse };
+                        ? TypeFacts.ZeroBigIntAlwaysFalse
+                        : TypeFacts.NonZeroBigIntAlwaysFalse;
             }
             if (flags & TypeFlags.Boolean) {
-                return {
-                    alwaysTrue: strictNullChecks ? TypeFacts.BooleanStrictAlwaysTrue : TypeFacts.BooleanAlwaysTrue,
-                    alwaysFalse: strictNullChecks ?
-                        TypeFacts.BooleanStrictAlwaysFalse : TypeFacts.BooleanAlwaysFalse,
-                };
+                return strictNullChecks ? TypeFacts.BooleanStrictAlwaysFalse : TypeFacts.BooleanAlwaysFalse;
             }
             if (flags & TypeFlags.BooleanLike) {
                 return strictNullChecks
                     ? (type === falseType || type === regularFalseType)
-                        ? { alwaysTrue: TypeFacts.FalseStrictAlwaysTrue, alwaysFalse: TypeFacts.FalseStrictAlwaysFalse }
-                        : { alwaysTrue: TypeFacts.TrueStrictAlwaysTrue, alwaysFalse: TypeFacts.TrueStrictAlwaysFalse }
+                        ? TypeFacts.FalseStrictAlwaysFalse
+                        : TypeFacts.TrueStrictAlwaysFalse
                     : (type === falseType || type === regularFalseType)
-                        ? { alwaysTrue: TypeFacts.FalseAlwaysTrue, alwaysFalse: TypeFacts.FalseAlwaysFalse }
-                        : { alwaysTrue: TypeFacts.TrueAlwaysTrue, alwaysFalse: TypeFacts.TrueAlwaysFalse };
+                        ? TypeFacts.FalseAlwaysFalse
+                        : TypeFacts.TrueAlwaysFalse;
             }
             if (flags & TypeFlags.Object) {
                 if (ignoreObjects) {
-                    return {
-                        alwaysTrue: TypeFacts.None,
-                        alwaysFalse: TypeFacts.None,
-                    };
+                    return TypeFacts.None;
                 }
                 return getObjectFlags(type) & ObjectFlags.Anonymous && isEmptyObjectType(type as ObjectType)
                     ? strictNullChecks
-                        ? { alwaysTrue: TypeFacts.EmptyObjectStrictAlwaysTrue, alwaysFalse: TypeFacts.EmptyObjectStrictAlwaysFalse }
-                        : { alwaysTrue: TypeFacts.EmptyObjectAlwaysTrue, alwaysFalse: TypeFacts.EmptyObjectAlwaysFalse }
+                        ? TypeFacts.EmptyObjectStrictAlwaysFalse
+                        : TypeFacts.EmptyObjectAlwaysFalse
                     : isFunctionObjectType(type as ObjectType)
                         ? strictNullChecks
-                            ? { alwaysTrue: TypeFacts.FunctionStrictAlwaysTrue, alwaysFalse: TypeFacts.FunctionStrictAlwaysFalse }
-                            : { alwaysTrue: TypeFacts.FunctionAlwaysTrue, alwaysFalse: TypeFacts.FunctionAlwaysFalse }
+                            ? TypeFacts.FunctionStrictAlwaysFalse
+                            : TypeFacts.FunctionAlwaysFalse
                         : strictNullChecks
-                            ? { alwaysTrue: TypeFacts.ObjectStrictAlwaysTrue, alwaysFalse: TypeFacts.ObjectStrictAlwaysFalse }
-                            : { alwaysTrue: TypeFacts.ObjectAlwaysTrue, alwaysFalse: TypeFacts.ObjectAlwaysFalse };
+                            ? TypeFacts.ObjectStrictAlwaysFalse
+                            : TypeFacts.ObjectAlwaysFalse;
             }
             if (flags & (TypeFlags.Void | TypeFlags.Undefined)) {
-                return { alwaysTrue: TypeFacts.UndefinedAlwaysTrue, alwaysFalse: TypeFacts.UndefinedAlwaysFalse };
+                return TypeFacts.UndefinedAlwaysFalse;
             }
             if (flags & TypeFlags.Null) {
-                return { alwaysTrue: TypeFacts.NullAlwaysTrue, alwaysFalse: TypeFacts.NullAlwaysFalse };
+                return TypeFacts.NullAlwaysFalse;
             }
             if (flags & TypeFlags.ESSymbolLike) {
-                return {
-                    alwaysTrue: strictNullChecks ? TypeFacts.SymbolStrictAlwaysTrue : TypeFacts.SymbolAlwaysTrue,
-                    alwaysFalse: strictNullChecks ? TypeFacts.SymbolStrictAlwaysFalse : TypeFacts.SymbolAlwaysFalse,
-                };
+                return strictNullChecks ? TypeFacts.SymbolStrictAlwaysFalse : TypeFacts.SymbolAlwaysFalse;
             }
             if (flags & TypeFlags.NonPrimitive) {
-                return strictNullChecks ?
-                    { alwaysTrue: TypeFacts.ObjectStrictAlwaysTrue, alwaysFalse: TypeFacts.ObjectStrictAlwaysFalse } :
-                    { alwaysTrue: TypeFacts.ObjectAlwaysTrue, alwaysFalse: TypeFacts.ObjectAlwaysFalse };
+                return strictNullChecks ? TypeFacts.ObjectStrictAlwaysFalse : TypeFacts.ObjectAlwaysFalse;
             }
             if (flags & TypeFlags.Never) {
-                return {
-                    alwaysTrue: TypeFacts.None,
-                    alwaysFalse: TypeFacts.None,
-                };
+                return TypeFacts.None;
             }
             if (flags & TypeFlags.Instantiable) {
                 return !isPatternLiteralType(type)
-                    ? getAlwaysTypeFacts(getBaseConstraintOfType(type) || unknownType, ignoreObjects)
+                    ? getAlwaysFalseTypeFacts(getBaseConstraintOfType(type) || unknownType, ignoreObjects)
                     : strictNullChecks
-                        ? { alwaysTrue: TypeFacts.NonEmptyStringStrictAlwaysTrue, alwaysFalse: TypeFacts.NonEmptyStringStrictAlwaysFalse }
-                        : { alwaysTrue: TypeFacts.NonEmptyStringAlwaysTrue, alwaysFalse: TypeFacts.NonEmptyStringAlwaysFalse };
+                        ? TypeFacts.NonEmptyStringStrictAlwaysFalse
+                        : TypeFacts.NonEmptyStringAlwaysFalse;
             }
             if (flags & TypeFlags.Union) {
                 const types = (type as UnionType).types;
                 if (types.length) {
-                    return reduceLeft(types, (facts, t) => {
-                        const { alwaysTrue, alwaysFalse } = getAlwaysTypeFacts(t, ignoreObjects);
-                        return { alwaysTrue: facts.alwaysTrue & alwaysTrue, alwaysFalse: facts.alwaysFalse & alwaysFalse };
-                    }, { alwaysTrue: TypeFacts.All, alwaysFalse: TypeFacts.All }); // >> TODO: that's assuming union will never be empty; check that
+                    return reduceLeft(types, (facts, t) => facts & getAlwaysFalseTypeFacts(t, ignoreObjects), TypeFacts.All);
                 }
-                return {
-                    alwaysTrue: TypeFacts.None,
-                    alwaysFalse: TypeFacts.None,
-                };
+                return TypeFacts.None;
             }
             if (flags & TypeFlags.Intersection) {
                 // When an intersection contains a primitive type we ignore object type constituents as they are
                 // presumably type tags. For example, in string & { __kind__: "name" } we ignore the object type.
                 ignoreObjects ||= maybeTypeOfKind(type, TypeFlags.Primitive);
-                return reduceLeft((type as IntersectionType).types, (facts, t) => {
-                    const { alwaysTrue, alwaysFalse } = getAlwaysTypeFacts(t, ignoreObjects);
-                    return { alwaysTrue: facts.alwaysTrue | alwaysTrue, alwaysFalse: facts.alwaysFalse | alwaysFalse };
-                }, { alwaysTrue: TypeFacts.None, alwaysFalse: TypeFacts.None });
+                return reduceLeft((type as IntersectionType).types, (facts, t) => facts | getAlwaysFalseTypeFacts(t, ignoreObjects), TypeFacts.None);
             }
 
-            return {
-                alwaysTrue: TypeFacts.None,
-                alwaysFalse: TypeFacts.None,
-            };
+            return TypeFacts.None;
         }
 
         function getTypeWithFacts(type: Type, include: TypeFacts) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -134,6 +134,94 @@ namespace ts {
         EmptyObjectStrictFacts = All & ~(EQUndefined | EQNull | EQUndefinedOrNull),
         AllTypeofNE = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | NEUndefined,
         EmptyObjectFacts = All,
+        // Facts that are always true or always false (i.e. for all values of that type), to be used in `getIntersectionTypeFacts`.
+        // String
+        StringAlwaysTrue = TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject,
+        StringStrictAlwaysTrue = StringAlwaysTrue | TypeofEQString | NEUndefined | NENull | NEUndefinedOrNull,
+        StringAlwaysFalse = TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
+        StringStrictAlwaysFalse = StringAlwaysFalse | TypeofNEString | EQUndefined | EQNull | EQUndefinedOrNull,
+        // Empty string
+        EmptyStringAlwaysTrue = StringAlwaysTrue,
+        EmptyStringStrictAlwaysTrue = StringStrictAlwaysTrue | Falsy,
+        EmptyStringAlwaysFalse = StringAlwaysFalse,
+        EmptyStringStrictAlwaysFalse = StringStrictAlwaysFalse | Truthy,
+        // Non-empty string
+        NonEmptyStringAlwaysTrue = StringAlwaysTrue,
+        NonEmptyStringStrictAlwaysTrue = StringStrictAlwaysTrue | Truthy,
+        NonEmptyStringAlwaysFalse = StringAlwaysFalse,
+        NonEmptyStringStrictAlwaysFalse = StringStrictAlwaysFalse | Falsy,
+        // Number
+        NumberAlwaysTrue = TypeofNEString | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject,
+        NumberStrictAlwaysTrue = NumberAlwaysTrue | TypeofEQNumber | NEUndefined | NENull | NEUndefinedOrNull,
+        NumberAlwaysFalse = TypeofEQString | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
+        NumberStrictAlwaysFalse = NumberAlwaysFalse | TypeofNENumber | EQUndefined | EQNull | EQUndefinedOrNull,
+        // Zero number
+        ZeroNumberAlwaysTrue = NumberAlwaysTrue,
+        ZeroNumberStrictAlwaysTrue = NumberStrictAlwaysTrue | Falsy,
+        ZeroNumberAlwaysFalse = NumberAlwaysFalse,
+        ZeroNumberStrictAlwaysFalse = NumberStrictAlwaysFalse | Truthy,
+        // Non-zero number
+        NonZeroNumberAlwaysTrue = NumberAlwaysTrue,
+        NonZeroNumberStrictAlwaysTrue = NumberStrictAlwaysTrue | Truthy,
+        NonZeroNumberAlwaysFalse = NumberAlwaysFalse,
+        NonZeroNumberStrictAlwaysFalse = NumberStrictAlwaysFalse | Falsy,
+        // Big int
+        BigIntAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject,
+        BigIntStrictAlwaysTrue = BigIntAlwaysTrue | TypeofEQBigInt | NEUndefined | NENull | NEUndefinedOrNull,
+        BigIntAlwaysFalse = TypeofEQString | TypeofEQNumber | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
+        BigIntStrictAlwaysFalse = BigIntAlwaysFalse | TypeofNEBigInt | EQUndefined | EQNull | EQUndefinedOrNull,
+        // Zero big int
+        ZeroBigIntAlwaysTrue = BigIntAlwaysTrue,
+        ZeroBigIntStrictAlwaysTrue = BigIntStrictAlwaysTrue | Falsy,
+        ZeroBigIntAlwaysFalse = BigIntAlwaysFalse,
+        ZeroBigIntStrictAlwaysFalse = BigIntStrictAlwaysFalse | Truthy,
+        // Non-zero big int
+        NonZeroBigIntAlwaysTrue = BigIntAlwaysTrue,
+        NonZeroBigIntStrictAlwaysTrue = BigIntStrictAlwaysTrue | Truthy,
+        NonZeroBigIntAlwaysFalse = BigIntAlwaysFalse,
+        NonZeroBigIntStrictAlwaysFalse = BigIntStrictAlwaysFalse | Falsy,
+        // Boolean
+        BooleanAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject,
+        BooleanStrictAlwaysTrue = BooleanAlwaysTrue | TypeofEQBoolean | NEUndefined | NENull | NEUndefinedOrNull,
+        BooleanAlwaysFalse = TypeofEQString | TypeofEQNumber | TypeofEQBigInt | TypeofEQSymbol | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
+        BooleanStrictAlwaysFalse = BooleanAlwaysFalse | TypeofNEBoolean | EQUndefined | EQNull | EQUndefinedOrNull,
+        // Boolean-like
+        // False
+        FalseAlwaysTrue = BooleanAlwaysTrue,
+        FalseStrictAlwaysTrue = BooleanStrictAlwaysTrue | Falsy,
+        FalseAlwaysFalse = BooleanAlwaysFalse,
+        FalseStrictAlwaysFalse = BooleanStrictAlwaysFalse | Truthy,
+        // True
+        TrueAlwaysTrue = BooleanAlwaysTrue,
+        TrueStrictAlwaysTrue = BooleanStrictAlwaysTrue | Truthy,
+        TrueAlwaysFalse = BooleanAlwaysFalse,
+        TrueStrictAlwaysFalse = BooleanStrictAlwaysFalse | Falsy,
+        // Undefined
+        UndefinedAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject | EQUndefined | EQUndefinedOrNull | NENull | Falsy,
+        UndefinedAlwaysFalse = TypeofEQSymbol | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject | NEUndefined | NEUndefinedOrNull | EQNull | Truthy,
+        // Null
+        NullAlwaysTrue = TypeofEQObject | TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEFunction | TypeofNEHostObject | EQNull | EQUndefinedOrNull | NEUndefined | Falsy,
+        NullAlwaysFalse = TypeofNEObject | TypeofEQString | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQFunction | TypeofEQHostObject | NENull | NEUndefinedOrNull | EQUndefined | Truthy,
+        // Symbol
+        SymbolAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNEObject | TypeofNEFunction | TypeofNEHostObject,
+        SymbolStrictAlwaysTrue = SymbolAlwaysTrue | TypeofEQSymbol | NEUndefined | NENull | NEUndefinedOrNull | Truthy,
+        SymbolAlwaysFalse = TypeofEQString | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQObject | TypeofEQFunction | TypeofEQHostObject,
+        SymbolStrictAlwaysFalse = SymbolAlwaysFalse | TypeofNESymbol | EQUndefined | EQNull | EQUndefinedOrNull,
+        // Function
+        FunctionAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol | TypeofNEObject,
+        FunctionStrictAlwaysTrue = FunctionAlwaysTrue | TypeofEQFunction | NEUndefined | NENull | NEUndefinedOrNull | Truthy, // >> TODO: what about `TypeofEQHostObject`?
+        FunctionAlwaysFalse = TypeofEQSymbol | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol | TypeofEQObject,
+        FunctionStrictAlwaysFalse = FunctionAlwaysFalse | TypeofNEFunction | EQUndefined | EQNull | EQUndefinedOrNull | Falsy,
+        // Object
+        ObjectAlwaysTrue = TypeofNEString | TypeofNENumber | TypeofNEBigInt | TypeofNEBoolean | TypeofNESymbol, // could it still be e.g. a symbol?
+        ObjectStrictAlwaysTrue = ObjectAlwaysTrue | NEUndefined | NENull | NEUndefinedOrNull | Truthy, // >> TODO: what about `TypeofEQHostObject`
+        ObjectAlwaysFalse = TypeofEQSymbol | TypeofEQNumber | TypeofEQBigInt | TypeofEQBoolean | TypeofEQSymbol,
+        ObjectStrictAlwaysFalse = ObjectAlwaysFalse | EQUndefined | EQNull | EQUndefinedOrNull | Falsy,
+        // Empty object
+        EmptyObjectAlwaysTrue = None,
+        EmptyObjectStrictAlwaysTrue = NEUndefined | NENull | NEUndefinedOrNull,
+        EmptyObjectAlwaysFalse = None,
+        EmptyObjectStrictAlwaysFalse = EQUndefined | EQNull | EQUndefinedOrNull,
     }
 
     const typeofEQFacts: ReadonlyESMap<string, TypeFacts> = new Map(getEntries({
@@ -22965,12 +23053,178 @@ namespace ts {
                 return reduceLeft((type as UnionType).types, (facts, t) => facts | getTypeFacts(t, ignoreObjects), TypeFacts.None);
             }
             if (flags & TypeFlags.Intersection) {
+                // // When an intersection contains a primitive type we ignore object type constituents as they are
+                // // presumably type tags. For example, in string & { __kind__: "name" } we ignore the object type.
+                // const hasPrimitive = maybeTypeOfKind(type, TypeFlags.Primitive);
+                // ignoreObjects ||= hasPrimitive;
+                // if (hasPrimitive) {
+                //     return reduceLeft((type as IntersectionType).types, (facts, t) => facts & getTypeFacts(t, ignoreObjects), TypeFacts.All);
+                // }
+                // else {
+                //     return reduceLeft((type as IntersectionType).types, (facts, t) => facts | getTypeFacts(t, ignoreObjects), TypeFacts.None);
+                // }
+                return getIntersectionTypeFacts(type as IntersectionType, ignoreObjects);
+            }
+            return TypeFacts.All;
+        }
+
+        function getIntersectionTypeFacts(type: IntersectionType, ignoreObjects: boolean): TypeFacts {
+            ignoreObjects ||= maybeTypeOfKind(type, TypeFlags.Primitive);
+            let alwaysTrue = TypeFacts.None;
+            let alwaysFalse = TypeFacts.None;
+            let facts = TypeFacts.None;
+            for (const t of type.types) {
+                facts |= getTypeFacts(t, ignoreObjects);
+                const { alwaysTrue: tTrue, alwaysFalse: tFalse } = getAlwaysTypeFacts(t, ignoreObjects);
+                alwaysTrue |= tTrue;
+                alwaysFalse |= tFalse;
+            }
+
+            if (alwaysTrue & alwaysFalse) {
+                // Contradiction
+                return TypeFacts.None;
+            }
+
+            return (facts | alwaysTrue) & (~alwaysFalse);
+        }
+
+        function getAlwaysTypeFacts(type: Type, ignoreObjects: boolean): { alwaysTrue: TypeFacts, alwaysFalse: TypeFacts } {
+            const flags = type.flags;
+            if (flags & TypeFlags.String) {
+                return {
+                    alwaysTrue: strictNullChecks ? TypeFacts.StringStrictAlwaysTrue : TypeFacts.StringAlwaysTrue,
+                    alwaysFalse: strictNullChecks ?
+                        TypeFacts.StringStrictAlwaysFalse : TypeFacts.StringAlwaysFalse,
+                };
+            }
+            if (flags & TypeFlags.StringLiteral) {
+                const isEmpty = (type as StringLiteralType).value === "";
+                return strictNullChecks
+                    ? isEmpty
+                        ? { alwaysTrue: TypeFacts.EmptyStringStrictAlwaysTrue, alwaysFalse: TypeFacts.EmptyStringStrictAlwaysFalse }
+                        : { alwaysTrue: TypeFacts.NonEmptyStringStrictAlwaysTrue, alwaysFalse: TypeFacts.NonEmptyStringStrictAlwaysFalse }
+                    : isEmpty
+                    ? { alwaysTrue: TypeFacts.EmptyStringAlwaysTrue, alwaysFalse: TypeFacts.EmptyStringAlwaysFalse }
+                    : { alwaysTrue: TypeFacts.NonEmptyStringAlwaysTrue, alwaysFalse: TypeFacts.NonEmptyStringAlwaysFalse };
+            }
+            if (flags & (TypeFlags.Number | TypeFlags.Enum)) {
+                return {
+                    alwaysTrue: strictNullChecks ? TypeFacts.NumberStrictAlwaysTrue : TypeFacts.NumberAlwaysTrue,
+                    alwaysFalse: strictNullChecks ? TypeFacts.NumberStrictAlwaysFalse : TypeFacts.NumberAlwaysFalse,
+                };
+            }
+            if (flags & TypeFlags.NumberLiteral) {
+                const isZero = (type as NumberLiteralType).value === 0;
+                return strictNullChecks
+                    ? isZero
+                        ? { alwaysTrue: TypeFacts.ZeroNumberStrictAlwaysTrue, alwaysFalse: TypeFacts.ZeroNumberStrictAlwaysFalse }
+                        : { alwaysTrue: TypeFacts.NonZeroNumberStrictAlwaysTrue, alwaysFalse: TypeFacts.NonZeroNumberStrictAlwaysFalse }
+                    : isZero
+                        ? { alwaysTrue: TypeFacts.ZeroNumberAlwaysTrue, alwaysFalse: TypeFacts.ZeroNumberAlwaysFalse }
+                        : { alwaysTrue: TypeFacts.NonZeroNumberAlwaysTrue, alwaysFalse: TypeFacts.NonZeroNumberAlwaysFalse };
+            }
+            if (flags & TypeFlags.BigInt) {
+                return {
+                    alwaysTrue: strictNullChecks ? TypeFacts.BigIntStrictAlwaysTrue : TypeFacts.BigIntAlwaysTrue,
+                    alwaysFalse: strictNullChecks ? TypeFacts.BigIntStrictAlwaysFalse : TypeFacts.BigIntAlwaysFalse,
+                };
+            }
+            if (flags & TypeFlags.BigIntLiteral) {
+                const isZero = isZeroBigInt(type as BigIntLiteralType);
+                 return strictNullChecks
+                    ? isZero
+                        ? { alwaysTrue: TypeFacts.ZeroBigIntStrictAlwaysTrue, alwaysFalse: TypeFacts.ZeroBigIntStrictAlwaysFalse }
+                        : { alwaysTrue: TypeFacts.NonZeroBigIntStrictAlwaysTrue, alwaysFalse: TypeFacts.NonZeroBigIntStrictAlwaysFalse }
+                    : isZero
+                        ? { alwaysTrue: TypeFacts.ZeroBigIntAlwaysTrue, alwaysFalse: TypeFacts.ZeroBigIntAlwaysFalse }
+                        : { alwaysTrue: TypeFacts.NonZeroBigIntAlwaysTrue, alwaysFalse: TypeFacts.NonZeroBigIntAlwaysFalse };
+            }
+            if (flags & TypeFlags.Boolean) {
+                return {
+                    alwaysTrue: strictNullChecks ? TypeFacts.BooleanStrictAlwaysTrue : TypeFacts.BooleanAlwaysTrue,
+                    alwaysFalse: strictNullChecks ?
+                        TypeFacts.BooleanStrictAlwaysFalse : TypeFacts.BooleanAlwaysFalse,
+                };
+            }
+            if (flags & TypeFlags.BooleanLike) {
+                return strictNullChecks
+                    ? (type === falseType || type === regularFalseType)
+                        ? { alwaysTrue: TypeFacts.FalseStrictAlwaysTrue, alwaysFalse: TypeFacts.FalseStrictAlwaysFalse }
+                        : { alwaysTrue: TypeFacts.TrueStrictAlwaysTrue, alwaysFalse: TypeFacts.TrueStrictAlwaysFalse }
+                    : (type === falseType || type === regularFalseType)
+                        ? { alwaysTrue: TypeFacts.FalseAlwaysTrue, alwaysFalse: TypeFacts.FalseAlwaysFalse }
+                        : { alwaysTrue: TypeFacts.TrueAlwaysTrue, alwaysFalse: TypeFacts.TrueAlwaysFalse };
+            }
+            if (flags & TypeFlags.Object && !ignoreObjects) {
+                return getObjectFlags(type) & ObjectFlags.Anonymous && isEmptyObjectType(type as ObjectType)
+                    ? strictNullChecks
+                        ? { alwaysTrue: TypeFacts.EmptyObjectStrictAlwaysTrue, alwaysFalse: TypeFacts.EmptyObjectStrictAlwaysFalse }
+                        : { alwaysTrue: TypeFacts.EmptyObjectAlwaysTrue, alwaysFalse: TypeFacts.EmptyObjectAlwaysFalse }
+                    : isFunctionObjectType(type as ObjectType)
+                        ? strictNullChecks
+                            ? { alwaysTrue: TypeFacts.FunctionStrictAlwaysTrue, alwaysFalse: TypeFacts.FunctionStrictAlwaysFalse }
+                            : { alwaysTrue: TypeFacts.FunctionAlwaysTrue, alwaysFalse: TypeFacts.FunctionAlwaysFalse }
+                        : strictNullChecks
+                            ? { alwaysTrue: TypeFacts.ObjectStrictAlwaysTrue, alwaysFalse: TypeFacts.ObjectStrictAlwaysFalse }
+                            : { alwaysTrue: TypeFacts.ObjectAlwaysTrue, alwaysFalse: TypeFacts.ObjectAlwaysFalse };
+            }
+            if (flags & (TypeFlags.Void | TypeFlags.Undefined)) {
+                return { alwaysTrue: TypeFacts.UndefinedAlwaysTrue, alwaysFalse: TypeFacts.UndefinedAlwaysFalse };
+            }
+            if (flags & TypeFlags.Null) {
+                return { alwaysTrue: TypeFacts.NullAlwaysTrue, alwaysFalse: TypeFacts.NullAlwaysFalse };
+            }
+            if (flags & TypeFlags.ESSymbolLike) {
+                return {
+                    alwaysTrue: strictNullChecks ? TypeFacts.SymbolStrictAlwaysTrue : TypeFacts.SymbolAlwaysTrue,
+                    alwaysFalse: strictNullChecks ? TypeFacts.SymbolStrictAlwaysFalse : TypeFacts.SymbolAlwaysFalse,
+                };
+            }
+            if (flags & TypeFlags.NonPrimitive) {
+                return strictNullChecks ?
+                    { alwaysTrue: TypeFacts.ObjectStrictAlwaysTrue, alwaysFalse: TypeFacts.ObjectStrictAlwaysFalse } :
+                    { alwaysTrue: TypeFacts.ObjectAlwaysTrue, alwaysFalse: TypeFacts.ObjectAlwaysFalse };
+            }
+            if (flags & TypeFlags.Never) {
+                return {
+                    alwaysTrue: TypeFacts.None,
+                    alwaysFalse: TypeFacts.None,
+                };
+            }
+            if (flags & TypeFlags.Instantiable) {
+                return !isPatternLiteralType(type)
+                    ? getAlwaysTypeFacts(getBaseConstraintOfType(type) || unknownType, ignoreObjects)
+                    : strictNullChecks
+                        ? { alwaysTrue: TypeFacts.NonEmptyStringStrictAlwaysTrue, alwaysFalse: TypeFacts.NonEmptyStringStrictAlwaysFalse }
+                        : { alwaysTrue: TypeFacts.NonEmptyStringAlwaysTrue, alwaysFalse: TypeFacts.NonEmptyStringAlwaysFalse };
+            }
+            if (flags & TypeFlags.Union) {
+                const types = (type as UnionType).types;
+                if (types.length) {
+                    return reduceLeft(types, (facts, t) => {
+                        const { alwaysTrue, alwaysFalse } = getAlwaysTypeFacts(t, ignoreObjects);
+                        return { alwaysTrue: facts.alwaysTrue & alwaysTrue, alwaysFalse: facts.alwaysFalse & alwaysFalse };
+                    }, { alwaysTrue: TypeFacts.All, alwaysFalse: TypeFacts.All }); // >> TODO: that's assuming union will never be empty; check that
+                }
+                return {
+                    alwaysTrue: TypeFacts.None,
+                    alwaysFalse: TypeFacts.None,
+                };
+            }
+            if (flags & TypeFlags.Intersection) {
                 // When an intersection contains a primitive type we ignore object type constituents as they are
                 // presumably type tags. For example, in string & { __kind__: "name" } we ignore the object type.
                 ignoreObjects ||= maybeTypeOfKind(type, TypeFlags.Primitive);
-                return reduceLeft((type as UnionType).types, (facts, t) => facts & getTypeFacts(t, ignoreObjects), TypeFacts.All);
+                return reduceLeft((type as IntersectionType).types, (facts, t) => {
+                    const { alwaysTrue, alwaysFalse } = getAlwaysTypeFacts(t, ignoreObjects);
+                    return { alwaysTrue: facts.alwaysTrue | alwaysTrue, alwaysFalse: facts.alwaysFalse | alwaysFalse };
+                }, { alwaysTrue: TypeFacts.None, alwaysFalse: TypeFacts.None });
             }
-            return TypeFacts.All;
+
+            return {
+                alwaysTrue: TypeFacts.None,
+                alwaysFalse: TypeFacts.None,
+            };
         }
 
         function getTypeWithFacts(type: Type, include: TypeFacts) {

--- a/tests/baselines/reference/narrowingTypeof.js
+++ b/tests/baselines/reference/narrowingTypeof.js
@@ -1,0 +1,15 @@
+//// [narrowingTypeof.ts]
+type __String = (string & { __escapedIdentifier: void }) | (void & { __escapedIdentifier: void });
+
+declare const s: __String;
+declare let t: string | number | undefined;
+
+declare function assert(e: unknown): asserts e;
+
+assert(typeof s === "string");
+t = s;
+
+
+//// [narrowingTypeof.js]
+assert(typeof s === "string");
+t = s;

--- a/tests/baselines/reference/narrowingTypeof.symbols
+++ b/tests/baselines/reference/narrowingTypeof.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/narrowingTypeof.ts ===
+type __String = (string & { __escapedIdentifier: void }) | (void & { __escapedIdentifier: void });
+>__String : Symbol(__String, Decl(narrowingTypeof.ts, 0, 0))
+>__escapedIdentifier : Symbol(__escapedIdentifier, Decl(narrowingTypeof.ts, 0, 27))
+>__escapedIdentifier : Symbol(__escapedIdentifier, Decl(narrowingTypeof.ts, 0, 68))
+
+declare const s: __String;
+>s : Symbol(s, Decl(narrowingTypeof.ts, 2, 13))
+>__String : Symbol(__String, Decl(narrowingTypeof.ts, 0, 0))
+
+declare let t: string | number | undefined;
+>t : Symbol(t, Decl(narrowingTypeof.ts, 3, 11))
+
+declare function assert(e: unknown): asserts e;
+>assert : Symbol(assert, Decl(narrowingTypeof.ts, 3, 43))
+>e : Symbol(e, Decl(narrowingTypeof.ts, 5, 24))
+>e : Symbol(e, Decl(narrowingTypeof.ts, 5, 24))
+
+assert(typeof s === "string");
+>assert : Symbol(assert, Decl(narrowingTypeof.ts, 3, 43))
+>s : Symbol(s, Decl(narrowingTypeof.ts, 2, 13))
+
+t = s;
+>t : Symbol(t, Decl(narrowingTypeof.ts, 3, 11))
+>s : Symbol(s, Decl(narrowingTypeof.ts, 2, 13))
+

--- a/tests/baselines/reference/narrowingTypeof.types
+++ b/tests/baselines/reference/narrowingTypeof.types
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/narrowingTypeof.ts ===
+type __String = (string & { __escapedIdentifier: void }) | (void & { __escapedIdentifier: void });
+>__String : __String
+>__escapedIdentifier : void
+>__escapedIdentifier : void
+
+declare const s: __String;
+>s : __String
+
+declare let t: string | number | undefined;
+>t : string | number
+
+declare function assert(e: unknown): asserts e;
+>assert : (e: unknown) => asserts e
+>e : unknown
+
+assert(typeof s === "string");
+>assert(typeof s === "string") : void
+>assert : (e: unknown) => asserts e
+>typeof s === "string" : boolean
+>typeof s : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>s : __String
+>"string" : "string"
+
+t = s;
+>t = s : string & { __escapedIdentifier: void; }
+>t : string | number
+>s : string & { __escapedIdentifier: void; }
+

--- a/tests/baselines/reference/narrowingTypeofFunction.js
+++ b/tests/baselines/reference/narrowingTypeofFunction.js
@@ -1,0 +1,27 @@
+//// [narrowingTypeofFunction.ts]
+type Meta = { foo: string }
+interface F { (): string }
+
+const x = (a: (F & Meta) | string) => {
+    if (typeof a === "function") {
+        // ts.version >= 4.3.5: never -- unexpected
+        // ts.version <= 4.2.3: F & Meta -- expected
+        a;
+    }
+    else {
+        a;
+    }
+}
+
+//// [narrowingTypeofFunction.js]
+"use strict";
+var x = function (a) {
+    if (typeof a === "function") {
+        // ts.version >= 4.3.5: never -- unexpected
+        // ts.version <= 4.2.3: F & Meta -- expected
+        a;
+    }
+    else {
+        a;
+    }
+};

--- a/tests/baselines/reference/narrowingTypeofFunction.symbols
+++ b/tests/baselines/reference/narrowingTypeofFunction.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/narrowingTypeofFunction.ts ===
+type Meta = { foo: string }
+>Meta : Symbol(Meta, Decl(narrowingTypeofFunction.ts, 0, 0))
+>foo : Symbol(foo, Decl(narrowingTypeofFunction.ts, 0, 13))
+
+interface F { (): string }
+>F : Symbol(F, Decl(narrowingTypeofFunction.ts, 0, 27))
+
+const x = (a: (F & Meta) | string) => {
+>x : Symbol(x, Decl(narrowingTypeofFunction.ts, 3, 5))
+>a : Symbol(a, Decl(narrowingTypeofFunction.ts, 3, 11))
+>F : Symbol(F, Decl(narrowingTypeofFunction.ts, 0, 27))
+>Meta : Symbol(Meta, Decl(narrowingTypeofFunction.ts, 0, 0))
+
+    if (typeof a === "function") {
+>a : Symbol(a, Decl(narrowingTypeofFunction.ts, 3, 11))
+
+        // ts.version >= 4.3.5: never -- unexpected
+        // ts.version <= 4.2.3: F & Meta -- expected
+        a;
+>a : Symbol(a, Decl(narrowingTypeofFunction.ts, 3, 11))
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(narrowingTypeofFunction.ts, 3, 11))
+    }
+}

--- a/tests/baselines/reference/narrowingTypeofFunction.types
+++ b/tests/baselines/reference/narrowingTypeofFunction.types
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/narrowingTypeofFunction.ts ===
+type Meta = { foo: string }
+>Meta : Meta
+>foo : string
+
+interface F { (): string }
+
+const x = (a: (F & Meta) | string) => {
+>x : (a: (F & Meta) | string) => void
+>(a: (F & Meta) | string) => {    if (typeof a === "function") {        // ts.version >= 4.3.5: never -- unexpected        // ts.version <= 4.2.3: F & Meta -- expected        a;    }    else {        a;    }} : (a: (F & Meta) | string) => void
+>a : string | (F & Meta)
+
+    if (typeof a === "function") {
+>typeof a === "function" : boolean
+>typeof a : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>a : string | (F & Meta)
+>"function" : "function"
+
+        // ts.version >= 4.3.5: never -- unexpected
+        // ts.version <= 4.2.3: F & Meta -- expected
+        a;
+>a : F & Meta
+    }
+    else {
+        a;
+>a : string
+    }
+}

--- a/tests/cases/compiler/narrowingTypeof.ts
+++ b/tests/cases/compiler/narrowingTypeof.ts
@@ -1,0 +1,10 @@
+
+type __String = (string & { __escapedIdentifier: void }) | (void & { __escapedIdentifier: void });
+
+declare const s: __String;
+declare let t: string | number | undefined;
+
+declare function assert(e: unknown): asserts e;
+
+assert(typeof s === "string");
+t = s;

--- a/tests/cases/compiler/narrowingTypeofFunction.ts
+++ b/tests/cases/compiler/narrowingTypeofFunction.ts
@@ -1,0 +1,15 @@
+// @strict: true
+
+type Meta = { foo: string }
+interface F { (): string }
+
+const x = (a: (F & Meta) | string) => {
+    if (typeof a === "function") {
+        // ts.version >= 4.3.5: never -- unexpected
+        // ts.version <= 4.2.3: F & Meta -- expected
+        a;
+    }
+    else {
+        a;
+    }
+}


### PR DESCRIPTION
Fixes #45801

### Brief background
When narrowing a type, we rely on `TypeFacts` flags that tell us what narrowing facts could be true for a value of a given type. The flags cover the possible results of narrowing using `typeof` (e.g. `TypeFacts.TypeofEQString`), comparsions to `null` or `undefined` (e.g. `TypeFacts.UndefinedOrNull` means `if (v === null || v === undefined)` could be true), or if the value is truthy or falsy (e.g. `TypeFacts.Truthy` means `if (v) { ... }` could be true).
To compute the type facts for a type `T`, we call `getTypeFacts(T)`.

###  The issue
Up until v4.2, when computing type facts for an intersection type, we `or`ed the facts of each of the intersection type's component type. e.g. `getTypeFacts(A & B)` = `getTypeFacts(A) | getTypeFacts(B)`.
Starting at v4.3, [this changed to an `and`](https://github.com/microsoft/TypeScript/pull/43131/files#diff-d9ab6589e714c71e657f601cf30ff51dfc607fc98419bf72e04f6b0fa92cc4b8R21763) of the facts of each intersection type's component type, e.g. `getTypeFacts(A & B)` = `getTypeFacts(A) & getTypeFacts(B)`, to fix cases like the following:

```ts
function f3<T>(x: T & string | T & number) {
    if (typeof x === "string") {
        x;  // Should narrow to T & string
            // <= 4.2: x: T & string | T & number
    }
    else {
        x;  // Should narrow to T & number
            // <= 4.2: x: T & string | T & number
    }
}
```

If we have `T & number`, we know the value can only be of type number (or null or undefined, in non-strict), never of type string. However, we don't know anything about `T`, so when computing type facts for `T`, we think it can be anything at all (including of type string). If we `or` the type facts for `T` and `number`, then, we get that `T & number` could be string. If we `and` the type facts, we know `T & number` can't be of type string, because `number` can't be of type string.

However, in some cases we don't want an `and` of the type facts. Consider the example from issue #45801:

```ts
type Meta = { foo: string }
interface F { (): string}
const x = (a: (F & Meta) | string) => {
    if (typeof a === "function"){
        // ts.version >= 4.3.5: never -- unexpected
        // ts.version <= 4.2.3: F & Meta -- expected
        a;
    } else {
        // ts.version >= 4.3.5: string -- expected
        // ts.version <= 4.2.3: string | (F & Meta) -- unexpected
        a;
    }
}
```

For type `F & Meta`, we know values of `F` have to be functions, since `F` has a call signature declared. But type `Meta` doesn't, it is a regular object. If we `and` those facts, we conclude `F & Meta` cannot be a function, because we don't think values of `Meta` could be functions (no call signature). So in this case, we probably want to `or` the type facts.

(Note: We could include `TypeFacts.TypeofEQFunction` in the flags returned for object types such as `Meta` above, and keep using `and` for computing type facts of intersection types. I think we don't want to do that, since we explicitly make that distinction in `getTypeFacts`'s code and it generally seems a useful distinction.)

### The possible fix

Considering both examples above, it seems we sometimes know a fact will *always* be true (i.e. true for all values of a type), e.g. values of type `T & number` can't be strings (`if (typeof v === 'string')` can't be true). This contrasts with the other uses of type facts, which are facts that *can* be true for values of type T, but are not necessarily always true/true for all values.
So that's why sometimes we want to use an `and` to compute facts of intersection types, and sometimes we want to use an `or`.

#### *tl;dr*
This PR changes the way we compute type facts of intersection types. For each component type, in addition to computing its type facts, we also compute which facts are always true (true for all values of that type) and which are always false.
We then `or` the regular type facts of the component types, and we also `or` the always false facts. We then exclude the facts that are always false from the regular facts.
So, in cases like `T & number`, even though when we `or` the components' type facts, we include a flag such as `TypeFacts.TypeofEQString` (because that's one of the flags for `T`), we will delete it later because `TypeFacts.TypeofEQString` is always false for type `number`.

#### Questions I had
- ~~When is `TypeFacts.TypeofEQHostObject` always false?~~ It seems `typeof v === "xxx"` ("xxx" being something other than the usual strings returned by `typeof`) can only be true if `v` is a host object (and hosts return a custom `typeof` for those), or if we don't yet recognize the "xxx" in question (e.g. if there's ever a new `Fraction` type and `typeof v === "fraction"`).  So it should always be false for known primitives at least.
- ~~Should we care about contradictory types (e.g. `string & number`) in `getTypeFacts` or `getAlwaysFalseTypeFacts`?~~ I'm assuming we shouldn't, because existing code for `getTypeFacts` doesn't address this, and this looks like something `getIntersectionType` takes care of.




