### PR TITLE
Add undefined to type of ParameterDeclaration.name

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4264,7 +4264,7 @@ namespace ts {
                 && !parameter.questionToken         // parameter may not be optional
                 && !parameter.type                  // parameter may not have a type annotation
                 && !parameter.initializer           // parameter may not have an initializer
-                && isIdentifier(parameter.name);    // parameter name must be identifier
+                && isIdentifier(parameter.name!);    // parameter name must be identifier
         }
 
         function emitParametersForArrow(parentNode: FunctionTypeNode | ArrowFunction, parameters: NodeArray<ParameterDeclaration>) {

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -1151,7 +1151,7 @@ namespace ts {
             decorators: readonly Decorator[] | undefined,
             modifiers: readonly Modifier[] | undefined,
             dotDotDotToken: DotDotDotToken | undefined,
-            name: string | BindingName,
+            name: string | BindingName | undefined,
             questionToken?: QuestionToken,
             type?: TypeNode,
             initializer?: Expression
@@ -1186,7 +1186,7 @@ namespace ts {
             decorators: readonly Decorator[] | undefined,
             modifiers: readonly Modifier[] | undefined,
             dotDotDotToken: DotDotDotToken | undefined,
-            name: string | BindingName,
+            name: string | BindingName | undefined,
             questionToken: QuestionToken | undefined,
             type: TypeNode | undefined,
             initializer: Expression | undefined

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3031,7 +3031,7 @@ namespace ts {
                     /*modifiers*/ undefined,
                     /*dotDotDotToken*/ undefined,
                     // TODO(rbuckton): JSDoc parameters don't have names (except `this`/`new`), should we manufacture an empty identifier?
-                    name!,
+                    name,
                     /*questionToken*/ undefined,
                     parseJSDocType(),
                     /*initializer*/ undefined

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -447,8 +447,8 @@ namespace ts {
             return ret;
         }
 
-        function filterBindingPatternInitializers(name: BindingName) {
-            if (name.kind === SyntaxKind.Identifier) {
+        function filterBindingPatternInitializers(name: BindingName | undefined) {
+            if (!name || name.kind === SyntaxKind.Identifier) {
                 return name;
             }
             else {
@@ -465,7 +465,7 @@ namespace ts {
                 if (elem.kind === SyntaxKind.OmittedExpression) {
                     return elem;
                 }
-                return factory.updateBindingElement(elem, elem.dotDotDotToken, elem.propertyName, filterBindingPatternInitializers(elem.name), shouldPrintWithInitializer(elem) ? elem.initializer : undefined);
+                return factory.updateBindingElement(elem, elem.dotDotDotToken, elem.propertyName, filterBindingPatternInitializers(elem.name)!, shouldPrintWithInitializer(elem) ? elem.initializer : undefined);
             }
         }
 
@@ -1371,6 +1371,7 @@ namespace ts {
                         const oldDiag = getSymbolAccessibilityDiagnostic;
                         parameterProperties = compact(flatMap(ctor.parameters, (param) => {
                             if (!hasSyntacticModifier(param, ModifierFlags.ParameterPropertyModifier) || shouldStripInternal(param)) return;
+                            Debug.type<BindingName>(param.name);
                             getSymbolAccessibilityDiagnostic = createGetSymbolAccessibilityDiagnosticForNode(param);
                             if (param.name.kind === SyntaxKind.Identifier) {
                                 return preserveJsDoc(factory.createPropertyDeclaration(

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -1310,6 +1310,7 @@ namespace ts {
                     added = insertDefaultValueAssignmentForBindingPattern(statements, parameter, name, initializer) || added;
                 }
                 else if (initializer) {
+                    Debug.type<BindingName>(name);
                     insertDefaultValueAssignmentForInitializer(statements, parameter, name, initializer);
                     added = true;
                 }
@@ -1439,6 +1440,7 @@ namespace ts {
 
             // `declarationName` is the name of the local declaration for the parameter.
             // TODO(rbuckton): Does this need to be parented?
+            Debug.type<BindingName>(parameter.name);
             const declarationName = parameter.name.kind === SyntaxKind.Identifier ? setParent(setTextRange(factory.cloneNode(parameter.name), parameter.name), parameter.name.parent) : factory.createTempVariable(/*recordTempVariable*/ undefined);
             setEmitFlags(declarationName, EmitFlags.NoSourceMap);
 

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -373,6 +373,7 @@ namespace ts {
         }
 
         function recordDeclarationName({ name }: ParameterDeclaration | VariableDeclaration | BindingElement, names: Set<__String>) {
+            Debug.type<BindingName>(name);
             if (isIdentifier(name)) {
                 names.add(name.escapedText);
             }

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -891,6 +891,7 @@ namespace ts {
 
             if (parametersWithPropertyAssignments) {
                 for (const parameter of parametersWithPropertyAssignments) {
+                    Debug.type<BindingName>(parameter.name);
                     if (isIdentifier(parameter.name)) {
                         members.push(setOriginalNode(factory.createPropertyDeclaration(
                             /*decorators*/ undefined,
@@ -1414,11 +1415,9 @@ namespace ts {
          */
         function serializeParameterTypesOfNode(node: Node, container: ClassLikeDeclaration): ArrayLiteralExpression {
             const valueDeclaration =
-                isClassLike(node)
-                    ? getFirstConstructorWithBody(node)
-                    : isFunctionLike(node) && nodeIsPresent((node as FunctionLikeDeclaration).body)
-                        ? node
-                        : undefined;
+                isClassLike(node) ? getFirstConstructorWithBody(node)
+                : isFunctionLike(node) && nodeIsPresent((node as FunctionLikeDeclaration).body) ? node
+                : undefined;
 
             const expressions: SerializedTypeNode[] = [];
             if (valueDeclaration) {
@@ -1426,6 +1425,7 @@ namespace ts {
                 const numParameters = parameters.length;
                 for (let i = 0; i < numParameters; i++) {
                     const parameter = parameters[i];
+                    Debug.type<BindingName>(parameter.name);
                     if (i === 0 && isIdentifier(parameter.name) && parameter.name.escapedText === "this") {
                         continue;
                     }
@@ -2176,7 +2176,9 @@ namespace ts {
                 setCommentRange(updated, node);
                 setTextRange(updated, moveRangePastModifiers(node));
                 setSourceMapRange(updated, moveRangePastModifiers(node));
-                setEmitFlags(updated.name, EmitFlags.NoTrailingSourceMap);
+                if (updated.name) {
+                    setEmitFlags(updated.name, EmitFlags.NoTrailingSourceMap);
+                }
             }
             return updated;
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1304,7 +1304,7 @@ namespace ts {
         readonly kind: SyntaxKind.Parameter;
         readonly parent: SignatureDeclaration;
         readonly dotDotDotToken?: DotDotDotToken;    // Present on rest parameter
-        readonly name: BindingName;                  // Declared parameter name.
+        readonly name?: BindingName;                 // Declared parameter name.
         readonly questionToken?: QuestionToken;      // Present on optional parameter
         readonly type?: TypeNode;                    // Optional type annotation
         readonly initializer?: Expression;           // Optional initializer
@@ -7188,8 +7188,8 @@ namespace ts {
 
         createTypeParameterDeclaration(name: string | Identifier, constraint?: TypeNode, defaultType?: TypeNode): TypeParameterDeclaration;
         updateTypeParameterDeclaration(node: TypeParameterDeclaration, name: Identifier, constraint: TypeNode | undefined, defaultType: TypeNode | undefined): TypeParameterDeclaration;
-        createParameterDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration;
-        updateParameterDeclaration(node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): ParameterDeclaration;
+        createParameterDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName | undefined, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration;
+        updateParameterDeclaration(node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName | undefined, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): ParameterDeclaration;
         createDecorator(expression: Expression): Decorator;
         updateDecorator(node: Decorator, expression: Expression): Decorator;
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2206,7 +2206,7 @@ namespace ts {
     /** Get the declaration initializer when it is container-like (See getExpandoInitializer). */
     export function getDeclaredExpandoInitializer(node: HasExpressionInitializer) {
         const init = getEffectiveInitializer(node);
-        return init && getExpandoInitializer(init, isPrototypeAccess(node.name));
+        return init && node.name && getExpandoInitializer(init, isPrototypeAccess(node.name));
     }
 
     function hasExpandoValueProperty(node: ObjectLiteralExpression, isPrototypeAssignment: boolean) {
@@ -2780,7 +2780,7 @@ namespace ts {
         if (!decl) {
             return undefined;
         }
-        const parameter = find(decl.parameters, p => p.name.kind === SyntaxKind.Identifier && p.name.escapedText === name);
+        const parameter = find(decl.parameters, p => !!p.name && p.name.kind === SyntaxKind.Identifier && p.name.escapedText === name);
         return parameter && parameter.symbol;
     }
 

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -201,12 +201,13 @@ namespace ts {
         // so let's just ignore it.
         return parameter.dotDotDotToken ? parameter :
             isBindingPattern(parameter.name) ? addDefaultValueAssignmentForBindingPattern(parameter, context) :
-            parameter.initializer ? addDefaultValueAssignmentForInitializer(parameter, parameter.name, parameter.initializer, context) :
+            parameter.initializer && parameter.name ? addDefaultValueAssignmentForInitializer(parameter, parameter.name, parameter.initializer, context) :
             parameter;
     }
 
     function addDefaultValueAssignmentForBindingPattern(parameter: ParameterDeclaration, context: TransformationContext) {
         const { factory } = context;
+        Debug.type<BindingPattern>(parameter.name);
         context.addInitializationStatement(
             factory.createVariableStatement(
                 /*modifiers*/ undefined,
@@ -391,6 +392,7 @@ namespace ts {
 
             case SyntaxKind.Parameter:
                 Debug.type<ParameterDeclaration>(node);
+                Debug.type<BindingName>(node.name);
                 return factory.updateParameterDeclaration(node,
                     nodesVisitor(node.decorators, visitor, isDecorator),
                     nodesVisitor(node.modifiers, visitor, isModifier),

--- a/src/services/codefixes/addOptionalPropertyUndefined.ts
+++ b/src/services/codefixes/addOptionalPropertyUndefined.ts
@@ -64,7 +64,7 @@ namespace ts.codefix {
             const i = errorNode.parent.arguments.indexOf(errorNode);
             if (i === -1) return undefined;
             const name = (n.valueDeclaration as any as SignatureDeclaration).parameters[i].name;
-            if (isIdentifier(name)) return { source: errorNode, target: name };
+            if (name && isIdentifier(name)) return { source: errorNode, target: name };
         }
         else if (isPropertyAssignment(errorNode.parent) && isIdentifier(errorNode.parent.name) ||
             isShorthandPropertyAssignment(errorNode.parent)) {

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -746,6 +746,7 @@ namespace ts.codefix {
         if (isFunctionLikeDeclaration(funcNode)) {
             if (funcNode.parameters.length > 0) {
                 const param = funcNode.parameters[0].name;
+                Debug.type<BindingName>(param);
                 name = getMappedBindingNameOrDefault(param);
             }
         }

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -167,7 +167,7 @@ namespace ts.codefix {
             if (!(signature && signature.declaration && signature.parameters[argIndex])) return undefined;
 
             const param = signature.parameters[argIndex].valueDeclaration;
-            if (!(param && isParameter(param) && isIdentifier(param.name))) return undefined;
+            if (!(param && isParameter(param) && param.name && isIdentifier(param.name))) return undefined;
 
             const properties = arrayFrom(checker.getUnmatchedProperties(checker.getTypeAtLocation(parent), checker.getTypeAtLocation(param), /* requireOptionalProperties */ false, /* matchDiscriminantProperties */ false));
             if (!length(properties)) return undefined;

--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -255,7 +255,7 @@ namespace ts.codefix {
         isFixAll = false): void {
         if (mayDeleteParameter(checker, sourceFile, parameter, sourceFiles, program, cancellationToken, isFixAll)) {
             if (parameter.modifiers && parameter.modifiers.length > 0 &&
-                (!isIdentifier(parameter.name) || FindAllReferences.Core.isSymbolReferencedInFile(parameter.name, checker, sourceFile))) {
+                (!parameter.name || !isIdentifier(parameter.name) || FindAllReferences.Core.isSymbolReferencedInFile(parameter.name, checker, sourceFile))) {
                 parameter.modifiers.forEach(modifier => changes.deleteModifier(sourceFile, modifier));
             }
             else if (!parameter.initializer && isNotProvidedArguments(parameter, checker, sourceFiles)) {
@@ -331,7 +331,7 @@ namespace ts.codefix {
         const index = parameters.indexOf(parameter);
         Debug.assert(index !== -1, "The parameter should already be in the list");
         return isFixAll ?
-            parameters.slice(index + 1).every(p => isIdentifier(p.name) && !p.symbol.isReferenced) :
+            parameters.slice(index + 1).every(p => p.name && isIdentifier(p.name) && !p.symbol.isReferenced) :
             index === parameters.length - 1;
     }
 

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -121,7 +121,7 @@ namespace ts.codefix {
                     else {
                         Debug.assertNode(accessor, isSetAccessorDeclaration, "The counterpart to a getter should be a setter");
                         const parameter = getSetAccessorValueParameter(accessor);
-                        const parameterName = parameter && isIdentifier(parameter.name) ? idText(parameter.name) : undefined;
+                        const parameterName = parameter?.name && isIdentifier(parameter.name) ? idText(parameter.name) : undefined;
                         addClassElement(factory.createSetAccessorDeclaration(
                             /*decorators*/ undefined,
                             modifiers,

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -270,7 +270,7 @@ namespace ts.InlayHints {
                 const param = node.parameters[i];
                 const effectiveTypeAnnotation = getEffectiveTypeAnnotationNode(param);
 
-                if (effectiveTypeAnnotation) {
+                if (effectiveTypeAnnotation || !param.name) {
                     continue;
                 }
 

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -266,6 +266,7 @@ namespace ts.JsDoc {
         if (!isFunctionLike(fn)) return [];
 
         return mapDefined(fn.parameters, param => {
+            Debug.type<BindingName>(param.name);
             if (!isIdentifier(param.name)) return undefined;
 
             const name = param.name.text;
@@ -372,6 +373,7 @@ namespace ts.JsDoc {
 
     function parameterDocComments(parameters: readonly ParameterDeclaration[], isJavaScriptFile: boolean, indentationStr: string, newLine: string): string {
         return parameters.map(({ name, dotDotDotToken }, i) => {
+            Debug.type<BindingName>(name);
             const paramName = name.kind === SyntaxKind.Identifier ? name.text : "param" + i;
             const type = isJavaScriptFile ? (dotDotDotToken ? "{...any} " : "{any} ") : "";
             return `${indentationStr} * @param ${type}${paramName}${newLine}`;

--- a/src/services/refactors/convertOverloadListToSingleSignature.ts
+++ b/src/services/refactors/convertOverloadListToSingleSignature.ts
@@ -142,7 +142,7 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
         }
 
         function convertParameterToNamedTupleMember(p: ParameterDeclaration): NamedTupleMember {
-            Debug.assert(isIdentifier(p.name)); // This is checked during refactoring applicability checking
+            Debug.assert(p.name && isIdentifier(p.name)); // This is checked during refactoring applicability checking
             const result = setTextRange(factory.createNamedTupleMember(
                 p.dotDotDotToken,
                 p.name,
@@ -209,7 +209,7 @@ ${newComment.split("\n").map(c => ` * ${c}`).join("\n")}
             return;
         }
         const signatureDecls = decls as (MethodSignature | MethodDeclaration | CallSignatureDeclaration | ConstructorDeclaration | ConstructSignatureDeclaration | FunctionDeclaration)[];
-        if (some(signatureDecls, d => !!d.typeParameters || some(d.parameters, p => !!p.decorators || !!p.modifiers || !isIdentifier(p.name)))) {
+        if (some(signatureDecls, d => !!d.typeParameters || some(d.parameters, p => !!p.decorators || !!p.modifiers || !p.name || !isIdentifier(p.name)))) {
             return;
         }
         const signatures = mapDefined(signatureDecls, d => checker.getSignatureFromDeclaration(d));

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -404,7 +404,7 @@ namespace ts.refactor.convertParamsToDestructuredObject {
             const type = checker.getTypeAtLocation(parameterDeclaration);
             if (!checker.isArrayType(type) && !checker.isTupleType(type)) return false;
         }
-        return !parameterDeclaration.modifiers && !parameterDeclaration.decorators && isIdentifier(parameterDeclaration.name);
+        return !parameterDeclaration.modifiers && !parameterDeclaration.decorators && !!parameterDeclaration.name && isIdentifier(parameterDeclaration.name);
     }
 
     function isValidVariableDeclaration(node: Node): node is ValidVariableDeclaration {
@@ -412,7 +412,7 @@ namespace ts.refactor.convertParamsToDestructuredObject {
     }
 
     function hasThisParameter(parameters: NodeArray<ParameterDeclaration>): boolean {
-        return parameters.length > 0 && isThis(parameters[0].name);
+        return parameters.length > 0 && !!parameters[0].name && isThis(parameters[0].name);
     }
 
     function getRefactorableParametersLength(parameters: NodeArray<ParameterDeclaration>): number {
@@ -492,8 +492,8 @@ namespace ts.refactor.convertParamsToDestructuredObject {
                 /*questionToken*/ undefined,
                 thisParameter.type);
 
-            suppressLeadingAndTrailingTrivia(newThisParameter.name);
-            copyComments(thisParameter.name, newThisParameter.name);
+            suppressLeadingAndTrailingTrivia(newThisParameter.name!);
+            copyComments(thisParameter.name, newThisParameter.name!);
             if (thisParameter.type) {
                 suppressLeadingAndTrailingTrivia(newThisParameter.type!);
                 copyComments(thisParameter.type, newThisParameter.type!);

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1291,7 +1291,7 @@ namespace ts.refactor.extractSymbol {
                     const firstParameter = firstOrUndefined(parameters);
                     // If the function signature has a this parameter and if the first defined parameter is not the this parameter, we must add it
                     // Note: If this parameter was already there, it would have been previously updated with the type if not type was present
-                    if ((!firstParameter || (isIdentifier(firstParameter.name) && firstParameter.name.escapedText !== "this"))) {
+                    if (!firstParameter || !firstParameter.name || (isIdentifier(firstParameter.name) && firstParameter.name.escapedText !== "this")) {
                         const thisType = checker.getTypeOfSymbolAtLocation(functionSignature.thisParameter, node);
                         parameters.splice(0, 0, factory.createParameterDeclaration(
                             /* decorators */ undefined,

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -540,6 +540,8 @@ namespace ts.textChanges {
                 }
             }
             else {
+                Debug.assert(node.parent.kind !== SyntaxKind.JSDocFunctionType);
+                Debug.type<BindingName | PropertyName>(node.name);
                 endNode = (node.kind === SyntaxKind.VariableDeclaration ? node.exclamationToken : node.questionToken) ?? node.name;
             }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -720,7 +720,7 @@ declare namespace ts {
         readonly kind: SyntaxKind.Parameter;
         readonly parent: SignatureDeclaration;
         readonly dotDotDotToken?: DotDotDotToken;
-        readonly name: BindingName;
+        readonly name?: BindingName;
         readonly questionToken?: QuestionToken;
         readonly type?: TypeNode;
         readonly initializer?: Expression;
@@ -3355,8 +3355,8 @@ declare namespace ts {
         updateComputedPropertyName(node: ComputedPropertyName, expression: Expression): ComputedPropertyName;
         createTypeParameterDeclaration(name: string | Identifier, constraint?: TypeNode, defaultType?: TypeNode): TypeParameterDeclaration;
         updateTypeParameterDeclaration(node: TypeParameterDeclaration, name: Identifier, constraint: TypeNode | undefined, defaultType: TypeNode | undefined): TypeParameterDeclaration;
-        createParameterDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration;
-        updateParameterDeclaration(node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): ParameterDeclaration;
+        createParameterDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName | undefined, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration;
+        updateParameterDeclaration(node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName | undefined, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): ParameterDeclaration;
         createDecorator(expression: Expression): Decorator;
         updateDecorator(node: Decorator, expression: Expression): Decorator;
         createPropertySignature(modifiers: readonly Modifier[] | undefined, name: PropertyName | string, questionToken: QuestionToken | undefined, type: TypeNode | undefined): PropertySignature;
@@ -10693,9 +10693,9 @@ declare namespace ts {
     /** @deprecated Use `factory.updateTypeParameterDeclaration` or the factory supplied by your transformation context instead. */
     const updateTypeParameterDeclaration: (node: TypeParameterDeclaration, name: Identifier, constraint: TypeNode | undefined, defaultType: TypeNode | undefined) => TypeParameterDeclaration;
     /** @deprecated Use `factory.createParameterDeclaration` or the factory supplied by your transformation context instead. */
-    const createParameter: (decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken?: QuestionToken | undefined, type?: TypeNode | undefined, initializer?: Expression | undefined) => ParameterDeclaration;
+    const createParameter: (decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName | undefined, questionToken?: QuestionToken | undefined, type?: TypeNode | undefined, initializer?: Expression | undefined) => ParameterDeclaration;
     /** @deprecated Use `factory.updateParameterDeclaration` or the factory supplied by your transformation context instead. */
-    const updateParameter: (node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined) => ParameterDeclaration;
+    const updateParameter: (node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName | undefined, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined) => ParameterDeclaration;
     /** @deprecated Use `factory.createDecorator` or the factory supplied by your transformation context instead. */
     const createDecorator: (expression: Expression) => Decorator;
     /** @deprecated Use `factory.updateDecorator` or the factory supplied by your transformation context instead. */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -720,7 +720,7 @@ declare namespace ts {
         readonly kind: SyntaxKind.Parameter;
         readonly parent: SignatureDeclaration;
         readonly dotDotDotToken?: DotDotDotToken;
-        readonly name: BindingName;
+        readonly name?: BindingName;
         readonly questionToken?: QuestionToken;
         readonly type?: TypeNode;
         readonly initializer?: Expression;
@@ -3355,8 +3355,8 @@ declare namespace ts {
         updateComputedPropertyName(node: ComputedPropertyName, expression: Expression): ComputedPropertyName;
         createTypeParameterDeclaration(name: string | Identifier, constraint?: TypeNode, defaultType?: TypeNode): TypeParameterDeclaration;
         updateTypeParameterDeclaration(node: TypeParameterDeclaration, name: Identifier, constraint: TypeNode | undefined, defaultType: TypeNode | undefined): TypeParameterDeclaration;
-        createParameterDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration;
-        updateParameterDeclaration(node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): ParameterDeclaration;
+        createParameterDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName | undefined, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration;
+        updateParameterDeclaration(node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName | undefined, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): ParameterDeclaration;
         createDecorator(expression: Expression): Decorator;
         updateDecorator(node: Decorator, expression: Expression): Decorator;
         createPropertySignature(modifiers: readonly Modifier[] | undefined, name: PropertyName | string, questionToken: QuestionToken | undefined, type: TypeNode | undefined): PropertySignature;
@@ -6882,9 +6882,9 @@ declare namespace ts {
     /** @deprecated Use `factory.updateTypeParameterDeclaration` or the factory supplied by your transformation context instead. */
     const updateTypeParameterDeclaration: (node: TypeParameterDeclaration, name: Identifier, constraint: TypeNode | undefined, defaultType: TypeNode | undefined) => TypeParameterDeclaration;
     /** @deprecated Use `factory.createParameterDeclaration` or the factory supplied by your transformation context instead. */
-    const createParameter: (decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken?: QuestionToken | undefined, type?: TypeNode | undefined, initializer?: Expression | undefined) => ParameterDeclaration;
+    const createParameter: (decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName | undefined, questionToken?: QuestionToken | undefined, type?: TypeNode | undefined, initializer?: Expression | undefined) => ParameterDeclaration;
     /** @deprecated Use `factory.updateParameterDeclaration` or the factory supplied by your transformation context instead. */
-    const updateParameter: (node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined) => ParameterDeclaration;
+    const updateParameter: (node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName | undefined, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined) => ParameterDeclaration;
     /** @deprecated Use `factory.createDecorator` or the factory supplied by your transformation context instead. */
     const createDecorator: (expression: Expression) => Decorator;
     /** @deprecated Use `factory.updateDecorator` or the factory supplied by your transformation context instead. */


### PR DESCRIPTION
Only parameters to JSDocFunctionTypes may not have names, but these parameters cause crashes from time to time, most recently #47606.

This PR is NOT in a mergeable state because of how inconsistently I remove `undefined` -- and having fixed all the compile errors, I don't actually think it's worthwhile. A lot of the difficulty comes from deciding whether to handle an undefined name instead of just asserting that it's defined. Any piece of code that only handles function *values* doesn't need to handle undefined parameters. However, it's difficult to know when this is the case.