### PR TITLE
Allow moduleSymbolToValidIdentifier to be uppercase for JSX tags

### DIFF
--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -541,7 +541,7 @@ namespace ts.codefix {
             if (isLiteralImportTypeNode(node) && node.qualifier) {
                 // Symbol for the left-most thing after the dot
                 const firstIdentifier = getFirstIdentifier(node.qualifier);
-                const name = getNameForExportedSymbol(firstIdentifier.symbol, scriptTarget);
+                const name = getNameForExportedSymbol(firstIdentifier.symbol, scriptTarget).name;
                 const qualifier = name !== firstIdentifier.text
                     ? replaceFirstIdentifierOfEntityName(node.qualifier, factory.createIdentifier(name))
                     : node.qualifier;

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -541,7 +541,7 @@ namespace ts.codefix {
             if (isLiteralImportTypeNode(node) && node.qualifier) {
                 // Symbol for the left-most thing after the dot
                 const firstIdentifier = getFirstIdentifier(node.qualifier);
-                const name = getNameForExportedSymbol(firstIdentifier.symbol, scriptTarget).name;
+                const name = getNameForExportedSymbol(firstIdentifier.symbol, scriptTarget);
                 const qualifier = name !== firstIdentifier.text
                     ? replaceFirstIdentifierOfEntityName(node.qualifier, factory.createIdentifier(name))
                     : node.qualifier;

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -70,10 +70,10 @@ namespace ts.codefix {
 
         function addImportFromExportedSymbol(exportedSymbol: Symbol, isValidTypeOnlyUseSite?: boolean) {
             const moduleSymbol = Debug.checkDefined(exportedSymbol.parent);
-            const symbolName = getNameForExportedSymbol(exportedSymbol, getEmitScriptTarget(compilerOptions));
+            const symbolName = getNameForExportedSymbol(exportedSymbol, getEmitScriptTarget(compilerOptions)).name;
             const checker = program.getTypeChecker();
             const symbol = checker.getMergedSymbol(skipAlias(exportedSymbol, checker));
-            const exportInfos = getAllReExportingModules(sourceFile, symbol, moduleSymbol, symbolName, host, program, preferences, useAutoImportProvider);
+            const exportInfos = getAllReExportingModules(sourceFile, symbol, moduleSymbol, symbolName, /*isJsxTagName*/ false, host, program, preferences, useAutoImportProvider);
             const useRequire = shouldUseRequire(sourceFile, program);
             const fix = getImportFixForSymbol(sourceFile, exportInfos, moduleSymbol, symbolName, program, /*position*/ undefined, !!isValidTypeOnlyUseSite, useRequire, host, preferences);
             if (fix) {
@@ -277,6 +277,7 @@ namespace ts.codefix {
         moduleSymbol: Symbol,
         sourceFile: SourceFile,
         symbolName: string,
+        isJsxTagName: boolean,
         host: LanguageServiceHost,
         program: Program,
         formatContext: formatting.FormatContext,
@@ -286,7 +287,7 @@ namespace ts.codefix {
         const compilerOptions = program.getCompilerOptions();
         const exportInfos = pathIsBareSpecifier(stripQuotes(moduleSymbol.name))
             ? [getSymbolExportInfoForSymbol(targetSymbol, moduleSymbol, program, host)]
-            : getAllReExportingModules(sourceFile, targetSymbol, moduleSymbol, symbolName, host, program, preferences, /*useAutoImportProvider*/ true);
+            : getAllReExportingModules(sourceFile, targetSymbol, moduleSymbol, symbolName, isJsxTagName, host, program, preferences, /*useAutoImportProvider*/ true);
         const useRequire = shouldUseRequire(sourceFile, program);
         const isValidTypeOnlyUseSite = isValidTypeOnlyAliasUseSite(getTokenAtPosition(sourceFile, position));
         const fix = Debug.checkDefined(getImportFixForSymbol(sourceFile, exportInfos, moduleSymbol, symbolName, program, position, isValidTypeOnlyUseSite, useRequire, host, preferences));
@@ -332,7 +333,7 @@ namespace ts.codefix {
         }
     }
 
-    function getAllReExportingModules(importingFile: SourceFile, targetSymbol: Symbol, exportingModuleSymbol: Symbol, symbolName: string, host: LanguageServiceHost, program: Program, preferences: UserPreferences, useAutoImportProvider: boolean): readonly SymbolExportInfo[] {
+    function getAllReExportingModules(importingFile: SourceFile, targetSymbol: Symbol, exportingModuleSymbol: Symbol, symbolName: string, isJsxTagName: boolean, host: LanguageServiceHost, program: Program, preferences: UserPreferences, useAutoImportProvider: boolean): readonly SymbolExportInfo[] {
         const result: SymbolExportInfo[] = [];
         const compilerOptions = program.getCompilerOptions();
         const getModuleSpecifierResolutionHost = memoizeOne((isFromPackageJson: boolean) => {
@@ -347,7 +348,7 @@ namespace ts.codefix {
             }
 
             const defaultInfo = getDefaultLikeExportInfo(moduleSymbol, checker, compilerOptions);
-            if (defaultInfo && (defaultInfo.name === symbolName || moduleSymbolToValidIdentifier(moduleSymbol, getEmitScriptTarget(compilerOptions)) === symbolName) && skipAlias(defaultInfo.symbol, checker) === targetSymbol && isImportable(program, moduleFile, isFromPackageJson)) {
+            if (defaultInfo && (defaultInfo.name === symbolName || moduleSymbolToValidIdentifier(moduleSymbol, getEmitScriptTarget(compilerOptions), isJsxTagName) === symbolName) && skipAlias(defaultInfo.symbol, checker) === targetSymbol && isImportable(program, moduleFile, isFromPackageJson)) {
                 result.push({ symbol: defaultInfo.symbol, moduleSymbol, moduleFileName: moduleFile?.fileName, exportKind: defaultInfo.exportKind, targetFlags: skipAlias(defaultInfo.symbol, checker).flags, isFromPackageJson });
             }
 
@@ -774,7 +775,7 @@ namespace ts.codefix {
 
         const isValidTypeOnlyUseSite = isValidTypeOnlyAliasUseSite(symbolToken);
         const useRequire = shouldUseRequire(sourceFile, program);
-        const exportInfos = getExportInfos(symbolName, getMeaningFromLocation(symbolToken), cancellationToken, sourceFile, program, useAutoImportProvider, host, preferences);
+        const exportInfos = getExportInfos(symbolName, isJSXTagName(symbolToken), getMeaningFromLocation(symbolToken), cancellationToken, sourceFile, program, useAutoImportProvider, host, preferences);
         const fixes = arrayFrom(flatMapIterator(exportInfos.entries(), ([_, exportInfos]) =>
             getImportFixes(exportInfos, symbolName, symbolToken.getStart(sourceFile), isValidTypeOnlyUseSite, useRequire, program, sourceFile, host, preferences)));
         return { fixes, symbolName };
@@ -798,6 +799,7 @@ namespace ts.codefix {
     // Returns a map from an exported symbol's ID to a list of every way it's (re-)exported.
     function getExportInfos(
         symbolName: string,
+        isJsxTagName: boolean,
         currentTokenMeaning: SemanticMeaning,
         cancellationToken: CancellationToken,
         fromFile: SourceFile,
@@ -829,7 +831,7 @@ namespace ts.codefix {
 
             const compilerOptions = program.getCompilerOptions();
             const defaultInfo = getDefaultLikeExportInfo(moduleSymbol, checker, compilerOptions);
-            if (defaultInfo && (defaultInfo.name === symbolName || moduleSymbolToValidIdentifier(moduleSymbol, getEmitScriptTarget(compilerOptions)) === symbolName) && symbolHasMeaning(defaultInfo.symbolForMeaning, currentTokenMeaning)) {
+            if (defaultInfo && (defaultInfo.name === symbolName || moduleSymbolToValidIdentifier(moduleSymbol, getEmitScriptTarget(compilerOptions), isJsxTagName) === symbolName) && symbolHasMeaning(defaultInfo.symbolForMeaning, currentTokenMeaning)) {
                 addSymbol(moduleSymbol, sourceFile, defaultInfo.symbol, defaultInfo.exportKind, program, isFromPackageJson);
             }
 
@@ -1128,17 +1130,20 @@ namespace ts.codefix {
         return some(declarations, decl => !!(getMeaningFromDeclaration(decl) & meaning));
     }
 
-    export function moduleSymbolToValidIdentifier(moduleSymbol: Symbol, target: ScriptTarget | undefined): string {
-        return moduleSpecifierToValidIdentifier(removeFileExtension(stripQuotes(moduleSymbol.name)), target);
+    export function moduleSymbolToValidIdentifier(moduleSymbol: Symbol, target: ScriptTarget | undefined, forceUppercase: boolean): string {
+        return moduleSpecifierToValidIdentifier(removeFileExtension(stripQuotes(moduleSymbol.name)), target, forceUppercase);
     }
 
-    export function moduleSpecifierToValidIdentifier(moduleSpecifier: string, target: ScriptTarget | undefined): string {
+    export function moduleSpecifierToValidIdentifier(moduleSpecifier: string, target: ScriptTarget | undefined, forceUppercase?: boolean): string {
         const baseName = getBaseFileName(removeSuffix(moduleSpecifier, "/index"));
         let res = "";
         let lastCharWasValid = true;
         const firstCharCode = baseName.charCodeAt(0);
         if (isIdentifierStart(firstCharCode, target)) {
             res += String.fromCharCode(firstCharCode);
+            if (forceUppercase) {
+                res = res.toUpperCase();
+            }
         }
         else {
             lastCharWasValid = false;

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -1130,18 +1130,18 @@ namespace ts.codefix {
         return some(declarations, decl => !!(getMeaningFromDeclaration(decl) & meaning));
     }
 
-    export function moduleSymbolToValidIdentifier(moduleSymbol: Symbol, target: ScriptTarget | undefined, forceUppercase: boolean): string {
-        return moduleSpecifierToValidIdentifier(removeFileExtension(stripQuotes(moduleSymbol.name)), target, forceUppercase);
+    export function moduleSymbolToValidIdentifier(moduleSymbol: Symbol, target: ScriptTarget | undefined, forceCapitalize: boolean): string {
+        return moduleSpecifierToValidIdentifier(removeFileExtension(stripQuotes(moduleSymbol.name)), target, forceCapitalize);
     }
 
-    export function moduleSpecifierToValidIdentifier(moduleSpecifier: string, target: ScriptTarget | undefined, forceUppercase?: boolean): string {
+    export function moduleSpecifierToValidIdentifier(moduleSpecifier: string, target: ScriptTarget | undefined, forceCapitalize?: boolean): string {
         const baseName = getBaseFileName(removeSuffix(moduleSpecifier, "/index"));
         let res = "";
         let lastCharWasValid = true;
         const firstCharCode = baseName.charCodeAt(0);
         if (isIdentifierStart(firstCharCode, target)) {
             res += String.fromCharCode(firstCharCode);
-            if (forceUppercase) {
+            if (forceCapitalize) {
                 res = res.toUpperCase();
             }
         }

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -70,7 +70,7 @@ namespace ts.codefix {
 
         function addImportFromExportedSymbol(exportedSymbol: Symbol, isValidTypeOnlyUseSite?: boolean) {
             const moduleSymbol = Debug.checkDefined(exportedSymbol.parent);
-            const symbolName = getNameForExportedSymbol(exportedSymbol, getEmitScriptTarget(compilerOptions)).name;
+            const symbolName = getNameForExportedSymbol(exportedSymbol, getEmitScriptTarget(compilerOptions));
             const checker = program.getTypeChecker();
             const symbol = checker.getMergedSymbol(skipAlias(exportedSymbol, checker));
             const exportInfos = getAllReExportingModules(sourceFile, symbol, moduleSymbol, symbolName, /*isJsxTagName*/ false, host, program, preferences, useAutoImportProvider);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2447,7 +2447,7 @@ namespace ts.Completions {
                 !!importCompletionNode,
                 context => {
                     exportInfo.forEach(sourceFile.path, (info, getSymbolName, isFromAmbientModule, exportMapKey) => {
-                        const symbolName = getSymbolName(/*preferUppercase*/ isRightOfOpenTag);
+                        const symbolName = getSymbolName(/*preferCapitalized*/ isRightOfOpenTag);
                         if (!isIdentifierText(symbolName, getEmitScriptTarget(host.getCompilationSettings()))) return;
                         if (!detailsEntryId && isStringANonContextualKeyword(symbolName)) return;
                         // `targetFlags` should be the same for each `info`

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -59,7 +59,7 @@ namespace ts {
         getPackageJsonAutoImportProvider(): Program | undefined;
     }
 
-    export function createCacheableExportInfoMap(host: CacheableExportInfoMapHost, scriptTarget: ScriptTarget): ExportInfoMap {
+    export function createCacheableExportInfoMap(host: CacheableExportInfoMapHost): ExportInfoMap {
         let exportInfoId = 1;
         const exportInfo = createMultiMap<string, CachedSymbolExportInfo>();
         const symbols = new Map<number, [symbol: Symbol, moduleSymbol: Symbol]>();
@@ -88,7 +88,7 @@ namespace ts {
                 //    get a better name.
                 const importedName = exportKind === ExportKind.Named || isExternalModuleSymbol(namedSymbol)
                     ? unescapeLeadingUnderscores(symbolTableKey)
-                    : getNameForExportedSymbol(namedSymbol, scriptTarget);
+                    : getNameForExportedSymbol(namedSymbol, /*scriptTarget*/ undefined);
 
                 const moduleName = stripQuotes(moduleSymbol.name);
                 const id = exportInfoId++;
@@ -125,7 +125,7 @@ namespace ts {
                         rehydrated,
                         preferUppercase => {
                             return preferUppercase
-                                ? getNameForExportedSymbol(rehydrated[0].symbol, scriptTarget, /*preferUppercase*/ true)
+                                ? getNameForExportedSymbol(rehydrated[0].symbol, /*scriptTarget*/ undefined, /*preferUppercase*/ true)
                                 : symbolName;
                         },
                         !!ambientModuleName,
@@ -322,7 +322,7 @@ namespace ts {
         const cache = host.getCachedExportInfoMap?.() || createCacheableExportInfoMap({
             getCurrentProgram: () => program,
             getPackageJsonAutoImportProvider: () => host.getPackageJsonAutoImportProvider?.(),
-        }, getEmitScriptTarget(program.getCompilerOptions()));
+        });
 
         if (cache.isUsableByFile(importingFile.path)) {
             host.log?.("getExportInfoMap: cache hit");

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -47,7 +47,7 @@ namespace ts {
         clear(): void;
         add(importingFile: Path, symbol: Symbol, key: __String, moduleSymbol: Symbol, moduleFile: SourceFile | undefined, exportKind: ExportKind, isFromPackageJson: boolean, checker: TypeChecker): void;
         get(importingFile: Path, key: string): readonly SymbolExportInfo[] | undefined;
-        forEach(importingFile: Path, action: (info: readonly SymbolExportInfo[], getSymbolName: (preferUppercase?: boolean) => string, isFromAmbientModule: boolean, key: string) => void): void;
+        forEach(importingFile: Path, action: (info: readonly SymbolExportInfo[], getSymbolName: (preferCapitalized?: boolean) => string, isFromAmbientModule: boolean, key: string) => void): void;
         releaseSymbols(): void;
         isEmpty(): boolean;
         /** @returns Whether the change resulted in the cache being cleared */
@@ -123,9 +123,9 @@ namespace ts {
                     const rehydrated = info.map(rehydrateCachedInfo);
                     action(
                         rehydrated,
-                        preferUppercase => {
-                            return preferUppercase
-                                ? getNameForExportedSymbol(rehydrated[0].symbol, /*scriptTarget*/ undefined, /*preferUppercase*/ true)
+                        preferCapitalized => {
+                            return preferCapitalized
+                                ? getNameForExportedSymbol(rehydrated[0].symbol, /*scriptTarget*/ undefined, /*preferCapitalized*/ true)
                                 : symbolName;
                         },
                         !!ambientModuleName,

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -124,8 +124,10 @@ namespace ts {
                     action(
                         rehydrated,
                         preferCapitalized => {
+                            const { symbol, exportKind } = rehydrated[0];
+                            const namedSymbol = exportKind === ExportKind.Default && getLocalSymbolForExportDefault(symbol) || symbol;
                             return preferCapitalized
-                                ? getNameForExportedSymbol(rehydrated[0].symbol, /*scriptTarget*/ undefined, /*preferCapitalized*/ true)
+                                ? getNameForExportedSymbol(namedSymbol, /*scriptTarget*/ undefined, /*preferCapitalized*/ true)
                                 : symbolName;
                         },
                         !!ambientModuleName,

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3210,11 +3210,11 @@ namespace ts {
         return isArray(valueOrArray) ? first(valueOrArray) : valueOrArray;
     }
 
-    export function getNameForExportedSymbol(symbol: Symbol, scriptTarget: ScriptTarget | undefined, preferUppercase?: boolean) {
+    export function getNameForExportedSymbol(symbol: Symbol, scriptTarget: ScriptTarget | undefined, preferCapitalized?: boolean) {
         if (!(symbol.flags & SymbolFlags.Transient) && (symbol.escapedName === InternalSymbolName.ExportEquals || symbol.escapedName === InternalSymbolName.Default)) {
             // Name of "export default foo;" is "foo". Name of "export default 0" is the filename converted to camelCase.
             return firstDefined(symbol.declarations, d => isExportAssignment(d) ? tryCast(skipOuterExpressions(d.expression), isIdentifier)?.text : undefined)
-                || codefix.moduleSymbolToValidIdentifier(getSymbolParentOrFail(symbol), scriptTarget, !!preferUppercase);
+                || codefix.moduleSymbolToValidIdentifier(getSymbolParentOrFail(symbol), scriptTarget, !!preferCapitalized);
         }
         return symbol.name;
     }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3210,19 +3210,13 @@ namespace ts {
         return isArray(valueOrArray) ? first(valueOrArray) : valueOrArray;
     }
 
-    export function getNameForExportedSymbol(symbol: Symbol, scriptTarget: ScriptTarget | undefined, forceUppercase?: boolean): { name: string, isSynthesizedFromFileName: boolean } {
+    export function getNameForExportedSymbol(symbol: Symbol, scriptTarget: ScriptTarget | undefined, preferUppercase?: boolean) {
         if (!(symbol.flags & SymbolFlags.Transient) && (symbol.escapedName === InternalSymbolName.ExportEquals || symbol.escapedName === InternalSymbolName.Default)) {
             // Name of "export default foo;" is "foo". Name of "export default 0" is the filename converted to camelCase.
-            const nameFromDeclaration = firstDefined(symbol.declarations, d => isExportAssignment(d) ? tryCast(skipOuterExpressions(d.expression), isIdentifier)?.text : undefined);
-            if (nameFromDeclaration) {
-                return { name: nameFromDeclaration, isSynthesizedFromFileName: false };
-            }
-            return {
-                name: codefix.moduleSymbolToValidIdentifier(getSymbolParentOrFail(symbol), scriptTarget, !!forceUppercase),
-                isSynthesizedFromFileName: true,
-            };
+            return firstDefined(symbol.declarations, d => isExportAssignment(d) ? tryCast(skipOuterExpressions(d.expression), isIdentifier)?.text : undefined)
+                || codefix.moduleSymbolToValidIdentifier(getSymbolParentOrFail(symbol), scriptTarget, !!preferUppercase);
         }
-        return { name: symbol.name, isSynthesizedFromFileName: false };
+        return symbol.name;
     }
 
     function getSymbolParentOrFail(symbol: Symbol) {

--- a/src/testRunner/unittests/tsserver/exportMapCache.ts
+++ b/src/testRunner/unittests/tsserver/exportMapCache.ts
@@ -87,8 +87,8 @@ namespace ts.projectSystem {
             // transient symbols are recreated with every new checker.
             const programBefore = project.getCurrentProgram()!;
             let sigintPropBefore: readonly SymbolExportInfo[] | undefined;
-            exportMapCache.forEach(bTs.path as Path, (info, name) => {
-                if (name === "SIGINT") sigintPropBefore = info;
+            exportMapCache.forEach(bTs.path as Path, (info, getSymbolName) => {
+                if (getSymbolName() === "SIGINT") sigintPropBefore = info;
             });
             assert.ok(sigintPropBefore);
             assert.ok(sigintPropBefore![0].symbol.flags & SymbolFlags.Transient);
@@ -113,8 +113,8 @@ namespace ts.projectSystem {
 
             // Get same info from cache again
             let sigintPropAfter: readonly SymbolExportInfo[] | undefined;
-            exportMapCache.forEach(bTs.path as Path, (info, name) => {
-                if (name === "SIGINT") sigintPropAfter = info;
+            exportMapCache.forEach(bTs.path as Path, (info, getSymbolName) => {
+                if (getSymbolName() === "SIGINT") sigintPropAfter = info;
             });
             assert.ok(sigintPropAfter);
             assert.notEqual(symbolIdBefore, getSymbolId(sigintPropAfter![0].symbol));

--- a/tests/cases/fourslash/completionsImport_jsxOpeningTagImportDefault.ts
+++ b/tests/cases/fourslash/completionsImport_jsxOpeningTagImportDefault.ts
@@ -1,0 +1,39 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+// @jsx: react
+
+// @Filename: /component.tsx
+//// export default function (props: any) {}
+
+// @Filename: /index.tsx
+//// export function Index() {
+////     return <Component/**/
+//// }
+
+goTo.marker("");
+verify.completions({
+  marker: "",
+  includes: {
+    name: "Component",
+    source: "/component",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  },
+  excludes: "component",
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "Component",
+  source: "/component",
+  description: `Import default 'Component' from module "./component"`,
+  newFileContent:
+`import Component from "./component";
+
+export function Index() {
+    return <Component
+}`,
+});

--- a/tests/cases/fourslash/importNameCodeFix_jsxOpeningTagImportDefault.ts
+++ b/tests/cases/fourslash/importNameCodeFix_jsxOpeningTagImportDefault.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+// @jsx: react-jsx
+
+// @Filename: /component.tsx
+//// export default function (props: any) {}
+
+// @Filename: /index.tsx
+//// export function Index() {
+////     return <Component/**/ />;
+//// }
+
+goTo.marker("");
+verify.importFixAtPosition([`import Component from "./component";
+
+export function Index() {
+    return <Component />;
+}`]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #47110
