### PR TITLE
Use relative paths for the end of compile report

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8328,6 +8328,11 @@ namespace ts {
         getCurrentDirectory?(): string;
     }
 
+    /* @internal */
+    export interface HasCurrentDirectory {
+        getCurrentDirectory(): string;
+    }
+
     /*@internal*/
     export interface ModuleSpecifierResolutionHost {
         useCaseSensitiveFileNames?(): boolean;

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -773,7 +773,7 @@ namespace ts {
 
     function createReportErrorSummary(sys: System, options: CompilerOptions | BuildOptions): ReportEmitErrorSummary | undefined {
         return shouldBePretty(sys, options) ?
-            (errorCount, filesInError) => sys.write(getErrorSummaryText(errorCount, filesInError, sys.newLine)) :
+            (errorCount, filesInError) => sys.write(getErrorSummaryText(errorCount, filesInError, sys.newLine, sys)) :
             undefined;
     }
 

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -537,7 +537,7 @@ namespace Harness {
                 outputLines += content;
             }
             if (pretty) {
-                outputLines += ts.getErrorSummaryText(ts.getErrorCountForSummary(diagnostics), ts.getFilesInErrorForSummary(diagnostics), IO.newLine());
+                outputLines += ts.getErrorSummaryText(ts.getErrorCountForSummary(diagnostics), ts.getFilesInErrorForSummary(diagnostics), IO.newLine(), { getCurrentDirectory: () => "" });
             }
             return outputLines;
         }

--- a/src/testRunner/unittests/tsbuild/publicApi.ts
+++ b/src/testRunner/unittests/tsbuild/publicApi.ts
@@ -54,7 +54,7 @@ export function f22() { } // trailing`,
                     /*createProgram*/ undefined,
                 createDiagnosticReporter(sys, /*pretty*/ true),
                 createBuilderStatusReporter(sys, /*pretty*/ true),
-                (errorCount, filesInError) => sys.write(getErrorSummaryText(errorCount, filesInError, sys.newLine))
+                (errorCount, filesInError) => sys.write(getErrorSummaryText(errorCount, filesInError, sys.newLine, sys))
             );
             buildHost.afterProgramEmitAndDiagnostics = cb;
             buildHost.afterEmitBundle = cb;

--- a/src/testRunner/unittests/tscWatch/helpers.ts
+++ b/src/testRunner/unittests/tscWatch/helpers.ts
@@ -215,7 +215,7 @@ namespace ts.tscWatch {
             [
                 ...map(errors, hostOutputDiagnostic),
                 ...reportErrorSummary ?
-                    [hostOutputWatchDiagnostic(getErrorSummaryText(errors.length, files, host.newLine))] :
+                    [hostOutputWatchDiagnostic(getErrorSummaryText(errors.length, files, host.newLine, host))] :
                     emptyArray
             ]
         );

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-composite.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-composite.js
@@ -313,8 +313,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
@@ -722,9 +722,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
@@ -939,9 +939,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
@@ -977,8 +977,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
@@ -1014,8 +1014,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
@@ -1056,9 +1056,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-incremental-declaration.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-incremental-declaration.js
@@ -313,8 +313,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
@@ -722,9 +722,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
@@ -939,9 +939,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
@@ -977,8 +977,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
@@ -1014,8 +1014,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
@@ -1056,9 +1056,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-incremental.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-incremental.js
@@ -281,8 +281,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
@@ -680,9 +680,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
@@ -885,9 +885,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 
@@ -923,8 +923,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
@@ -960,8 +960,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
 
 
@@ -1002,9 +1002,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-composite.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-composite.js
@@ -440,9 +440,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-incremental-declaration.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-incremental-declaration.js
@@ -440,9 +440,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-incremental.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-incremental.js
@@ -405,9 +405,9 @@ Output::
 Found 3 errors in 3 files.
 
 Errors  Files
-     1  /src/project/src/directUse.ts:2
-     1  /src/project/src/indirectUse.ts:2
-     1  /src/project/src/noChangeFileWithEmitSpecificError.ts:1
+     1  src/project/src/directUse.ts:2
+     1  src/project/src/indirectUse.ts:2
+     1  src/project/src/noChangeFileWithEmitSpecificError.ts:1
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 
 

--- a/tests/baselines/reference/tsc/incremental/initial-build/when-global-file-is-added,-the-signatures-are-updated.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/when-global-file-is-added,-the-signatures-are-updated.js
@@ -50,8 +50,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/anotherFileWithSameReferenes.ts:2
-     1  /src/project/src/main.ts:2
+     1  src/project/src/anotherFileWithSameReferenes.ts:2
+     1  src/project/src/main.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 Program root files: ["/src/project/src/anotherFileWithSameReferenes.ts","/src/project/src/filePresent.ts","/src/project/src/main.ts"]
 Program options: {"composite":true,"project":"/src/project","configFilePath":"/src/project/tsconfig.json"}
@@ -202,8 +202,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/anotherFileWithSameReferenes.ts:2
-     1  /src/project/src/main.ts:2
+     1  src/project/src/anotherFileWithSameReferenes.ts:2
+     1  src/project/src/main.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 Program root files: ["/src/project/src/anotherFileWithSameReferenes.ts","/src/project/src/filePresent.ts","/src/project/src/main.ts"]
 Program options: {"composite":true,"project":"/src/project","configFilePath":"/src/project/tsconfig.json"}
@@ -247,8 +247,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/anotherFileWithSameReferenes.ts:2
-     1  /src/project/src/main.ts:2
+     1  src/project/src/anotherFileWithSameReferenes.ts:2
+     1  src/project/src/main.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 Program root files: ["/src/project/src/anotherFileWithSameReferenes.ts","/src/project/src/filePresent.ts","/src/project/src/main.ts"]
 Program options: {"composite":true,"project":"/src/project","configFilePath":"/src/project/tsconfig.json"}
@@ -377,8 +377,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/anotherFileWithSameReferenes.ts:2
-     1  /src/project/src/main.ts:2
+     1  src/project/src/anotherFileWithSameReferenes.ts:2
+     1  src/project/src/main.ts:2
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 Program root files: ["/src/project/src/anotherFileWithSameReferenes.ts","/src/project/src/filePresent.ts","/src/project/src/main.ts"]
 Program options: {"composite":true,"project":"/src/project","configFilePath":"/src/project/tsconfig.json"}
@@ -503,8 +503,8 @@ Output::
 Found 2 errors in 2 files.
 
 Errors  Files
-     1  /src/project/src/anotherFileWithSameReferenes.ts:2
-     1  /src/project/src/main.ts:3
+     1  src/project/src/anotherFileWithSameReferenes.ts:2
+     1  src/project/src/main.ts:3
 exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
 Program root files: ["/src/project/src/anotherFileWithSameReferenes.ts","/src/project/src/filePresent.ts","/src/project/src/main.ts","/src/project/src/newFile.ts"]
 Program options: {"composite":true,"project":"/src/project","configFilePath":"/src/project/tsconfig.json"}


### PR DESCRIPTION
In 4.6, when a compile ends and there is more than one file with an error, we present something like:

```
Found 4 errors in 4 files.

Errors  Files
     1  /path/to/typescript/src/compiler/watch.ts:487
     1  /path/to/typescript/src/services/codefixes/requireInTs.ts:54
     1  /path/to/typescript/src/services/globalThisShim.ts:9
     1  /path/to/typescript/src/testRunner/externalCompileRunner.ts:4
```

This PR changes it to:

```
Found 4 errors in 4 files.

Errors  Files
     1  src/compiler/watch.ts:487
     1  src/services/codefixes/requireInTs.ts:54
     1  src/services/globalThisShim.ts:9
     1  src/testRunner/externalCompileRunner.ts:4
```

Based on your current working directory.