### PR TITLE
Deprecate ScriptElementKind.jsxAttribute

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -83,18 +83,8 @@ namespace ts.SymbolDisplay {
                 }
                 return unionPropertyKind;
             }
-            // If we requested completions after `x.` at the top-level, we may be at a source file location.
-            switch (location.parent && location.parent.kind) {
-                // If we've typed a character of the attribute name, will be 'JsxAttribute', else will be 'JsxOpeningElement'.
-                case SyntaxKind.JsxOpeningElement:
-                case SyntaxKind.JsxElement:
-                case SyntaxKind.JsxSelfClosingElement:
-                    return location.kind === SyntaxKind.Identifier ? ScriptElementKind.memberVariableElement : ScriptElementKind.jsxAttribute;
-                case SyntaxKind.JsxAttribute:
-                    return ScriptElementKind.jsxAttribute;
-                default:
-                    return ScriptElementKind.memberVariableElement;
-            }
+
+            return ScriptElementKind.memberVariableElement;
         }
 
         return ScriptElementKind.unknown;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1457,6 +1457,7 @@ namespace ts {
 
         /**
          * <JsxTagName attribute1 attribute2={0} />
+         * @deprecated
          */
         jsxAttribute = "JSX attribute",
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6594,6 +6594,7 @@ declare namespace ts {
         externalModuleName = "external module name",
         /**
          * <JsxTagName attribute1 attribute2={0} />
+         * @deprecated
          */
         jsxAttribute = "JSX attribute",
         /** String literal */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6594,6 +6594,7 @@ declare namespace ts {
         externalModuleName = "external module name",
         /**
          * <JsxTagName attribute1 attribute2={0} />
+         * @deprecated
          */
         jsxAttribute = "JSX attribute",
         /** String literal */

--- a/tests/cases/fourslash/completionsInJsxTag.ts
+++ b/tests/cases/fourslash/completionsInJsxTag.ts
@@ -26,16 +26,16 @@ verify.completions({
     exact: [
         {
             name: "aria-label",
-            text: "(JSX attribute) \"aria-label\": string",
+            text: "(property) \"aria-label\": string",
             documentation: "Label docs",
-            kind: "JSX attribute",
+            kind: "property",
             kindModifiers: "declare",
         },
         {
             name: "foo",
-            text: "(JSX attribute) foo: string",
+            text: "(property) foo: string",
             documentation: "Doc",
-            kind: "JSX attribute",
+            kind: "property",
             kindModifiers: "declare",
         },
     ],

--- a/tests/cases/fourslash/completionsJsxAttribute.ts
+++ b/tests/cases/fourslash/completionsJsxAttribute.ts
@@ -17,8 +17,8 @@
 ////<div /**/></div>;
 
 const exact: ReadonlyArray<FourSlashInterface.ExpectedCompletionEntry> = [
-    { name: "bar", kind: "JSX attribute", kindModifiers: "declare", text: "(JSX attribute) bar: string" },
-    { name: "foo", kind: "JSX attribute", kindModifiers: "declare", text: "(JSX attribute) foo: boolean", documentation: "Doc" },
+    { name: "bar", kind: "property", kindModifiers: "declare", text: "(property) bar: string" },
+    { name: "foo", kind: "property", kindModifiers: "declare", text: "(property) foo: boolean", documentation: "Doc" },
 ];
 verify.completions({ marker: "", exact });
 edit.insert("f");

--- a/tests/cases/fourslash/completionsJsxAttributeGeneric.ts
+++ b/tests/cases/fourslash/completionsJsxAttributeGeneric.ts
@@ -11,7 +11,7 @@
     marker,
     exact: [{
       name: 'name',
-      kind: 'JSX attribute',
+      kind: 'property',
       kindModifiers: 'declare'
     }]
   })

--- a/tests/cases/fourslash/completionsJsxAttributeInitializer.ts
+++ b/tests/cases/fourslash/completionsJsxAttributeInitializer.ts
@@ -9,8 +9,8 @@ verify.completions({
     marker: "",
     includes: [
         { name: "x", text: "(parameter) x: number", kind: "parameter", insertText: "{x}" },
-        { name: "p", text: "(JSX attribute) p: number", kind: "JSX attribute", insertText: "{this.p}", sortText: completion.SortText.SuggestedClassMembers, source: completion.CompletionSource.ThisProperty },
-        { name: "a b", text: '(JSX attribute) "a b": number', kind: "JSX attribute", insertText: '{this["a b"]}', sortText: completion.SortText.SuggestedClassMembers, source: completion.CompletionSource.ThisProperty },
+        { name: "p", text: "(property) p: number", kind: "property", insertText: "{this.p}", sortText: completion.SortText.SuggestedClassMembers, source: completion.CompletionSource.ThisProperty },
+        { name: "a b", text: '(property) "a b": number', kind: "property", insertText: '{this["a b"]}', sortText: completion.SortText.SuggestedClassMembers, source: completion.CompletionSource.ThisProperty },
     ],
     preferences: {
         includeInsertTextCompletions: true,

--- a/tests/cases/fourslash/jsxAttributeSnippetCompletionClosed.ts
+++ b/tests/cases/fourslash/jsxAttributeSnippetCompletionClosed.ts
@@ -60,15 +60,15 @@ var preferences: FourSlashInterface.UserPreferences = {
 }; 
 
 verify.completions(
-    { marker: "1", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "2", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "3", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "4", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "5", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "6", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "7", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "8", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "9", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "10", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "11", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "1", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "2", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "3", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "4", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "5", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "6", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "7", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "8", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "9", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "10", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "11", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
 )

--- a/tests/cases/fourslash/jsxAttributeSnippetCompletionUnclosed.ts
+++ b/tests/cases/fourslash/jsxAttributeSnippetCompletionUnclosed.ts
@@ -60,15 +60,15 @@ var preferences: FourSlashInterface.UserPreferences = {
 }; 
 
 verify.completions(
-    { marker: "1", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "2", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "3", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "4", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "5", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "6", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "1", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "2", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "3", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "4", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "5", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "6", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
     { marker: "7", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "8", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "9", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "8", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "9", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
     { marker: "10", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
-    { marker: "11", preferences, includes: { name: "className", insertText: "className={$1}", text: "(JSX attribute) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "11", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
 )

--- a/tests/cases/fourslash/jsxGenericQuickInfo.tsx
+++ b/tests/cases/fourslash/jsxGenericQuickInfo.tsx
@@ -29,6 +29,6 @@
 verify.quickInfoAt("0", "(property) PropsA<number>.renderItem: (item: number) => string");
 verify.quickInfoAt("1", "(parameter) item: number");
 verify.quickInfoAt("2", `(property) PropsA<T>.name: "A"`, 'comments for A');
-verify.quickInfoAt("3", "(JSX attribute) PropsA<number>.renderItem: (item: number) => string");
+verify.quickInfoAt("3", "(property) PropsA<number>.renderItem: (item: number) => string");
 verify.quickInfoAt("4", "(parameter) item: number");
-verify.quickInfoAt("5", `(JSX attribute) PropsA<T>.name: "A"`, 'comments for A');
+verify.quickInfoAt("5", `(property) PropsA<T>.name: "A"`, 'comments for A');

--- a/tests/cases/fourslash/jsxTagNameCompletionClosed.ts
+++ b/tests/cases/fourslash/jsxTagNameCompletionClosed.ts
@@ -47,8 +47,8 @@ var preferences: FourSlashInterface.UserPreferences = {
 verify.completions(
     { marker: "1", preferences, includes: { name: "Foo", text: "const Foo: NestedInterface" } },
     { marker: "2", preferences, includes: { name: "Foo", text: "const Foo: NestedInterface" } },
-    { marker: "3", preferences, includes: { name: "Foo", text: "(JSX attribute) NestedInterface.Foo: NestedInterface" } },
+    { marker: "3", preferences, includes: { name: "Foo", text: "(property) NestedInterface.Foo: NestedInterface" } },
     { marker: "4", preferences, includes: { name: "Foo", text: "(property) NestedInterface.Foo: NestedInterface" } },
-    { marker: "5", preferences, includes: { name: "Foo", text: "(JSX attribute) NestedInterface.Foo: NestedInterface" } },
+    { marker: "5", preferences, includes: { name: "Foo", text: "(property) NestedInterface.Foo: NestedInterface" } },
     { marker: "6", preferences, includes: { name: "Foo", text: "(property) NestedInterface.Foo: NestedInterface" } },
 )

--- a/tests/cases/fourslash/jsxTagNameCompletionUnclosed.ts
+++ b/tests/cases/fourslash/jsxTagNameCompletionUnclosed.ts
@@ -47,8 +47,8 @@ var preferences: FourSlashInterface.UserPreferences = {
 verify.completions(
     { marker: "1", preferences, includes: { name: "Foo", text: "const Foo: NestedInterface" } },
     { marker: "2", preferences, includes: { name: "Foo", text: "const Foo: NestedInterface" } },
-    { marker: "3", preferences, includes: { name: "Foo", text: "(JSX attribute) NestedInterface.Foo: NestedInterface" } },
+    { marker: "3", preferences, includes: { name: "Foo", text: "(property) NestedInterface.Foo: NestedInterface" } },
     { marker: "4", preferences, includes: { name: "Foo", text: "(property) NestedInterface.Foo: NestedInterface" } },
-    { marker: "5", preferences, includes: { name: "Foo", text: "(JSX attribute) NestedInterface.Foo: NestedInterface" } },
+    { marker: "5", preferences, includes: { name: "Foo", text: "(property) NestedInterface.Foo: NestedInterface" } },
     { marker: "6", preferences, includes: { name: "Foo", text: "(property) NestedInterface.Foo: NestedInterface" } },
 )

--- a/tests/cases/fourslash/jsxTagNameCompletionUnderElementClosed.ts
+++ b/tests/cases/fourslash/jsxTagNameCompletionUnderElementClosed.ts
@@ -29,7 +29,7 @@ var preferences: FourSlashInterface.UserPreferences = {
 }; 
 
 verify.completions(
-    { marker: "1", preferences, includes: { name: "button", text: "(JSX attribute) JSX.IntrinsicElements.button: any" } },
-    { marker: "2", preferences, includes: { name: "button", text: "(JSX attribute) JSX.IntrinsicElements.button: any" } },
-    { marker: "3", preferences, includes: { name: "button", text: "(JSX attribute) JSX.IntrinsicElements.button: any" } },
+    { marker: "1", preferences, includes: { name: "button", text: "(property) JSX.IntrinsicElements.button: any" } },
+    { marker: "2", preferences, includes: { name: "button", text: "(property) JSX.IntrinsicElements.button: any" } },
+    { marker: "3", preferences, includes: { name: "button", text: "(property) JSX.IntrinsicElements.button: any" } },
 )

--- a/tests/cases/fourslash/jsxTagNameCompletionUnderElementUnclosed.ts
+++ b/tests/cases/fourslash/jsxTagNameCompletionUnderElementUnclosed.ts
@@ -29,7 +29,7 @@ var preferences: FourSlashInterface.UserPreferences = {
 }; 
 
 verify.completions(
-    { marker: "1", preferences, includes: { name: "button", text: "(JSX attribute) JSX.IntrinsicElements.button: any" } },
-    { marker: "2", preferences, includes: { name: "button", text: "(JSX attribute) JSX.IntrinsicElements.button: any" } },
-    { marker: "3", preferences, includes: { name: "button", text: "(JSX attribute) JSX.IntrinsicElements.button: any" } },
+    { marker: "1", preferences, includes: { name: "button", text: "(property) JSX.IntrinsicElements.button: any" } },
+    { marker: "2", preferences, includes: { name: "button", text: "(property) JSX.IntrinsicElements.button: any" } },
+    { marker: "3", preferences, includes: { name: "button", text: "(property) JSX.IntrinsicElements.button: any" } },
 )

--- a/tests/cases/fourslash/tsxCompletion12.ts
+++ b/tests/cases/fourslash/tsxCompletion12.ts
@@ -28,14 +28,14 @@ verify.completions(
         exact: [
             "propString",
             "propx",
-            { name: "optional", kind: "JSX attribute", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
+            { name: "optional", kind: "property", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
         ]
     },
     {
         marker: "3",
         exact: [
             "propString",
-            { name: "optional", kind: "JSX attribute", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
+            { name: "optional", kind: "property", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
         ]
     },
     { marker: "4", exact: "propString" },

--- a/tests/cases/fourslash/tsxCompletion13.ts
+++ b/tests/cases/fourslash/tsxCompletion13.ts
@@ -36,8 +36,8 @@ verify.completions(
         exact: [
           "goTo",
           "onClick",
-          { name: "children", kind: "JSX attribute", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
-          { name: "className", kind: "JSX attribute", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
+          { name: "children", kind: "property", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
+          { name: "className", kind: "property", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
         ]
     },
     {
@@ -45,14 +45,14 @@ verify.completions(
       exact: [
         "goTo",
         "onClick",
-        { name: "className", kind: "JSX attribute", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
+        { name: "className", kind: "property", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
       ]
     },
     {
       marker: ["3", "4", "5"],
       exact: [
-        { name: "children", kind: "JSX attribute", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
-        { name: "className", kind: "JSX attribute", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
+        { name: "children", kind: "property", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
+        { name: "className", kind: "property", kindModifiers: "optional", sortText: completion.SortText.OptionalMember },
       ]
     },
 );

--- a/tests/cases/fourslash/tsxCompletion7.ts
+++ b/tests/cases/fourslash/tsxCompletion7.ts
@@ -13,7 +13,7 @@
 verify.completions({
   marker: "",
   exact: [
-    { name: "TWO", kind: "JSX attribute", kindModifiers: "declare", sortText: completion.SortText.LocationPriority },
-    { name: "ONE", kind: "JSX attribute", kindModifiers: "declare", sortText: completion.SortText.MemberDeclaredBySpreadAssignment },
+    { name: "TWO", kind: "property", kindModifiers: "declare", sortText: completion.SortText.LocationPriority },
+    { name: "ONE", kind: "property", kindModifiers: "declare", sortText: completion.SortText.MemberDeclaredBySpreadAssignment },
   ]
 });

--- a/tests/cases/fourslash/tsxQuickInfo3.ts
+++ b/tests/cases/fourslash/tsxQuickInfo3.ts
@@ -24,7 +24,7 @@
 
 verify.quickInfos({
     1: "class Opt",
-    2: "(JSX attribute) propx: number",
+    2: "(property) propx: number",
     3: "const obj1: OptionProp",
-    4: "(JSX attribute) propx: true"
+    4: "(property) propx: true"
 });

--- a/tests/cases/fourslash/tsxQuickInfo4.ts
+++ b/tests/cases/fourslash/tsxQuickInfo4.ts
@@ -48,8 +48,8 @@
 
 verify.quickInfos({
     1: "function MainButton(linkProps: LinkProps): JSX.Element (+1 overload)",
-    2: "(JSX attribute) LinkProps.to: string",
+    2: "(property) LinkProps.to: string",
     3: "function MainButton(buttonProps: ButtonProps): JSX.Element (+1 overload)",
     4: "(method) ButtonProps.onClick(event?: React.MouseEvent<HTMLButtonElement>): void",
-    5: "(JSX attribute) extra-prop: true"
+    5: "(property) extra-prop: true"
 });

--- a/tests/cases/fourslash/tsxQuickInfo5.ts
+++ b/tests/cases/fourslash/tsxQuickInfo5.ts
@@ -13,6 +13,6 @@
 
 verify.quickInfos({
     1: "function ComponentWithTwoAttributes<T, U>(l: {\n    key1: T;\n    value: U;\n}): JSX.Element",
-    2: "(JSX attribute) key1: T",
-    3: "(JSX attribute) value: U",
+    2: "(property) key1: T",
+    3: "(property) value: U",
 });


### PR DESCRIPTION
`SymbolKind.getSymbolKind`'s handling of JSX attributes appears to be pretty broken (and has been for a while), but doesn't seem to have been noticed (or at least reported) by anyone until the JSX attribute snippet feature started using it as a way to detect that an attribute was being completed (#47090, #47280).

For example:

![image](https://user-images.githubusercontent.com/5341706/149231188-4f9bd9d2-3c77-4d94-9322-94636145c06b.png)


Rather than attempt to fix it by introducing `contextToken` into the mix (which I attempted in a revision of #47096), we decided that it was inconsistent that this function (which mainly powers the parenthesized string at the beginning of tooltips) uses syntactic context at all, as opposed to just describing the symbol.

This PR eliminates `jsxAttribute` entirely, which means that JSX attributes, tag names, etc, will all show as variables/properties/etc, the same as they would be shown when used in other places (since JSX attributes are just properties on a parameter object), eliminating the broken logic used to detect attributes.

Now:

![image](https://user-images.githubusercontent.com/5341706/149231345-082bbb18-af14-4139-a976-11bbb1fb1523.png)

![image](https://user-images.githubusercontent.com/5341706/149231405-af19d0df-6dc0-41a8-81af-b58cce939c92.png)

![image](https://user-images.githubusercontent.com/5341706/149231370-32724482-e3ef-45e3-96be-e4faf273d311.png)

![image](https://user-images.githubusercontent.com/5341706/149231509-44375fdf-b019-4e35-b5c2-86c9aed6ad26.png)