### PR TITLE
Add `assert` keyword in completions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -450,7 +450,6 @@ namespace ts.Completions {
             isInSnippetScope,
             isNewIdentifierLocation,
             location,
-            previousToken,
             propertyAccessToConvert,
             keywordFilters,
             literals,
@@ -548,7 +547,7 @@ namespace ts.Completions {
         }
 
         const entryNames = new Set(entries.map(e => e.name));
-        for (const keywordEntry of getContextualKeywords(location, previousToken, contextToken, position)) {
+        for (const keywordEntry of getContextualKeywords(contextToken, position)) {
             if (!entryNames.has(keywordEntry.name)) {
                 insertSorted(entries, keywordEntry, compareCompletionEntries, /*allowDuplicates*/ true);
             }
@@ -3588,8 +3587,6 @@ namespace ts.Completions {
     }
 
     function getContextualKeywords(
-        _location: Node,
-        _previousToken: Node | undefined,
         contextToken: Node | undefined,
         position: number,
     ): readonly CompletionEntry[] {

--- a/tests/cases/fourslash/completionsAssertKeyword.ts
+++ b/tests/cases/fourslash/completionsAssertKeyword.ts
@@ -1,0 +1,54 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @Filename: a.ts
+//// const f = {
+////    a: 1
+////};
+//// import * as thing from "thing" /*0*/
+//// export { foo } from "foo" /*1*/
+//// import "foo" as /*2*/
+//// import "foo" a/*3*/
+//// import * as that from "that"
+//// /*4*/
+//// import * /*5*/ as those from "those"
+
+// @Filename: b.js
+//// import * as thing from "thing" /*js*/;
+
+const assertEntry = {
+    name: "assert",
+    kind: "keyword",
+    sortText: completion.SortText.GlobalsOrKeywords,
+};
+
+verify.completions(
+    {
+        marker: "0",
+        includes: [assertEntry],
+    },
+    {
+        marker: "1",
+        includes: [assertEntry],
+    },
+    {
+        marker: "2",
+        excludes: ["assert"],
+    },
+    {
+        marker: "3",
+        includes: [assertEntry],
+    },
+    {
+        marker: "4",
+        excludes: ["assert"],
+    },
+    {
+        marker: "5",
+        excludes: ["assert"],
+    },
+    {
+        marker: "js",
+        includes: [assertEntry],
+    },
+);


### PR DESCRIPTION
Fixes #46371

I added a new function, `getContextualKeywords`, that is called in `completionInfoFromData`.
The alternative I've considered would be to use the existing `keywordFilter` mechanism, and have a new filter, `KeywordFilter.Assert`. However, that felt odd and difficult to implement, because `keywordFilter` is created in `getCompletionData` and assigned inside that function, and in other functions it calls, in multiple places. So it's (a) hard to follow all the conditionals and function calls that could assign to `keywordFilter` to make sure the variable ends up being assigned to `KeywordFilter.Assert` in the right places, and (b) the existing conditionals didn't reflect the cases where we should offer `assert` in completions.