### PR TITLE
Fix implicit glob detection when ancestor directory contains `.`

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -3509,7 +3509,7 @@ namespace ts {
                     ? WatchDirectoryFlags.Recursive : WatchDirectoryFlags.None
             };
         }
-        if (isImplicitGlob(spec)) {
+        if (isImplicitGlob(spec.substring(spec.lastIndexOf(directorySeparator) + 1))) {
             return {
                 key: useCaseSensitiveFileNames ? spec : toFileNameLowerCase(spec),
                 flags: WatchDirectoryFlags.Recursive

--- a/src/testRunner/unittests/config/tsconfigParsing.ts
+++ b/src/testRunner/unittests/config/tsconfigParsing.ts
@@ -412,5 +412,14 @@ namespace ts {
                 Diagnostics.Compiler_option_0_requires_a_value_of_type_1.code,
                 /*noLocation*/ true);
         });
+
+        it("parses wildcard directories even when parent directories have dots", () => {
+            const parsed = parseConfigFileTextToJson("/foo.bar/tsconfig.json", JSON.stringify({
+                include: ["src"]
+            }));
+
+            const parsedCommand = parseJsonConfigFileContent(parsed.config, sys, "/foo.bar");
+            assert.deepEqual(parsedCommand.wildcardDirectories, { "/foo.bar/src": WatchDirectoryFlags.Recursive });
+        });
     });
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #45721 

Big thanks to @lgarron 🌟 
