### PR TITLE
Deprioritize import paths made up of only dots and slashes

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -684,8 +684,9 @@ namespace ts.codefix {
         return Comparison.EqualTo;
     }
 
+    const notDotOrSlashPattern = /[^.\/]/g;
     function isOnlyDotsAndSlashes(path: string) {
-        return !/[^.\/]/g.test(path);
+        return !notDotOrSlashPattern.test(path);
     }
 
     function compareNodeCoreModuleSpecifiers(a: string, b: string, importingFile: SourceFile, program: Program): Comparison {

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -684,7 +684,7 @@ namespace ts.codefix {
         return Comparison.EqualTo;
     }
 
-    const notDotOrSlashPattern = /[^.\/]/g;
+    const notDotOrSlashPattern = /[^.\/]/;
     function isOnlyDotsAndSlashes(path: string) {
         return !notDotOrSlashPattern.test(path);
     }

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -678,9 +678,14 @@ namespace ts.codefix {
         if (a.kind !== ImportFixKind.UseNamespace && b.kind !== ImportFixKind.UseNamespace) {
             return compareBooleans(allowsImportingSpecifier(b.moduleSpecifier), allowsImportingSpecifier(a.moduleSpecifier))
                 || compareNodeCoreModuleSpecifiers(a.moduleSpecifier, b.moduleSpecifier, importingFile, program)
+                || compareBooleans(isOnlyDotsAndSlashes(a.moduleSpecifier), isOnlyDotsAndSlashes(b.moduleSpecifier))
                 || compareNumberOfDirectorySeparators(a.moduleSpecifier, b.moduleSpecifier);
         }
         return Comparison.EqualTo;
+    }
+
+    function isOnlyDotsAndSlashes(path: string) {
+        return !/[^.\/]/g.test(path);
     }
 
     function compareNodeCoreModuleSpecifiers(a: string, b: string, importingFile: SourceFile, program: Program): Comparison {

--- a/tests/cases/fourslash/importNameCodeFix_barrelExport.ts
+++ b/tests/cases/fourslash/importNameCodeFix_barrelExport.ts
@@ -1,0 +1,29 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+
+// @Filename: /foo/a.ts
+//// export const A = 0;
+
+// @Filename: /foo/b.ts
+//// export {};
+//// A/*sibling*/
+
+// @Filename: /foo/index.ts
+//// export * from "./a";
+//// export * from "./b";
+
+// @Filename: /index.ts
+//// export * from "./foo";
+//// export * from "./src";
+
+// @Filename: /src/a.ts
+//// export {};
+//// A/*parent*/
+
+// @Filename: /src/index.ts
+//// export * from "./a";
+
+// Module specifiers made up of only "." and ".." components are deprioritized
+verify.importFixModuleSpecifiers("sibling", ["./a", "."]);
+verify.importFixModuleSpecifiers("parent", ["../foo", "../foo/a", ".."]);

--- a/tests/cases/fourslash/importNameCodeFix_barrelExport.ts
+++ b/tests/cases/fourslash/importNameCodeFix_barrelExport.ts
@@ -25,5 +25,5 @@
 //// export * from "./a";
 
 // Module specifiers made up of only "." and ".." components are deprioritized
-verify.importFixModuleSpecifiers("sibling", ["./a", "."]);
+verify.importFixModuleSpecifiers("sibling", ["./a", ".", ".."]);
 verify.importFixModuleSpecifiers("parent", ["../foo", "../foo/a", ".."]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #45953 

Paths like `"."` and `".."` are still available in the codefix dropdown, but sorted to the end of the list. Completions takes only the first module specifier from the list, so they should be gone from completions entirely.
