### PR TITLE
Use node moduleResolution everywhere

### DIFF
--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../tsconfig-noncomposite-base",
     "compilerOptions": {
         "outFile": "../../built/local/run.js",
-        "moduleResolution": "node",
         "composite": false,
         "declaration": false,
         "declarationMap": false,

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -3,7 +3,7 @@
         "pretty": true,
         "lib": ["es2015.iterable", "es2015.generator", "es5"],
         "target": "es5",
-        "moduleResolution": "classic",
+        "moduleResolution": "node",
         "rootDir": ".",
 
         "declaration": true,


### PR DESCRIPTION
TestRunner was already using it, but upstream projects (e.g. Compiler) were not, causing TestRunner to re-parse and re-bind all upstream files in (at least) editor scenarios), slowing down initial project load.

In local testing, this cut a find-all-refs call in checker.ts from 5s to 2.5s.