### PR TITLE
Add basic supports for template literal as jsx attribute value

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2796,10 +2796,7 @@ namespace ts {
             return createNodeArray(list, pos);
         }
 
-        function parseTemplateExpression(isTaggedTemplate: boolean, isJsxAttributeValue: boolean): TemplateExpression {
-            if (isJsxAttributeValue) {
-                // WIP
-            }
+        function parseTemplateExpression(isTaggedTemplate: boolean): TemplateExpression {
             const pos = getNodePos();
             return finishNode(
                 factory.createTemplateExpression(
@@ -5286,7 +5283,7 @@ namespace ts {
                 return parseLiteralNode() as StringLiteral | NoSubstitutionTemplateLiteral;
             }
             if (jsxAttributeValueToken === SyntaxKind.TemplateHead) {
-                return parseTemplateExpression(/*isTaggedTemplate*/ false, /*isJsxAttributeValue*/ true);
+                return parseTemplateExpression(/*isTaggedTemplate*/ false);
             }
             return parseJsxExpression(/*inExpressionContext*/ true);
         }
@@ -5474,7 +5471,7 @@ namespace ts {
                 typeArguments,
                 token() === SyntaxKind.NoSubstitutionTemplateLiteral ?
                     (reScanTemplateHeadOrNoSubstitutionTemplate(), parseLiteralNode() as NoSubstitutionTemplateLiteral) :
-                    parseTemplateExpression(/*isTaggedTemplate*/ true, /*isJsxAttributeValue*/ true)
+                    parseTemplateExpression(/*isTaggedTemplate*/ true)
             );
             if (questionDotToken || tag.flags & NodeFlags.OptionalChain) {
                 (tagExpression as Mutable<Node>).flags |= NodeFlags.OptionalChain;
@@ -5642,7 +5639,7 @@ namespace ts {
                     }
                     break;
                 case SyntaxKind.TemplateHead:
-                    return parseTemplateExpression(/* isTaggedTemplate */ false, /*isJsxAttributeValue*/ true);
+                    return parseTemplateExpression(/* isTaggedTemplate */ false);
                 case SyntaxKind.PrivateIdentifier:
                     return parsePrivateIdentifier();
             }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1246,7 +1246,7 @@ namespace ts {
          * Sets the current 'tokenValue' and returns a NoSubstitutionTemplateLiteral or
          * a literal component of a TemplateExpression.
          */
-        function scanTemplateAndSetTokenValue(isTaggedTemplate: boolean): SyntaxKind {
+        function scanTemplateAndSetTokenValue(isTaggedTemplate: boolean, jsxAttributeString: boolean): SyntaxKind {
             const startedWithBacktick = text.charCodeAt(pos) === CharacterCodes.backtick;
 
             pos++;
@@ -1282,7 +1282,7 @@ namespace ts {
                 }
 
                 // Escape character
-                if (currChar === CharacterCodes.backslash) {
+                if (currChar === CharacterCodes.backslash && !jsxAttributeString) {
                     contents += text.substring(start, pos);
                     contents += scanEscapeSequence(isTaggedTemplate);
                     start = pos;
@@ -1692,7 +1692,7 @@ namespace ts {
                         tokenValue = scanString();
                         return token = SyntaxKind.StringLiteral;
                     case CharacterCodes.backtick:
-                        return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ false);
+                        return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ false, /* isJsxAttributeValue */ false);
                     case CharacterCodes.percent:
                         if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
                             return pos += 2, token = SyntaxKind.PercentEqualsToken;
@@ -2232,12 +2232,12 @@ namespace ts {
         function reScanTemplateToken(isTaggedTemplate: boolean): SyntaxKind {
             Debug.assert(token === SyntaxKind.CloseBraceToken, "'reScanTemplateToken' should only be called on a '}'");
             pos = tokenPos;
-            return token = scanTemplateAndSetTokenValue(isTaggedTemplate);
+            return token = scanTemplateAndSetTokenValue(isTaggedTemplate, /*isJsxAttributeValue*/ false);
         }
 
         function reScanTemplateHeadOrNoSubstitutionTemplate(): SyntaxKind {
             pos = tokenPos;
-            return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ true);
+            return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ true, /*isJsxAttributeValue*/ false);
         }
 
         function reScanJsxToken(allowMultilineJsxText = true): JsxTokenSyntaxKind {
@@ -2387,6 +2387,8 @@ namespace ts {
                 case CharacterCodes.singleQuote:
                     tokenValue = scanString(/*jsxAttributeString*/ true);
                     return token = SyntaxKind.StringLiteral;
+                case CharacterCodes.backtick:
+                    return token = scanTemplateAndSetTokenValue(/*isTaggedTemplate*/ false, /*isJsxAttributeValue*/ true);
                 default:
                     // If this scans anything other than `{`, it's a parse error.
                     return scan();

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1246,7 +1246,7 @@ namespace ts {
          * Sets the current 'tokenValue' and returns a NoSubstitutionTemplateLiteral or
          * a literal component of a TemplateExpression.
          */
-        function scanTemplateAndSetTokenValue(isTaggedTemplate: boolean, jsxAttributeString: boolean): SyntaxKind {
+        function scanTemplateAndSetTokenValue(isTaggedTemplate: boolean): SyntaxKind {
             const startedWithBacktick = text.charCodeAt(pos) === CharacterCodes.backtick;
 
             pos++;
@@ -1282,7 +1282,7 @@ namespace ts {
                 }
 
                 // Escape character
-                if (currChar === CharacterCodes.backslash && !jsxAttributeString) {
+                if (currChar === CharacterCodes.backslash) {
                     contents += text.substring(start, pos);
                     contents += scanEscapeSequence(isTaggedTemplate);
                     start = pos;
@@ -1692,7 +1692,7 @@ namespace ts {
                         tokenValue = scanString();
                         return token = SyntaxKind.StringLiteral;
                     case CharacterCodes.backtick:
-                        return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ false, /* isJsxAttributeValue */ false);
+                        return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ false);
                     case CharacterCodes.percent:
                         if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
                             return pos += 2, token = SyntaxKind.PercentEqualsToken;
@@ -2232,12 +2232,12 @@ namespace ts {
         function reScanTemplateToken(isTaggedTemplate: boolean): SyntaxKind {
             Debug.assert(token === SyntaxKind.CloseBraceToken, "'reScanTemplateToken' should only be called on a '}'");
             pos = tokenPos;
-            return token = scanTemplateAndSetTokenValue(isTaggedTemplate, /*isJsxAttributeValue*/ false);
+            return token = scanTemplateAndSetTokenValue(isTaggedTemplate);
         }
 
         function reScanTemplateHeadOrNoSubstitutionTemplate(): SyntaxKind {
             pos = tokenPos;
-            return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ true, /*isJsxAttributeValue*/ false);
+            return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ true);
         }
 
         function reScanJsxToken(allowMultilineJsxText = true): JsxTokenSyntaxKind {
@@ -2388,7 +2388,7 @@ namespace ts {
                     tokenValue = scanString(/*jsxAttributeString*/ true);
                     return token = SyntaxKind.StringLiteral;
                 case CharacterCodes.backtick:
-                    return token = scanTemplateAndSetTokenValue(/*isTaggedTemplate*/ false, /*isJsxAttributeValue*/ true);
+                    return token = scanTemplateAndSetTokenValue(/*isTaggedTemplate*/ false);
                 default:
                     // If this scans anything other than `{`, it's a parse error.
                     return scan();

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -595,7 +595,7 @@ namespace ts {
                 return factory.createJsxAttribute(
                     visitNode(node.name, visitor, isIdentifier),
                     factory.createJsxExpression(
-                        undefined,
+                        /* dotDotDotToken */ undefined,
                         visitNode(node.initializer, visitor, isExpression)
                     )
                 );

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -549,6 +549,9 @@ namespace ts {
                 case SyntaxKind.VoidExpression:
                     return visitVoidExpression(node as VoidExpression);
 
+                case SyntaxKind.JsxAttribute:
+                    return visitJsxAttribute(node as JsxAttribute);
+
                 default:
                     return visitEachChild(node, visitor, context);
             }
@@ -583,6 +586,19 @@ namespace ts {
                 const result = visitEachChild(node, visitor, context);
                 convertedLoopState.allowedNonLabeledJumps = savedAllowedNonLabeledJumps;
                 return result;
+            }
+            return visitEachChild(node, visitor, context);
+        }
+
+        function visitJsxAttribute(node: JsxAttribute) {
+            if (node.initializer && isTemplateExpression(node.initializer)) {
+                return factory.createJsxAttribute(
+                    visitNode(node.name, visitor, isIdentifier),
+                    factory.createJsxExpression(
+                        undefined,
+                        visitNode(node.initializer, visitor, isExpression)
+                    )
+                );
             }
             return visitEachChild(node, visitor, context);
         }

--- a/src/compiler/transformers/jsx.ts
+++ b/src/compiler/transformers/jsx.ts
@@ -400,7 +400,7 @@ namespace ts {
             return factory.createPropertyAssignment(name, expression);
         }
 
-        function transformJsxAttributeInitializer(node: StringLiteral | JsxExpression | undefined): Expression {
+        function transformJsxAttributeInitializer(node: StringLiteral | TemplateLiteral | JsxExpression | undefined): Expression {
             if (node === undefined) {
                 return factory.createTrue();
             }
@@ -410,6 +410,43 @@ namespace ts {
                 const singleQuote = node.singleQuote !== undefined ? node.singleQuote : !isStringDoubleQuoted(node, currentSourceFile);
                 const literal = factory.createStringLiteral(tryDecodeEntities(node.text) || node.text, singleQuote);
                 return setTextRange(literal, node);
+            }
+            else if (node.kind === SyntaxKind.NoSubstitutionTemplateLiteral) {
+                return setTextRange(
+                    factory.createNoSubstitutionTemplateLiteral(
+                        tryDecodeEntities(node.text) || node.text
+                    ),
+                    node
+                );
+            }
+            else if (node.kind === SyntaxKind.TemplateExpression) {
+                const newNode = setTextRange(
+                    factory.createTemplateExpression(
+                        setTextRange(
+                            factory.createTemplateHead(
+                                tryDecodeEntities(node.head.text) || node.head.text,
+                                /*rawText*/ undefined,
+                                node.head.templateFlags
+                            ),
+                            node.head
+                        ),
+                        node.templateSpans.map(span => {
+                            return setTextRange(
+                                factory.createTemplateSpan(
+                                    visitNode(span.expression, visitor, isExpression),
+                                    factory.createTemplateTail(
+                                        tryDecodeEntities(span.literal.text) || span.literal.text,
+                                        /*rawText*/ undefined,
+                                        span.literal.templateFlags
+                                    )
+                                ),
+                                span
+                            );
+                        })
+                    ),
+                    node
+                );
+                return newNode;
             }
             else if (node.kind === SyntaxKind.JsxExpression) {
                 if (node.expression === undefined) {

--- a/src/compiler/transformers/jsx.ts
+++ b/src/compiler/transformers/jsx.ts
@@ -411,42 +411,8 @@ namespace ts {
                 const literal = factory.createStringLiteral(tryDecodeEntities(node.text) || node.text, singleQuote);
                 return setTextRange(literal, node);
             }
-            else if (node.kind === SyntaxKind.NoSubstitutionTemplateLiteral) {
-                return setTextRange(
-                    factory.createNoSubstitutionTemplateLiteral(
-                        tryDecodeEntities(node.text) || node.text
-                    ),
-                    node
-                );
-            }
-            else if (node.kind === SyntaxKind.TemplateExpression) {
-                const newNode = setTextRange(
-                    factory.createTemplateExpression(
-                        setTextRange(
-                            factory.createTemplateHead(
-                                tryDecodeEntities(node.head.text) || node.head.text,
-                                /*rawText*/ undefined,
-                                node.head.templateFlags
-                            ),
-                            node.head
-                        ),
-                        node.templateSpans.map(span => {
-                            return setTextRange(
-                                factory.createTemplateSpan(
-                                    visitNode(span.expression, visitor, isExpression),
-                                    factory.createTemplateTail(
-                                        tryDecodeEntities(span.literal.text) || span.literal.text,
-                                        /*rawText*/ undefined,
-                                        span.literal.templateFlags
-                                    )
-                                ),
-                                span
-                            );
-                        })
-                    ),
-                    node
-                );
-                return newNode;
+            else if (node.kind === SyntaxKind.NoSubstitutionTemplateLiteral || node.kind === SyntaxKind.TemplateExpression) {
+                return node;
             }
             else if (node.kind === SyntaxKind.JsxExpression) {
                 if (node.expression === undefined) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2589,7 +2589,7 @@ namespace ts {
         readonly parent: JsxAttributes;
         readonly name: Identifier;
         /// JSX attribute initializers are optional; <X y /> is sugar for <X y={true} />
-        readonly initializer?: StringLiteral | JsxExpression;
+        readonly initializer?: StringLiteral | TemplateLiteral | JsxExpression;
     }
 
     export interface JsxSpreadAttribute extends ObjectLiteralElement {
@@ -7572,8 +7572,8 @@ namespace ts {
         createJsxOpeningFragment(): JsxOpeningFragment;
         createJsxJsxClosingFragment(): JsxClosingFragment;
         updateJsxFragment(node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment): JsxFragment;
-        createJsxAttribute(name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
-        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
+        createJsxAttribute(name: Identifier, initializer: StringLiteral | TemplateLiteral | JsxExpression | undefined): JsxAttribute;
+        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: StringLiteral | TemplateLiteral | JsxExpression | undefined): JsxAttribute;
         createJsxAttributes(properties: readonly JsxAttributeLike[]): JsxAttributes;
         updateJsxAttributes(node: JsxAttributes, properties: readonly JsxAttributeLike[]): JsxAttributes;
         createJsxSpreadAttribute(expression: Expression): JsxSpreadAttribute;

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -1880,6 +1880,10 @@ namespace ts {
             || kind === SyntaxKind.JsxExpression;
     }
 
+    export function isStringLiteralOrTemplateExpressionOrJsxExpression(node: Node): node is StringLiteral | TemplateExpression | JsxExpression {
+        return node.kind === SyntaxKind.TemplateExpression || isStringLiteralOrJsxExpression(node);
+    }
+
     export function isJsxOpeningLikeElement(node: Node): node is JsxOpeningLikeElement {
         const kind = node.kind;
         return kind === SyntaxKind.JsxOpeningElement

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -1880,6 +1880,7 @@ namespace ts {
             || kind === SyntaxKind.JsxExpression;
     }
 
+    /* @internal */
     export function isStringLiteralOrTemplateExpressionOrJsxExpression(node: Node): node is StringLiteral | TemplateExpression | JsxExpression {
         return node.kind === SyntaxKind.TemplateExpression || isStringLiteralOrJsxExpression(node);
     }

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -1194,7 +1194,7 @@ namespace ts {
                 Debug.type<JsxAttribute>(node);
                 return factory.updateJsxAttribute(node,
                     nodeVisitor(node.name, visitor, isIdentifier),
-                    nodeVisitor(node.initializer, visitor, isStringLiteralOrJsxExpression));
+                    nodeVisitor(node.initializer, visitor, isExpression));
 
             case SyntaxKind.JsxAttributes:
                 Debug.type<JsxAttributes>(node);

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -1194,7 +1194,7 @@ namespace ts {
                 Debug.type<JsxAttribute>(node);
                 return factory.updateJsxAttribute(node,
                     nodeVisitor(node.name, visitor, isIdentifier),
-                    nodeVisitor(node.initializer, visitor, isExpression));
+                    nodeVisitor(node.initializer, visitor, isStringLiteralOrTemplateExpressionOrJsxExpression));
 
             case SyntaxKind.JsxAttributes:
                 Debug.type<JsxAttributes>(node);

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1373,7 +1373,7 @@ declare namespace ts {
         readonly kind: SyntaxKind.JsxAttribute;
         readonly parent: JsxAttributes;
         readonly name: Identifier;
-        readonly initializer?: StringLiteral | JsxExpression;
+        readonly initializer?: StringLiteral | TemplateLiteral | JsxExpression;
     }
     export interface JsxSpreadAttribute extends ObjectLiteralElement {
         readonly kind: SyntaxKind.JsxSpreadAttribute;
@@ -3686,8 +3686,8 @@ declare namespace ts {
         createJsxOpeningFragment(): JsxOpeningFragment;
         createJsxJsxClosingFragment(): JsxClosingFragment;
         updateJsxFragment(node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment): JsxFragment;
-        createJsxAttribute(name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
-        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
+        createJsxAttribute(name: Identifier, initializer: StringLiteral | TemplateLiteral | JsxExpression | undefined): JsxAttribute;
+        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: StringLiteral | TemplateLiteral | JsxExpression | undefined): JsxAttribute;
         createJsxAttributes(properties: readonly JsxAttributeLike[]): JsxAttributes;
         updateJsxAttributes(node: JsxAttributes, properties: readonly JsxAttributeLike[]): JsxAttributes;
         createJsxSpreadAttribute(expression: Expression): JsxSpreadAttribute;
@@ -11179,9 +11179,9 @@ declare namespace ts {
     /** @deprecated Use `factory.updateJsxFragment` or the factory supplied by your transformation context instead. */
     const updateJsxFragment: (node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment) => JsxFragment;
     /** @deprecated Use `factory.createJsxAttribute` or the factory supplied by your transformation context instead. */
-    const createJsxAttribute: (name: Identifier, initializer: StringLiteral | JsxExpression | undefined) => JsxAttribute;
+    const createJsxAttribute: (name: Identifier, initializer: StringLiteral | TemplateLiteral | JsxExpression | undefined) => JsxAttribute;
     /** @deprecated Use `factory.updateJsxAttribute` or the factory supplied by your transformation context instead. */
-    const updateJsxAttribute: (node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined) => JsxAttribute;
+    const updateJsxAttribute: (node: JsxAttribute, name: Identifier, initializer: StringLiteral | TemplateLiteral | JsxExpression | undefined) => JsxAttribute;
     /** @deprecated Use `factory.createJsxAttributes` or the factory supplied by your transformation context instead. */
     const createJsxAttributes: (properties: readonly JsxAttributeLike[]) => JsxAttributes;
     /** @deprecated Use `factory.updateJsxAttributes` or the factory supplied by your transformation context instead. */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1373,7 +1373,7 @@ declare namespace ts {
         readonly kind: SyntaxKind.JsxAttribute;
         readonly parent: JsxAttributes;
         readonly name: Identifier;
-        readonly initializer?: StringLiteral | JsxExpression;
+        readonly initializer?: StringLiteral | TemplateLiteral | JsxExpression;
     }
     export interface JsxSpreadAttribute extends ObjectLiteralElement {
         readonly kind: SyntaxKind.JsxSpreadAttribute;
@@ -3686,8 +3686,8 @@ declare namespace ts {
         createJsxOpeningFragment(): JsxOpeningFragment;
         createJsxJsxClosingFragment(): JsxClosingFragment;
         updateJsxFragment(node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment): JsxFragment;
-        createJsxAttribute(name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
-        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
+        createJsxAttribute(name: Identifier, initializer: StringLiteral | TemplateLiteral | JsxExpression | undefined): JsxAttribute;
+        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: StringLiteral | TemplateLiteral | JsxExpression | undefined): JsxAttribute;
         createJsxAttributes(properties: readonly JsxAttributeLike[]): JsxAttributes;
         updateJsxAttributes(node: JsxAttributes, properties: readonly JsxAttributeLike[]): JsxAttributes;
         createJsxSpreadAttribute(expression: Expression): JsxSpreadAttribute;
@@ -7368,9 +7368,9 @@ declare namespace ts {
     /** @deprecated Use `factory.updateJsxFragment` or the factory supplied by your transformation context instead. */
     const updateJsxFragment: (node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment) => JsxFragment;
     /** @deprecated Use `factory.createJsxAttribute` or the factory supplied by your transformation context instead. */
-    const createJsxAttribute: (name: Identifier, initializer: StringLiteral | JsxExpression | undefined) => JsxAttribute;
+    const createJsxAttribute: (name: Identifier, initializer: StringLiteral | TemplateLiteral | JsxExpression | undefined) => JsxAttribute;
     /** @deprecated Use `factory.updateJsxAttribute` or the factory supplied by your transformation context instead. */
-    const updateJsxAttribute: (node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined) => JsxAttribute;
+    const updateJsxAttribute: (node: JsxAttribute, name: Identifier, initializer: StringLiteral | TemplateLiteral | JsxExpression | undefined) => JsxAttribute;
     /** @deprecated Use `factory.createJsxAttributes` or the factory supplied by your transformation context instead. */
     const createJsxAttributes: (properties: readonly JsxAttributeLike[]) => JsxAttributes;
     /** @deprecated Use `factory.updateJsxAttributes` or the factory supplied by your transformation context instead. */

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=es5).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=es5).js
@@ -16,41 +16,14 @@ const a = 42;
 <Comp foo=`foo${a}foo` />;
 
 
-tests/cases/conformance/jsx/template/file.jsx(9,16): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/template/file.jsx(9,23): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/template/file.jsx(9,27): error TS1109: Expression expected.
-tests/cases/conformance/jsx/template/file.jsx(9,28): error TS1109: Expression expected.
-tests/cases/conformance/jsx/template/file.jsx(10,16): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/template/file.jsx(10,23): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/template/file.jsx(10,34): error TS1109: Expression expected.
-tests/cases/conformance/jsx/template/file.jsx(10,35): error TS1109: Expression expected.
-
-
-==== tests/cases/conformance/jsx/template/file.jsx (8 errors) ====
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    var React = require("react");
-    function Comp(p) {
-        return <div>{p.foo}</div>;
-    }
-    var a = 42;
-    <Comp foo="foo"/>;
-    <Comp foo="foo".concat(a)/>;
-                   ~
-!!! error TS1003: Identifier expected.
-                          ~
-!!! error TS1003: Identifier expected.
-                              ~
-!!! error TS1109: Expression expected.
-                               ~
-!!! error TS1109: Expression expected.
-    <Comp foo="foo".concat(a, "foo")/>;
-                   ~
-!!! error TS1003: Identifier expected.
-                          ~
-!!! error TS1003: Identifier expected.
-                                     ~
-!!! error TS1109: Expression expected.
-                                      ~
-!!! error TS1109: Expression expected.
-    
+//// [file.jsx]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var React = require("react");
+function Comp(p) {
+    return <div>{p.foo}</div>;
+}
+var a = 42;
+<Comp foo="foo"/>;
+<Comp foo={"foo".concat(a)}/>;
+<Comp foo={"foo".concat(a, "foo")}/>;

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=es5).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=es5).js
@@ -1,0 +1,56 @@
+//// [file.tsx]
+import React = require('react');
+
+interface Prop {
+    foo: string,
+}
+
+function Comp(p: Prop) {
+    return <div>{p.foo}</div>;
+}
+
+const a = 42;
+
+<Comp foo=`foo` />;
+<Comp foo=`foo${a}` />;
+<Comp foo=`foo${a}foo` />;
+
+
+tests/cases/conformance/jsx/template/file.jsx(9,16): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/template/file.jsx(9,23): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/template/file.jsx(9,27): error TS1109: Expression expected.
+tests/cases/conformance/jsx/template/file.jsx(9,28): error TS1109: Expression expected.
+tests/cases/conformance/jsx/template/file.jsx(10,16): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/template/file.jsx(10,23): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/template/file.jsx(10,34): error TS1109: Expression expected.
+tests/cases/conformance/jsx/template/file.jsx(10,35): error TS1109: Expression expected.
+
+
+==== tests/cases/conformance/jsx/template/file.jsx (8 errors) ====
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var React = require("react");
+    function Comp(p) {
+        return <div>{p.foo}</div>;
+    }
+    var a = 42;
+    <Comp foo="foo"/>;
+    <Comp foo="foo".concat(a)/>;
+                   ~
+!!! error TS1003: Identifier expected.
+                          ~
+!!! error TS1003: Identifier expected.
+                              ~
+!!! error TS1109: Expression expected.
+                               ~
+!!! error TS1109: Expression expected.
+    <Comp foo="foo".concat(a, "foo")/>;
+                   ~
+!!! error TS1003: Identifier expected.
+                          ~
+!!! error TS1003: Identifier expected.
+                                     ~
+!!! error TS1109: Expression expected.
+                                      ~
+!!! error TS1109: Expression expected.
+    

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=es5).symbols
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=es5).symbols
@@ -1,0 +1,41 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface Prop {
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    foo: string,
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+}
+
+function Comp(p: Prop) {
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    return <div>{p.foo}</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>p.foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+}
+
+const a = 42;
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`foo` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 12, 5))
+
+<Comp foo=`foo${a}` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 13, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`foo${a}foo` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 14, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=es5).types
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=es5).types
@@ -1,0 +1,45 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface Prop {
+    foo: string,
+>foo : string
+}
+
+function Comp(p: Prop) {
+>Comp : (p: Prop) => JSX.Element
+>p : Prop
+
+    return <div>{p.foo}</div>;
+><div>{p.foo}</div> : JSX.Element
+>div : any
+>p.foo : string
+>p : Prop
+>foo : string
+>div : any
+}
+
+const a = 42;
+>a : 42
+>42 : 42
+
+<Comp foo=`foo` />;
+><Comp foo=`foo` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo=`foo${a}` />;
+><Comp foo=`foo${a}` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`foo${a}` : string
+>a : 42
+
+<Comp foo=`foo${a}foo` />;
+><Comp foo=`foo${a}foo` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`foo${a}foo` : string
+>a : 42
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=esnext).errors.txt
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=esnext).errors.txt
@@ -1,0 +1,22 @@
+tests/cases/conformance/jsx/template/file.tsx(1,1): error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+
+
+==== tests/cases/conformance/jsx/template/file.tsx (1 errors) ====
+    import React = require('react');
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+    
+    interface Prop {
+        foo: string,
+    }
+    
+    function Comp(p: Prop) {
+        return <div>{p.foo}</div>;
+    }
+    
+    const a = 42;
+    
+    <Comp foo=`foo` />;
+    <Comp foo=`foo${a}` />;
+    <Comp foo=`foo${a}foo` />;
+    

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=esnext).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=esnext).js
@@ -1,0 +1,29 @@
+//// [file.tsx]
+import React = require('react');
+
+interface Prop {
+    foo: string,
+}
+
+function Comp(p: Prop) {
+    return <div>{p.foo}</div>;
+}
+
+const a = 42;
+
+<Comp foo=`foo` />;
+<Comp foo=`foo${a}` />;
+<Comp foo=`foo${a}foo` />;
+
+
+//// [file.jsx]
+import { createRequire as _createRequire } from "module";
+const __require = _createRequire(import.meta.url);
+const React = __require("react");
+function Comp(p) {
+    return <div>{p.foo}</div>;
+}
+const a = 42;
+<Comp foo=`foo`/>;
+<Comp foo=`foo${a}`/>;
+<Comp foo=`foo${a}foo`/>;

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=esnext).symbols
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=esnext).symbols
@@ -1,0 +1,41 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface Prop {
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    foo: string,
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+}
+
+function Comp(p: Prop) {
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    return <div>{p.foo}</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>p.foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+}
+
+const a = 42;
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`foo` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 12, 5))
+
+<Comp foo=`foo${a}` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 13, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`foo${a}foo` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 14, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=esnext).types
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=preserve,target=esnext).types
@@ -1,0 +1,45 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface Prop {
+    foo: string,
+>foo : string
+}
+
+function Comp(p: Prop) {
+>Comp : (p: Prop) => JSX.Element
+>p : Prop
+
+    return <div>{p.foo}</div>;
+><div>{p.foo}</div> : JSX.Element
+>div : any
+>p.foo : string
+>p : Prop
+>foo : string
+>div : any
+}
+
+const a = 42;
+>a : 42
+>42 : 42
+
+<Comp foo=`foo` />;
+><Comp foo=`foo` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo=`foo${a}` />;
+><Comp foo=`foo${a}` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`foo${a}` : string
+>a : 42
+
+<Comp foo=`foo${a}foo` />;
+><Comp foo=`foo${a}foo` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`foo${a}foo` : string
+>a : 42
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=es5).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=es5).js
@@ -1,0 +1,29 @@
+//// [file.tsx]
+import React = require('react');
+
+interface Prop {
+    foo: string,
+}
+
+function Comp(p: Prop) {
+    return <div>{p.foo}</div>;
+}
+
+const a = 42;
+
+<Comp foo=`foo` />;
+<Comp foo=`foo${a}` />;
+<Comp foo=`foo${a}foo` />;
+
+
+//// [file.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var React = require("react");
+function Comp(p) {
+    return React.createElement("div", null, p.foo);
+}
+var a = 42;
+React.createElement(Comp, { foo: "foo" });
+React.createElement(Comp, { foo: "foo".concat(a) });
+React.createElement(Comp, { foo: "foo".concat(a, "foo") });

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=es5).symbols
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=es5).symbols
@@ -1,0 +1,41 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface Prop {
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    foo: string,
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+}
+
+function Comp(p: Prop) {
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    return <div>{p.foo}</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>p.foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+}
+
+const a = 42;
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`foo` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 12, 5))
+
+<Comp foo=`foo${a}` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 13, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`foo${a}foo` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 14, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=es5).types
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=es5).types
@@ -1,0 +1,45 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface Prop {
+    foo: string,
+>foo : string
+}
+
+function Comp(p: Prop) {
+>Comp : (p: Prop) => JSX.Element
+>p : Prop
+
+    return <div>{p.foo}</div>;
+><div>{p.foo}</div> : JSX.Element
+>div : any
+>p.foo : string
+>p : Prop
+>foo : string
+>div : any
+}
+
+const a = 42;
+>a : 42
+>42 : 42
+
+<Comp foo=`foo` />;
+><Comp foo=`foo` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo=`foo${a}` />;
+><Comp foo=`foo${a}` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`foo${a}` : string
+>a : 42
+
+<Comp foo=`foo${a}foo` />;
+><Comp foo=`foo${a}foo` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`foo${a}foo` : string
+>a : 42
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=esnext).errors.txt
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=esnext).errors.txt
@@ -1,0 +1,22 @@
+tests/cases/conformance/jsx/template/file.tsx(1,1): error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+
+
+==== tests/cases/conformance/jsx/template/file.tsx (1 errors) ====
+    import React = require('react');
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+    
+    interface Prop {
+        foo: string,
+    }
+    
+    function Comp(p: Prop) {
+        return <div>{p.foo}</div>;
+    }
+    
+    const a = 42;
+    
+    <Comp foo=`foo` />;
+    <Comp foo=`foo${a}` />;
+    <Comp foo=`foo${a}foo` />;
+    

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=esnext).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=esnext).js
@@ -1,0 +1,29 @@
+//// [file.tsx]
+import React = require('react');
+
+interface Prop {
+    foo: string,
+}
+
+function Comp(p: Prop) {
+    return <div>{p.foo}</div>;
+}
+
+const a = 42;
+
+<Comp foo=`foo` />;
+<Comp foo=`foo${a}` />;
+<Comp foo=`foo${a}foo` />;
+
+
+//// [file.js]
+import { createRequire as _createRequire } from "module";
+const __require = _createRequire(import.meta.url);
+const React = __require("react");
+function Comp(p) {
+    return React.createElement("div", null, p.foo);
+}
+const a = 42;
+React.createElement(Comp, { foo: `foo` });
+React.createElement(Comp, { foo: `foo${a}` });
+React.createElement(Comp, { foo: `foo${a}foo` });

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=esnext).symbols
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=esnext).symbols
@@ -1,0 +1,41 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface Prop {
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    foo: string,
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+}
+
+function Comp(p: Prop) {
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    return <div>{p.foo}</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>p.foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+}
+
+const a = 42;
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`foo` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 12, 5))
+
+<Comp foo=`foo${a}` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 13, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`foo${a}foo` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 14, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=esnext).types
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral1(jsx=react,target=esnext).types
@@ -1,0 +1,45 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface Prop {
+    foo: string,
+>foo : string
+}
+
+function Comp(p: Prop) {
+>Comp : (p: Prop) => JSX.Element
+>p : Prop
+
+    return <div>{p.foo}</div>;
+><div>{p.foo}</div> : JSX.Element
+>div : any
+>p.foo : string
+>p : Prop
+>foo : string
+>div : any
+}
+
+const a = 42;
+>a : 42
+>42 : 42
+
+<Comp foo=`foo` />;
+><Comp foo=`foo` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo=`foo${a}` />;
+><Comp foo=`foo${a}` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`foo${a}` : string
+>a : 42
+
+<Comp foo=`foo${a}foo` />;
+><Comp foo=`foo${a}foo` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`foo${a}foo` : string
+>a : 42
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=es5).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=es5).js
@@ -1,0 +1,43 @@
+//// [file.tsx]
+import React = require('react');
+
+interface Prop {
+    foo: string,
+}
+
+function Comp(p: Prop) {
+    return <div>{p.foo}</div>;
+}
+
+const a = 42;
+
+<Comp foo=`&amp;` />;
+<Comp foo={`&amp;`} />;
+<Comp foo='&amp;' />;
+
+<Comp foo=`&amp;${a}` />;
+<Comp foo={`&amp;${a}`} />;
+<Comp foo={'&amp;' + a} />;
+
+<Comp foo=`&amp;${a}&amp;` />;
+<Comp foo={`&amp;${a}&amp;`} />;
+<Comp foo={'&amp;' + a + '&amp;'} />;
+
+
+//// [file.jsx]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var React = require("react");
+function Comp(p) {
+    return <div>{p.foo}</div>;
+}
+var a = 42;
+<Comp foo="&amp;"/>;
+<Comp foo={"&amp;"}/>;
+<Comp foo='&amp;'/>;
+<Comp foo={"&amp;".concat(a)}/>;
+<Comp foo={"&amp;".concat(a)}/>;
+<Comp foo={'&amp;' + a}/>;
+<Comp foo={"&amp;".concat(a, "&amp;")}/>;
+<Comp foo={"&amp;".concat(a, "&amp;")}/>;
+<Comp foo={'&amp;' + a + '&amp;'}/>;

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=es5).symbols
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=es5).symbols
@@ -1,0 +1,69 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface Prop {
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    foo: string,
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+}
+
+function Comp(p: Prop) {
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    return <div>{p.foo}</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>p.foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+}
+
+const a = 42;
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`&amp;` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 12, 5))
+
+<Comp foo={`&amp;`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 13, 5))
+
+<Comp foo='&amp;' />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 14, 5))
+
+<Comp foo=`&amp;${a}` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 16, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={`&amp;${a}`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 17, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={'&amp;' + a} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 18, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`&amp;${a}&amp;` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 20, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={`&amp;${a}&amp;`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 21, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={'&amp;' + a + '&amp;'} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 22, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=es5).types
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=es5).types
@@ -1,0 +1,88 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface Prop {
+    foo: string,
+>foo : string
+}
+
+function Comp(p: Prop) {
+>Comp : (p: Prop) => JSX.Element
+>p : Prop
+
+    return <div>{p.foo}</div>;
+><div>{p.foo}</div> : JSX.Element
+>div : any
+>p.foo : string
+>p : Prop
+>foo : string
+>div : any
+}
+
+const a = 42;
+>a : 42
+>42 : 42
+
+<Comp foo=`&amp;` />;
+><Comp foo=`&amp;` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo={`&amp;`} />;
+><Comp foo={`&amp;`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;` : "&amp;"
+
+<Comp foo='&amp;' />;
+><Comp foo='&amp;' /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo=`&amp;${a}` />;
+><Comp foo=`&amp;${a}` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}` : string
+>a : 42
+
+<Comp foo={`&amp;${a}`} />;
+><Comp foo={`&amp;${a}`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}` : string
+>a : 42
+
+<Comp foo={'&amp;' + a} />;
+><Comp foo={'&amp;' + a} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>'&amp;' + a : string
+>'&amp;' : "&amp;"
+>a : 42
+
+<Comp foo=`&amp;${a}&amp;` />;
+><Comp foo=`&amp;${a}&amp;` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}&amp;` : string
+>a : 42
+
+<Comp foo={`&amp;${a}&amp;`} />;
+><Comp foo={`&amp;${a}&amp;`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}&amp;` : string
+>a : 42
+
+<Comp foo={'&amp;' + a + '&amp;'} />;
+><Comp foo={'&amp;' + a + '&amp;'} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>'&amp;' + a + '&amp;' : string
+>'&amp;' + a : string
+>'&amp;' : "&amp;"
+>a : 42
+>'&amp;' : "&amp;"
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=esnext).errors.txt
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=esnext).errors.txt
@@ -1,0 +1,30 @@
+tests/cases/conformance/jsx/template/file.tsx(1,1): error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+
+
+==== tests/cases/conformance/jsx/template/file.tsx (1 errors) ====
+    import React = require('react');
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+    
+    interface Prop {
+        foo: string,
+    }
+    
+    function Comp(p: Prop) {
+        return <div>{p.foo}</div>;
+    }
+    
+    const a = 42;
+    
+    <Comp foo=`&amp;` />;
+    <Comp foo={`&amp;`} />;
+    <Comp foo='&amp;' />;
+    
+    <Comp foo=`&amp;${a}` />;
+    <Comp foo={`&amp;${a}`} />;
+    <Comp foo={'&amp;' + a} />;
+    
+    <Comp foo=`&amp;${a}&amp;` />;
+    <Comp foo={`&amp;${a}&amp;`} />;
+    <Comp foo={'&amp;' + a + '&amp;'} />;
+    

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=esnext).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=esnext).js
@@ -1,0 +1,43 @@
+//// [file.tsx]
+import React = require('react');
+
+interface Prop {
+    foo: string,
+}
+
+function Comp(p: Prop) {
+    return <div>{p.foo}</div>;
+}
+
+const a = 42;
+
+<Comp foo=`&amp;` />;
+<Comp foo={`&amp;`} />;
+<Comp foo='&amp;' />;
+
+<Comp foo=`&amp;${a}` />;
+<Comp foo={`&amp;${a}`} />;
+<Comp foo={'&amp;' + a} />;
+
+<Comp foo=`&amp;${a}&amp;` />;
+<Comp foo={`&amp;${a}&amp;`} />;
+<Comp foo={'&amp;' + a + '&amp;'} />;
+
+
+//// [file.jsx]
+import { createRequire as _createRequire } from "module";
+const __require = _createRequire(import.meta.url);
+const React = __require("react");
+function Comp(p) {
+    return <div>{p.foo}</div>;
+}
+const a = 42;
+<Comp foo=`&amp;`/>;
+<Comp foo={`&amp;`}/>;
+<Comp foo='&amp;'/>;
+<Comp foo=`&amp;${a}`/>;
+<Comp foo={`&amp;${a}`}/>;
+<Comp foo={'&amp;' + a}/>;
+<Comp foo=`&amp;${a}&amp;`/>;
+<Comp foo={`&amp;${a}&amp;`}/>;
+<Comp foo={'&amp;' + a + '&amp;'}/>;

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=esnext).symbols
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=esnext).symbols
@@ -1,0 +1,69 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface Prop {
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    foo: string,
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+}
+
+function Comp(p: Prop) {
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    return <div>{p.foo}</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>p.foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+}
+
+const a = 42;
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`&amp;` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 12, 5))
+
+<Comp foo={`&amp;`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 13, 5))
+
+<Comp foo='&amp;' />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 14, 5))
+
+<Comp foo=`&amp;${a}` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 16, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={`&amp;${a}`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 17, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={'&amp;' + a} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 18, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`&amp;${a}&amp;` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 20, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={`&amp;${a}&amp;`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 21, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={'&amp;' + a + '&amp;'} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 22, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=esnext).types
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=preserve,target=esnext).types
@@ -1,0 +1,88 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface Prop {
+    foo: string,
+>foo : string
+}
+
+function Comp(p: Prop) {
+>Comp : (p: Prop) => JSX.Element
+>p : Prop
+
+    return <div>{p.foo}</div>;
+><div>{p.foo}</div> : JSX.Element
+>div : any
+>p.foo : string
+>p : Prop
+>foo : string
+>div : any
+}
+
+const a = 42;
+>a : 42
+>42 : 42
+
+<Comp foo=`&amp;` />;
+><Comp foo=`&amp;` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo={`&amp;`} />;
+><Comp foo={`&amp;`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;` : "&amp;"
+
+<Comp foo='&amp;' />;
+><Comp foo='&amp;' /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo=`&amp;${a}` />;
+><Comp foo=`&amp;${a}` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}` : string
+>a : 42
+
+<Comp foo={`&amp;${a}`} />;
+><Comp foo={`&amp;${a}`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}` : string
+>a : 42
+
+<Comp foo={'&amp;' + a} />;
+><Comp foo={'&amp;' + a} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>'&amp;' + a : string
+>'&amp;' : "&amp;"
+>a : 42
+
+<Comp foo=`&amp;${a}&amp;` />;
+><Comp foo=`&amp;${a}&amp;` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}&amp;` : string
+>a : 42
+
+<Comp foo={`&amp;${a}&amp;`} />;
+><Comp foo={`&amp;${a}&amp;`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}&amp;` : string
+>a : 42
+
+<Comp foo={'&amp;' + a + '&amp;'} />;
+><Comp foo={'&amp;' + a + '&amp;'} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>'&amp;' + a + '&amp;' : string
+>'&amp;' + a : string
+>'&amp;' : "&amp;"
+>a : 42
+>'&amp;' : "&amp;"
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=es5).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=es5).js
@@ -1,0 +1,43 @@
+//// [file.tsx]
+import React = require('react');
+
+interface Prop {
+    foo: string,
+}
+
+function Comp(p: Prop) {
+    return <div>{p.foo}</div>;
+}
+
+const a = 42;
+
+<Comp foo=`&amp;` />;
+<Comp foo={`&amp;`} />;
+<Comp foo='&amp;' />;
+
+<Comp foo=`&amp;${a}` />;
+<Comp foo={`&amp;${a}`} />;
+<Comp foo={'&amp;' + a} />;
+
+<Comp foo=`&amp;${a}&amp;` />;
+<Comp foo={`&amp;${a}&amp;`} />;
+<Comp foo={'&amp;' + a + '&amp;'} />;
+
+
+//// [file.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var React = require("react");
+function Comp(p) {
+    return React.createElement("div", null, p.foo);
+}
+var a = 42;
+React.createElement(Comp, { foo: "&" });
+React.createElement(Comp, { foo: "&amp;" });
+React.createElement(Comp, { foo: '&' });
+React.createElement(Comp, { foo: "&".concat(a) });
+React.createElement(Comp, { foo: "&amp;".concat(a) });
+React.createElement(Comp, { foo: '&amp;' + a });
+React.createElement(Comp, { foo: "&".concat(a, "&") });
+React.createElement(Comp, { foo: "&amp;".concat(a, "&amp;") });
+React.createElement(Comp, { foo: '&amp;' + a + '&amp;' });

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=es5).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=es5).js
@@ -32,12 +32,12 @@ function Comp(p) {
     return React.createElement("div", null, p.foo);
 }
 var a = 42;
-React.createElement(Comp, { foo: "&" });
+React.createElement(Comp, { foo: "&amp;" });
 React.createElement(Comp, { foo: "&amp;" });
 React.createElement(Comp, { foo: '&' });
-React.createElement(Comp, { foo: "&".concat(a) });
+React.createElement(Comp, { foo: "&amp;".concat(a) });
 React.createElement(Comp, { foo: "&amp;".concat(a) });
 React.createElement(Comp, { foo: '&amp;' + a });
-React.createElement(Comp, { foo: "&".concat(a, "&") });
+React.createElement(Comp, { foo: "&amp;".concat(a, "&amp;") });
 React.createElement(Comp, { foo: "&amp;".concat(a, "&amp;") });
 React.createElement(Comp, { foo: '&amp;' + a + '&amp;' });

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=es5).symbols
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=es5).symbols
@@ -1,0 +1,69 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface Prop {
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    foo: string,
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+}
+
+function Comp(p: Prop) {
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    return <div>{p.foo}</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>p.foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+}
+
+const a = 42;
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`&amp;` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 12, 5))
+
+<Comp foo={`&amp;`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 13, 5))
+
+<Comp foo='&amp;' />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 14, 5))
+
+<Comp foo=`&amp;${a}` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 16, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={`&amp;${a}`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 17, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={'&amp;' + a} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 18, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`&amp;${a}&amp;` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 20, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={`&amp;${a}&amp;`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 21, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={'&amp;' + a + '&amp;'} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 22, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=es5).types
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=es5).types
@@ -1,0 +1,88 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface Prop {
+    foo: string,
+>foo : string
+}
+
+function Comp(p: Prop) {
+>Comp : (p: Prop) => JSX.Element
+>p : Prop
+
+    return <div>{p.foo}</div>;
+><div>{p.foo}</div> : JSX.Element
+>div : any
+>p.foo : string
+>p : Prop
+>foo : string
+>div : any
+}
+
+const a = 42;
+>a : 42
+>42 : 42
+
+<Comp foo=`&amp;` />;
+><Comp foo=`&amp;` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo={`&amp;`} />;
+><Comp foo={`&amp;`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;` : "&amp;"
+
+<Comp foo='&amp;' />;
+><Comp foo='&amp;' /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo=`&amp;${a}` />;
+><Comp foo=`&amp;${a}` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}` : string
+>a : 42
+
+<Comp foo={`&amp;${a}`} />;
+><Comp foo={`&amp;${a}`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}` : string
+>a : 42
+
+<Comp foo={'&amp;' + a} />;
+><Comp foo={'&amp;' + a} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>'&amp;' + a : string
+>'&amp;' : "&amp;"
+>a : 42
+
+<Comp foo=`&amp;${a}&amp;` />;
+><Comp foo=`&amp;${a}&amp;` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}&amp;` : string
+>a : 42
+
+<Comp foo={`&amp;${a}&amp;`} />;
+><Comp foo={`&amp;${a}&amp;`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}&amp;` : string
+>a : 42
+
+<Comp foo={'&amp;' + a + '&amp;'} />;
+><Comp foo={'&amp;' + a + '&amp;'} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>'&amp;' + a + '&amp;' : string
+>'&amp;' + a : string
+>'&amp;' : "&amp;"
+>a : 42
+>'&amp;' : "&amp;"
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=esnext).errors.txt
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=esnext).errors.txt
@@ -1,0 +1,30 @@
+tests/cases/conformance/jsx/template/file.tsx(1,1): error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+
+
+==== tests/cases/conformance/jsx/template/file.tsx (1 errors) ====
+    import React = require('react');
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+    
+    interface Prop {
+        foo: string,
+    }
+    
+    function Comp(p: Prop) {
+        return <div>{p.foo}</div>;
+    }
+    
+    const a = 42;
+    
+    <Comp foo=`&amp;` />;
+    <Comp foo={`&amp;`} />;
+    <Comp foo='&amp;' />;
+    
+    <Comp foo=`&amp;${a}` />;
+    <Comp foo={`&amp;${a}`} />;
+    <Comp foo={'&amp;' + a} />;
+    
+    <Comp foo=`&amp;${a}&amp;` />;
+    <Comp foo={`&amp;${a}&amp;`} />;
+    <Comp foo={'&amp;' + a + '&amp;'} />;
+    

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=esnext).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=esnext).js
@@ -1,0 +1,43 @@
+//// [file.tsx]
+import React = require('react');
+
+interface Prop {
+    foo: string,
+}
+
+function Comp(p: Prop) {
+    return <div>{p.foo}</div>;
+}
+
+const a = 42;
+
+<Comp foo=`&amp;` />;
+<Comp foo={`&amp;`} />;
+<Comp foo='&amp;' />;
+
+<Comp foo=`&amp;${a}` />;
+<Comp foo={`&amp;${a}`} />;
+<Comp foo={'&amp;' + a} />;
+
+<Comp foo=`&amp;${a}&amp;` />;
+<Comp foo={`&amp;${a}&amp;`} />;
+<Comp foo={'&amp;' + a + '&amp;'} />;
+
+
+//// [file.js]
+import { createRequire as _createRequire } from "module";
+const __require = _createRequire(import.meta.url);
+const React = __require("react");
+function Comp(p) {
+    return React.createElement("div", null, p.foo);
+}
+const a = 42;
+React.createElement(Comp, { foo: `&` });
+React.createElement(Comp, { foo: `&amp;` });
+React.createElement(Comp, { foo: '&' });
+React.createElement(Comp, { foo: `&${a}` });
+React.createElement(Comp, { foo: `&amp;${a}` });
+React.createElement(Comp, { foo: '&amp;' + a });
+React.createElement(Comp, { foo: `&${a}&` });
+React.createElement(Comp, { foo: `&amp;${a}&amp;` });
+React.createElement(Comp, { foo: '&amp;' + a + '&amp;' });

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=esnext).js
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=esnext).js
@@ -32,12 +32,12 @@ function Comp(p) {
     return React.createElement("div", null, p.foo);
 }
 const a = 42;
-React.createElement(Comp, { foo: `&` });
+React.createElement(Comp, { foo: `&amp;` });
 React.createElement(Comp, { foo: `&amp;` });
 React.createElement(Comp, { foo: '&' });
-React.createElement(Comp, { foo: `&${a}` });
+React.createElement(Comp, { foo: `&amp;${a}` });
 React.createElement(Comp, { foo: `&amp;${a}` });
 React.createElement(Comp, { foo: '&amp;' + a });
-React.createElement(Comp, { foo: `&${a}&` });
+React.createElement(Comp, { foo: `&amp;${a}&amp;` });
 React.createElement(Comp, { foo: `&amp;${a}&amp;` });
 React.createElement(Comp, { foo: '&amp;' + a + '&amp;' });

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=esnext).symbols
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=esnext).symbols
@@ -1,0 +1,69 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface Prop {
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    foo: string,
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+}
+
+function Comp(p: Prop) {
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>Prop : Symbol(Prop, Decl(file.tsx, 0, 32))
+
+    return <div>{p.foo}</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>p.foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>p : Symbol(p, Decl(file.tsx, 6, 14))
+>foo : Symbol(Prop.foo, Decl(file.tsx, 2, 16))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+}
+
+const a = 42;
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`&amp;` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 12, 5))
+
+<Comp foo={`&amp;`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 13, 5))
+
+<Comp foo='&amp;' />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 14, 5))
+
+<Comp foo=`&amp;${a}` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 16, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={`&amp;${a}`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 17, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={'&amp;' + a} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 18, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo=`&amp;${a}&amp;` />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 20, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={`&amp;${a}&amp;`} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 21, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+
+<Comp foo={'&amp;' + a + '&amp;'} />;
+>Comp : Symbol(Comp, Decl(file.tsx, 4, 1))
+>foo : Symbol(foo, Decl(file.tsx, 22, 5))
+>a : Symbol(a, Decl(file.tsx, 10, 5))
+

--- a/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=esnext).types
+++ b/tests/baselines/reference/tsxAttributeValueTemplateLiteral2(jsx=react,target=esnext).types
@@ -1,0 +1,88 @@
+=== tests/cases/conformance/jsx/template/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface Prop {
+    foo: string,
+>foo : string
+}
+
+function Comp(p: Prop) {
+>Comp : (p: Prop) => JSX.Element
+>p : Prop
+
+    return <div>{p.foo}</div>;
+><div>{p.foo}</div> : JSX.Element
+>div : any
+>p.foo : string
+>p : Prop
+>foo : string
+>div : any
+}
+
+const a = 42;
+>a : 42
+>42 : 42
+
+<Comp foo=`&amp;` />;
+><Comp foo=`&amp;` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo={`&amp;`} />;
+><Comp foo={`&amp;`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;` : "&amp;"
+
+<Comp foo='&amp;' />;
+><Comp foo='&amp;' /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+
+<Comp foo=`&amp;${a}` />;
+><Comp foo=`&amp;${a}` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}` : string
+>a : 42
+
+<Comp foo={`&amp;${a}`} />;
+><Comp foo={`&amp;${a}`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}` : string
+>a : 42
+
+<Comp foo={'&amp;' + a} />;
+><Comp foo={'&amp;' + a} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>'&amp;' + a : string
+>'&amp;' : "&amp;"
+>a : 42
+
+<Comp foo=`&amp;${a}&amp;` />;
+><Comp foo=`&amp;${a}&amp;` /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}&amp;` : string
+>a : 42
+
+<Comp foo={`&amp;${a}&amp;`} />;
+><Comp foo={`&amp;${a}&amp;`} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>`&amp;${a}&amp;` : string
+>a : 42
+
+<Comp foo={'&amp;' + a + '&amp;'} />;
+><Comp foo={'&amp;' + a + '&amp;'} /> : JSX.Element
+>Comp : (p: Prop) => JSX.Element
+>foo : string
+>'&amp;' + a + '&amp;' : string
+>'&amp;' + a : string
+>'&amp;' : "&amp;"
+>a : 42
+>'&amp;' : "&amp;"
+

--- a/tests/cases/conformance/jsx/template/tsxAttributeValueTemplateLiteral1.tsx
+++ b/tests/cases/conformance/jsx/template/tsxAttributeValueTemplateLiteral1.tsx
@@ -1,0 +1,22 @@
+//@filename: file.tsx
+//@jsx: preserve, react
+//@target: esnext, es5
+// @noLib: true
+// @skipLibCheck: true
+// @libFiles: react.d.ts,lib.d.ts
+
+import React = require('react');
+
+interface Prop {
+    foo: string,
+}
+
+function Comp(p: Prop) {
+    return <div>{p.foo}</div>;
+}
+
+const a = 42;
+
+<Comp foo=`foo` />;
+<Comp foo=`foo${a}` />;
+<Comp foo=`foo${a}foo` />;

--- a/tests/cases/conformance/jsx/template/tsxAttributeValueTemplateLiteral2.tsx
+++ b/tests/cases/conformance/jsx/template/tsxAttributeValueTemplateLiteral2.tsx
@@ -1,0 +1,30 @@
+//@filename: file.tsx
+//@jsx: preserve, react
+//@target: esnext, es5
+// @noLib: true
+// @skipLibCheck: true
+// @libFiles: react.d.ts,lib.d.ts
+
+import React = require('react');
+
+interface Prop {
+    foo: string,
+}
+
+function Comp(p: Prop) {
+    return <div>{p.foo}</div>;
+}
+
+const a = 42;
+
+<Comp foo=`&amp;` />;
+<Comp foo={`&amp;`} />;
+<Comp foo='&amp;' />;
+
+<Comp foo=`&amp;${a}` />;
+<Comp foo={`&amp;${a}`} />;
+<Comp foo={'&amp;' + a} />;
+
+<Comp foo=`&amp;${a}&amp;` />;
+<Comp foo={`&amp;${a}&amp;`} />;
+<Comp foo={'&amp;' + a + '&amp;'} />;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #47589 

There's a problem is that we assume template literal as a ecma2015 syntax or jsx syntax? 


|          | esnext              | es5       |
|----------|---------------------|-----------|
| preserve | template expression | ?         |
| react    | template expression | downgrade |

What should we do what if` jsx: preserve` and `target: es5`? downgrade to `jsxExpression`?