### PR TITLE
Fix checker initialization crash with esModuleInterop and global merges resolving to ImportEquals aliases

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3675,7 +3675,7 @@ namespace ts {
                         if (!sigs || !sigs.length) {
                             sigs = getSignaturesOfStructuredType(type, SignatureKind.Construct);
                         }
-                        if ((sigs && sigs.length) || getPropertyOfType(type, InternalSymbolName.Default)) {
+                        if ((sigs && sigs.length) || getPropertyOfType(type, InternalSymbolName.Default, /*skipObjectFunctionPropertyAugment*/ true)) {
                             const moduleType = getTypeWithSyntheticDefaultImportType(type, symbol, moduleSymbol!, reference);
                             return cloneTypeAsModuleType(symbol, moduleType, referenceParent);
                         }

--- a/tests/baselines/reference/checkerInitializationCrash.js
+++ b/tests/baselines/reference/checkerInitializationCrash.js
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/checkerInitializationCrash.ts] ////
+
+//// [index.d.ts]
+import * as react from 'react';
+declare global {
+  namespace FullCalendarVDom {
+    export import VNode = react.ReactNode;
+  }
+}
+
+export default class FullCalendar {
+}
+
+//// [index.d.ts]
+import * as preact from 'preact';
+declare global {
+  namespace FullCalendarVDom {
+    type VNode = preact.VNode<any>;
+  }
+}
+
+export type EventInput = any;
+
+//// [index.d.ts]
+export = React;
+export as namespace React;
+declare namespace React {
+    type ReactNode = any;
+    function useMemo<T>(factory: () => T, deps: undefined): T;
+}
+
+//// [index.d.ts]
+export as namespace preact;
+export interface VNode<P = {}> {}
+
+//// [index.tsx]
+import FullCalendar from "@fullcalendar/react";
+import { EventInput } from "@fullcalendar/core";
+
+
+//// [index.js]
+export {};

--- a/tests/baselines/reference/checkerInitializationCrash.symbols
+++ b/tests/baselines/reference/checkerInitializationCrash.symbols
@@ -1,0 +1,78 @@
+=== /node_modules/@fullcalendar/react/index.d.ts ===
+import * as react from 'react';
+>react : Symbol(react, Decl(index.d.ts, 0, 6))
+
+declare global {
+>global : Symbol(global, Decl(index.d.ts, 0, 31))
+
+  namespace FullCalendarVDom {
+>FullCalendarVDom : Symbol(FullCalendarVDom, Decl(index.d.ts, 1, 16), Decl(index.d.ts, 1, 16))
+
+    export import VNode = react.ReactNode;
+>VNode : Symbol(FullCalendarVDom.VNode, Decl(index.d.ts, 2, 30))
+>react : Symbol(react, Decl(index.d.ts, 0, 6))
+>ReactNode : Symbol(react.ReactNode, Decl(index.d.ts, 2, 25), Decl(index.d.ts, 2, 30))
+  }
+}
+
+export default class FullCalendar {
+>FullCalendar : Symbol(FullCalendar, Decl(index.d.ts, 5, 1))
+}
+
+=== /node_modules/@fullcalendar/core/index.d.ts ===
+import * as preact from 'preact';
+>preact : Symbol(preact, Decl(index.d.ts, 0, 6))
+
+declare global {
+>global : Symbol(global, Decl(index.d.ts, 0, 33))
+
+  namespace FullCalendarVDom {
+>FullCalendarVDom : Symbol(FullCalendarVDom, Decl(index.d.ts, 1, 16), Decl(index.d.ts, 1, 16))
+
+    type VNode = preact.VNode<any>;
+>VNode : Symbol(React.ReactNode, Decl(index.d.ts, 2, 25), Decl(index.d.ts, 2, 30))
+>preact : Symbol(preact, Decl(index.d.ts, 0, 6))
+>VNode : Symbol(preact.VNode, Decl(index.d.ts, 0, 27))
+  }
+}
+
+export type EventInput = any;
+>EventInput : Symbol(EventInput, Decl(index.d.ts, 5, 1))
+
+=== /node_modules/@types/react/index.d.ts ===
+export = React;
+>React : Symbol(React, Decl(index.d.ts, 1, 26))
+
+export as namespace React;
+>React : Symbol(React, Decl(index.d.ts, 0, 15))
+
+declare namespace React {
+>React : Symbol(React, Decl(index.d.ts, 1, 26))
+
+    type ReactNode = any;
+>ReactNode : Symbol(ReactNode, Decl(index.d.ts, 2, 25), Decl(index.d.ts, 2, 30))
+
+    function useMemo<T>(factory: () => T, deps: undefined): T;
+>useMemo : Symbol(useMemo, Decl(index.d.ts, 3, 25))
+>T : Symbol(T, Decl(index.d.ts, 4, 21))
+>factory : Symbol(factory, Decl(index.d.ts, 4, 24))
+>T : Symbol(T, Decl(index.d.ts, 4, 21))
+>deps : Symbol(deps, Decl(index.d.ts, 4, 41))
+>T : Symbol(T, Decl(index.d.ts, 4, 21))
+}
+
+=== /node_modules/preact/index.d.ts ===
+export as namespace preact;
+>preact : Symbol(preact, Decl(index.d.ts, 0, 0))
+
+export interface VNode<P = {}> {}
+>VNode : Symbol(VNode, Decl(index.d.ts, 0, 27))
+>P : Symbol(P, Decl(index.d.ts, 1, 23))
+
+=== /index.tsx ===
+import FullCalendar from "@fullcalendar/react";
+>FullCalendar : Symbol(FullCalendar, Decl(index.tsx, 0, 6))
+
+import { EventInput } from "@fullcalendar/core";
+>EventInput : Symbol(EventInput, Decl(index.tsx, 1, 8))
+

--- a/tests/baselines/reference/checkerInitializationCrash.types
+++ b/tests/baselines/reference/checkerInitializationCrash.types
@@ -1,0 +1,70 @@
+=== /node_modules/@fullcalendar/react/index.d.ts ===
+import * as react from 'react';
+>react : typeof react
+
+declare global {
+>global : typeof global
+
+  namespace FullCalendarVDom {
+>FullCalendarVDom : typeof FullCalendarVDom
+
+    export import VNode = react.ReactNode;
+>VNode : any
+>react : typeof react
+>ReactNode : any
+  }
+}
+
+export default class FullCalendar {
+>FullCalendar : FullCalendar
+}
+
+=== /node_modules/@fullcalendar/core/index.d.ts ===
+import * as preact from 'preact';
+>preact : typeof preact
+
+declare global {
+>global : any
+
+  namespace FullCalendarVDom {
+    type VNode = preact.VNode<any>;
+>VNode : any
+>preact : any
+  }
+}
+
+export type EventInput = any;
+>EventInput : any
+
+=== /node_modules/@types/react/index.d.ts ===
+export = React;
+>React : typeof React
+
+export as namespace React;
+>React : typeof React
+
+declare namespace React {
+>React : typeof React
+
+    type ReactNode = any;
+>ReactNode : any
+
+    function useMemo<T>(factory: () => T, deps: undefined): T;
+>useMemo : <T>(factory: () => T, deps: undefined) => T
+>factory : () => T
+>deps : undefined
+}
+
+=== /node_modules/preact/index.d.ts ===
+export as namespace preact;
+>preact : typeof import("/node_modules/preact/index")
+
+export interface VNode<P = {}> {}
+
+=== /index.tsx ===
+import FullCalendar from "@fullcalendar/react";
+>FullCalendar : typeof FullCalendar
+
+import { EventInput } from "@fullcalendar/core";
+>EventInput : any
+

--- a/tests/cases/compiler/checkerInitializationCrash.ts
+++ b/tests/cases/compiler/checkerInitializationCrash.ts
@@ -1,0 +1,40 @@
+// @module: esnext
+// @moduleResolution: node
+// @esModuleInterop: true
+
+// @Filename: /node_modules/@fullcalendar/react/index.d.ts
+import * as react from 'react';
+declare global {
+  namespace FullCalendarVDom {
+    export import VNode = react.ReactNode;
+  }
+}
+
+export default class FullCalendar {
+}
+
+// @Filename: /node_modules/@fullcalendar/core/index.d.ts
+import * as preact from 'preact';
+declare global {
+  namespace FullCalendarVDom {
+    type VNode = preact.VNode<any>;
+  }
+}
+
+export type EventInput = any;
+
+// @Filename: /node_modules/@types/react/index.d.ts
+export = React;
+export as namespace React;
+declare namespace React {
+    type ReactNode = any;
+    function useMemo<T>(factory: () => T, deps: undefined): T;
+}
+
+// @Filename: /node_modules/preact/index.d.ts
+export as namespace preact;
+export interface VNode<P = {}> {}
+
+// @Filename: /index.tsx
+import FullCalendar from "@fullcalendar/react";
+import { EventInput } from "@fullcalendar/core";


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #47299 
