### PR TITLE
fix(32941): Template tag constraints not displayed in vscode intellisense

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -169,7 +169,27 @@ namespace ts.JsDoc {
             case SyntaxKind.JSDocAugmentsTag:
                 return withNode((tag as JSDocAugmentsTag).class);
             case SyntaxKind.JSDocTemplateTag:
-                return addComment((tag as JSDocTemplateTag).typeParameters.map(tp => tp.getText()).join(", "));
+                const templateTag = tag as JSDocTemplateTag;
+                const displayParts: SymbolDisplayPart[] = [];
+                if (templateTag.constraint) {
+                    displayParts.push(textPart(templateTag.constraint.getText()));
+                }
+                if (length(templateTag.typeParameters)) {
+                    if (length(displayParts)) {
+                        displayParts.push(spacePart());
+                    }
+                    const lastTypeParameter = templateTag.typeParameters[templateTag.typeParameters.length - 1];
+                    forEach(templateTag.typeParameters, tp => {
+                        displayParts.push(namePart(tp.getText()));
+                        if (lastTypeParameter !== tp) {
+                            displayParts.push(...[punctuationPart(SyntaxKind.CommaToken), spacePart()]);
+                        }
+                    });
+                }
+                if (comment) {
+                    displayParts.push(...[spacePart(), ...getDisplayPartsFromComment(comment, checker)]);
+                }
+                return displayParts;
             case SyntaxKind.JSDocTypeTag:
                 return withNode((tag as JSDocTypeTag).typeExpression);
             case SyntaxKind.JSDocTypedefTag:

--- a/tests/baselines/reference/jsdocReturnsTag.baseline
+++ b/tests/baselines/reference/jsdocReturnsTag.baseline
@@ -117,7 +117,7 @@
               "text": [
                 {
                   "text": "T",
-                  "kind": "text"
+                  "kind": "typeParameterName"
                 }
               ]
             },

--- a/tests/baselines/reference/quickInfoJsDocTags10.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags10.baseline
@@ -1,0 +1,177 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocTags10.js",
+      "position": 80,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "const",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 80,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "const",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "foo",
+          "kind": "localName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "<",
+          "kind": "punctuation"
+        },
+        {
+          "text": "T1",
+          "kind": "typeParameterName"
+        },
+        {
+          "text": ",",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "T2",
+          "kind": "typeParameterName"
+        },
+        {
+          "text": ">",
+          "kind": "punctuation"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "a",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "T1",
+          "kind": "typeParameterName"
+        },
+        {
+          "text": ",",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "b",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "any",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "template",
+          "text": [
+            {
+              "text": "T1",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "T2",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Comment Text",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/quickInfoJsDocTags11.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags11.baseline
@@ -1,0 +1,230 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocTags11.js",
+      "position": 120,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "const",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 120,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "const",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "foo",
+          "kind": "localName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "<",
+          "kind": "punctuation"
+        },
+        {
+          "text": "T1",
+          "kind": "typeParameterName"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "extends",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        },
+        {
+          "text": ",",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "T2",
+          "kind": "typeParameterName"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "extends",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        },
+        {
+          "text": ">",
+          "kind": "punctuation"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "a",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "T1",
+          "kind": "typeParameterName"
+        },
+        {
+          "text": ",",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "b",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "T2",
+          "kind": "typeParameterName"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "template",
+          "text": [
+            {
+              "text": "{number}",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "T1",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Comment T1",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "template",
+          "text": [
+            {
+              "text": "{number}",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "T2",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Comment T2",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/quickInfoJsDocTags7.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags7.baseline
@@ -1,0 +1,100 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocTags7.js",
+      "position": 116,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "const",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 116,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "const",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "foo",
+          "kind": "localName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "t",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "T",
+          "kind": "typeParameterName"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "type",
+          "text": [
+            {
+              "text": "{(t: T) => number}",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "template",
+          "text": [
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/quickInfoJsDocTags8.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags8.baseline
@@ -1,0 +1,108 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocTags8.js",
+      "position": 122,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "const",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 122,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "const",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "foo",
+          "kind": "localName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "t",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "T",
+          "kind": "typeParameterName"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "type",
+          "text": [
+            {
+              "text": "{(t: T) => number}",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "template",
+          "text": [
+            {
+              "text": "{Foo}",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/quickInfoJsDocTags9.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags9.baseline
@@ -1,0 +1,116 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJsDocTags9.js",
+      "position": 135,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "const",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 135,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "const",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "foo",
+          "kind": "localName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "t",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "T",
+          "kind": "typeParameterName"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "type",
+          "text": [
+            {
+              "text": "{(t: T) => number}",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "template",
+          "text": [
+            {
+              "text": "{Foo}",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Comment Text",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/signatureHelpTypeArguments2.baseline
+++ b/tests/baselines/reference/signatureHelpTypeArguments2.baseline
@@ -213,7 +213,7 @@
               "text": [
                 {
                   "text": "W",
-                  "kind": "text"
+                  "kind": "typeParameterName"
                 }
               ]
             },
@@ -221,7 +221,19 @@
               "name": "template",
               "text": [
                 {
-                  "text": "U, V",
+                  "text": "U",
+                  "kind": "typeParameterName"
+                },
+                {
+                  "text": ",",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "V",
                   "kind": "typeParameterName"
                 },
                 {
@@ -494,7 +506,7 @@
               "text": [
                 {
                   "text": "W",
-                  "kind": "text"
+                  "kind": "typeParameterName"
                 }
               ]
             },
@@ -502,7 +514,19 @@
               "name": "template",
               "text": [
                 {
-                  "text": "U, V",
+                  "text": "U",
+                  "kind": "typeParameterName"
+                },
+                {
+                  "text": ",",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "V",
                   "kind": "typeParameterName"
                 },
                 {
@@ -775,7 +799,7 @@
               "text": [
                 {
                   "text": "W",
-                  "kind": "text"
+                  "kind": "typeParameterName"
                 }
               ]
             },
@@ -783,7 +807,19 @@
               "name": "template",
               "text": [
                 {
-                  "text": "U, V",
+                  "text": "U",
+                  "kind": "typeParameterName"
+                },
+                {
+                  "text": ",",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "V",
                   "kind": "typeParameterName"
                 },
                 {
@@ -1056,7 +1092,7 @@
               "text": [
                 {
                   "text": "W",
-                  "kind": "text"
+                  "kind": "typeParameterName"
                 }
               ]
             },
@@ -1064,7 +1100,19 @@
               "name": "template",
               "text": [
                 {
-                  "text": "U, V",
+                  "text": "U",
+                  "kind": "typeParameterName"
+                },
+                {
+                  "text": ",",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "V",
                   "kind": "typeParameterName"
                 },
                 {

--- a/tests/cases/fourslash/quickInfoJsDocTags10.ts
+++ b/tests/cases/fourslash/quickInfoJsDocTags10.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @noEmit: true
+// @allowJs: true
+
+// @Filename: quickInfoJsDocTags10.js
+/////**
+//// * @param {T1} a
+//// * @param {T2} a
+//// * @template T1,T2 Comment Text
+//// */
+////const /**/foo = (a, b) => {};
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/quickInfoJsDocTags11.ts
+++ b/tests/cases/fourslash/quickInfoJsDocTags11.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+
+// @noEmit: true
+// @allowJs: true
+
+// @Filename: quickInfoJsDocTags11.js
+/////**
+//// * @param {T1} a
+//// * @param {T2} b
+//// * @template {number} T1 Comment T1
+//// * @template {number} T2 Comment T2
+//// */
+////const /**/foo = (a, b) => {};
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/quickInfoJsDocTags7.ts
+++ b/tests/cases/fourslash/quickInfoJsDocTags7.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @noEmit: true
+// @allowJs: true
+
+// @Filename: quickInfoJsDocTags7.js
+/////**
+//// * @typedef {{ [x: string]: any, y: number }} Foo
+//// */
+////
+/////**
+//// * @type {(t: T) => number}
+//// * @template T
+//// */
+////const /**/foo = t => t.y;
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/quickInfoJsDocTags8.ts
+++ b/tests/cases/fourslash/quickInfoJsDocTags8.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @noEmit: true
+// @allowJs: true
+
+// @Filename: quickInfoJsDocTags8.js
+/////**
+//// * @typedef {{ [x: string]: any, y: number }} Foo
+//// */
+////
+/////**
+//// * @type {(t: T) => number}
+//// * @template {Foo} T
+//// */
+////const /**/foo = t => t.y;
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/quickInfoJsDocTags9.ts
+++ b/tests/cases/fourslash/quickInfoJsDocTags9.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @noEmit: true
+// @allowJs: true
+
+// @Filename: quickInfoJsDocTags9.js
+/////**
+//// * @typedef {{ [x: string]: any, y: number }} Foo
+//// */
+////
+/////**
+//// * @type {(t: T) => number}
+//// * @template {Foo} T Comment Text
+//// */
+////const /**/foo = t => t.y;
+
+verify.baselineQuickInfo();


### PR DESCRIPTION
Fixes #32941