### PR TITLE
Delay "File change detected" reporting until createProgram

### DIFF
--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -452,6 +452,7 @@ namespace ts {
             }
 
             changesAffectResolution = false; // reset for next sync
+            reportWatchDiagnosticOnCreateProgram = undefined;
 
             if (host.afterProgramCreate && program !== builderProgram) {
                 host.afterProgramCreate(builderProgram);

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -273,7 +273,7 @@ namespace ts {
         let sharedExtendedConfigFileWatchers: ESMap<Path, SharedExtendedConfigFileWatcher<Path>>; // Map of file watchers for extended files, shared between different referenced projects
         let extendedConfigCache = host.extendedConfigCache;                 // Cache for extended config evaluation
         let changesAffectResolution = false;                                // Flag for indicating non-config changes affect module resolution
-        let reportFileChangeDetectedOnCreateProgram = false;                // True if synchronizeProgram should report "File change detected..."
+        let reportFileChangeDetectedOnCreateProgram = false;                // True if synchronizeProgram should report "File change detected..." when a new program is created
 
         const sourceFilesCache = new Map<string, HostFileInfo>();           // Cache that stores the source file and version info
         let missingFilePathsRequestedForRelease: Path[] | undefined;        // These paths are held temporarily so that we can remove the entry from source file cache if the file is not tracked by missing files

--- a/src/testRunner/unittests/tscWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/programUpdates.ts
@@ -1815,5 +1815,29 @@ import { x } from "../b";`),
                 },
             ]
         });
+
+        verifyTscWatch({
+            scenario,
+            subScenario: "when creating extensionless file",
+            commandLineArgs: ["-w", "-p", ".", "--extendedDiagnostics"],
+            sys: () => {
+                const module1: File = {
+                    path: `${projectRoot}/index.ts`,
+                    content: ``
+                };
+                const config: File = {
+                    path: `${projectRoot}/tsconfig.json`,
+                    content: `{}`
+                };
+                return createWatchedSystem([module1, config, libFile], { currentDirectory: projectRoot });
+            },
+            changes: [
+                {
+                    caption: "Create foo in project root",
+                    change: sys => sys.writeFile(`${projectRoot}/foo`, ``),
+                    timeouts: checkSingleTimeoutQueueLengthAndRun,
+                },
+            ]
+        });
     });
 }

--- a/src/testRunner/unittests/tscWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/programUpdates.ts
@@ -640,6 +640,34 @@ export class A {
 
         verifyTscWatch({
             scenario,
+            subScenario: "file in files is deleted",
+            commandLineArgs: ["-w", "-p", configFilePath],
+            sys: () => {
+                const file1 = {
+                    path: "/a/b/f1.ts",
+                    content: "let x = 1"
+                };
+                const file2 = {
+                    path: "/a/b/f2.ts",
+                    content: "let y = 1"
+                };
+                const configFile = {
+                    path: configFilePath,
+                    content: JSON.stringify({ compilerOptions: {}, files: ["f1.ts", "f2.ts"] })
+                };
+                return createWatchedSystem([file1, file2, libFile, configFile]);
+            },
+            changes: [
+                {
+                    caption: "Delete f2",
+                    change: sys => sys.deleteFile("/a/b/f2.ts"),
+                    timeouts: checkSingleTimeoutQueueLengthAndRun,
+                }
+            ]
+        });
+
+        verifyTscWatch({
+            scenario,
             subScenario: "config file is deleted",
             commandLineArgs: ["-w", "-p", configFilePath],
             sys: () => {

--- a/tests/baselines/reference/tscWatch/consoleClearing/with---diagnostics.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/with---diagnostics.js
@@ -72,11 +72,11 @@ FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source fil
 Scheduling update
 Elapsed:: *ms FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source file
 Synchronizing program
+[[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/f.ts"]
   options: {"watch":true,"diagnostics":true}
-[[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
-
 [[90m12:00:21 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/consoleClearing/with---diagnostics.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/with---diagnostics.js
@@ -71,12 +71,12 @@ Output::
 FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source file
 Scheduling update
 Elapsed:: *ms FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source file
-[[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
-
 Synchronizing program
 CreatingProgramWith::
   roots: ["/f.ts"]
   options: {"watch":true,"diagnostics":true}
+[[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
+
 [[90m12:00:21 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/consoleClearing/with---extendedDiagnostics.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/with---extendedDiagnostics.js
@@ -73,12 +73,12 @@ Output::
 FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source file
 Scheduling update
 Elapsed:: *ms FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source file
-[[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
-
 Synchronizing program
 CreatingProgramWith::
   roots: ["/f.ts"]
   options: {"watch":true,"extendedDiagnostics":true}
+[[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
+
 [[90m12:00:21 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/consoleClearing/with---extendedDiagnostics.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/with---extendedDiagnostics.js
@@ -74,11 +74,11 @@ FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source fil
 Scheduling update
 Elapsed:: *ms FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source file
 Synchronizing program
+[[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/f.ts"]
   options: {"watch":true,"extendedDiagnostics":true}
-[[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
-
 [[90m12:00:21 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/config-file-is-deleted.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/config-file-is-deleted.js
@@ -84,9 +84,6 @@ Input::
 //// [/a/b/tsconfig.json] deleted
 
 Output::
->> Screen clear
-[[90m12:00:24 AM[0m] File change detected. Starting incremental compilation...
-
 [91merror[0m[90m TS5083: [0mCannot read file '/a/b/tsconfig.json'.
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/file-in-files-is-deleted.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/file-in-files-is-deleted.js
@@ -1,0 +1,131 @@
+Input::
+//// [/a/b/f1.ts]
+let x = 1
+
+//// [/a/b/f2.ts]
+let y = 1
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/a/b/tsconfig.json]
+{"compilerOptions":{},"files":["f1.ts","f2.ts"]}
+
+
+/a/lib/tsc.js -w -p /a/b/tsconfig.json
+Output::
+>> Screen clear
+[[90m12:00:17 AM[0m] Starting compilation in watch mode...
+
+[[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/a/b/f1.ts","/a/b/f2.ts"]
+Program options: {"watch":true,"project":"/a/b/tsconfig.json","configFilePath":"/a/b/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/a/b/f1.ts
+/a/b/f2.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/a/b/f1.ts
+/a/b/f2.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/a/b/f1.ts (used version)
+/a/b/f2.ts (used version)
+
+WatchedFiles::
+/a/b/tsconfig.json:
+  {"fileName":"/a/b/tsconfig.json","pollingInterval":250}
+/a/b/f1.ts:
+  {"fileName":"/a/b/f1.ts","pollingInterval":250}
+/a/b/f2.ts:
+  {"fileName":"/a/b/f2.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/a/b/node_modules/@types:
+  {"directoryName":"/a/b/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/a/b/f1.js]
+var x = 1;
+
+
+//// [/a/b/f2.js]
+var y = 1;
+
+
+
+Change:: Delete f2
+
+Input::
+//// [/a/b/f2.ts] deleted
+
+Output::
+>> Screen clear
+[[90m12:00:24 AM[0m] File change detected. Starting incremental compilation...
+
+[91merror[0m[90m TS6053: [0mFile '/a/b/f2.ts' not found.
+  The file is in the program because:
+    Part of 'files' list in tsconfig.json
+
+  [96ma/b/tsconfig.json[0m:[93m1[0m:[93m40[0m
+    [7m1[0m {"compilerOptions":{},"files":["f1.ts","f2.ts"]}
+    [7m [0m [96m                                       ~~~~~~~[0m
+    File is matched by 'files' list specified here.
+
+[[90m12:00:28 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/a/b/f1.ts","/a/b/f2.ts"]
+Program options: {"watch":true,"project":"/a/b/tsconfig.json","configFilePath":"/a/b/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/a/b/f1.ts
+
+No cached semantic diagnostics in the builder::
+
+Shape signatures in builder refreshed for::
+/a/b/f1.ts (computed .d.ts)
+
+WatchedFiles::
+/a/b/tsconfig.json:
+  {"fileName":"/a/b/tsconfig.json","pollingInterval":250}
+/a/b/f1.ts:
+  {"fileName":"/a/b/f1.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/a/b/f2.ts:
+  {"fileName":"/a/b/f2.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/a/b/node_modules/@types:
+  {"directoryName":"/a/b/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/a/b/f1.js] file written with same contents

--- a/tests/baselines/reference/tscWatch/programUpdates/when-creating-extensionless-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-creating-extensionless-file.js
@@ -87,8 +87,6 @@ Output::
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/foo :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/foo :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
-[[90m12:00:27 AM[0m] File change detected. Starting incremental compilation...
-
 Reloading new file names and options
 Synchronizing program
 

--- a/tests/baselines/reference/tscWatch/programUpdates/when-creating-extensionless-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-creating-extensionless-file.js
@@ -1,0 +1,113 @@
+Input::
+//// [/user/username/projects/myproject/index.ts]
+
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{}
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+
+/a/lib/tsc.js -w -p . --extendedDiagnostics
+Output::
+[[90m12:00:21 AM[0m] Starting compilation in watch mode...
+
+Current directory: /user/username/projects/myproject CaseSensitiveFileNames: false
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Config file
+Synchronizing program
+CreatingProgramWith::
+  roots: ["/user/username/projects/myproject/index.ts"]
+  options: {"watch":true,"project":"/user/username/projects/myproject","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/index.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 undefined Source file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+[[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
+
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+
+
+Program root files: ["/user/username/projects/myproject/index.ts"]
+Program options: {"watch":true,"project":"/user/username/projects/myproject","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/index.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/user/username/projects/myproject/index.ts (used version)
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/index.ts:
+  {"fileName":"/user/username/projects/myproject/index.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/index.js]
+
+
+
+Change:: Create foo in project root
+
+Input::
+//// [/user/username/projects/myproject/foo]
+
+
+
+Output::
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/foo :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/foo :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+[[90m12:00:27 AM[0m] File change detected. Starting incremental compilation...
+
+Reloading new file names and options
+Synchronizing program
+
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/index.ts:
+  {"fileName":"/user/username/projects/myproject/index.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+

--- a/tests/baselines/reference/tscWatch/programUpdates/when-creating-new-file-in-symlinked-folder.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-creating-new-file-in-symlinked-folder.js
@@ -115,13 +115,13 @@ Output::
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/folder2/module3.ts :: WatchInfo: /user/username/projects/myproject/folder2 1 undefined Wild card directory
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/folder2/module3.ts :: WatchInfo: /user/username/projects/myproject/folder2 1 undefined Wild card directory
-[[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
-
 Reloading new file names and options
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/client/folder1/module1.ts","/user/username/projects/myproject/client/linktofolder2/module2.ts","/user/username/projects/myproject/client/linktofolder2/module3.ts"]
   options: {"baseUrl":"/user/username/projects/myproject/client","paths":{"*":["*"]},"pathsBasePath":"/user/username/projects/myproject","watch":true,"project":"/user/username/projects/myproject","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+[[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
+
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/client/linktofolder2/module3.ts 250 undefined Source file
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/folder2/module3.js :: WatchInfo: /user/username/projects/myproject/folder2 1 undefined Wild card directory
 Project: /user/username/projects/myproject/tsconfig.json Detected file add/remove of non supported extension: /user/username/projects/myproject/folder2/module3.js

--- a/tests/baselines/reference/tscWatch/programUpdates/when-creating-new-file-in-symlinked-folder.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-creating-new-file-in-symlinked-folder.js
@@ -117,11 +117,11 @@ Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/folder2/module3.ts :: WatchInfo: /user/username/projects/myproject/folder2 1 undefined Wild card directory
 Reloading new file names and options
 Synchronizing program
+[[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/client/folder1/module1.ts","/user/username/projects/myproject/client/linktofolder2/module2.ts","/user/username/projects/myproject/client/linktofolder2/module3.ts"]
   options: {"baseUrl":"/user/username/projects/myproject/client","paths":{"*":["*"]},"pathsBasePath":"/user/username/projects/myproject","watch":true,"project":"/user/username/projects/myproject","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
-[[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/client/linktofolder2/module3.ts 250 undefined Source file
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/folder2/module3.js :: WatchInfo: /user/username/projects/myproject/folder2 1 undefined Wild card directory
 Project: /user/username/projects/myproject/tsconfig.json Detected file add/remove of non supported extension: /user/username/projects/myproject/folder2/module3.js

--- a/tests/baselines/reference/tscWatch/programUpdates/when-new-file-is-added-to-the-referenced-project.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-new-file-is-added-to-the-referenced-project.js
@@ -171,14 +171,14 @@ Output::
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
-[[90m12:00:45 AM[0m] File change detected. Starting incremental compilation...
-
 Synchronizing program
 Reloading new file names and options
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"watch":true,"project":"/user/username/projects/myproject/projects/project2/tsconfig.json","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
+[[90m12:00:45 AM[0m] File change detected. Starting incremental compilation...
+
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Missing file
 [91merror[0m[90m TS6053: [0mFile '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.
   The file is in the program because:
@@ -251,13 +251,13 @@ Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/pro
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
-[[90m12:00:49 AM[0m] File change detected. Starting incremental compilation...
-
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"watch":true,"project":"/user/username/projects/myproject/projects/project2/tsconfig.json","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
+[[90m12:00:49 AM[0m] File change detected. Starting incremental compilation...
+
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 [[90m12:00:59 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -424,13 +424,13 @@ Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/pro
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
-[[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
-
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"watch":true,"project":"/user/username/projects/myproject/projects/project2/tsconfig.json","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
+[[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
+
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Missing file
 [91merror[0m[90m TS6053: [0mFile '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.
@@ -550,13 +550,13 @@ Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/pro
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
-[[90m12:01:24 AM[0m] File change detected. Starting incremental compilation...
-
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"watch":true,"project":"/user/username/projects/myproject/projects/project2/tsconfig.json","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
+[[90m12:01:24 AM[0m] File change detected. Starting incremental compilation...
+
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 [[90m12:01:34 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/when-new-file-is-added-to-the-referenced-project.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-new-file-is-added-to-the-referenced-project.js
@@ -173,12 +173,12 @@ Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Synchronizing program
 Reloading new file names and options
+[[90m12:00:45 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"watch":true,"project":"/user/username/projects/myproject/projects/project2/tsconfig.json","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
-[[90m12:00:45 AM[0m] File change detected. Starting incremental compilation...
-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Missing file
 [91merror[0m[90m TS6053: [0mFile '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.
   The file is in the program because:
@@ -252,12 +252,12 @@ DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/pro
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Synchronizing program
+[[90m12:00:49 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"watch":true,"project":"/user/username/projects/myproject/projects/project2/tsconfig.json","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
-[[90m12:00:49 AM[0m] File change detected. Starting incremental compilation...
-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 [[90m12:00:59 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -425,12 +425,12 @@ DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/pro
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Synchronizing program
+[[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"watch":true,"project":"/user/username/projects/myproject/projects/project2/tsconfig.json","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
-[[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
-
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Missing file
 [91merror[0m[90m TS6053: [0mFile '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.
@@ -551,12 +551,12 @@ DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/pro
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Synchronizing program
+[[90m12:01:24 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"watch":true,"project":"/user/username/projects/myproject/projects/project2/tsconfig.json","extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
-[[90m12:01:24 AM[0m] File change detected. Starting incremental compilation...
-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 [[90m12:01:34 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
@@ -217,11 +217,11 @@ Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Reloading new file names and options
 Synchronizing program
+[[90m12:00:48 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
-[[90m12:00:48 AM[0m] File change detected. Starting incremental compilation...
-
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/globals.d.ts 250 undefined Source file
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
@@ -312,11 +312,11 @@ Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Reloading new file names and options
 Synchronizing program
+[[90m12:00:59 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
-[[90m12:00:59 AM[0m] File change detected. Starting incremental compilation...
-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/mocha/package.json 2000 undefined package.json file
 [96mworker.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS2580: [0mCannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
@@ -384,11 +384,11 @@ Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Reloading new file names and options
 Synchronizing program
+[[90m12:01:03 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
-[[90m12:01:03 AM[0m] File change detected. Starting incremental compilation...
-
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/mocha/package.json 2000 undefined package.json file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/package.json 2000 undefined package.json file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/node/package.json 2000 undefined package.json file
@@ -483,11 +483,11 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 Scheduling update
 Reloading new file names and options
 Synchronizing program
+[[90m12:01:15 AM[0m] File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
-[[90m12:01:15 AM[0m] File change detected. Starting incremental compilation...
-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/index.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
@@ -215,13 +215,13 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
-[[90m12:00:48 AM[0m] File change detected. Starting incremental compilation...
-
 Reloading new file names and options
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+[[90m12:00:48 AM[0m] File change detected. Starting incremental compilation...
+
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/globals.d.ts 250 undefined Source file
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
@@ -310,13 +310,13 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
-[[90m12:00:59 AM[0m] File change detected. Starting incremental compilation...
-
 Reloading new file names and options
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+[[90m12:00:59 AM[0m] File change detected. Starting incremental compilation...
+
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/mocha/package.json 2000 undefined package.json file
 [96mworker.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS2580: [0mCannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
@@ -382,13 +382,13 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
-[[90m12:01:03 AM[0m] File change detected. Starting incremental compilation...
-
 Reloading new file names and options
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+[[90m12:01:03 AM[0m] File change detected. Starting incremental compilation...
+
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/mocha/package.json 2000 undefined package.json file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/package.json 2000 undefined package.json file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/node/package.json 2000 undefined package.json file
@@ -481,13 +481,13 @@ DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules
 Project: /user/username/projects/myproject/tsconfig.json Detected file add/remove of non supported extension: /user/username/projects/myproject/node_modules/@types/node/ts3.6
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Scheduling update
-[[90m12:01:15 AM[0m] File change detected. Starting incremental compilation...
-
 Reloading new file names and options
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+[[90m12:01:15 AM[0m] File change detected. Starting incremental compilation...
+
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/index.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file

--- a/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine-without-implementing-useSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine-without-implementing-useSourceOfProjectReferenceRedirect.js
@@ -135,13 +135,13 @@ Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Synchronizing program
 Loading config file: /user/username/projects/myproject/projects/project1/tsconfig.json
+
+12:00:43 AM - File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
-
-12:00:43 AM - File change detected. Starting incremental compilation...
-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Missing file
 error TS6053: File '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.
   The file is in the program because:
@@ -209,13 +209,13 @@ DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/pro
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Synchronizing program
+
+12:00:47 AM - File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
-
-12:00:47 AM - File change detected. Starting incremental compilation...
-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 
 12:00:57 AM - Found 0 errors. Watching for file changes.
@@ -341,13 +341,13 @@ DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/pro
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Synchronizing program
+
+12:01:03 AM - File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
-
-12:01:03 AM - File change detected. Starting incremental compilation...
-
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Missing file
 error TS6053: File '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.
@@ -425,13 +425,13 @@ DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/pro
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Synchronizing program
+
+12:01:16 AM - File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
-
-12:01:16 AM - File change detected. Starting incremental compilation...
-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 
 12:01:26 AM - Found 0 errors. Watching for file changes.

--- a/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine-without-implementing-useSourceOfProjectReferenceRedirect.js
+++ b/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine-without-implementing-useSourceOfProjectReferenceRedirect.js
@@ -133,15 +133,15 @@ Output::
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
-
-12:00:43 AM - File change detected. Starting incremental compilation...
-
 Synchronizing program
 Loading config file: /user/username/projects/myproject/projects/project1/tsconfig.json
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
+
+12:00:43 AM - File change detected. Starting incremental compilation...
+
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Missing file
 error TS6053: File '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.
   The file is in the program because:
@@ -208,14 +208,14 @@ Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/pro
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
-
-12:00:47 AM - File change detected. Starting incremental compilation...
-
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
+
+12:00:47 AM - File change detected. Starting incremental compilation...
+
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 
 12:00:57 AM - Found 0 errors. Watching for file changes.
@@ -340,14 +340,14 @@ Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/pro
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
-
-12:01:03 AM - File change detected. Starting incremental compilation...
-
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
+
+12:01:03 AM - File change detected. Starting incremental compilation...
+
 FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 500 undefined Missing file
 error TS6053: File '/user/username/projects/myproject/projects/project1/class3.d.ts' not found.
@@ -424,14 +424,14 @@ Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/pro
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Project: /user/username/projects/myproject/projects/project1/tsconfig.json Detected output file: /user/username/projects/myproject/projects/project1/class3.d.ts
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.d.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
-
-12:01:16 AM - File change detected. Starting incremental compilation...
-
 Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
+
+12:01:16 AM - File change detected. Starting incremental compilation...
+
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.d.ts 250 undefined Source file
 
 12:01:26 AM - Found 0 errors. Watching for file changes.

--- a/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine.js
+++ b/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine.js
@@ -135,13 +135,13 @@ Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Synchronizing program
 Loading config file: /user/username/projects/myproject/projects/project1/tsconfig.json
+
+12:00:43 AM - File change detected. Starting incremental compilation...
+
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
-
-12:00:43 AM - File change detected. Starting incremental compilation...
-
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.ts 250 undefined Source file
 
 12:00:53 AM - Found 0 errors. Watching for file changes.

--- a/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine.js
+++ b/tests/baselines/reference/tscWatch/watchApi/when-new-file-is-added-to-the-referenced-project-with-host-implementing-getParsedCommandLine.js
@@ -133,15 +133,15 @@ Output::
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
 Scheduling update
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/projects/project1/class3.ts :: WatchInfo: /user/username/projects/myproject/projects/project1 1 undefined Wild card directory of referenced project
-
-12:00:43 AM - File change detected. Starting incremental compilation...
-
 Synchronizing program
 Loading config file: /user/username/projects/myproject/projects/project1/tsconfig.json
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/projects/project2/class2.ts"]
   options: {"module":0,"composite":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/projects/project2/tsconfig.json"}
   projectReferences: [{"path":"/user/username/projects/myproject/projects/project1","originalPath":"../project1"}]
+
+12:00:43 AM - File change detected. Starting incremental compilation...
+
 FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/projects/project1/class3.ts 250 undefined Source file
 
 12:00:53 AM - Found 0 errors. Watching for file changes.


### PR DESCRIPTION
There are cases where the file/directory watching handler can't determine whether or not a change should be ignored or not. For files with unsupported extensions (like `.txt`), the watcher never calls the handler. However, extensionless files _do_ cause the watcher to call the handler (among other cases).

Rather than trying to perfect the watcher logic, delay printing of the "file change detected" message until we actually know we're going to create a new program (i.e. after it's determined that something important changed, and therefore a new program needs to be created).

Fixes #46949