### PR TITLE
Fix inlay hint crash for jsdoc function type syntax

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31508,6 +31508,9 @@ namespace ts {
         }
 
         function getParameterIdentifierNameAtPosition(signature: Signature, pos: number): [parameterName: __String, isRestParameter: boolean] | undefined {
+            if (signature.declaration?.kind === SyntaxKind.JSDocFunctionType) {
+                return undefined;
+            }
             const paramCount = signature.parameters.length - (signatureHasRestParameter(signature) ? 1 : 0);
             if (pos < paramCount) {
                 const param = signature.parameters[pos];

--- a/tests/cases/fourslash/inlayHintsCrash1.ts
+++ b/tests/cases/fourslash/inlayHintsCrash1.ts
@@ -5,10 +5,9 @@
 //// /**
 ////  * @param {function(string): boolean} f
 ////  */
-//// function doThing(f/**/) {
+//// function doThing(f) {
 ////     f(100)
 //// }
-const markers = test.markers();
 verify.getInlayHints([], undefined, {
     includeInlayVariableTypeHints: true,
     includeInlayParameterNameHints: "all",

--- a/tests/cases/fourslash/inlayHintsCrash1.ts
+++ b/tests/cases/fourslash/inlayHintsCrash1.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+// @allowJs: true
+// @checkJs: true
+// @Filename: foo.js
+//// /**
+////  * @param {function(string): boolean} f
+////  */
+//// function doThing(f/**/) {
+////     f(100)
+//// }
+const markers = test.markers();
+verify.getInlayHints([], undefined, {
+    includeInlayVariableTypeHints: true,
+    includeInlayParameterNameHints: "all",
+});


### PR DESCRIPTION
Parameters in JSDoc function types do not have names. The type does not reflect this. This PR fixes the crash; I'll see how much churn it causes to fix the type as well.

Fixes #47606
