### PR TITLE
Avoid global mutations

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -499,12 +499,16 @@ namespace ts {
     /*@internal*/
     export const ignoredPaths = ["/node_modules/.", "/.git", "/.#"];
 
+    let curSysLog: (s: string) => void = noop; // eslint-disable-line prefer-const
+
     /*@internal*/
-    export let sysLog: (s: string) => void = noop; // eslint-disable-line prefer-const
+    export function sysLog(s: string) {
+        return curSysLog(s);
+    }
 
     /*@internal*/
     export function setSysLog(logger: typeof sysLog) {
-        sysLog = logger;
+        curSysLog = logger;
     }
 
     /*@internal*/

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -5886,7 +5886,7 @@ namespace ts {
     }
 
     // eslint-disable-next-line prefer-const
-    export let objectAllocator: ObjectAllocator = {
+    export const objectAllocator: ObjectAllocator = {
         getNodeConstructor: () => Node as any,
         getTokenConstructor: () => Token as any,
         getIdentifierConstructor: () => Identifier as any,
@@ -5899,18 +5899,25 @@ namespace ts {
     };
 
     export function setObjectAllocator(alloc: ObjectAllocator) {
-        objectAllocator = alloc;
+        Object.assign(objectAllocator, alloc);
     }
 
     export function formatStringFromArgs(text: string, args: ArrayLike<string | number>, baseIndex = 0): string {
         return text.replace(/{(\d+)}/g, (_match, index: string) => "" + Debug.checkDefined(args[+index + baseIndex]));
     }
 
-    export let localizedDiagnosticMessages: MapLike<string> | undefined;
+    let localizedDiagnosticMessages: MapLike<string> | undefined;
 
     /* @internal */
     export function setLocalizedDiagnosticMessages(messages: typeof localizedDiagnosticMessages) {
         localizedDiagnosticMessages = messages;
+    }
+
+    /* @internal */
+    export function maybeSetLocalizedDiagnosticMessages(getMessages: undefined | (() => typeof localizedDiagnosticMessages)) {
+        if (!localizedDiagnosticMessages && getMessages) {
+            localizedDiagnosticMessages = getMessages();
+        }
     }
 
     export function getLocaleSpecificMessage(message: DiagnosticMessage) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1259,10 +1259,9 @@ namespace ts {
             : NoopCancellationToken;
 
         const currentDirectory = host.getCurrentDirectory();
-        // Check if the localized messages json is set, otherwise query the host for it
-        if (!localizedDiagnosticMessages && host.getLocalizedDiagnosticMessages) {
-            setLocalizedDiagnosticMessages(host.getLocalizedDiagnosticMessages());
-        }
+
+        // Checks if the localized messages json is set, and if not, query the host for it
+        maybeSetLocalizedDiagnosticMessages(host.getLocalizedDiagnosticMessages?.bind(host));
 
         function log(message: string) {
             if (host.log) {


### PR DESCRIPTION
This removes a few places where global compiler bindings are mutated:

1. Make `sysLog` call an internal binding which is changed via
   `setSysLog`.

2. Use `Object.assign` to change values *in* `objectAllocator` instead
   of mutating the binding itself.  (The type should verify that any
   future uses of this will properly override all bindings.)

3. `localizedDiagnosticMessages` is not really needed as an exported
   value, there's only one place that uses it to test whether it is set
   or not.  So drop the export and replace it with a new
   `maybeSetLocalizedDiagnosticMessages` (internal) function.
