### PR TITLE
Fix dropped watches

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1663,7 +1663,7 @@ namespace ts {
                             if (watcher) {
                                 sysLog(`sysLog:: ${relativeName}:: Resetting watch on present file after rename event`);
                                 watcher.close();
-                                watcher = watchPresentFileSystemEntryWithFsWatchFile();
+                                watcher = watchPresentFileSystemEntry();
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #47466

On unix systems, fs.watch places a watch on an inode, not a file path. If a given file is assigned a new inode, the watch is no longer valid and any changes to that file will not generate a watch for TypeScript to consume. This is quite common when using standard tools like vim and git.

This changes the watch handling code to always recreate the watch any time a rename event occurs and the file still exists. In this case, it is very likely that the inode changed (at least in my experience), so its a simple solution to the problem and I would guess it has low overhead. This patch eliminates the most common cause of this bug. There are still race conditions after this PR if someone is editing a file in the background at the exact same time that tsc is setting the watch for the first time. To fix that, setting a watch should be done as follows:

1. stat the file
2. create the watch with fs.watch
3. stat the file and make sure that the inode has not changed. If it hasn't, the watch is active.

IMO the TypeScript team should seriously consider just using chokidar. In addition to avoiding bugs like these (both the one fixed here and the one not fixed and described above), it will also provide much better performance on MacOS because it uses the native fsevents system calls.