### PR TITLE
Fix type error in fourslash.ts

### DIFF
--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -772,7 +772,7 @@ declare namespace FourSlashInterface {
     export interface VerifyInlayHintsOptions {
         text: string;
         position: number;
-        kind?: VerifyInlayHintKind;
+        kind?: ts.InlayHintKind;
         whitespaceBefore?: boolean;
         whitespaceAfter?: boolean;
     }


### PR DESCRIPTION
Noticed this while working on another PR.

I guess this file isn't checked?