### PR TITLE
Fix detecting an existing `Map`/`Set`

### DIFF
--- a/src/compiler/corePublic.ts
+++ b/src/compiler/corePublic.ts
@@ -114,16 +114,21 @@ namespace ts {
 
     /* @internal */
     namespace NativeCollections {
-        declare const Map: MapConstructor | undefined;
-        declare const Set: SetConstructor | undefined;
+        declare const self: any;
+
+        const globals = typeof globalThis !== "undefined" ? globalThis :
+                  typeof global !== "undefined" ? global :
+                  typeof self !== "undefined" ? self :
+                  undefined;
 
         /**
          * Returns the native Map implementation if it is available and compatible (i.e. supports iteration).
          */
         export function tryGetNativeMap(): MapConstructor | undefined {
             // Internet Explorer's Map doesn't support iteration, so don't use it.
+            const gMap = globals?.Map;
             // eslint-disable-next-line no-in-operator
-            return typeof Map !== "undefined" && "entries" in Map.prototype && new Map([[0, 0]]).size === 1 ? Map : undefined;
+            return typeof gMap !== "undefined" && "entries" in gMap.prototype && new gMap([[0, 0]]).size === 1 ? gMap : undefined;
         }
 
         /**
@@ -131,8 +136,9 @@ namespace ts {
          */
         export function tryGetNativeSet(): SetConstructor | undefined {
             // Internet Explorer's Set doesn't support iteration, so don't use it.
+            const gSet = globals?.Set;
             // eslint-disable-next-line no-in-operator
-            return typeof Set !== "undefined" && "entries" in Set.prototype && new Set([0]).size === 1 ? Set : undefined;
+            return typeof gSet !== "undefined" && "entries" in gSet.prototype && new gSet([0]).size === 1 ? gSet : undefined;
         }
     }
 


### PR DESCRIPTION
This didn't affect compilation to CJS since that sets `exports.Map`
instead of creating a global.
