### PR TITLE
Fix bug in ensureProjectStructuresUpToDate that [maybe?] can lead to poisoned cache

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -614,7 +614,7 @@ namespace ts.server {
     /*@internal*/
     export function updateProjectIfDirty(project: Project) {
         project.invalidateResolutionsOfFailedLookupLocations();
-        return project.dirty && project.updateGraph();
+        return !project.dirty || project.updateGraph();
     }
 
     function setProjectOptionsUsed(project: ConfiguredProject | ExternalProject) {
@@ -1192,7 +1192,7 @@ namespace ts.server {
             let hasChanges = this.pendingEnsureProjectForOpenFiles;
             this.pendingProjectUpdates.clear();
             const updateGraph = (project: Project) => {
-                hasChanges = updateProjectIfDirty(project) || hasChanges;
+                hasChanges = !updateProjectIfDirty(project) || hasChanges;
             };
 
             this.externalProjects.forEach(updateGraph);


### PR DESCRIPTION
This PR may improve (but does not seem to fully fix) #47274

The return value of `updateProjectIfDirty` is not obvious to callers. It returns true if the project is dirty but when the set of files in the project stayed the same (`Project.updateGraph` returns true if set of files in the project stays the same and false - otherwise). I have to imagine that this is a bug, because this is a very nuanced return value.

There is only one call site of `updateProjectIfDirty` that checks the return value - in `ensureProjectStructuresUptoDate`. That code appears to assume that the function returns true if the project changed.

This PR changes updateProjectIfDirty to return boolean in similar fashion to updateGraph (true if set of files in the project stays the same, false otherwise). Update the call site to properly handle the return value.

I don't have a good sense of how to test this. Happy to add a unit test if someone can point me to another test that tests something similar.

Suspect that...

Fixes #47274 