### PR TITLE
fix(47438): No auto-complete for 'this.' or the class inside static blocks

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2086,8 +2086,7 @@ namespace ts.Completions {
                 // GH#39946. Pulling on the type of a node inside of a function with a contextual `this` parameter can result in a circularity
                 // if the `node` is part of the exprssion of a `yield` or `return`. This circularity doesn't exist at compile time because
                 // we will check (and cache) the type of `this` *before* checking the type of the node.
-                const container = getThisContainer(node, /*includeArrowFunctions*/ false);
-                if (!isSourceFile(container) && container.parent) typeChecker.getTypeAtLocation(container);
+                typeChecker.tryGetThisTypeAt(node, /*includeGlobalThis*/ false);
 
                 let type = typeChecker.getTypeAtLocation(node).getNonOptionalType();
                 let insertQuestionDot = false;

--- a/tests/cases/fourslash/completionListInClassStaticBlocks.ts
+++ b/tests/cases/fourslash/completionListInClassStaticBlocks.ts
@@ -1,0 +1,28 @@
+/// <reference path="fourslash.ts" />
+
+// @target: esnext
+////class Foo {
+////    static #a = 1;
+////    static a() {
+////        this./*1*/
+////    }
+////    static b() {
+////        Foo./*2*/
+////    }
+////    static {
+////        this./*3*/
+////    }
+////    static {
+////        Foo./*4*/
+////    }
+////}
+
+verify.completions({
+    marker: ["1", "2", "3", "4"],
+    exact: completion.functionMembersPlus([
+        { name: "#a", sortText: completion.SortText.LocalDeclarationPriority },
+        { name: "a", sortText: completion.SortText.LocalDeclarationPriority },
+        { name: "b", sortText: completion.SortText.LocalDeclarationPriority },
+        { name: "prototype" }
+    ])
+});


### PR DESCRIPTION
Fixes #47438