### PR TITLE
Avoid crash for import code fixes with dotted require

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -3274,7 +3274,7 @@ namespace ts {
             return isEnumConst(node)
                 ? bindBlockScopedDeclaration(node, SymbolFlags.ConstEnum, SymbolFlags.ConstEnumExcludes)
                 : bindBlockScopedDeclaration(node, SymbolFlags.RegularEnum, SymbolFlags.RegularEnumExcludes);
-            }
+        }
 
         function bindVariableDeclarationOrBindingElement(node: VariableDeclaration | BindingElement) {
             if (inStrictMode) {
@@ -3282,7 +3282,7 @@ namespace ts {
             }
 
             if (!isBindingPattern(node.name)) {
-                if (isInJSFile(node) && isAccessedOrBareRequireVariableDeclaration(node) && !getJSDocTypeTag(node)) {
+                if (isInJSFile(node) && isVariableDeclarationInitializedToBareOrAccessedRequire(node) && !getJSDocTypeTag(node)) {
                     declareSymbolAndAddToSymbolTable(node as Declaration, SymbolFlags.Alias, SymbolFlags.AliasExcludes);
                 }
                 else if (isBlockOrCatchScoped(node)) {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -3274,7 +3274,7 @@ namespace ts {
             return isEnumConst(node)
                 ? bindBlockScopedDeclaration(node, SymbolFlags.ConstEnum, SymbolFlags.ConstEnumExcludes)
                 : bindBlockScopedDeclaration(node, SymbolFlags.RegularEnum, SymbolFlags.RegularEnumExcludes);
-        }
+            }
 
         function bindVariableDeclarationOrBindingElement(node: VariableDeclaration | BindingElement) {
             if (inStrictMode) {
@@ -3282,7 +3282,7 @@ namespace ts {
             }
 
             if (!isBindingPattern(node.name)) {
-                if (isInJSFile(node) && isRequireVariableDeclaration(node) && !getJSDocTypeTag(node)) {
+                if (isInJSFile(node) && isAccessedOrBareRequireVariableDeclaration(node) && !getJSDocTypeTag(node)) {
                     declareSymbolAndAddToSymbolTable(node as Declaration, SymbolFlags.Alias, SymbolFlags.AliasExcludes);
                 }
                 else if (isBlockOrCatchScoped(node)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2596,7 +2596,7 @@ namespace ts {
                     && isAliasableOrJsExpression(node.parent.right)
                 || node.kind === SyntaxKind.ShorthandPropertyAssignment
                 || node.kind === SyntaxKind.PropertyAssignment && isAliasableOrJsExpression((node as PropertyAssignment).initializer)
-                || isAccessedOrBareRequireVariableDeclaration(node);
+                || isVariableDeclarationInitializedToBareOrAccessedRequire(node);
         }
 
         function isAliasableOrJsExpression(e: Expression) {
@@ -36984,7 +36984,7 @@ namespace ts {
             }
             // For a commonjs `const x = require`, validate the alias and exit
             const symbol = getSymbolOfNode(node);
-            if (symbol.flags & SymbolFlags.Alias && isAccessedOrBareRequireVariableDeclaration(node)) {
+            if (symbol.flags & SymbolFlags.Alias && isVariableDeclarationInitializedToBareOrAccessedRequire(node)) {
                 checkAliasSymbol(node);
                 return;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2596,7 +2596,7 @@ namespace ts {
                     && isAliasableOrJsExpression(node.parent.right)
                 || node.kind === SyntaxKind.ShorthandPropertyAssignment
                 || node.kind === SyntaxKind.PropertyAssignment && isAliasableOrJsExpression((node as PropertyAssignment).initializer)
-                || isRequireVariableDeclaration(node);
+                || isAccessedOrBareRequireVariableDeclaration(node);
         }
 
         function isAliasableOrJsExpression(e: Expression) {
@@ -36984,7 +36984,7 @@ namespace ts {
             }
             // For a commonjs `const x = require`, validate the alias and exit
             const symbol = getSymbolOfNode(node);
-            if (symbol.flags & SymbolFlags.Alias && isRequireVariableDeclaration(node)) {
+            if (symbol.flags & SymbolFlags.Alias && isAccessedOrBareRequireVariableDeclaration(node)) {
                 checkAliasSymbol(node);
                 return;
             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4664,14 +4664,12 @@ namespace ts {
     export type RequireOrImportCall = CallExpression & { expression: Identifier, arguments: [StringLiteralLike] };
 
     /* @internal */
-    export interface RequireVariableDeclaration extends VariableDeclaration {
-        readonly initializer: RequireOrImportCall;
+    export interface VariableDeclarationInitializedTo<T extends Expression> extends VariableDeclaration {
+        readonly initializer: T;
     }
 
     /* @internal */
-    export interface AccessedOrBareRequireVariableDeclaration extends VariableDeclaration {
-        readonly initializer: RequireOrImportCall | AccessExpression;
-    }
+    export type RequireVariableDeclaration = VariableDeclarationInitializedTo<RequireOrImportCall>;
 
     /* @internal */
     export interface RequireVariableStatement extends VariableStatement {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4669,6 +4669,11 @@ namespace ts {
     }
 
     /* @internal */
+    export interface AccessedOrBareRequireVariableDeclaration extends VariableDeclaration {
+        readonly initializer: RequireOrImportCall | AccessExpression;
+    }
+
+    /* @internal */
     export interface RequireVariableStatement extends VariableStatement {
         readonly declarationList: RequireVariableDeclarationList;
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4639,7 +4639,7 @@ namespace ts {
     export type AnyImportSyntax = ImportDeclaration | ImportEqualsDeclaration;
 
     /* @internal */
-    export type AnyImportOrRequire = AnyImportSyntax | RequireVariableDeclaration;
+    export type AnyImportOrRequire = AnyImportSyntax | VariableDeclarationInitializedTo<RequireOrImportCall>;
 
     /* @internal */
     export type AnyImportOrRequireStatement = AnyImportSyntax | RequireVariableStatement;
@@ -4669,16 +4669,13 @@ namespace ts {
     }
 
     /* @internal */
-    export type RequireVariableDeclaration = VariableDeclarationInitializedTo<RequireOrImportCall>;
-
-    /* @internal */
     export interface RequireVariableStatement extends VariableStatement {
         readonly declarationList: RequireVariableDeclarationList;
     }
 
     /* @internal */
     export interface RequireVariableDeclarationList extends VariableDeclarationList {
-        readonly declarations: NodeArray<RequireVariableDeclaration>;
+        readonly declarations: NodeArray<VariableDeclarationInitializedTo<RequireOrImportCall>>;
     }
 
     /* @internal */

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2113,12 +2113,12 @@ namespace ts {
      * Returns true if the node is a VariableDeclaration initialized to a require call (see `isRequireCall`).
      * This function does not test if the node is in a JavaScript file or not.
      */
-    export function isRequireVariableDeclaration(node: Node): node is RequireVariableDeclaration {
+    export function isVariableDeclarationInitializedToRequire(node: Node): node is VariableDeclarationInitializedTo<RequireOrImportCall> {
         return isVariableDeclarationInitializedWithRequireHelper(node, /*allowAccessedRequire*/ false);
     }
 
     /**
-     * Like `isRequireVariableDeclaration` but allows things like `require("...").foo.bar` or `require("...")["baz"]`.
+     * Like {@link isVariableDeclarationInitializedToRequire} but allows things like `require("...").foo.bar` or `require("...")["baz"]`.
      */
     export function isVariableDeclarationInitializedToBareOrAccessedRequire(node: Node): node is VariableDeclarationInitializedTo<RequireOrImportCall | AccessExpression> {
         return isVariableDeclarationInitializedWithRequireHelper(node, /*allowAccessedRequire*/ true);
@@ -2136,7 +2136,7 @@ namespace ts {
     export function isRequireVariableStatement(node: Node): node is RequireVariableStatement {
         return isVariableStatement(node)
             && node.declarationList.declarations.length > 0
-            && every(node.declarationList.declarations, decl => isRequireVariableDeclaration(decl));
+            && every(node.declarationList.declarations, decl => isVariableDeclarationInitializedToRequire(decl));
     }
 
     export function isSingleOrDoubleQuote(charCode: number) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2046,7 +2046,7 @@ namespace ts {
     }
 
     export function getExternalModuleRequireArgument(node: Node) {
-        return isAccessedOrBareRequireVariableDeclaration(node) && (getLeftmostAccessExpression(node.initializer) as CallExpression).arguments[0] as StringLiteral;
+        return isVariableDeclarationInitializedToBareOrAccessedRequire(node) && (getLeftmostAccessExpression(node.initializer) as CallExpression).arguments[0] as StringLiteral;
     }
 
     export function isInternalModuleImportEqualsDeclaration(node: Node): node is ImportEqualsDeclaration {
@@ -2120,7 +2120,7 @@ namespace ts {
     /**
      * Like `isRequireVariableDeclaration` but allows things like `require("...").foo.bar` or `require("...")["baz"]`.
      */
-    export function isAccessedOrBareRequireVariableDeclaration(node: Node): node is AccessedOrBareRequireVariableDeclaration {
+    export function isVariableDeclarationInitializedToBareOrAccessedRequire(node: Node): node is VariableDeclarationInitializedTo<RequireOrImportCall | AccessExpression> {
         return isVariableDeclarationInitializedWithRequireHelper(node, /*allowAccessedRequire*/ true);
     }
 

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -535,7 +535,7 @@ namespace ts.codefix {
         const importKind = getImportKind(importingFile, exportKind, compilerOptions);
         return mapDefined(importingFile.imports, (moduleSpecifier): FixAddToExistingImportInfo | undefined => {
             const i = importFromModuleSpecifier(moduleSpecifier);
-            if (isRequireVariableDeclaration(i.parent)) {
+            if (isVariableDeclarationInitializedToRequire(i.parent)) {
                 return checker.resolveExternalModuleName(moduleSpecifier) === moduleSymbol ? { declaration: i.parent, importKind, symbol, targetFlags } : undefined;
             }
             if (i.kind === SyntaxKind.ImportDeclaration || i.kind === SyntaxKind.ImportEqualsDeclaration) {

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1531,7 +1531,7 @@ namespace ts.FindAllReferences {
             // Use the parent symbol if the location is commonjs require syntax on javascript files only.
             if (isInJSFile(referenceLocation)
                 && referenceLocation.parent.kind === SyntaxKind.BindingElement
-                && isRequireVariableDeclaration(referenceLocation.parent)) {
+                && isAccessedOrBareRequireVariableDeclaration(referenceLocation.parent)) {
                 referenceSymbol = referenceLocation.parent.symbol;
                 // The parent will not have a symbol if it's an ObjectBindingPattern (when destructuring is used).  In
                 // this case, just skip it, since the bound identifiers are not an alias of the import.

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1531,7 +1531,7 @@ namespace ts.FindAllReferences {
             // Use the parent symbol if the location is commonjs require syntax on javascript files only.
             if (isInJSFile(referenceLocation)
                 && referenceLocation.parent.kind === SyntaxKind.BindingElement
-                && isAccessedOrBareRequireVariableDeclaration(referenceLocation.parent)) {
+                && isVariableDeclarationInitializedToBareOrAccessedRequire(referenceLocation.parent)) {
                 referenceSymbol = referenceLocation.parent.symbol;
                 // The parent will not have a symbol if it's an ObjectBindingPattern (when destructuring is used).  In
                 // this case, just skip it, since the bound identifiers are not an alias of the import.

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -290,7 +290,7 @@ namespace ts.GoToDefinition {
                 return declaration.parent.kind === SyntaxKind.NamedImports;
             case SyntaxKind.BindingElement:
             case SyntaxKind.VariableDeclaration:
-                return isInJSFile(declaration) && isAccessedOrBareRequireVariableDeclaration(declaration);
+                return isInJSFile(declaration) && isVariableDeclarationInitializedToBareOrAccessedRequire(declaration);
             default:
                 return false;
         }

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -290,7 +290,7 @@ namespace ts.GoToDefinition {
                 return declaration.parent.kind === SyntaxKind.NamedImports;
             case SyntaxKind.BindingElement:
             case SyntaxKind.VariableDeclaration:
-                return isInJSFile(declaration) && isRequireVariableDeclaration(declaration);
+                return isInJSFile(declaration) && isAccessedOrBareRequireVariableDeclaration(declaration);
             default:
                 return false;
         }

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -621,7 +621,7 @@ namespace ts.FindAllReferences {
                 Debug.assert((parent as ImportClause | NamespaceImport).name === node);
                 return true;
             case SyntaxKind.BindingElement:
-                return isInJSFile(node) && isRequireVariableDeclaration(parent);
+                return isInJSFile(node) && isAccessedOrBareRequireVariableDeclaration(parent);
             default:
                 return false;
         }

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -621,7 +621,7 @@ namespace ts.FindAllReferences {
                 Debug.assert((parent as ImportClause | NamespaceImport).name === node);
                 return true;
             case SyntaxKind.BindingElement:
-                return isInJSFile(node) && isAccessedOrBareRequireVariableDeclaration(parent);
+                return isInJSFile(node) && isVariableDeclarationInitializedToBareOrAccessedRequire(parent);
             default:
                 return false;
         }

--- a/tests/cases/fourslash/importFixesWithExistingDottedRequire.ts
+++ b/tests/cases/fourslash/importFixesWithExistingDottedRequire.ts
@@ -1,14 +1,21 @@
 /// <reference path="./fourslash.ts" />
 
-// @allowJs: true
-// @Filename: /library.js
+// @module: commonjs
+// @checkJs: true
+
+// @Filename: ./library.js
 //// module.exports.aaa = function() {}
 //// module.exports.bbb = function() {}
 
-// @Filename: /foo.js
+// @Filename: ./foo.js
 //// var aaa = require("./library.js").aaa;
 //// aaa();
-//// /**/bbb
+//// /*$*/bbb
 
-goTo.marker();
-verify.getAndApplyCodeFix(ts.Diagnostics.Cannot_find_name_0.code);
+goTo.marker("$")
+verify.codeFixAvailable([
+    { description: "Import 'bbb' from module \"./library.js\"" },
+    { description: "Ignore this error message" },
+    { description: "Disable checking for this file" },
+    { description: "Convert to ES module" },
+]);

--- a/tests/cases/fourslash/importFixesWithExistingDottedRequire.ts
+++ b/tests/cases/fourslash/importFixesWithExistingDottedRequire.ts
@@ -1,14 +1,14 @@
 /// <reference path="./fourslash.ts" />
 
 // @allowJs: true
-// @module: commonjs
 // @Filename: /library.js
-//// export function aaa() {}
-//// export function bbb() {}
+//// module.exports.aaa = function() {}
+//// module.exports.bbb = function() {}
 
 // @Filename: /foo.js
-//// var a = require("./library").aaa;
-//// bbb/**/
+//// var aaa = require("./library.js").aaa;
+//// aaa();
+//// /**/bbb
 
 goTo.marker();
-verify.codeFixAvailable();
+verify.getAndApplyCodeFix(ts.Diagnostics.Cannot_find_name_0.code);

--- a/tests/cases/fourslash/importFixesWithExistingDottedRequire.ts
+++ b/tests/cases/fourslash/importFixesWithExistingDottedRequire.ts
@@ -1,0 +1,14 @@
+/// <reference path="./fourslash.ts" />
+
+// @allowJs: true
+// @module: commonjs
+// @Filename: /library.js
+//// export function aaa() {}
+//// export function bbb() {}
+
+// @Filename: /foo.js
+//// var a = require("./library").aaa;
+//// bbb/**/
+
+goTo.marker();
+verify.codeFixAvailable();


### PR DESCRIPTION
Fixes #47428.

Okay, here's the summary:

First, we have a type predicate in our services layer that determines whether something is an `import` statement or a variable initialized with a `require` call.

https://github.com/microsoft/TypeScript/blob/0f1496f3546dd51b64099732ddac1e59a0367905/src/services/utilities.ts#L2032

That type predicate is wrong because it takes a dependency on `isRequireVariableStatement`...

https://github.com/microsoft/TypeScript/blob/0f1496f3546dd51b64099732ddac1e59a0367905/src/compiler/utilities.ts#L2123-L2127

which relies on `isRequireVariableDeclaration`...

https://github.com/microsoft/TypeScript/blob/0f1496f3546dd51b64099732ddac1e59a0367905/src/compiler/utilities.ts#L2116-L2121

which returns `true` a variable like in `const foo = require("yadda").foo`.

Because the type predicate is wrong, we eventually end up crashing because we think we have a `CallExpression` on the initializer and can't access the first argument, resulting in:

> TypeError: Cannot read property '0' of undefined

So my solution here is to split up the usages of the function - some for when a consumer can tolerate the property access version (`require("yadda").foo`), and some for tolerating the bare `require("yadda")` version. `isRequireVariableStatement` can safely be changed to rely on the bare version because it's only called by the type predicate function.

This at the very least avoids crashing for code-fixes without impacting go-to-definition, and other functionality in the type-checker itself.