### PR TITLE
fix(47670): "Organize imports" should remove import any alias that are aliased as the same name as the export

### DIFF
--- a/tests/cases/fourslash/organizeImports8.ts
+++ b/tests/cases/fourslash/organizeImports8.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////import { foo as foo } from "foo";
+////foo;
+
+verify.organizeImports(
+`import { foo } from "foo";
+foo;`
+);

--- a/tests/cases/fourslash/organizeImports9.ts
+++ b/tests/cases/fourslash/organizeImports9.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////import { a as a, b, c, d as d, e as e } from "foo";
+////a(b, d);
+
+verify.organizeImports(
+`import { a, b, d } from "foo";
+a(b, d);`
+);


### PR DESCRIPTION
Fixes #47670

