### PR TITLE
Auto-import perf: Do symbol name/flags filtering before cache rehydration

### DIFF
--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -158,7 +158,6 @@ namespace ts {
                 return result?.map(rehydrateCachedInfo);
             },
             search: (importingFile, preferCapitalized, matches, action) => {
-
                 if (importingFile !== usableByFileName) return;
                 exportInfo.forEach((info, key) => {
                     const { symbolName, ambientModuleName } = parseKey(key);
@@ -167,7 +166,7 @@ namespace ts {
                         const rehydrated = info.map(rehydrateCachedInfo);
                         const filtered = rehydrated.filter((r, i) => isNotShadowedByDeeperNodeModulesPackage(r, info[i].packageName));
                         if (filtered.length) {
-                            action(filtered, symbolName, !!ambientModuleName, key);
+                            action(filtered, name, !!ambientModuleName, key);
                         }
                     }
                 });

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -157,11 +157,12 @@ namespace ts {
                 const result = exportInfo.get(key);
                 return result?.map(rehydrateCachedInfo);
             },
-            search: (importingFile, preferCaptialized, matches, action) => {
+            search: (importingFile, preferCapitalized, matches, action) => {
+
                 if (importingFile !== usableByFileName) return;
                 exportInfo.forEach((info, key) => {
                     const { symbolName, ambientModuleName } = parseKey(key);
-                    const name = preferCaptialized && info[0].capitalizedSymbolName || symbolName;
+                    const name = preferCapitalized && info[0].capitalizedSymbolName || symbolName;
                     if (matches(name, info[0].targetFlags)) {
                         const rehydrated = info.map(rehydrateCachedInfo);
                         const filtered = rehydrated.filter((r, i) => isNotShadowedByDeeperNodeModulesPackage(r, info[i].packageName));

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -29,6 +29,7 @@ namespace ts {
         // Used to rehydrate `symbol` and `moduleSymbol` when transient
         id: number;
         symbolName: string;
+        capitalizedSymbolName: string | undefined;
         symbolTableKey: __String;
         moduleName: string;
         moduleFile: SourceFile | undefined;
@@ -48,7 +49,7 @@ namespace ts {
         clear(): void;
         add(importingFile: Path, symbol: Symbol, key: __String, moduleSymbol: Symbol, moduleFile: SourceFile | undefined, exportKind: ExportKind, isFromPackageJson: boolean, checker: TypeChecker): void;
         get(importingFile: Path, key: string): readonly SymbolExportInfo[] | undefined;
-        forEach(importingFile: Path, action: (info: readonly SymbolExportInfo[], getSymbolName: (preferCapitalized?: boolean) => string, isFromAmbientModule: boolean, key: string) => void): void;
+        search(importingFile: Path, preferCapitalized: boolean, matches: (name: string, targetFlags: SymbolFlags) => boolean, action: (info: readonly SymbolExportInfo[], symbolName: string, isFromAmbientModule: boolean, key: string) => void): void;
         releaseSymbols(): void;
         isEmpty(): boolean;
         /** @returns Whether the change resulted in the cache being cleared */
@@ -121,9 +122,12 @@ namespace ts {
                 // 3. Otherwise, we have a default/namespace import that can be imported by any name, and
                 //    `symbolTableKey` will be something undesirable like `export=` or `default`, so we try to
                 //    get a better name.
-                const importedName = exportKind === ExportKind.Named || isExternalModuleSymbol(namedSymbol)
+                const names = exportKind === ExportKind.Named || isExternalModuleSymbol(namedSymbol)
                     ? unescapeLeadingUnderscores(symbolTableKey)
-                    : getNameForExportedSymbol(namedSymbol, /*scriptTarget*/ undefined);
+                    : getNamesForExportedSymbol(namedSymbol, /*scriptTarget*/ undefined);
+
+                const symbolName = typeof names === "string" ? names : names[0];
+                const capitalizedSymbolName = typeof names === "string" ? undefined : names[1];
 
                 const moduleName = stripQuotes(moduleSymbol.name);
                 const id = exportInfoId++;
@@ -132,10 +136,11 @@ namespace ts {
                 const storedModuleSymbol = moduleSymbol.flags & SymbolFlags.Transient ? undefined : moduleSymbol;
                 if (!storedSymbol || !storedModuleSymbol) symbols.set(id, [symbol, moduleSymbol]);
 
-                exportInfo.add(key(importedName, symbol, isExternalModuleNameRelative(moduleName) ? undefined : moduleName, checker), {
+                exportInfo.add(key(symbolName, symbol, isExternalModuleNameRelative(moduleName) ? undefined : moduleName, checker), {
                     id,
                     symbolTableKey,
-                    symbolName: importedName,
+                    symbolName,
+                    capitalizedSymbolName,
                     moduleName,
                     moduleFile,
                     moduleFileName: moduleFile?.fileName,
@@ -152,24 +157,17 @@ namespace ts {
                 const result = exportInfo.get(key);
                 return result?.map(rehydrateCachedInfo);
             },
-            forEach: (importingFile, action) => {
+            search: (importingFile, preferCaptialized, matches, action) => {
                 if (importingFile !== usableByFileName) return;
                 exportInfo.forEach((info, key) => {
                     const { symbolName, ambientModuleName } = parseKey(key);
-                    const rehydrated = info.map(rehydrateCachedInfo);
-                    const filtered = rehydrated.filter((r, i) => isNotShadowedByDeeperNodeModulesPackage(r, info[i].packageName));
-                    if (filtered.length) {
-                        action(
-                            filtered,
-                            preferCapitalized => {
-                                const { symbol, exportKind } = rehydrated[0];
-                                const namedSymbol = exportKind === ExportKind.Default && getLocalSymbolForExportDefault(symbol) || symbol;
-                                return preferCapitalized
-                                    ? getNameForExportedSymbol(namedSymbol, /*scriptTarget*/ undefined, /*preferCapitalized*/ true)
-                                    : symbolName;
-                            },
-                            !!ambientModuleName,
-                            key);
+                    const name = preferCaptialized && info[0].capitalizedSymbolName || symbolName;
+                    if (matches(name, info[0].targetFlags)) {
+                        const rehydrated = info.map(rehydrateCachedInfo);
+                        const filtered = rehydrated.filter((r, i) => isNotShadowedByDeeperNodeModulesPackage(r, info[i].packageName));
+                        if (filtered.length) {
+                            action(filtered, symbolName, !!ambientModuleName, key);
+                        }
                     }
                 });
             },

--- a/src/testRunner/unittests/tsserver/exportMapCache.ts
+++ b/src/testRunner/unittests/tsserver/exportMapCache.ts
@@ -87,8 +87,8 @@ namespace ts.projectSystem {
             // transient symbols are recreated with every new checker.
             const programBefore = project.getCurrentProgram()!;
             let sigintPropBefore: readonly SymbolExportInfo[] | undefined;
-            exportMapCache.forEach(bTs.path as Path, (info, getSymbolName) => {
-                if (getSymbolName() === "SIGINT") sigintPropBefore = info;
+            exportMapCache.search(bTs.path as Path, /*preferCapitalized*/ false, returnTrue, (info, symbolName) => {
+                if (symbolName === "SIGINT") sigintPropBefore = info;
             });
             assert.ok(sigintPropBefore);
             assert.ok(sigintPropBefore![0].symbol.flags & SymbolFlags.Transient);
@@ -113,8 +113,8 @@ namespace ts.projectSystem {
 
             // Get same info from cache again
             let sigintPropAfter: readonly SymbolExportInfo[] | undefined;
-            exportMapCache.forEach(bTs.path as Path, (info, getSymbolName) => {
-                if (getSymbolName() === "SIGINT") sigintPropAfter = info;
+            exportMapCache.search(bTs.path as Path, /*preferCapitalized*/ false, returnTrue, (info, symbolName) => {
+                if (symbolName === "SIGINT") sigintPropAfter = info;
             });
             assert.ok(sigintPropAfter);
             assert.notEqual(symbolIdBefore, getSymbolId(sigintPropAfter![0].symbol));


### PR DESCRIPTION
In my brief tests, this doesn't make a measurable difference, but it's not worse and theoretically ought to be better, so maybe worth taking after I did the work to try it? When we cache exported symbols, we drop the actual symbol references with the program so we don't retain old TypeCheckers. When reading from the cache, we retrieve the (potentially new) symbols from the new program. Previously, we did that rehydration up front, only to have the completions code skip many of them due to filtering logic on info we already had before rehydrating. This PR allows consumers of the ExportInfoMap to supply a predicate on symbol name and flags before it does the work to rehydrate that cached symbol info.