### PR TITLE
Better reuse of package.json cache, module resolution cache, and package.json auto import filter

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4722,6 +4722,7 @@ namespace ts {
                         getCommonSourceDirectory: !!(host as Program).getCommonSourceDirectory ? () => (host as Program).getCommonSourceDirectory() : () => "",
                         getCurrentDirectory: () => host.getCurrentDirectory(),
                         getSymlinkCache: maybeBind(host, host.getSymlinkCache),
+                        getPackageJsonInfoCache: () => host.getPackageJsonInfoCache?.(),
                         useCaseSensitiveFileNames: maybeBind(host, host.useCaseSensitiveFileNames),
                         redirectTargetsMap: host.redirectTargetsMap,
                         getProjectReferenceRedirect: fileName => host.getProjectReferenceRedirect(fileName),

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -45,7 +45,7 @@ namespace ts.moduleSpecifiers {
         && getEmitModuleResolutionKind(compilerOptions) !== ModuleResolutionKind.NodeNext) {
             return false;
         }
-        return getImpliedNodeFormatForFile(importingSourceFileName, /*packageJsonInfoCache*/ undefined, getModuleResolutionHost(host), compilerOptions) !== ModuleKind.CommonJS;
+        return getImpliedNodeFormatForFile(importingSourceFileName, host.getPackageJsonInfoCache?.(), getModuleResolutionHost(host), compilerOptions) !== ModuleKind.CommonJS;
     }
 
     function getModuleResolutionHost(host: ModuleSpecifierResolutionHost): ModuleResolutionHost {

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -715,8 +715,9 @@ namespace ts.moduleSpecifiers {
             const packageRootPath = path.substring(0, packageRootIndex);
             const packageJsonPath = combinePaths(packageRootPath, "package.json");
             let moduleFileToTry = path;
-            if (host.fileExists(packageJsonPath)) {
-                const packageJsonContent = JSON.parse(host.readFile!(packageJsonPath)!);
+            const cachedPackageJson = host.getPackageJsonInfoCache?.()?.getPackageJsonInfo(packageJsonPath);
+            if (typeof cachedPackageJson === "object" || cachedPackageJson === undefined && host.fileExists(packageJsonPath)) {
+                const packageJsonContent = cachedPackageJson?.packageJsonContent || JSON.parse(host.readFile!(packageJsonPath)!);
                 if (getEmitModuleResolutionKind(options) === ModuleResolutionKind.Node12 || getEmitModuleResolutionKind(options) === ModuleResolutionKind.NodeNext) {
                     // `conditions` *could* be made to go against `importingSourceFile.impliedNodeFormat` if something wanted to generate
                     // an ImportEqualsDeclaration in an ESM-implied file or an ImportCall in a CJS-implied file. But since this function is

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8344,6 +8344,7 @@ namespace ts {
         realpath?(path: string): string;
         getSymlinkCache?(): SymlinkCache;
         getModuleSpecifierCache?(): ModuleSpecifierCache;
+        getPackageJsonInfoCache?(): PackageJsonInfoCache | undefined;
         getGlobalTypingsCacheLocation?(): string | undefined;
         getNearestAncestorDirectoryWithPackageJson?(fileName: string, rootDir?: string): string | undefined;
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1983,7 +1983,9 @@ namespace ts.server {
                 }
             }
 
-            hostProject.log(`AutoImportProviderProject: found ${rootNames?.length || 0} root files in ${dependenciesAdded} dependencies in ${timestamp() - start} ms`);
+            if (rootNames?.length) {
+                hostProject.log(`AutoImportProviderProject: found ${rootNames.length} root files in ${dependenciesAdded} dependencies in ${timestamp() - start} ms`);
+            }
             return rootNames || ts.emptyArray;
 
             function addDependency(dependency: string) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -476,6 +476,10 @@ namespace ts.server {
             return this.resolutionCache.resolveModuleNames(moduleNames, containingFile, reusedNames, redirectedReference, containingSourceFile);
         }
 
+        getModuleResolutionCache(): ModuleResolutionCache | undefined {
+            return this.resolutionCache.getModuleResolutionCache();
+        }
+
         getResolvedModuleWithFailedLookupLocationsFromCache(moduleName: string, containingFile: string, resolutionMode?: ModuleKind.CommonJS | ModuleKind.ESNext): ResolvedModuleWithFailedLookupLocations | undefined {
             return this.resolutionCache.getResolvedModuleWithFailedLookupLocationsFromCache(moduleName, containingFile, resolutionMode);
         }
@@ -1915,6 +1919,7 @@ namespace ts.server {
                 return ts.emptyArray;
             }
 
+            const start = timestamp();
             let dependencyNames: Set<string> | undefined;
             let rootNames: string[] | undefined;
             const rootFileName = combinePaths(hostProject.currentDirectory, inferredTypesContainingFile);
@@ -1924,13 +1929,13 @@ namespace ts.server {
                 packageJson.peerDependencies?.forEach((_, dependencyName) => addDependency(dependencyName));
             }
 
+            let dependenciesAdded = 0;
             if (dependencyNames) {
-                let dependenciesAdded = 0;
                 const symlinkCache = hostProject.getSymlinkCache();
                 for (const name of arrayFrom(dependencyNames.keys())) {
                     // Avoid creating a large project that would significantly slow down time to editor interactivity
                     if (dependencySelection === PackageJsonAutoImportPreference.Auto && dependenciesAdded > this.maxDependencies) {
-                        hostProject.log(`Auto-import provider attempted to add more than ${this.maxDependencies} dependencies.`);
+                        hostProject.log(`AutoImportProviderProject: attempted to add more than ${this.maxDependencies} dependencies. Aborting.`);
                         return ts.emptyArray;
                     }
 
@@ -1978,6 +1983,7 @@ namespace ts.server {
                 }
             }
 
+            hostProject.log(`AutoImportProviderProject: found ${rootNames?.length || 0} root files in ${dependenciesAdded} dependencies in ${timestamp() - start} ms`);
             return rootNames || ts.emptyArray;
 
             function addDependency(dependency: string) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2146,6 +2146,16 @@ namespace ts.server {
         getSymlinkCache() {
             return this.hostProject.getSymlinkCache();
         }
+
+        /*@internal*/
+        resolveModuleNames(moduleNames: string[], containingFile: string, reusedNames?: string[], redirectedReference?: ResolvedProjectReference, _options?: CompilerOptions, containingSourceFile?: SourceFile) {
+            return this.hostProject.resolveModuleNames(moduleNames, containingFile, reusedNames, redirectedReference, _options, containingSourceFile);
+        }
+
+        /*@internal*/
+        getModuleResolutionCache() {
+            return this.hostProject.getCurrentProgram()?.getModuleResolutionCache();
+        }
     }
 
     /**

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2156,11 +2156,6 @@ namespace ts.server {
         }
 
         /*@internal*/
-        resolveModuleNames(moduleNames: string[], containingFile: string, reusedNames?: string[], redirectedReference?: ResolvedProjectReference, _options?: CompilerOptions, containingSourceFile?: SourceFile) {
-            return this.hostProject.resolveModuleNames(moduleNames, containingFile, reusedNames, redirectedReference, _options, containingSourceFile);
-        }
-
-        /*@internal*/
         getModuleResolutionCache() {
             return this.hostProject.getCurrentProgram()?.getModuleResolutionCache();
         }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -177,6 +177,7 @@ namespace ts.Completions {
         cb: (context: ModuleSpecifierResolutioContext) => TReturn,
     ): TReturn {
         const start = timestamp();
+        const packageJsonImportFilter = createPackageJsonImportFilter(sourceFile, preferences, host);
         let resolutionLimitExceeded = false;
         let ambientCount = 0;
         let resolvedCount = 0;
@@ -202,7 +203,7 @@ namespace ts.Completions {
             const shouldResolveModuleSpecifier = isForImportStatementCompletion || preferences.allowIncompleteCompletions && resolvedCount < moduleSpecifierResolutionLimit;
             const shouldGetModuleSpecifierFromCache = !shouldResolveModuleSpecifier && preferences.allowIncompleteCompletions && cacheAttemptCount < moduleSpecifierResolutionCacheAttemptLimit;
             const result = (shouldResolveModuleSpecifier || shouldGetModuleSpecifierFromCache)
-                ? codefix.getModuleSpecifierForBestExportInfo(exportInfo, sourceFile, program, host, preferences, shouldGetModuleSpecifierFromCache)
+                ? codefix.getModuleSpecifierForBestExportInfo(exportInfo, sourceFile, program, host, preferences, packageJsonImportFilter, shouldGetModuleSpecifierFromCache)
                 : undefined;
 
             if (!shouldResolveModuleSpecifier && !shouldGetModuleSpecifierFromCache || shouldGetModuleSpecifierFromCache && !result) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1376,6 +1376,7 @@ namespace ts {
                 hasChangedAutomaticTypeDirectiveNames,
                 trace: parseConfigHost.trace,
                 resolveModuleNames: maybeBind(host, host.resolveModuleNames),
+                getModuleResolutionCache: maybeBind(host, host.getModuleResolutionCache),
                 resolveTypeReferenceDirectives: maybeBind(host, host.resolveTypeReferenceDirectives),
                 useSourceOfProjectReferenceRedirect: maybeBind(host, host.useSourceOfProjectReferenceRedirect),
                 getParsedCommandLine,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -284,6 +284,8 @@ namespace ts {
         /* @internal */ hasChangedAutomaticTypeDirectiveNames?: HasChangedAutomaticTypeDirectiveNames;
         /* @internal */ getGlobalTypingsCacheLocation?(): string | undefined;
         /* @internal */ getSymlinkCache?(files?: readonly SourceFile[]): SymlinkCache;
+        /* Lets the Program from a AutoImportProviderProject use its host project's ModuleResolutionCache */
+        /* @internal */ getModuleResolutionCache?(): ModuleResolutionCache | undefined;
 
         /*
          * Required for full import and type reference completions.

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1907,6 +1907,7 @@ namespace ts {
             useCaseSensitiveFileNames: maybeBind(host, host.useCaseSensitiveFileNames),
             getSymlinkCache: maybeBind(host, host.getSymlinkCache) || program.getSymlinkCache,
             getModuleSpecifierCache: maybeBind(host, host.getModuleSpecifierCache),
+            getPackageJsonInfoCache: () => program.getModuleResolutionCache()?.getPackageJsonInfoCache(),
             getGlobalTypingsCacheLocation: maybeBind(host, host.getGlobalTypingsCacheLocation),
             redirectTargetsMap: program.redirectTargetsMap,
             getProjectReferenceRedirect: fileName => program.getProjectReferenceRedirect(fileName),

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9874,6 +9874,7 @@ declare namespace ts.server {
         writeFile(fileName: string, content: string): void;
         fileExists(file: string): boolean;
         resolveModuleNames(moduleNames: string[], containingFile: string, reusedNames?: string[], redirectedReference?: ResolvedProjectReference, _options?: CompilerOptions, containingSourceFile?: SourceFile): (ResolvedModuleFull | undefined)[];
+        getModuleResolutionCache(): ModuleResolutionCache | undefined;
         getResolvedModuleWithFailedLookupLocationsFromCache(moduleName: string, containingFile: string, resolutionMode?: ModuleKind.CommonJS | ModuleKind.ESNext): ResolvedModuleWithFailedLookupLocations | undefined;
         resolveTypeReferenceDirectives(typeDirectiveNames: string[], containingFile: string, redirectedReference?: ResolvedProjectReference): (ResolvedTypeReferenceDirective | undefined)[];
         directoryExists(path: string): boolean;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

I made a test project that contained a lot of dependencies with export maps to ensure the new code paths were being hit. The slowdown from main to #47092 can largely be explained by the fact that we’re finding more things to auto-import, as the baseline case completely ignored those export maps. The cache reuse pays off in `collectAutoImports`, where previously we had to read package.jsons that have already been read and cached. Note that `getExportInfoMap` and `collectAutoImports` are components of `completionInfo`, which is the “bottom line” perf number for the server-side work of getting completions.

|                   | dev.20220109 | #47092 | This PR |
|-------------------|-------------:|--------:|-------:|
| createAutoImportProviderProgram | 354 ms | 395 ms | 408 ms |
| AutoImportProvider files | 6 | 30 | 30 |
| getExportInfoMap | 34 ms | 48 ms | 44 ms |
| collectAutoImports | 89 ms | 98 ms | 76 ms |
| completionInfo | 246 ms | 245 ms | 230 ms |
| completion entries | 3075 | 3149 | 3149 |
