### PR TITLE
TSServer Web Allow Opening in Semantic Mode

### DIFF
--- a/.github/workflows/ensure-related-repos-run-crons.yml
+++ b/.github/workflows/ensure-related-repos-run-crons.yml
@@ -8,7 +8,7 @@ name: Related Repo Commit Bumps
 on:
     schedule:
         # Monthly, https://crontab.guru/#0_0_*_1-12_*
-        - cron: '0 0 * 1-12 *'
+        - cron: '0 0 1 * *'
     workflow_dispatch: {}
 
 jobs:
@@ -18,8 +18,8 @@ jobs:
     steps:
     - name: Configure git and update package-lock.json
       run: |
-        git config user.email "typescriptbot@microsoft.com"
-        git config user.name "TypeScript Bot"
+        git config --global user.email "typescriptbot@microsoft.com"
+        git config --global user.name "TypeScript Bot"
 
     - uses: actions/checkout@v2
       with: 

--- a/src/tsserver/webServer.ts
+++ b/src/tsserver/webServer.ts
@@ -43,8 +43,8 @@ namespace ts.server {
             args,
             logger: createLogger(),
             cancellationToken: nullCancellationToken,
-            // Webserver defaults to partial semantic mode
-            serverMode: serverMode ?? LanguageServiceMode.PartialSemantic,
+            // Webserver defaults to semantic mode similar to how a fs based TS server does
+            serverMode: serverMode ?? LanguageServiceMode.Semantic,
             unknownServerMode,
             startSession: startWebSession
         };


### PR DESCRIPTION
Today a Web TSServer cannot open in Semantic mode:

This is where we take the args from the launch: 

```
    function parseServerMode(): LanguageServiceMode | string | undefined {
        const mode = findArgument("--serverMode");
        if (!mode) return undefined;
        switch (mode.toLowerCase()) {
            case "partialsemantic":
                return LanguageServiceMode.PartialSemantic;
            case "syntactic":
                return LanguageServiceMode.Syntactic;
            default:
                return mode;
        }
    }
``` 

If we return `mode` via the default case we're still getting a string and not the enum value of `LanguageServiceMode.Syntax`. 

This PR allows setting no server mode to default to syntax server similar to how the main TSServer does. Today, as I assume vscode is realistically the only user of this API, it is currently always passing:

```
args.push('--serverMode', 'partialSemantic');
```

And so it should be backwards compatible with those changes.