### PR TITLE
fix(47451): Implicit 'any' quick fix text grabs text from wrong file

### DIFF
--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -58,7 +58,7 @@ namespace ts.codefix {
             });
             const name = declaration && getNameOfDeclaration(declaration);
             return !name || changes.length === 0 ? undefined
-                : [createCodeFixAction(fixId, changes, [getDiagnostic(errorCode, token), name.getText(sourceFile)], fixId, Diagnostics.Infer_all_types_from_usage)];
+                : [createCodeFixAction(fixId, changes, [getDiagnostic(errorCode, token), getTextOfNode(name)], fixId, Diagnostics.Infer_all_types_from_usage)];
         },
         fixIds: [fixId],
         getAllCodeActions(context) {
@@ -141,7 +141,7 @@ namespace ts.codefix {
             case Diagnostics.Variable_0_implicitly_has_an_1_type.code: {
                 const symbol = program.getTypeChecker().getSymbolAtLocation(token);
                 if (symbol && symbol.valueDeclaration && isVariableDeclaration(symbol.valueDeclaration) && markSeen(symbol.valueDeclaration)) {
-                    annotateVariableDeclaration(changes, importAdder, sourceFile, symbol.valueDeclaration, program, host, cancellationToken);
+                    annotateVariableDeclaration(changes, importAdder, getSourceFileOfNode(symbol.valueDeclaration), symbol.valueDeclaration, program, host, cancellationToken);
                     importAdder.writeFixes(changes);
                     return symbol.valueDeclaration;
                 }

--- a/tests/cases/fourslash/codeFixInferFromUsageVariable5.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageVariable5.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitAny: true
+
+// @Filename: /a.ts
+////var foobarfoobarfoobarfoobar;
+
+// @Filename: /b.ts
+////function bar() {
+////    let y = foobarfoobarfoobarfoobar/**/;
+////}
+
+goTo.file("/b.ts");
+goTo.marker("");
+verify.codeFix({
+    description: "Infer type of 'foobarfoobarfoobarfoobar' from usage",
+    index: 0,
+    newFileContent: {
+        "/a.ts": "var foobarfoobarfoobarfoobar: any;"
+    }
+});


### PR DESCRIPTION
Fixes #47451