### PR TITLE
Manual revert of AbortSignal.abort in webworker.generated.d.ts

### DIFF
--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -701,7 +701,7 @@ interface AbortSignal extends EventTarget {
 declare var AbortSignal: {
     prototype: AbortSignal;
     new(): AbortSignal;
-    abort(reason?: any): AbortSignal;
+    // abort(): AbortSignal; - To be re-added in the future
 };
 
 interface AbstractWorkerEventMap {


### PR DESCRIPTION
Same as #47643, I just missed it until looking at remaining DT failures.

I need to update the DOM-lib-generator automation, but for now I want to get TS types corrected.
