### PR TITLE
Remove abort from the abort signal

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -1885,7 +1885,7 @@ interface AbortSignal extends EventTarget {
 declare var AbortSignal: {
     prototype: AbortSignal;
     new(): AbortSignal;
-    abort(reason?: any): AbortSignal;
+    // abort(): AbortSignal; - To be re-added in the future
 };
 
 interface AbstractRange {


### PR DESCRIPTION
This code clashes with the abort signal in node's dts, making it not possible to have both DOM and node in the same project:

> ../node/globals.d.ts(72,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'AbortSignal' must be of type '{ new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; }', but here has type '{ new (): AbortSignal; prototype: AbortSignal; }'.

[Logs](https://typescript.visualstudio.com/TypeScript/_build/results?buildId=117592&view=logs&j=ae5f67bc-b508-52d0-18c7-3e0886a35c88&t=344fa42e-5be7-595c-913e-e7acf0f0490f)

The [automation](https://github.com/microsoft/TypeScript-DOM-lib-generator/blob/9f18e0959a9891f04ca2576d128d2a21a049dfb9/deploy/createTypesPackages.js#L195-L206) during the deploy process to this repo should ave persisted the comment, but didn't because of the new `reason` param