### PR TITLE
Add codefix and completions for promoting existing type-only imports to non-type-only

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6466,6 +6466,14 @@
         "category": "Message",
         "code": 90054
     },
+    "Remove 'type' from import declaration from \"{0}\"": {
+        "category": "Message",
+        "code": 90055
+    },
+    "Remove 'type' from import of '{0}' from \"{1}\"": {
+        "category": "Message",
+        "code": 90056
+    },
 
     "Convert function to an ES2015 class": {
         "category": "Message",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3141,8 +3141,8 @@ namespace ts {
         | ImportClause & { readonly isTypeOnly: true, readonly name: Identifier }
         | ImportEqualsDeclaration & { readonly isTypeOnly: true }
         | NamespaceImport & { readonly parent: ImportClause & { readonly isTypeOnly: true } }
-        | ImportSpecifier & { readonly parent: NamedImports & { readonly parent: ImportClause & { readonly isTypeOnly: true } } }
-        | ExportSpecifier & { readonly parent: NamedExports & { readonly parent: ExportDeclaration & { readonly isTypeOnly: true } } }
+        | ImportSpecifier & ({ readonly isTypeOnly: true } | { readonly parent: NamedImports & { readonly parent: ImportClause & { readonly isTypeOnly: true } } })
+        | ExportSpecifier & ({ readonly isTypeOnly: true } | { readonly parent: NamedExports & { readonly parent: ExportDeclaration & { readonly isTypeOnly: true } } })
         ;
 
     /**

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -10,7 +10,8 @@ namespace ts.codefix {
         Diagnostics.Cannot_find_namespace_0.code,
         Diagnostics._0_refers_to_a_UMD_global_but_the_current_file_is_a_module_Consider_adding_an_import_instead.code,
         Diagnostics._0_only_refers_to_a_type_but_is_being_used_as_a_value_here.code,
-        Diagnostics.No_value_exists_in_scope_for_the_shorthand_property_0_Either_declare_one_or_provide_an_initializer.code
+        Diagnostics.No_value_exists_in_scope_for_the_shorthand_property_0_Either_declare_one_or_provide_an_initializer.code,
+        Diagnostics._0_cannot_be_used_as_a_value_because_it_was_imported_using_import_type.code,
     ];
 
     registerCodeFix({
@@ -133,6 +134,9 @@ namespace ts.codefix {
                     }
                     break;
                 }
+                case ImportFixKind.PromoteTypeOnly:
+                    // Excluding from fix-all
+                    break;
                 default:
                     Debug.assertNever(fix, `fix wasn't never - got kind ${(fix as ImportFix).kind}`);
             }
@@ -225,7 +229,7 @@ namespace ts.codefix {
     }
 
     // Sorted with the preferred fix coming first.
-    const enum ImportFixKind { UseNamespace, JsdocTypeImport, AddToExisting, AddNew }
+    const enum ImportFixKind { UseNamespace, JsdocTypeImport, AddToExisting, AddNew, PromoteTypeOnly }
     // These should not be combined as bitflags, but are given powers of 2 values to
     // easily detect conflicts between `NotAllowed` and `Required` by giving them a unique sum.
     // They're also ordered in terms of increasing priority for a fix-all scenario (see
@@ -235,7 +239,8 @@ namespace ts.codefix {
         Required   = 1 << 1,
         NotAllowed = 1 << 2,
     }
-    type ImportFix = FixUseNamespaceImport | FixAddJsdocTypeImport | FixAddToExistingImport | FixAddNewImport;
+    type ImportFix = FixUseNamespaceImport | FixAddJsdocTypeImport | FixAddToExistingImport | FixAddNewImport | FixPromoteTypeOnlyImport;
+    type ImportFixWithModuleSpecifier = FixUseNamespaceImport | FixAddJsdocTypeImport | FixAddToExistingImport | FixAddNewImport;
     interface FixUseNamespaceImport {
         readonly kind: ImportFixKind.UseNamespace;
         readonly namespacePrefix: string;
@@ -263,6 +268,11 @@ namespace ts.codefix {
         readonly useRequire: boolean;
         readonly exportInfo?: SymbolExportInfo;
     }
+    interface FixPromoteTypeOnlyImport {
+        readonly kind: ImportFixKind.PromoteTypeOnly;
+        readonly typeOnlyAliasDeclaration: TypeOnlyAliasDeclaration;
+    }
+
 
     /** Information needed to augment an existing import declaration. */
     interface FixAddToExistingImportInfo {
@@ -398,7 +408,7 @@ namespace ts.codefix {
         sourceFile: SourceFile,
         host: LanguageServiceHost,
         preferences: UserPreferences,
-    ): readonly ImportFix[] {
+    ): readonly ImportFixWithModuleSpecifier[] {
         const checker = program.getTypeChecker();
         const existingImports = flatMap(exportInfos, info => getExistingImportDeclarations(info, checker, sourceFile, program.getCompilerOptions()));
         const useNamespace = position === undefined ? undefined : tryUseExistingNamespaceImport(existingImports, symbolName, position, checker);
@@ -651,18 +661,28 @@ namespace ts.codefix {
     interface FixesInfo { readonly fixes: readonly ImportFix[]; readonly symbolName: string; }
     function getFixesInfo(context: CodeFixContextBase, errorCode: number, pos: number, useAutoImportProvider: boolean): FixesInfo | undefined {
         const symbolToken = getTokenAtPosition(context.sourceFile, pos);
-        const info = errorCode === Diagnostics._0_refers_to_a_UMD_global_but_the_current_file_is_a_module_Consider_adding_an_import_instead.code
-            ? getFixesInfoForUMDImport(context, symbolToken)
-            : isIdentifier(symbolToken) ? getFixesInfoForNonUMDImport(context, symbolToken, useAutoImportProvider) : undefined;
+        if (errorCode === Diagnostics._0_refers_to_a_UMD_global_but_the_current_file_is_a_module_Consider_adding_an_import_instead.code) {
+            return getFixesInfoForUMDImport(context, symbolToken);
+        }
+        if (!isIdentifier(symbolToken)) {
+            return undefined;
+        }
+        if (errorCode === Diagnostics._0_cannot_be_used_as_a_value_because_it_was_imported_using_import_type.code) {
+            const symbolName = getSymbolName(context.sourceFile, context.program.getTypeChecker(), symbolToken, context.program.getCompilerOptions());
+            const fix = getTypeOnlyPromotionFix(context.sourceFile, symbolToken, symbolName, context.program);
+            return fix && { fixes: [fix], symbolName };
+        }
+
+        const info = getFixesInfoForNonUMDImport(context, symbolToken, useAutoImportProvider);
         const packageJsonImportFilter = createPackageJsonImportFilter(context.sourceFile, context.preferences, context.host);
         return info && { ...info, fixes: sortFixes(info.fixes, context.sourceFile, context.program, packageJsonImportFilter) };
     }
 
-    function sortFixes(fixes: readonly ImportFix[], sourceFile: SourceFile, program: Program, packageJsonImportFilter: PackageJsonImportFilter): readonly ImportFix[] {
+    function sortFixes(fixes: readonly ImportFixWithModuleSpecifier[], sourceFile: SourceFile, program: Program, packageJsonImportFilter: PackageJsonImportFilter): readonly ImportFixWithModuleSpecifier[] {
         return sort(fixes, (a, b) => compareValues(a.kind, b.kind) || compareModuleSpecifiers(a, b, sourceFile, program, packageJsonImportFilter.allowsImportingSpecifier));
     }
 
-    function getBestFix<T extends ImportFix>(fixes: readonly T[], sourceFile: SourceFile, program: Program, packageJsonImportFilter: PackageJsonImportFilter): T | undefined {
+    function getBestFix<T extends ImportFixWithModuleSpecifier>(fixes: readonly T[], sourceFile: SourceFile, program: Program, packageJsonImportFilter: PackageJsonImportFilter): T | undefined {
         if (!some(fixes)) return;
         // These will always be placed first if available, and are better than other kinds
         if (fixes[0].kind === ImportFixKind.UseNamespace || fixes[0].kind === ImportFixKind.AddToExisting) {
@@ -675,7 +695,7 @@ namespace ts.codefix {
     }
 
     /** @returns `Comparison.LessThan` if `a` is better than `b`. */
-    function compareModuleSpecifiers(a: ImportFix, b: ImportFix, importingFile: SourceFile, program: Program, allowsImportingSpecifier: (specifier: string) => boolean): Comparison {
+    function compareModuleSpecifiers(a: ImportFixWithModuleSpecifier, b: ImportFixWithModuleSpecifier, importingFile: SourceFile, program: Program, allowsImportingSpecifier: (specifier: string) => boolean): Comparison {
         if (a.kind !== ImportFixKind.UseNamespace && b.kind !== ImportFixKind.UseNamespace) {
             return compareBooleans(allowsImportingSpecifier(b.moduleSpecifier), allowsImportingSpecifier(a.moduleSpecifier))
                 || compareNodeCoreModuleSpecifiers(a.moduleSpecifier, b.moduleSpecifier, importingFile, program)
@@ -765,7 +785,7 @@ namespace ts.codefix {
         }
     }
 
-    function getFixesInfoForNonUMDImport({ sourceFile, program, cancellationToken, host, preferences }: CodeFixContextBase, symbolToken: Identifier, useAutoImportProvider: boolean): FixesInfo | undefined {
+    function getFixesInfoForNonUMDImport({ sourceFile, program, cancellationToken, host, preferences }: CodeFixContextBase, symbolToken: Identifier, useAutoImportProvider: boolean): FixesInfo & { fixes: readonly ImportFixWithModuleSpecifier[] } | undefined {
         const checker = program.getTypeChecker();
         const compilerOptions = program.getCompilerOptions();
         const symbolName = getSymbolName(sourceFile, checker, symbolToken, compilerOptions);
@@ -778,6 +798,17 @@ namespace ts.codefix {
         const fixes = arrayFrom(flatMapIterator(exportInfos.entries(), ([_, exportInfos]) =>
             getImportFixes(exportInfos, symbolName, symbolToken.getStart(sourceFile), isValidTypeOnlyUseSite, useRequire, program, sourceFile, host, preferences)));
         return { fixes, symbolName };
+    }
+
+    function getTypeOnlyPromotionFix(sourceFile: SourceFile, symbolToken: Identifier, symbolName: string, program: Program): FixPromoteTypeOnlyImport | undefined {
+        const checker = program.getTypeChecker();
+        const symbol = checker.resolveName(symbolName, symbolToken, SymbolFlags.Value, /*excludeGlobals*/ true);
+        if (!symbol) return undefined;
+
+        const typeOnlyAliasDeclaration = checker.getTypeOnlyAliasDeclaration(symbol);
+        if (!typeOnlyAliasDeclaration || getSourceFileOfNode(typeOnlyAliasDeclaration) !== sourceFile) return undefined;
+
+        return { kind: ImportFixKind.PromoteTypeOnly, typeOnlyAliasDeclaration };
     }
 
     function jsxModeNeedsExplicitImport(jsx: JsxEmit | undefined) {
@@ -911,8 +942,60 @@ namespace ts.codefix {
                 insertImports(changes, sourceFile, getDeclarations(moduleSpecifier, quotePreference, defaultImport, namedImports, namespaceLikeImport), /*blankLineBetween*/ true);
                 return [importKind === ImportKind.Default ? Diagnostics.Import_default_0_from_module_1 : Diagnostics.Import_0_from_module_1, symbolName, moduleSpecifier];
             }
+            case ImportFixKind.PromoteTypeOnly: {
+                const { typeOnlyAliasDeclaration } = fix;
+                const promotedDeclaration = promoteFromTypeOnly(changes, typeOnlyAliasDeclaration, compilerOptions, sourceFile);
+                return promotedDeclaration.kind === SyntaxKind.ImportSpecifier
+                    ? [Diagnostics.Remove_type_from_import_of_0_from_1, symbolName, getModuleSpecifierText(promotedDeclaration.parent.parent)]
+                    : [Diagnostics.Remove_type_from_import_declaration_from_0, getModuleSpecifierText(promotedDeclaration)];
+            }
             default:
                 return Debug.assertNever(fix, `Unexpected fix kind ${(fix as ImportFix).kind}`);
+        }
+    }
+
+    function getModuleSpecifierText(promotedDeclaration: ImportClause | ImportEqualsDeclaration): string {
+        return promotedDeclaration.kind === SyntaxKind.ImportEqualsDeclaration
+            ? tryCast(tryCast(promotedDeclaration.moduleReference, isExternalModuleReference)?.expression, isStringLiteralLike)?.text || promotedDeclaration.moduleReference.getText()
+            : cast(promotedDeclaration.parent.moduleSpecifier, isStringLiteral).text;
+    }
+
+    function promoteFromTypeOnly(changes: textChanges.ChangeTracker, aliasDeclaration: TypeOnlyAliasDeclaration, compilerOptions: CompilerOptions, sourceFile: SourceFile) {
+        // See comment in `doAddExistingFix` on constant with the same name.
+        const convertExistingToTypeOnly = compilerOptions.preserveValueImports && compilerOptions.isolatedModules;
+        switch (aliasDeclaration.kind) {
+            case SyntaxKind.ImportSpecifier:
+                if (aliasDeclaration.isTypeOnly) {
+                    changes.deleteRange(sourceFile, aliasDeclaration.getFirstToken()!);
+                    return aliasDeclaration;
+                }
+                else {
+                    Debug.assert(aliasDeclaration.parent.parent.isTypeOnly);
+                    promoteImportClause(aliasDeclaration.parent.parent);
+                    return aliasDeclaration.parent.parent;
+                }
+            case SyntaxKind.ImportClause:
+                promoteImportClause(aliasDeclaration);
+                return aliasDeclaration;
+            case SyntaxKind.NamespaceImport:
+                promoteImportClause(aliasDeclaration.parent);
+                return aliasDeclaration.parent;
+            case SyntaxKind.ImportEqualsDeclaration:
+                changes.deleteRange(sourceFile, aliasDeclaration.getChildAt(1));
+                return aliasDeclaration;
+            default:
+                Debug.failBadSyntaxKind(aliasDeclaration);
+        }
+
+        function promoteImportClause(importClause: ImportClause) {
+            changes.delete(sourceFile, getTypeKeywordOfTypeOnlyImport(importClause, sourceFile));
+            if (convertExistingToTypeOnly) {
+                tryCast(importClause.namedBindings, isNamedImports)?.elements
+                    .filter(e => e !== aliasDeclaration && !e.isTypeOnly)
+                    .forEach(e => {
+                        changes.insertModifierBefore(sourceFile, SyntaxKind.TypeKeyword, e);
+                    });
+            }
         }
     }
 

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -979,7 +979,7 @@ namespace ts.codefix {
         switch (aliasDeclaration.kind) {
             case SyntaxKind.ImportSpecifier:
                 if (aliasDeclaration.isTypeOnly) {
-                    if (OrganizeImports.importSpecifiersAreSorted(aliasDeclaration.parent.elements)) {
+                    if (aliasDeclaration.parent.elements.length > 1 && OrganizeImports.importSpecifiersAreSorted(aliasDeclaration.parent.elements)) {
                         changes.delete(sourceFile, aliasDeclaration);
                         const newSpecifier = factory.updateImportSpecifier(aliasDeclaration, /*isTypeOnly*/ false, aliasDeclaration.propertyName, aliasDeclaration.name);
                         const insertionIndex = OrganizeImports.getImportSpecifierInsertionIndex(aliasDeclaration.parent.elements, newSpecifier);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -60,6 +60,8 @@ namespace ts.Completions {
         ThisProperty = "ThisProperty/",
         /** Auto-import that comes attached to a class member snippet */
         ClassMemberSnippet = "ClassMemberSnippet/",
+        /** A type-only import that needs to be promoted in order to be used at the completion location */
+        TypeOnlyAlias = "TypeOnlyAlias/",
     }
 
     const enum SymbolOriginInfoKind {
@@ -69,6 +71,7 @@ namespace ts.Completions {
         Promise             = 1 << 3,
         Nullable            = 1 << 4,
         ResolvedExport      = 1 << 5,
+        TypeOnlyAlias       = 1 << 6,
 
         SymbolMemberNoExport = SymbolMember,
         SymbolMemberExport   = SymbolMember | Export,
@@ -94,6 +97,10 @@ namespace ts.Completions {
         moduleSymbol: Symbol;
         exportName: string;
         moduleSpecifier: string;
+    }
+
+    interface SymbolOriginInfoTypeOnlyAlias extends SymbolOriginInfo {
+        declaration: TypeOnlyAliasDeclaration;
     }
 
     function originIsThisType(origin: SymbolOriginInfo): boolean {
@@ -126,6 +133,10 @@ namespace ts.Completions {
 
     function originIsNullableMember(origin: SymbolOriginInfo): boolean {
         return !!(origin.kind & SymbolOriginInfoKind.Nullable);
+    }
+
+    function originIsTypeOnlyAlias(origin: SymbolOriginInfo | undefined): origin is SymbolOriginInfoTypeOnlyAlias {
+        return !!(origin && origin.kind & SymbolOriginInfoKind.TypeOnlyAlias);
     }
 
     interface UniqueNameSet {
@@ -740,6 +751,10 @@ namespace ts.Completions {
             }
         }
 
+        if (origin?.kind === SymbolOriginInfoKind.TypeOnlyAlias) {
+            hasAction = true;
+        }
+
         if (preferences.includeCompletionsWithClassMemberSnippets &&
             preferences.includeCompletionsWithInsertText &&
             completionKind === CompletionKind.MemberLike &&
@@ -1168,6 +1183,9 @@ namespace ts.Completions {
         if (origin?.kind === SymbolOriginInfoKind.ThisType) {
             return CompletionSource.ThisProperty;
         }
+        if (origin?.kind === SymbolOriginInfoKind.TypeOnlyAlias) {
+            return CompletionSource.TypeOnlyAlias;
+        }
     }
 
     export function getCompletionEntriesFromSymbols(
@@ -1245,7 +1263,7 @@ namespace ts.Completions {
             }
 
             /** True for locals; false for globals, module exports from other files, `this.` completions. */
-            const shouldShadowLaterSymbols = !origin && !(symbol.parent === undefined && !some(symbol.declarations, d => d.getSourceFile() === location.getSourceFile()));
+            const shouldShadowLaterSymbols = (!origin || originIsTypeOnlyAlias(origin)) && !(symbol.parent === undefined && !some(symbol.declarations, d => d.getSourceFile() === location.getSourceFile()));
             uniques.set(name, shouldShadowLaterSymbols);
             insertSorted(entries, entry, compareCompletionEntries, /*allowDuplicates*/ true);
         }
@@ -1261,6 +1279,7 @@ namespace ts.Completions {
         };
 
         function shouldIncludeSymbol(symbol: Symbol, symbolToSortTextIdMap: SymbolSortTextIdMap): boolean {
+            let allFlags = symbol.flags;
             if (!isSourceFile(location)) {
                 // export = /**/ here we want to get all meanings, so any symbol is ok
                 if (isExportAssignment(location.parent)) {
@@ -1287,12 +1306,12 @@ namespace ts.Completions {
                         || symbolToSortTextIdMap[getSymbolId(symbolOrigin)] === SortTextId.LocationPriority)) {
                     return false;
                 }
-                // Continue with origin symbol
-                symbol = symbolOrigin;
+
+                allFlags |= getCombinedLocalAndExportSymbolFlags(symbolOrigin);
 
                 // import m = /**/ <-- It can only access namespace (if typing import = x. this would get member symbols and not namespace)
                 if (isInRightSideOfInternalImportEqualsDeclaration(location)) {
-                    return !!(symbol.flags & SymbolFlags.Namespace);
+                    return !!(allFlags & SymbolFlags.Namespace);
                 }
 
                 if (isTypeOnlyLocation) {
@@ -1302,7 +1321,7 @@ namespace ts.Completions {
             }
 
             // expressions are value space (which includes the value namespaces)
-            return !!(getCombinedLocalAndExportSymbolFlags(symbol) & SymbolFlags.Value);
+            return !!(allFlags & SymbolFlags.Value);
         }
     }
 
@@ -1531,6 +1550,19 @@ namespace ts.Completions {
                     }],
                 };
             }
+        }
+
+        if (originIsTypeOnlyAlias(origin)) {
+            const codeAction = codefix.getPromoteTypeOnlyCompletionAction(
+                sourceFile,
+                origin.declaration.name,
+                program,
+                host,
+                formatContext,
+                preferences);
+
+            Debug.assertIsDefined(codeAction, "Expected to have a code action for promoting type-only alias");
+            return { codeActions: [codeAction], sourceDisplay: undefined };
         }
 
         if (!origin || !(originIsExport(origin) || originIsResolvedExport(origin))) {
@@ -2314,13 +2346,22 @@ namespace ts.Completions {
             isInSnippetScope = isSnippetScope(scopeNode);
 
             const symbolMeanings = (isTypeOnlyLocation ? SymbolFlags.None : SymbolFlags.Value) | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias;
+            const typeOnlyAliasNeedsPromotion = previousToken && !isValidTypeOnlyAliasUseSite(previousToken);
 
             symbols = concatenate(symbols, typeChecker.getSymbolsInScope(scopeNode, symbolMeanings));
             Debug.assertEachIsDefined(symbols, "getSymbolsInScope() should all be defined");
-            for (const symbol of symbols) {
+            for (let i = 0; i < symbols.length; i++) {
+                const symbol = symbols[i];
                 if (!typeChecker.isArgumentsSymbol(symbol) &&
                     !some(symbol.declarations, d => d.getSourceFile() === sourceFile)) {
                     symbolToSortTextIdMap[getSymbolId(symbol)] = SortTextId.GlobalsOrKeywords;
+                }
+                if (typeOnlyAliasNeedsPromotion && !(symbol.flags & SymbolFlags.Value)) {
+                    const typeOnlyAliasDeclaration = symbol.declarations && find(symbol.declarations, isTypeOnlyImportOrExportDeclaration);
+                    if (typeOnlyAliasDeclaration) {
+                        const origin: SymbolOriginInfoTypeOnlyAlias = { kind: SymbolOriginInfoKind.TypeOnlyAlias, declaration: typeOnlyAliasDeclaration };
+                        symbolToOriginInfoMap[i] = origin;
+                    }
                 }
             }
 
@@ -3901,10 +3942,15 @@ namespace ts.Completions {
 
     /** True if symbol is a type or a module containing at least one type. */
     function symbolCanBeReferencedAtTypeLocation(symbol: Symbol, checker: TypeChecker, seenModules = new Map<SymbolId, true>()): boolean {
-        const sym = skipAlias(symbol.exportSymbol || symbol, checker);
-        return !!(sym.flags & SymbolFlags.Type) || checker.isUnknownSymbol(sym) ||
-            !!(sym.flags & SymbolFlags.Module) && addToSeen(seenModules, getSymbolId(sym)) &&
-                checker.getExportsOfModule(sym).some(e => symbolCanBeReferencedAtTypeLocation(e, checker, seenModules));
+        // Since an alias can be merged with a local declaration, we need to test both the alias and its target.
+        // This code used to just test the result of `skipAlias`, but that would ignore any locally introduced meanings.
+        return nonAliasCanBeReferencedAtTypeLocation(symbol) || nonAliasCanBeReferencedAtTypeLocation(skipAlias(symbol.exportSymbol || symbol, checker));
+
+        function nonAliasCanBeReferencedAtTypeLocation(symbol: Symbol): boolean {
+            return !!(symbol.flags & SymbolFlags.Type) || checker.isUnknownSymbol(symbol) ||
+                !!(symbol.flags & SymbolFlags.Module) && addToSeen(seenModules, getSymbolId(symbol)) &&
+                checker.getExportsOfModule(symbol).some(e => symbolCanBeReferencedAtTypeLocation(e, checker, seenModules));
+        }
     }
 
     function isDeprecated(symbol: Symbol, checker: TypeChecker) {

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -339,6 +339,7 @@ namespace ts.textChanges {
             this.deletedNodes.push({ sourceFile, node });
         }
 
+        /** Stop! Consider using `delete` instead, which has logic for deleting nodes from delimited lists. */
         public deleteNode(sourceFile: SourceFile, node: Node, options: ConfigurableStartEnd = { leadingTriviaOption: LeadingTriviaOption.IncludeAll }): void {
             this.deleteRange(sourceFile, getAdjustedRange(sourceFile, node, node, options));
         }
@@ -784,6 +785,20 @@ namespace ts.textChanges {
 
         public insertExportModifier(sourceFile: SourceFile, node: DeclarationStatement | VariableStatement): void {
             this.insertText(sourceFile, node.getStart(sourceFile), "export ");
+        }
+
+        public insertImportSpecifierAtIndex(sourceFile: SourceFile, importSpecifier: ImportSpecifier, namedImports: NamedImports, index: number) {
+            const prevSpecifier = namedImports.elements[index - 1];
+            if (prevSpecifier) {
+                this.insertNodeInListAfter(sourceFile, prevSpecifier, importSpecifier);
+            }
+            else {
+                this.insertNodeBefore(
+                    sourceFile,
+                    namedImports.elements[0],
+                    importSpecifier,
+                    !positionsAreOnSameLine(namedImports.elements[0].getStart(), namedImports.parent.parent.getStart(), sourceFile));
+            }
         }
 
         /**

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1720,19 +1720,23 @@ declare namespace ts {
         readonly parent: ImportClause & {
             readonly isTypeOnly: true;
         };
-    } | ImportSpecifier & {
+    } | ImportSpecifier & ({
+        readonly isTypeOnly: true;
+    } | {
         readonly parent: NamedImports & {
             readonly parent: ImportClause & {
                 readonly isTypeOnly: true;
             };
         };
-    } | ExportSpecifier & {
+    }) | ExportSpecifier & ({
+        readonly isTypeOnly: true;
+    } | {
         readonly parent: NamedExports & {
             readonly parent: ExportDeclaration & {
                 readonly isTypeOnly: true;
             };
         };
-    };
+    });
     /**
      * This is either an `export =` or an `export default` declaration.
      * Unless `isExportEquals` is set, this node was parsed as an `export default`.

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1720,19 +1720,23 @@ declare namespace ts {
         readonly parent: ImportClause & {
             readonly isTypeOnly: true;
         };
-    } | ImportSpecifier & {
+    } | ImportSpecifier & ({
+        readonly isTypeOnly: true;
+    } | {
         readonly parent: NamedImports & {
             readonly parent: ImportClause & {
                 readonly isTypeOnly: true;
             };
         };
-    } | ExportSpecifier & {
+    }) | ExportSpecifier & ({
+        readonly isTypeOnly: true;
+    } | {
         readonly parent: NamedExports & {
             readonly parent: ExportDeclaration & {
                 readonly isTypeOnly: true;
             };
         };
-    };
+    });
     /**
      * This is either an `export =` or an `export default` declaration.
      * Unless `isExportEquals` is set, this node was parsed as an `export default`.

--- a/tests/cases/fourslash/completionsImport_promoteTypeOnly1.ts
+++ b/tests/cases/fourslash/completionsImport_promoteTypeOnly1.ts
@@ -1,0 +1,34 @@
+/// <reference path="fourslash.ts" />
+// @module: es2015
+
+// @Filename: /exports.ts
+//// export interface SomeInterface {}
+//// export class SomePig {}
+
+// @Filename: /a.ts
+//// import type { SomeInterface, SomePig } from "./exports.js";
+//// new SomePig/**/
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "SomePig",
+    source: completion.CompletionSource.TypeOnlyAlias,
+    hasAction: true,
+  }]),
+  preferences: { includeCompletionsForModuleExports: true },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "SomePig",
+  source: completion.CompletionSource.TypeOnlyAlias,
+  description: `Remove 'type' from import declaration from "./exports.js"`,
+  newFileContent:
+`import { SomeInterface, SomePig } from "./exports.js";
+new SomePig`,
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeInsertTextCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/completionsImport_promoteTypeOnly2.ts
+++ b/tests/cases/fourslash/completionsImport_promoteTypeOnly2.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @module: es2015
+
+// @Filename: /exports.ts
+//// export interface SomeInterface {}
+
+// @Filename: /a.ts
+//// import type { SomeInterface } from "./exports.js";
+//// const SomeInterface = {};
+//// SomeI/**/
+
+// Should NOT promote this
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "SomeInterface"
+  }]
+});

--- a/tests/cases/fourslash/completionsImport_promoteTypeOnly3.ts
+++ b/tests/cases/fourslash/completionsImport_promoteTypeOnly3.ts
@@ -1,0 +1,33 @@
+/// <reference path="fourslash.ts" />
+// @module: es2015
+
+// @Filename: /exports.ts
+//// export interface SomeInterface {}
+//// export class SomePig {}
+
+// @Filename: /a.ts
+//// import { type SomePig } from "./exports.js";
+//// new SomePig/**/
+
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "SomePig",
+    source: completion.CompletionSource.TypeOnlyAlias,
+    hasAction: true,
+  }]
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "SomePig",
+  source: completion.CompletionSource.TypeOnlyAlias,
+  description: `Remove 'type' from import of 'SomePig' from "./exports.js"`,
+  newFileContent:
+`import { SomePig } from "./exports.js";
+new SomePig`,
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeInsertTextCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/completionsImport_promoteTypeOnly4.ts
+++ b/tests/cases/fourslash/completionsImport_promoteTypeOnly4.ts
@@ -1,0 +1,35 @@
+/// <reference path="fourslash.ts" />
+// @module: es2015
+// @isolatedModules: true
+// @preserveValueImports: true
+
+// @Filename: /exports.ts
+//// export interface SomeInterface {}
+//// export class SomePig {}
+
+// @Filename: /a.ts
+//// import type { SomePig, SomeInterface } from "./exports.js";
+//// new SomePig/**/
+
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "SomePig",
+    source: completion.CompletionSource.TypeOnlyAlias,
+    hasAction: true,
+  }]
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "SomePig",
+  source: completion.CompletionSource.TypeOnlyAlias,
+  description: `Remove 'type' from import declaration from "./exports.js"`,
+  newFileContent:
+`import { SomePig, type SomeInterface } from "./exports.js";
+new SomePig`,
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeInsertTextCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/completionsImport_promoteTypeOnly5.ts
+++ b/tests/cases/fourslash/completionsImport_promoteTypeOnly5.ts
@@ -1,0 +1,33 @@
+/// <reference path="fourslash.ts" />
+// @module: es2015
+
+// @Filename: /exports.ts
+//// export interface SomeInterface {}
+//// export class SomePig {}
+
+// @Filename: /a.ts
+//// import { type SomePig as Babe } from "./exports.js";
+//// new Babe/**/
+
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "Babe",
+    source: completion.CompletionSource.TypeOnlyAlias,
+    hasAction: true,
+  }]
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "Babe",
+  source: completion.CompletionSource.TypeOnlyAlias,
+  description: `Remove 'type' from import of 'Babe' from "./exports.js"`,
+  newFileContent:
+`import { SomePig as Babe } from "./exports.js";
+new Babe`,
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeInsertTextCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -858,6 +858,7 @@ declare namespace completion {
     export const enum CompletionSource {
         ThisProperty = "ThisProperty/",
         ClassMemberSnippet = "ClassMemberSnippet/",
+        TypeOnlyAlias = "TypeOnlyAlias/",
     }
     export const globalThisEntry: Entry;
     export const undefinedVarEntry: Entry;

--- a/tests/cases/fourslash/importNameCodeFix_importType5.ts
+++ b/tests/cases/fourslash/importNameCodeFix_importType5.ts
@@ -1,0 +1,34 @@
+/// <reference path="fourslash.ts" />
+
+// @module: es2015
+
+// @Filename: /exports.ts
+//// export interface SomeInterface {}
+//// export class SomePig {}
+
+// @Filename: /a.ts
+//// import type { SomeInterface, SomePig } from "./exports.js";
+//// new SomePig/**/
+
+goTo.marker("");
+verify.importFixAtPosition([
+`import { SomeInterface, SomePig } from "./exports.js";
+new SomePig`]);
+
+// verify.applyCodeActionFromCompletion("", {
+//   name: "SomePig",
+//   source: "./exports.js",
+//   description: `Add 'SomePig' to existing import declaration from "./exports.js"`,
+//   newFileContent:
+// `import { SomeInterface, SomePig } from "./exports.js";
+// new SomePig`,
+//   data: {
+//     exportName: "SomePig",
+//     fileName: "/exports.ts",
+//   },
+//   preferences: {
+//     includeCompletionsForModuleExports: true,
+//     allowIncompleteCompletions: true,
+//     includeInsertTextCompletions: true,
+//   },
+// });

--- a/tests/cases/fourslash/importNameCodeFix_importType6.ts
+++ b/tests/cases/fourslash/importNameCodeFix_importType6.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+// @module: es2015
+// @esModuleInterop: true
+// @jsx: react
+
+// @Filename: /types.d.ts
+//// declare module "react" { var React: any; export = React; export as namespace React; }
+
+// @Filename: /a.tsx
+//// import type React from "react";
+//// function Component() {}
+//// (<Component/**/ />)
+
+goTo.marker("");
+
+verify.importFixAtPosition([
+`import React from "react";
+function Component() {}
+(<Component />)`]);

--- a/tests/cases/fourslash/importNameCodeFix_importType7.ts
+++ b/tests/cases/fourslash/importNameCodeFix_importType7.ts
@@ -2,15 +2,23 @@
 
 // @module: es2015
 
+// sorting and multiline imports and trailing commas, oh my
+
 // @Filename: /exports.ts
 //// export interface SomeInterface {}
 //// export class SomePig {}
 
 // @Filename: /a.ts
-//// import type { SomeInterface, SomePig } from "./exports.js";
+//// import {
+////     type SomeInterface,
+////     type SomePig,
+//// } from "./exports.js";
 //// new SomePig/**/
 
 goTo.marker("");
 verify.importFixAtPosition([
-`import { SomeInterface, SomePig } from "./exports.js";
+`import {
+    SomePig,
+    type SomeInterface,
+} from "./exports.js";
 new SomePig`]);

--- a/tests/cases/fourslash/importNameCodeFix_importType8.ts
+++ b/tests/cases/fourslash/importNameCodeFix_importType8.ts
@@ -1,6 +1,8 @@
 /// <reference path="fourslash.ts" />
 
 // @module: es2015
+// @isolatedModules: true
+// @preserveValueImports: true
 
 // @Filename: /exports.ts
 //// export interface SomeInterface {}
@@ -12,5 +14,5 @@
 
 goTo.marker("");
 verify.importFixAtPosition([
-`import { SomeInterface, SomePig } from "./exports.js";
+`import { SomePig, type SomeInterface } from "./exports.js";
 new SomePig`]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #44804

We may want a corresponding VS Code update, because there is currently no indication in the completion details display that this completion has an associated action, even though we send a localized description with the code actions. I only just noticed that VS Code never uses that description; instead, the “Auto-import from ...” text seems to be hard-coded in the extension.

Was trying to get a screen recording, but my recorder software is crashing.

<img width="913" alt="completion entry" src="https://user-images.githubusercontent.com/3277153/150618025-c9b0711a-ba60-46b3-947c-ef59a68e9db3.png">

<img width="434" alt="codefix menu" src="https://user-images.githubusercontent.com/3277153/150618045-3f0bebf3-ec36-4a46-9e79-d7df49f8cca5.png">

<img width="426" alt="codefix menu" src="https://user-images.githubusercontent.com/3277153/150618054-25706288-128c-424d-a537-eacd0ddd5fdb.png">
