### PR TITLE
Associate paths with nodes when tracing

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2408,6 +2408,7 @@ namespace ts {
                 return;
             }
             setParent(node, parent);
+            if (tracing) (node as TracingNode).tracingPath = file.path;
             const saveInStrictMode = inStrictMode;
 
             // Even though in the AST the jsdoc @typedef node belongs to the current node,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34028,7 +34028,7 @@ namespace ts {
         }
 
         function checkExpression(node: Expression | QualifiedName, checkMode?: CheckMode, forceTuple?: boolean): Type {
-            tracing?.push(tracing.Phase.Check, "checkExpression", { kind: node.kind, pos: node.pos, end: node.end });
+            tracing?.push(tracing.Phase.Check, "checkExpression", { kind: node.kind, pos: node.pos, end: node.end, path: (node as TracingNode).tracingPath });
             const saveCurrentNode = currentNode;
             currentNode = node;
             instantiationCount = 0;
@@ -37104,7 +37104,7 @@ namespace ts {
         }
 
         function checkVariableDeclaration(node: VariableDeclaration) {
-            tracing?.push(tracing.Phase.Check, "checkVariableDeclaration", { kind: node.kind, pos: node.pos, end: node.end });
+            tracing?.push(tracing.Phase.Check, "checkVariableDeclaration", { kind: node.kind, pos: node.pos, end: node.end, path: (node as TracingNode).tracingPath });
             checkGrammarVariableDeclaration(node);
             checkVariableLikeDeclaration(node);
             tracing?.pop();
@@ -40531,7 +40531,7 @@ namespace ts {
         }
 
         function checkDeferredNode(node: Node) {
-            tracing?.push(tracing.Phase.Check, "checkDeferredNode", { kind: node.kind, pos: node.pos, end: node.end });
+            tracing?.push(tracing.Phase.Check, "checkDeferredNode", { kind: node.kind, pos: node.pos, end: node.end, path: (node as TracingNode).tracingPath });
             const saveCurrentNode = currentNode;
             currentNode = node;
             instantiationCount = 0;

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -341,4 +341,8 @@ namespace ts { // eslint-disable-line one-namespace-per-file
     // define after tracingEnabled is initialized
     export const startTracing = tracingEnabled.startTracing;
     export const dumpTracingLegend = tracingEnabled.dumpLegend;
+
+    export interface TracingNode {
+        tracingPath?: Path;
+    }
 }


### PR DESCRIPTION
Walking up the tree to find the enclosing SourceFile would distort the
timing too much so, instead, we attach a Path in the binder.

At present, the path is determined retroactively by walking up the call
stack in the trace visualizer, but this is both inconvenient and
routinely inaccurate (checking an expression in one file may require
checking an expression in another file and there's no way to determine
from the trace where this transition occurred).