### PR TITLE
Experiment: auto-import from yet-unimported referenced projects

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3918,8 +3918,8 @@ namespace ts {
             if (!symlinks) {
                 symlinks = createSymlinkCache(currentDirectory, getCanonicalFileName);
             }
-            if (files && resolvedTypeReferenceDirectives && !symlinks.hasProcessedResolutions()) {
-                symlinks.setSymlinksFromResolutions(files, resolvedTypeReferenceDirectives);
+            if (files && resolvedTypeReferenceDirectives && !symlinks.hasProcessedResolutions(/*projectName*/ undefined)) {
+                symlinks.setSymlinksFromResolutions(/*projectName*/ undefined, files, resolvedTypeReferenceDirectives);
             }
             return symlinks;
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8683,6 +8683,7 @@ namespace ts {
         readonly allowTextChangesInNewFiles?: boolean;
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
+        readonly includeProjectReferenceAutoImports?: "on" | "off";
         readonly provideRefactorNotApplicableReason?: boolean;
         readonly jsxAttributeCompletionStyle?: "auto" | "braces" | "none";
     }

--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -110,14 +110,12 @@ namespace ts.server {
                 }
             }
 
-            // verify the sequence numbers
-            Debug.assert(response.request_seq === request.seq, "Malformed response: response sequence number did not match request sequence number.");
-
             // unmarshal errors
             if (!response.success) {
                 throw new Error("Error " + response.message);
             }
 
+            Debug.assert(response.request_seq === request.seq, "Malformed response: response sequence number did not match request sequence number.");
             Debug.assert(expectEmptyBody || !!response.body, "Malformed response: Unexpected empty response body.");
             Debug.assert(!expectEmptyBody || !response.body, "Malformed response: Unexpected non-empty response body.");
 

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -3146,9 +3146,13 @@ namespace FourSlash {
             });
         }
 
-        public verifyImportFixModuleSpecifiers(markerName: string, moduleSpecifiers: string[]) {
+        public verifyImportFixModuleSpecifiers(markerName: string, moduleSpecifiers: string[], options?: ts.UserPreferences) {
+            if (options) {
+                this.configure(options);
+            }
             const marker = this.getMarkerByName(markerName);
             const codeFixes = this.getCodeFixes(marker.fileName, ts.Diagnostics.Cannot_find_name_0.code, {
+                ...options,
                 includeCompletionsForModuleExports: true,
                 includeCompletionsWithInsertText: true
             }, marker.position).filter(f => f.fixName === ts.codefix.importFixName);

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -982,6 +982,9 @@ namespace FourSlash {
             if (expected.isPackageJsonImport !== undefined) {
                 assert.equal<boolean | undefined>(actual.isPackageJsonImport, expected.isPackageJsonImport, "Expected 'isPackageJsonImport' properties to match");
             }
+            if (expected.data !== undefined) {
+                assert.deepEqual(actual.data, expected.data);
+            }
 
             assert.equal(actual.hasAction, expected.hasAction, `Expected 'hasAction' properties to match`);
             assert.equal(actual.isRecommended, expected.isRecommended, `Expected 'isRecommended' properties to match'`);

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -478,8 +478,8 @@ namespace FourSlashInterface {
             this.state.verifyImportFixAtPosition(expectedTextArray, errorCode, preferences);
         }
 
-        public importFixModuleSpecifiers(marker: string, moduleSpecifiers: string[]) {
-            this.state.verifyImportFixModuleSpecifiers(marker, moduleSpecifiers);
+        public importFixModuleSpecifiers(marker: string, moduleSpecifiers: string[], options?: ts.UserPreferences) {
+            this.state.verifyImportFixModuleSpecifiers(marker, moduleSpecifiers, options);
         }
 
         public navigationBar(json: any, options?: { checkSpans?: boolean }) {

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1694,6 +1694,7 @@ namespace FourSlashInterface {
         readonly sourceDisplay?: string;
         readonly tags?: readonly ts.JSDocTagInfo[];
         readonly sortText?: ts.Completions.SortText;
+        readonly data?: ts.CompletionEntryData;
     }
 
     export type ExpectedExactCompletionsPlus = readonly ExpectedCompletionEntry[] & {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -357,10 +357,20 @@ namespace ts.server {
             if (!this.symlinks) {
                 this.symlinks = createSymlinkCache(this.getCurrentDirectory(), this.getCanonicalFileName);
             }
-            if (this.program && !this.symlinks.hasProcessedResolutions()) {
+            if (this.program && !this.symlinks.hasProcessedResolutions(this.projectName)) {
                 this.symlinks.setSymlinksFromResolutions(
+                    this.projectName,
                     this.program.getSourceFiles(),
                     this.program.getResolvedTypeReferenceDirectives());
+            }
+            if (typeof this.autoImportProviderHost === "object" &&
+                this.autoImportProviderHost.program &&
+                !this.symlinks.hasProcessedResolutions(this.autoImportProviderHost.projectName)
+            ) {
+                this.symlinks.setSymlinksFromResolutions(
+                    this.autoImportProviderHost.projectName,
+                    this.autoImportProviderHost.program.getSourceFiles(),
+                    this.autoImportProviderHost.program.getResolvedTypeReferenceDirectives());
             }
             return this.symlinks;
         }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1768,6 +1768,11 @@ namespace ts.server {
         getIncompleteCompletionsCache() {
             return this.projectService.getIncompleteCompletionsCache();
         }
+
+        /*@internal*/
+        getProgramForReferencedProject(configFileName: string) {
+            return this.projectService.findConfiguredProjectByProjectName(toNormalizedPath(configFileName))?.getCurrentProgram();
+        }
     }
 
     function getUnresolvedImports(program: Program, cachedUnresolvedImportsPerFile: ESMap<Path, readonly string[]>): SortedReadonlyArray<string> {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3406,6 +3406,7 @@ namespace ts.server.protocol {
          * `class A { foo }`.
          */
         readonly includeCompletionsWithClassMemberSnippets?: boolean;
+        readonly includeProjectReferenceAutoImports?: "on" | "off";
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1978,9 +1978,7 @@ namespace ts.Completions {
         const symbolToSortTextIdMap: SymbolSortTextIdMap = [];
         const seenPropertySymbols = new Map<SymbolId, true>();
         const isTypeOnlyLocation = isTypeOnlyCompletion();
-        const getModuleSpecifierResolutionHost = memoizeOne((source: AutoImportSource) => {
-            return createModuleSpecifierResolutionHost(getProgramForAutoImport(source, program, host), host);
-        });
+        const moduleSpecifierResolutionHost = createModuleSpecifierResolutionHost(program, host);
 
         if (isRightOfDot || isRightOfQuestionDot) {
             getTypeScriptMemberSymbols();
@@ -2545,7 +2543,7 @@ namespace ts.Completions {
                         return false;
                     }
                     return packageJsonFilter
-                        ? packageJsonFilter.allowsImportingAmbientModule(info.moduleSymbol, getModuleSpecifierResolutionHost(info.source))
+                        ? packageJsonFilter.allowsImportingAmbientModule(info.moduleSymbol, moduleSpecifierResolutionHost)
                         : true;
                 }
                 return isImportableFile(
@@ -2554,7 +2552,7 @@ namespace ts.Completions {
                     moduleFile,
                     preferences,
                     packageJsonFilter,
-                    getModuleSpecifierResolutionHost(info.source),
+                    moduleSpecifierResolutionHost,
                     moduleSpecifierCache);
             }
         }

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -337,14 +337,15 @@ namespace ts {
         cb: (module: Symbol, moduleFile: SourceFile | undefined, program: Program, source: AutoImportSource) => void,
     ) {
         forEachExternalModule(program.getTypeChecker(), program.getSourceFiles(), (module, file) => cb(module, file, program, AutoImportSourceKind.Program));
-        const autoImportProvider = preferences.includePackageJsonAutoImports && host.getPackageJsonAutoImportProvider?.();
+        const { includePackageJson, includeProjectReferences } = getAutoImportPreferences(preferences);
+        const autoImportProvider = includePackageJson && host.getPackageJsonAutoImportProvider?.();
         if (autoImportProvider) {
             const start = timestamp();
             forEachExternalModule(autoImportProvider.getTypeChecker(), autoImportProvider.getSourceFiles(), (module, file) => cb(module, file, autoImportProvider, AutoImportSourceKind.PackageJson));
             host.log?.(`forEachExternalModuleToImportFrom autoImportProvider: ${timestamp() - start}`);
         }
 
-        if (preferences.includeProjectReferenceAutoImports && host.getProgramForReferencedProject) {
+        if (includeProjectReferences && host.getProgramForReferencedProject) {
             const projectReferences = program.getResolvedProjectReferences();
             if (projectReferences) {
                 for (const ref of projectReferences) {

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -365,9 +365,15 @@ namespace ts {
             for (const ref of resolvedReferencedProjects) {
                 const referencedProgram = host.getProgramForReferencedProject!(ref.sourceFile.fileName);
                 if (referencedProgram) {
+                    const useSourceOfProjectReferenceRedirect = !!host.useSourceOfProjectReferenceRedirect?.()
+                        && !program.getCompilerOptions().disableSourceOfProjectReferenceRedirect;
                     forEachExternalModule(
                         referencedProgram.getTypeChecker(),
                         mapDefined(referencedProgram.getRootFileNames(), fileName => {
+                            if (!useSourceOfProjectReferenceRedirect) {
+                                // `seenModules` will contain the .d.ts outputs of these input files
+                                fileName = program.getProjectReferenceRedirect(fileName) || fileName;
+                            }
                             const file = referencedProgram.getSourceFile(fileName);
                             return file && !seenModules!.has(file.path) ? file : undefined;
                         }),

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -345,6 +345,20 @@ namespace ts {
             forEachExternalModule(autoImportProvider.getTypeChecker(), autoImportProvider.getSourceFiles(), (module, file) => cb(module, file, autoImportProvider, /*isFromPackageJson*/ true));
             host.log?.(`forEachExternalModuleToImportFrom autoImportProvider: ${timestamp() - start}`);
         }
+
+        if (host.getProgramForReferencedProject) {
+            const projectReferences = program.getResolvedProjectReferences();
+            if (projectReferences) {
+                for (const ref of projectReferences) {
+                    if (ref) {
+                        const referencedProgram = host.getProgramForReferencedProject(ref.sourceFile.fileName);
+                        if (referencedProgram) {
+                            forEachExternalModule(referencedProgram.getTypeChecker(), referencedProgram.getSourceFiles(), (module, file) => cb(module, file, referencedProgram, /*isFromPackageJson*/ false));
+                        }
+                    }
+                }
+            }
+        }
     }
 
     function forEachExternalModule(checker: TypeChecker, allSourceFiles: readonly SourceFile[], cb: (module: Symbol, sourceFile: SourceFile | undefined) => void) {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -318,6 +318,7 @@ namespace ts {
         getParsedCommandLine?(fileName: string): ParsedCommandLine | undefined;
         /* @internal */ onReleaseParsedCommandLine?(configFileName: string, oldResolvedRef: ResolvedProjectReference | undefined, optionOptions: CompilerOptions): void;
         /* @internal */ getIncompleteCompletionsCache?(): IncompleteCompletionsCache;
+        /* @internal */ getProgramForReferencedProject?(configFileName: string): Program | undefined;
     }
 
     /* @internal */

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -220,6 +220,24 @@ namespace ts {
         Auto,
     }
 
+    /* @internal */
+    export const enum ProjectReferenceAutoImportPreference {
+        Off,
+        On,
+    }
+
+    /* @internal */
+    export function getAutoImportPreferences(preferences: UserPreferences) {
+        const includePackageJson =
+            preferences.includePackageJsonAutoImports === "off" ? PackageJsonAutoImportPreference.Off :
+            preferences.includePackageJsonAutoImports === "on" ? PackageJsonAutoImportPreference.On :
+            PackageJsonAutoImportPreference.Auto;
+        const includeProjectReferences =
+            preferences.includeProjectReferenceAutoImports === "on" ? ProjectReferenceAutoImportPreference.On :
+            ProjectReferenceAutoImportPreference.Off;
+        return { includePackageJson, includeProjectReferences };
+    }
+
     export interface PerformanceEvent {
         kind: "UpdateGraph" | "CreatePackageJsonAutoImportProvider";
         durationMs: number;
@@ -320,6 +338,13 @@ namespace ts {
         /* @internal */ getIncompleteCompletionsCache?(): IncompleteCompletionsCache;
         /* @internal */ getProgramForReferencedProject?(configFileName: string): Program | undefined;
     }
+
+    export const enum AutoImportSourceKind {
+        Program = 1,
+        PackageJson,
+    }
+
+    export type AutoImportSource = AutoImportSourceKind | string;
 
     /* @internal */
     export const emptyOptions = {};
@@ -1201,13 +1226,12 @@ namespace ts {
          * in the case of InternalSymbolName.ExportEquals and InternalSymbolName.Default.
          */
         exportName: string;
+        source: AutoImportSource;
         moduleSpecifier?: string;
         /** The file name declaring the export's module symbol, if it was an external module */
         fileName?: string;
         /** The module name (with quotes stripped) of the export's module symbol, if it was an ambient module */
         ambientModuleName?: string;
-        /** True if the export was found in the package.json AutoImportProvider */
-        isPackageJsonImport?: true;
     }
 
     export interface CompletionEntryDataUnresolved extends CompletionEntryDataAutoImport {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -226,18 +226,6 @@ namespace ts {
         On,
     }
 
-    /* @internal */
-    export function getAutoImportPreferences(preferences: UserPreferences) {
-        const includePackageJson =
-            preferences.includePackageJsonAutoImports === "off" ? PackageJsonAutoImportPreference.Off :
-            preferences.includePackageJsonAutoImports === "on" ? PackageJsonAutoImportPreference.On :
-            PackageJsonAutoImportPreference.Auto;
-        const includeProjectReferences =
-            preferences.includeProjectReferenceAutoImports === "on" ? ProjectReferenceAutoImportPreference.On :
-            ProjectReferenceAutoImportPreference.Off;
-        return { includePackageJson, includeProjectReferences };
-    }
-
     export interface PerformanceEvent {
         kind: "UpdateGraph" | "CreatePackageJsonAutoImportProvider";
         durationMs: number;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3314,5 +3314,20 @@ namespace ts {
         };
     }
 
+    export function getProgramForAutoImport(source: AutoImportSource, program: Program, host: CacheableExportInfoMapHost | LanguageServiceHost): Program {
+        switch (source) {
+            case AutoImportSourceKind.Program:
+                return program;
+            case AutoImportSourceKind.PackageJson:
+                return Debug.checkDefined(host.getPackageJsonAutoImportProvider?.(), "Could not retrieve package.json AutoImportProvider");
+            default:
+                return Debug.checkDefined(host.getProgramForReferencedProject?.(source), "Could not retrieve program for auto-importing from referenced project");
+        }
+    }
+
+    export function createMemoizedGetProgramForAutoImport(program: Program, host: CacheableExportInfoMapHost | LanguageServiceHost) {
+        return memoizeOne((source: AutoImportSource) => getProgramForAutoImport(source, program, host));
+    }
+
     // #endregion
 }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3329,5 +3329,18 @@ namespace ts {
         return memoizeOne((source: AutoImportSource) => getProgramForAutoImport(source, program, host));
     }
 
+    export function getAutoImportPreferences(preferences: UserPreferences) {
+        const includePackageJson =
+            preferences.includePackageJsonAutoImports === "off" ? PackageJsonAutoImportPreference.Off :
+            preferences.includePackageJsonAutoImports === "on" ? PackageJsonAutoImportPreference.On :
+            PackageJsonAutoImportPreference.Auto;
+        // TODO: flip default back to "off" if shipping as an opt-in experiment.
+        //       Needs to default to "on" until VS Code is able to set it.
+        const includeProjectReferences =
+            preferences.includeProjectReferenceAutoImports === "off" ? ProjectReferenceAutoImportPreference.Off :
+            ProjectReferenceAutoImportPreference.On;
+        return { includePackageJson, includeProjectReferences };
+    }
+
     // #endregion
 }

--- a/src/testRunner/unittests/tsserver/completions.ts
+++ b/src/testRunner/unittests/tsserver/completions.ts
@@ -42,7 +42,7 @@ namespace ts.projectSystem {
                 source: "/a",
                 sourceDisplay: undefined,
                 isSnippet: undefined,
-                data: { exportName: "foo", fileName: "/a.ts", ambientModuleName: undefined, isPackageJsonImport: undefined }
+                data: { exportName: "foo", fileName: "/a.ts", ambientModuleName: undefined, source: AutoImportSourceKind.Program }
             };
 
             // `data.exportMapKey` contains a SymbolId so should not be mocked up with an expected value here.
@@ -61,7 +61,7 @@ namespace ts.projectSystem {
 
             const detailsRequestArgs: protocol.CompletionDetailsRequestArgs = {
                 ...requestLocation,
-                entryNames: [{ name: "foo", source: "/a", data: { exportName: "foo", fileName: "/a.ts", exportMapKey } }],
+                entryNames: [{ name: "foo", source: "/a", data: { source: AutoImportSourceKind.Program, exportName: "foo", fileName: "/a.ts", exportMapKey } }],
             };
 
             const detailsResponse = executeSessionRequest<protocol.CompletionDetailsRequest, protocol.CompletionDetailsResponse>(session, protocol.CommandTypes.CompletionDetails, detailsRequestArgs);

--- a/src/testRunner/unittests/tsserver/exportMapCache.ts
+++ b/src/testRunner/unittests/tsserver/exportMapCache.ts
@@ -1,147 +1,248 @@
 namespace ts.projectSystem {
-    const packageJson: File = {
-        path: "/package.json",
-        content: `{ "dependencies": { "mobx": "*" } }`
-    };
-    const aTs: File = {
-        path: "/a.ts",
-        content: "export const foo = 0;",
-    };
-    const bTs: File = {
-        path: "/b.ts",
-        content: "foo",
-    };
-    const tsconfig: File = {
-        path: "/tsconfig.json",
-        content: "{}",
-    };
-    const ambientDeclaration: File = {
-        path: "/ambient.d.ts",
-        content: "declare module 'ambient' {}"
-    };
-    const mobxPackageJson: File = {
-        path: "/node_modules/mobx/package.json",
-        content: `{ "name": "mobx", "version": "1.0.0" }`
-    };
-    const mobxDts: File = {
-        path: "/node_modules/mobx/index.d.ts",
-        content: "export declare function observable(): unknown;"
-    };
-    const exportEqualsMappedType: File = {
-        path: "/lib/foo/constants.d.ts",
-        content: `
-            type Signals = "SIGINT" | "SIGABRT";
-            declare const exp: {} & { [K in Signals]: K };
-            export = exp;`,
-    };
-
     describe("unittests:: tsserver:: exportMapCache", () => {
-        it("caches auto-imports in the same file", () => {
-            const { exportMapCache } = setup();
-            assert.ok(exportMapCache.isUsableByFile(bTs.path as Path));
-            assert.ok(!exportMapCache.isEmpty());
-        });
 
-        it("invalidates the cache when new files are added", () => {
-            const { host, exportMapCache } = setup();
-            host.writeFile("/src/a2.ts", aTs.content);
-            host.runQueuedTimeoutCallbacks();
-            assert.ok(!exportMapCache.isUsableByFile(bTs.path as Path));
-            assert.ok(exportMapCache.isEmpty());
-        });
+        describe("unittests:: tsserver:: exportMapCache:: main program and package.json AutoImportProvider", () => {
+            const packageJson: File = {
+                path: "/package.json",
+                content: `{ "dependencies": { "mobx": "*" } }`
+            };
+            const aTs: File = {
+                path: "/a.ts",
+                content: "export const foo = 0;",
+            };
+            const bTs: File = {
+                path: "/b.ts",
+                content: "foo",
+            };
+            const tsconfig: File = {
+                path: "/tsconfig.json",
+                content: "{}",
+            };
+            const ambientDeclaration: File = {
+                path: "/ambient.d.ts",
+                content: "declare module 'ambient' {}"
+            };
+            const mobxPackageJson: File = {
+                path: "/node_modules/mobx/package.json",
+                content: `{ "name": "mobx", "version": "1.0.0" }`
+            };
+            const mobxDts: File = {
+                path: "/node_modules/mobx/index.d.ts",
+                content: "export declare function observable(): unknown;"
+            };
+            const exportEqualsMappedType: File = {
+                path: "/lib/foo/constants.d.ts",
+                content: `
+                    type Signals = "SIGINT" | "SIGABRT";
+                    declare const exp: {} & { [K in Signals]: K };
+                    export = exp;`,
+            };
 
-        it("invalidates the cache when files are deleted", () => {
-            const { host, projectService, exportMapCache } = setup();
-            projectService.closeClientFile(aTs.path);
-            host.deleteFile(aTs.path);
-            host.runQueuedTimeoutCallbacks();
-            assert.ok(!exportMapCache.isUsableByFile(bTs.path as Path));
-            assert.ok(exportMapCache.isEmpty());
-        });
-
-        it("does not invalidate the cache when package.json is changed inconsequentially", () => {
-            const { host, exportMapCache, project } = setup();
-            host.writeFile("/package.json", `{ "name": "blah", "dependencies": { "mobx": "*" } }`);
-            host.runQueuedTimeoutCallbacks();
-            project.getPackageJsonAutoImportProvider();
-            assert.ok(exportMapCache.isUsableByFile(bTs.path as Path));
-            assert.ok(!exportMapCache.isEmpty());
-        });
-
-        it("invalidates the cache when package.json change results in AutoImportProvider change", () => {
-            const { host, exportMapCache, project } = setup();
-            host.writeFile("/package.json", `{}`);
-            host.runQueuedTimeoutCallbacks();
-            project.getPackageJsonAutoImportProvider();
-            assert.ok(!exportMapCache.isUsableByFile(bTs.path as Path));
-            assert.ok(exportMapCache.isEmpty());
-        });
-
-        it("does not store transient symbols through program updates", () => {
-            const { exportMapCache, project, session } = setup();
-            // SIGINT, exported from /lib/foo/constants.d.ts, is a mapped type property, which will be a transient symbol.
-            // Transient symbols contain types, which retain the checkers they came from, so are not safe to cache.
-            // We clear symbols from the cache during updateGraph, leaving only the information about how to re-get them
-            // (see getters on `CachedSymbolExportInfo`). We can roughly test that this is working by ensuring that
-            // accessing a transient symbol with two different checkers results in different symbol identities, since
-            // transient symbols are recreated with every new checker.
-            const programBefore = project.getCurrentProgram()!;
-            let sigintPropBefore: readonly SymbolExportInfo[] | undefined;
-            exportMapCache.forEach(bTs.path as Path, (info, getSymbolName) => {
-                if (getSymbolName() === "SIGINT") sigintPropBefore = info;
-            });
-            assert.ok(sigintPropBefore);
-            assert.ok(sigintPropBefore![0].symbol.flags & SymbolFlags.Transient);
-            const symbolIdBefore = getSymbolId(sigintPropBefore![0].symbol);
-
-            // Update program without clearing cache
-            session.executeCommandSeq<protocol.UpdateOpenRequest>({
-                command: protocol.CommandTypes.UpdateOpen,
-                arguments: {
-                    changedFiles: [{
-                        fileName: bTs.path,
-                        textChanges: [{
-                            newText: " ",
-                            start: { line: 1, offset: 1 },
-                            end: { line: 1, offset: 1 },
-                        }]
-                    }]
-                }
-            });
-            project.getLanguageService(/*ensureSynchronized*/ true);
-            assert.notEqual(programBefore, project.getCurrentProgram()!);
-
-            // Get same info from cache again
-            let sigintPropAfter: readonly SymbolExportInfo[] | undefined;
-            exportMapCache.forEach(bTs.path as Path, (info, getSymbolName) => {
-                if (getSymbolName() === "SIGINT") sigintPropAfter = info;
-            });
-            assert.ok(sigintPropAfter);
-            assert.notEqual(symbolIdBefore, getSymbolId(sigintPropAfter![0].symbol));
-        });
-    });
-
-    function setup() {
-        const host = createServerHost([aTs, bTs, ambientDeclaration, tsconfig, packageJson, mobxPackageJson, mobxDts, exportEqualsMappedType]);
-        const session = createSession(host);
-        openFilesForSession([aTs, bTs], session);
-        const projectService = session.getProjectService();
-        const project = configuredProjectAt(projectService, 0);
-        triggerCompletions();
-        const checker = project.getLanguageService().getProgram()!.getTypeChecker();
-        return { host, project, projectService, session, exportMapCache: project.getCachedExportInfoMap(), checker, triggerCompletions };
-
-        function triggerCompletions() {
+            const files = [aTs, bTs, ambientDeclaration, tsconfig, packageJson, mobxPackageJson, mobxDts, exportEqualsMappedType];
+            const openFiles = [aTs, bTs];
             const requestLocation: protocol.FileLocationRequestArgs = {
                 file: bTs.path,
                 line: 1,
                 offset: 3,
             };
-            executeSessionRequest<protocol.CompletionsRequest, protocol.CompletionInfoResponse>(session, protocol.CommandTypes.CompletionInfo, {
-                ...requestLocation,
-                includeExternalModuleExports: true,
-                prefix: "foo",
+            const setup = createSetup(files, openFiles, requestLocation);
+
+            it("caches auto-imports in the same file", () => {
+                const { exportMapCache } = setup();
+                assert.ok(exportMapCache.isUsableByFile(bTs.path as Path));
+                assert.ok(!exportMapCache.isEmpty());
             });
+
+            it("invalidates the cache when new files are added", () => {
+                const { host, exportMapCache } = setup();
+                host.writeFile("/src/a2.ts", aTs.content);
+                host.runQueuedTimeoutCallbacks();
+                assert.ok(!exportMapCache.isUsableByFile(bTs.path as Path));
+                assert.ok(exportMapCache.isEmpty());
+            });
+
+            it("invalidates the cache when files are deleted", () => {
+                const { host, projectService, exportMapCache } = setup();
+                projectService.closeClientFile(aTs.path);
+                host.deleteFile(aTs.path);
+                host.runQueuedTimeoutCallbacks();
+                assert.ok(!exportMapCache.isUsableByFile(bTs.path as Path));
+                assert.ok(exportMapCache.isEmpty());
+            });
+
+            it("does not invalidate the cache when package.json is changed inconsequentially", () => {
+                const { host, exportMapCache, project } = setup();
+                host.writeFile("/package.json", `{ "name": "blah", "dependencies": { "mobx": "*" } }`);
+                host.runQueuedTimeoutCallbacks();
+                project.getPackageJsonAutoImportProvider();
+                assert.ok(exportMapCache.isUsableByFile(bTs.path as Path));
+                assert.ok(!exportMapCache.isEmpty());
+            });
+
+            it("invalidates the cache when package.json change results in AutoImportProvider change", () => {
+                const { host, exportMapCache, project } = setup();
+                host.writeFile("/package.json", `{}`);
+                host.runQueuedTimeoutCallbacks();
+                project.getPackageJsonAutoImportProvider();
+                assert.ok(!exportMapCache.isUsableByFile(bTs.path as Path));
+                assert.ok(exportMapCache.isEmpty());
+            });
+
+            it("does not store transient symbols through program updates", () => {
+                const { exportMapCache, project, session } = setup();
+                // SIGINT, exported from /lib/foo/constants.d.ts, is a mapped type property, which will be a transient symbol.
+                // Transient symbols contain types, which retain the checkers they came from, so are not safe to cache.
+                // We clear symbols from the cache during updateGraph, leaving only the information about how to re-get them
+                // (see getters on `CachedSymbolExportInfo`). We can roughly test that this is working by ensuring that
+                // accessing a transient symbol with two different checkers results in different symbol identities, since
+                // transient symbols are recreated with every new checker.
+                const programBefore = project.getCurrentProgram()!;
+                let sigintPropBefore: readonly SymbolExportInfo[] | undefined;
+                exportMapCache.forEach(bTs.path as Path, (info, getSymbolName) => {
+                    if (getSymbolName() === "SIGINT") sigintPropBefore = info;
+                });
+                assert.ok(sigintPropBefore);
+                assert.ok(sigintPropBefore![0].symbol.flags & SymbolFlags.Transient);
+                const symbolIdBefore = getSymbolId(sigintPropBefore![0].symbol);
+
+                // Update program without clearing cache
+                session.executeCommandSeq<protocol.UpdateOpenRequest>({
+                    command: protocol.CommandTypes.UpdateOpen,
+                    arguments: {
+                        changedFiles: [{
+                            fileName: bTs.path,
+                            textChanges: [{
+                                newText: " ",
+                                start: { line: 1, offset: 1 },
+                                end: { line: 1, offset: 1 },
+                            }]
+                        }]
+                    }
+                });
+                project.getLanguageService(/*ensureSynchronized*/ true);
+                assert.notEqual(programBefore, project.getCurrentProgram()!);
+
+                // Get same info from cache again
+                let sigintPropAfter: readonly SymbolExportInfo[] | undefined;
+                exportMapCache.forEach(bTs.path as Path, (info, getSymbolName) => {
+                    if (getSymbolName() === "SIGINT") sigintPropAfter = info;
+                });
+                assert.ok(sigintPropAfter);
+                assert.notEqual(symbolIdBefore, getSymbolId(sigintPropAfter![0].symbol));
+            });
+        });
+
+        describe("unittests:: tsserver:: exportMapCache:: project references", () => {
+            const libTsconfig: File = {
+                path: "/packages/lib/tsconfig.json",
+                content: `{
+                    "compilerOptions": {
+                        "composite": true,
+                        "module": "commonjs"
+                    }
+                }`,
+            };
+
+            const libIndex: File = {
+                path: "/packages/lib/index.ts",
+                content: `export const foo = 0;`,
+            };
+
+            const appTsconfig: File = {
+                path: "/packages/app/tsconfig.json",
+                content: `{
+                    "compilerOptions": {
+                        "composite": true,
+                        "module": "commonjs"
+                    },
+                    "references": [
+                        { "path": "../lib" }
+                    ]
+                }`,
+            };
+
+            const appIndex: File = {
+                path: "/packages/app/index.ts",
+                content: `foo`,
+            };
+
+            const setup = createSetup([libTsconfig, libIndex, appTsconfig, appIndex], [appIndex, libIndex], {
+                file: appIndex.path,
+                line: 1,
+                offset: 1,
+            });
+
+            it("does not invalidate the cache when referenced project changes inconsequentially", () => {
+                const { session, project, projectService, exportMapCache } = setup();
+                session.executeCommandSeq<protocol.UpdateOpenRequest>({
+                    command: protocol.CommandTypes.UpdateOpen,
+                    arguments: {
+                        changedFiles: [{
+                            fileName: libIndex.path,
+                            textChanges: [{
+                                newText: "\nfoo.toFixed()",
+                                start: { line: 1, offset: 3 },
+                                end: { line: 1, offset: 3 },
+                            }]
+                        }]
+                    }
+                });
+
+                projectService.findConfiguredProjectByProjectName(libTsconfig.path as server.NormalizedPath)!.getLanguageService(/*ensureSynchronized*/ true);
+                project.getLanguageService(/*ensureSynchronized*/ true);
+                assert.ok(exportMapCache.isUsableByFile(appIndex.path as Path));
+                assert.ok(!exportMapCache.isEmpty());
+            });
+
+            it("invalidates the cache when referenced project changes signatures", () => {
+                const { session, project, projectService, exportMapCache } = setup();
+                session.executeCommandSeq<protocol.UpdateOpenRequest>({
+                    command: protocol.CommandTypes.UpdateOpen,
+                    arguments: {
+                        changedFiles: [{
+                            fileName: libIndex.path,
+                            textChanges: [{
+                                newText: "export const bar = 0;",
+                                start: { line: 1, offset: 1 },
+                                end: { line: 1, offset: 3 },
+                            }]
+                        }]
+                    }
+                });
+
+                projectService.findConfiguredProjectByProjectName(libTsconfig.path as server.NormalizedPath)!.getLanguageService(/*ensureSynchronized*/ true);
+                project.getLanguageService(/*ensureSynchronized*/ true);
+                assert.ok(!exportMapCache.isUsableByFile(appIndex.path as Path));
+                assert.ok(exportMapCache.isEmpty());
+            });
+        });
+
+        function createSetup(files: readonly File[], openFiles: readonly File[], completionRequestLocation: protocol.FileLocationRequestArgs) {
+            return () => {
+                const host = createServerHost(files);
+                const session = createSession(host);
+                executeSessionRequest<protocol.ConfigureRequest, protocol.ConfigureResponse>(session, protocol.CommandTypes.Configure, {
+                    preferences: {
+                        includeProjectReferenceAutoImports: "on",
+                        includeCompletionsForModuleExports: true,
+                        allowIncompleteCompletions: true,
+                    },
+                });
+                openFilesForSession(openFiles, session);
+                const projectService = session.getProjectService();
+                const project = configuredProjectAt(projectService, 0);
+                triggerCompletions();
+                const checker = project.getLanguageService().getProgram()!.getTypeChecker();
+                return { host, project, projectService, session, exportMapCache: project.getCachedExportInfoMap(), checker, triggerCompletions };
+                function triggerCompletions() {
+                    executeSessionRequest<protocol.CompletionsRequest, protocol.CompletionInfoResponse>(session, protocol.CommandTypes.CompletionInfo, {
+                        ...completionRequestLocation,
+                        includeExternalModuleExports: true,
+                        prefix: "foo",
+                    });
+                }
+            };
         }
-    }
+    });
+
 }

--- a/src/testRunner/unittests/tsserver/symlinkCache.ts
+++ b/src/testRunner/unittests/tsserver/symlinkCache.ts
@@ -61,7 +61,7 @@ namespace ts.projectSystem {
         it("works for paths close to the root", () => {
             const cache = createSymlinkCache("/", createGetCanonicalFileName(/*useCaseSensitiveFileNames*/ false));
             // Used to crash, #44953
-            cache.setSymlinksFromResolutions([], new Map([["foo", {
+            cache.setSymlinksFromResolutions(/*projectName*/ undefined, [], new Map([["foo", {
                 primary: true,
                 originalPath: "/foo",
                 resolvedFileName: "/one/two/foo",

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4055,6 +4055,7 @@ declare namespace ts {
         readonly allowTextChangesInNewFiles?: boolean;
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
+        readonly includeProjectReferenceAutoImports?: "on" | "off";
         readonly provideRefactorNotApplicableReason?: boolean;
         readonly jsxAttributeCompletionStyle?: "auto" | "braces" | "none";
     }
@@ -5683,6 +5684,11 @@ declare namespace ts {
         writeFile?(fileName: string, content: string): void;
         getParsedCommandLine?(fileName: string): ParsedCommandLine | undefined;
     }
+    enum AutoImportSourceKind {
+        Program = 1,
+        PackageJson = 2
+    }
+    type AutoImportSource = AutoImportSourceKind | string;
     type WithMetadata<T> = T & {
         metadata?: unknown;
     };
@@ -6388,13 +6394,12 @@ declare namespace ts {
          * in the case of InternalSymbolName.ExportEquals and InternalSymbolName.Default.
          */
         exportName: string;
+        source: AutoImportSource;
         moduleSpecifier?: string;
         /** The file name declaring the export's module symbol, if it was an external module */
         fileName?: string;
         /** The module name (with quotes stripped) of the export's module symbol, if it was an ambient module */
         ambientModuleName?: string;
-        /** True if the export was found in the package.json AutoImportProvider */
-        isPackageJsonImport?: true;
     }
     interface CompletionEntryDataUnresolved extends CompletionEntryDataAutoImport {
         /** The key in the `ExportMapCache` where the completion entry's `SymbolExportInfo[]` is found */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4055,6 +4055,7 @@ declare namespace ts {
         readonly allowTextChangesInNewFiles?: boolean;
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
+        readonly includeProjectReferenceAutoImports?: "on" | "off";
         readonly provideRefactorNotApplicableReason?: boolean;
         readonly jsxAttributeCompletionStyle?: "auto" | "braces" | "none";
     }
@@ -5683,6 +5684,11 @@ declare namespace ts {
         writeFile?(fileName: string, content: string): void;
         getParsedCommandLine?(fileName: string): ParsedCommandLine | undefined;
     }
+    enum AutoImportSourceKind {
+        Program = 1,
+        PackageJson = 2
+    }
+    type AutoImportSource = AutoImportSourceKind | string;
     type WithMetadata<T> = T & {
         metadata?: unknown;
     };
@@ -6388,13 +6394,12 @@ declare namespace ts {
          * in the case of InternalSymbolName.ExportEquals and InternalSymbolName.Default.
          */
         exportName: string;
+        source: AutoImportSource;
         moduleSpecifier?: string;
         /** The file name declaring the export's module symbol, if it was an external module */
         fileName?: string;
         /** The module name (with quotes stripped) of the export's module symbol, if it was an ambient module */
         ambientModuleName?: string;
-        /** True if the export was found in the package.json AutoImportProvider */
-        isPackageJsonImport?: true;
     }
     interface CompletionEntryDataUnresolved extends CompletionEntryDataAutoImport {
         /** The key in the `ExportMapCache` where the completion entry's `SymbolExportInfo[]` is found */

--- a/tests/cases/fourslash/completionsImport_46332.ts
+++ b/tests/cases/fourslash/completionsImport_46332.ts
@@ -82,6 +82,7 @@ verify.applyCodeActionFromCompletion("", {
   source: "vue",
   description: `Update import from "vue"`,
   data: {
+    source: ts.AutoImportSourceKind.Program,
     exportName: "ref",
     fileName: "/node_modules/vue/dist/vue.d.ts",
   },

--- a/tests/cases/fourslash/completionsImport_defaultAndNamedConflict.ts
+++ b/tests/cases/fourslash/completionsImport_defaultAndNamedConflict.ts
@@ -41,7 +41,7 @@ verify.completions({
 verify.applyCodeActionFromCompletion("", {
   name: "someModule",
   source: "/someModule",
-  data: { exportName: "default", fileName: "/someModule.ts" },
+  data: { source: ts.AutoImportSourceKind.Program, exportName: "default", fileName: "/someModule.ts" },
   description: `Add import from "./someModule"`,
   newFileContent: `import someModule from "./someModule";
 

--- a/tests/cases/fourslash/completionsImport_details_withMisspelledName.ts
+++ b/tests/cases/fourslash/completionsImport_details_withMisspelledName.ts
@@ -24,6 +24,7 @@ verify.applyCodeActionFromCompletion("2", {
     name: "abc",
     source: "/a",
     data: {
+        source: ts.AutoImportSourceKind.Program,
         exportName: "abc",
         fileName: "/a.ts",
     },

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -116,6 +116,7 @@ declare module ts {
         ambientModuleName?: string;
         source: AutoImportSource;
         exportName: string;
+        moduleSpecifier?: string;
     }
 
     interface CompilerOptions {
@@ -700,6 +701,7 @@ declare namespace FourSlashInterface {
         readonly sortText?: completion.SortText;
         readonly isPackageJsonImport?: boolean;
         readonly isSnippet?: boolean;
+        readonly data?: ts.CompletionEntryData;
 
         // details
         readonly text?: string;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -104,10 +104,17 @@ declare module ts {
         character: number;
     }
 
+    const enum AutoImportSourceKind {
+        Program = 1,
+        PackageJson,
+    }
+
+    type AutoImportSource = AutoImportSourceKind | string;
+
     interface CompletionEntryData {
         fileName?: string;
         ambientModuleName?: string;
-        isPackageJsonImport?: true;
+        source: AutoImportSource;
         exportName: string;
     }
 
@@ -364,7 +371,7 @@ declare namespace FourSlashInterface {
         fileAfterApplyingRefactorAtMarker(markerName: string, expectedContent: string, refactorNameToApply: string, formattingOptions?: FormatCodeOptions): void;
         getAndApplyCodeFix(errorCode?: number, index?: number): void;
         importFixAtPosition(expectedTextArray: string[], errorCode?: number, options?: UserPreferences): void;
-        importFixModuleSpecifiers(marker: string, moduleSpecifiers: string[]): void;
+        importFixModuleSpecifiers(marker: string, moduleSpecifiers: string[], options?: UserPreferences): void;
 
         navigationBar(json: any, options?: { checkSpans?: boolean }): void;
         navigationTree(json: any, options?: { checkSpans?: boolean }): void;
@@ -654,6 +661,7 @@ declare namespace FourSlashInterface {
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         readonly importModuleSpecifierEnding?: "minimal" | "index" | "js";
         readonly jsxAttributeCompletionStyle?: "auto" | "braces" | "none";
+        readonly includeProjectReferenceAutoImports?: "on" | "off";
     }
     interface InlayHintsOptions extends UserPreferences {
         readonly includeInlayParameterNameHints?: "none" | "literals" | "all";

--- a/tests/cases/fourslash/server/autoImportProjectReferences1.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferences1.ts
@@ -1,0 +1,69 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////     "files": [],
+////     "references": [
+////         { "path": "packages/lib" },
+////         { "path": "packages/app" }
+////     ]
+//// }
+
+// @Filename: /packages/lib/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     }
+//// }
+
+// @Filename: /packages/lib/index.ts
+//// export const x = 0;
+
+// @Filename: /packages/app/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     },
+////     "references": [
+////         { "path": "../lib" }
+////     ]
+//// }
+
+// @Filename: /packages/app/index.ts
+//// x/**/
+
+goTo.marker("");
+verify.importFixModuleSpecifiers("", ["../lib"], { includeProjectReferenceAutoImports: "on" });
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "x",
+    source: "../lib",
+    sourceDisplay: "../lib",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeProjectReferenceAutoImports: "on",
+  },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "x",
+  source: "../lib",
+  description: `Add import from "../lib"`,
+  data: {
+    source: "/packages/lib/tsconfig.json",
+    exportName: "x",
+    fileName: "/packages/lib/index.ts",
+  },
+  newFileContent: `import { x } from "../lib";\r\n\r\nx`,
+  preferences: {
+    includeProjectReferenceAutoImports: "on"
+  }
+});

--- a/tests/cases/fourslash/server/autoImportProjectReferences2.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferences2.ts
@@ -1,0 +1,78 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /packages/lib/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     }
+//// }
+
+// @Filename: /packages/lib/index.ts
+//// export * from "./utils";
+//// export const x = 0;
+
+// @Filename: /packages/lib/utils.ts
+//// export const util = 1;
+
+// @Filename: /packages/app/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     },
+////     "references": [
+////         { "path": "../lib" }
+////     ]
+//// }
+
+// @Filename: /packages/app/utils.ts
+//// import "../lib";
+
+// @Filename: /packages/app/index.ts
+//// util/**/
+
+goTo.marker("");
+
+verify.importFixAtPosition(
+  [
+    `import { util } from "../lib";\r\n\r\nutil`,
+    `import { util } from "../lib/utils";\r\n\r\nutil`
+  ],
+  /*errorCode*/ undefined,
+  { includeProjectReferenceAutoImports: "on" });
+
+const expectedData: ts.CompletionEntryData = {
+  source: ts.AutoImportSourceKind.Program,
+  exportName: "util",
+  fileName: "/packages/lib/index.ts",
+  moduleSpecifier: "../lib"
+};
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "util",
+    source: "../lib",
+    sourceDisplay: "../lib",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+    data: expectedData,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeProjectReferenceAutoImports: "on",
+  },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "util",
+  source: "../lib",
+  description: `Add import from "../lib"`,
+  data: expectedData,
+  newFileContent: `import { util } from "../lib";\r\n\r\nutil`,
+  preferences: {
+    includeProjectReferenceAutoImports: "on"
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProjectReferences3.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferences3.ts
@@ -1,0 +1,71 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /packages/lib/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs",
+////         "baseUrl": "./"
+////     }
+//// }
+
+// @Filename: /packages/lib/foo.ts
+//// export const util = 0;
+
+// @Filename: /packages/app/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     },
+////     "references": [
+////         { "path": "../lib" }
+////     ]
+//// }
+
+// @Filename: /packages/app/index.ts
+//// util/**/
+
+// Ensure referenced project's `baseUrl` doesn't affect module specifier generated
+
+goTo.marker("");
+
+verify.importFixAtPosition(
+  [`import { util } from "../lib/foo";\r\n\r\nutil`],
+  /*errorCode*/ undefined,
+  { includeProjectReferenceAutoImports: "on" });
+
+const expectedData: ts.CompletionEntryData = {
+  source: "/packages/lib/tsconfig.json",
+  exportName: "util",
+  fileName: "/packages/lib/foo.ts",
+  moduleSpecifier: "../lib/foo"
+};
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "util",
+    source: "../lib/foo",
+    sourceDisplay: "../lib/foo",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+    data: expectedData,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeProjectReferenceAutoImports: "on",
+  },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "util",
+  source: "../lib",
+  description: `Add import from "../lib/foo"`,
+  data: expectedData,
+  newFileContent: `import { util } from "../lib/foo";\r\n\r\nutil`,
+  preferences: {
+    includeProjectReferenceAutoImports: "on"
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProjectReferences4.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferences4.ts
@@ -1,0 +1,67 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /packages/lib/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs",
+////         "outDir": "../../node_modules/lib",
+////         "rootDir": "./src"
+////     }
+//// }
+
+// @Filename: /packages/lib/src/index.ts
+//// export const util = 0;
+
+// @Filename: /node_modules/lib/index.d.ts
+//// export const util: number;
+
+// @Filename: /node_modules/lib/package.json
+//// { "name": "lib", "version": "1.0.0", "main": "index.js", "types": "index.d.ts" }
+
+// @Filename: /packages/app/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     },
+////     "references": [
+////         { "path": "../lib" }
+////     ]
+//// }
+
+// @Filename: /packages/app/index.ts
+//// util/**/
+
+// Test that the ModuleSpecifierResolutionHost used for resolving the specifier
+// for a file in the referenced project knows that lib/src/index.ts is a source
+// of a project reference redirect. This test is contrived and bizarre but I
+// I couldn't figure out another way to test this behavior.
+
+goTo.marker("");
+
+verify.importFixAtPosition([
+  `import { util } from "lib";\r\n\r\nutil`,
+], /*errorCode*/ undefined);
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "util",
+    source: "lib",
+    sourceDisplay: "lib",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+    data: {
+      source: "/packages/lib/tsconfig.json",
+      exportName: "util",
+      fileName: "/packages/lib/src/index.ts",
+      moduleSpecifier: "lib"
+    },
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeProjectReferenceAutoImports: "on",
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProjectReferences5.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferences5.ts
@@ -1,0 +1,73 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////     "files": [],
+////     "references": [
+////         { "path": "packages/lib" },
+////         { "path": "packages/app" }
+////     ]
+//// }
+
+// @Filename: /packages/lib/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     }
+//// }
+
+// @Filename: /packages/lib/index.ts
+//// export const x = 0;
+
+// @Filename: /packages/app/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs",
+////         "paths": {
+////             "lib": ["../lib/index.ts"],
+////             "lib/*": ["../lib/*"]
+////         }
+////     },
+////     "references": [
+////         { "path": "../lib" }
+////     ]
+//// }
+
+// @Filename: /packages/app/index.ts
+//// x/**/
+
+goTo.marker("");
+verify.importFixModuleSpecifiers("", ["lib"], { includeProjectReferenceAutoImports: "on" });
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "x",
+    source: "lib",
+    sourceDisplay: "lib",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeProjectReferenceAutoImports: "on",
+  },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "x",
+  source: "lib",
+  description: `Add import from "lib"`,
+  data: {
+    source: "/packages/lib/tsconfig.json",
+    exportName: "x",
+    fileName: "/packages/lib/index.ts",
+  },
+  newFileContent: `import { x } from "lib";\r\n\r\nx`,
+  preferences: {
+    includeProjectReferenceAutoImports: "on"
+  }
+});

--- a/tests/cases/fourslash/server/autoImportProjectReferences6.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferences6.ts
@@ -1,0 +1,74 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////     "files": [],
+////     "references": [
+////         { "path": "packages/lib" },
+////         { "path": "packages/app" }
+////     ]
+//// }
+
+// @Filename: /packages/lib/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs",
+////         "rootDir": "src",
+////         "outDir": "dist"
+////     }
+//// }
+
+// @Filename: /packages/lib/src/index.ts
+//// export const x = 0;
+
+// @Filename: /packages/lib/dist/index.d.ts
+//// export declare const x: number;
+
+// @Filename: /packages/app/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     },
+////     "references": [
+////         { "path": "../lib" }
+////     ]
+//// }
+
+// @Filename: /packages/app/index.ts
+//// x/**/
+
+goTo.marker("");
+verify.importFixModuleSpecifiers("", ["../lib/src"], { includeProjectReferenceAutoImports: "on" });
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "x",
+    source: "../lib/src",
+    sourceDisplay: "../lib/src",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeProjectReferenceAutoImports: "on",
+  },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "x",
+  source: "../lib/src",
+  description: `Add import from "../lib/src"`,
+  data: {
+    source: "/packages/lib/tsconfig.json",
+    exportName: "x",
+    fileName: "/packages/lib/src/index.ts",
+  },
+  newFileContent: `import { x } from "../lib/src";\r\n\r\nx`,
+  preferences: {
+    includeProjectReferenceAutoImports: "on"
+  }
+});

--- a/tests/cases/fourslash/server/autoImportProjectReferences7.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferences7.ts
@@ -1,0 +1,78 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////     "files": [],
+////     "references": [
+////         { "path": "packages/lib" },
+////         { "path": "packages/app" }
+////     ]
+//// }
+
+// @Filename: /packages/lib/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs",
+////         "rootDir": "src",
+////         "outDir": "dist"
+////     }
+//// }
+
+// @Filename: /packages/lib/src/index.ts
+//// export const x = 0;
+
+// @Filename: /packages/lib/dist/index.d.ts
+//// export declare const x: number;
+
+// @Filename: /packages/app/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs",
+////         "disableSourceOfProjectReferenceRedirect": true
+////     },
+////     "references": [
+////         { "path": "../lib" }
+////     ]
+//// }
+
+// @Filename: /packages/app/other.ts
+//// import "../lib/dist";
+
+// @Filename: /packages/app/index.ts
+//// x/**/
+
+goTo.marker("");
+verify.importFixModuleSpecifiers("", ["../lib/dist"], { includeProjectReferenceAutoImports: "on" });
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "x",
+    source: "../lib/dist",
+    sourceDisplay: "../lib/dist",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeProjectReferenceAutoImports: "on",
+  },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "x",
+  source: "../lib/dist",
+  description: `Add import from "../lib/dist"`,
+  data: {
+    source: ts.AutoImportSourceKind.Program,
+    exportName: "x",
+    fileName: "/packages/lib/dist/index.d.ts",
+  },
+  newFileContent: `import { x } from "../lib/dist";\r\n\r\nx`,
+  preferences: {
+    includeProjectReferenceAutoImports: "on"
+  }
+});

--- a/tests/cases/fourslash/server/autoImportProvider7.ts
+++ b/tests/cases/fourslash/server/autoImportProvider7.ts
@@ -53,6 +53,7 @@ verify.applyCodeActionFromCompletion("1", {
   source: "mylib",
   description: `Add import from "mylib"`,
   data: {
+    source: ts.AutoImportSourceKind.Program,
     exportName: "MyClass",
     fileName: "/packages/mylib/index.ts",
   },

--- a/tests/cases/fourslash/server/autoImportProvider8.ts
+++ b/tests/cases/fourslash/server/autoImportProvider8.ts
@@ -53,6 +53,7 @@ verify.applyCodeActionFromCompletion("1", {
   source: "mylib",
   description: `Add import from "mylib"`,
   data: {
+    source: ts.AutoImportSourceKind.Program,
     exportName: "MyClass",
     fileName: "/packages/mylib/index.ts",
   },

--- a/tests/cases/fourslash/server/autoImportProvider9.ts
+++ b/tests/cases/fourslash/server/autoImportProvider9.ts
@@ -1,0 +1,98 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /packages/lib/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs",
+////         "outDir": "./dist",
+////         "rootDir": "./src"
+////     }
+//// }
+
+// @Filename: /packages/lib/package.json
+//// {
+////     "name": "lib",
+////     "version": "1.0.0",
+////     "main": "dist/index.js",
+////     "types": "dist/index.d.ts"
+//// }
+
+// @Filename: /packages/lib/dist/index.js
+//// module.exports.util = 0;
+
+// @Filename: /packages/lib/dist/index.d.ts
+//// export const util: number;
+
+// @Filename: /packages/lib/src/index.ts
+//// export const util = 0;
+
+// @link: /packages/lib -> /node_modules/lib
+
+// @Filename: /node_modules/make-me-discover-a-symlink/package.json
+//// { "name": "make-me-discover-a-symlink", "version": "1.0.0" }
+
+// @Filename: /node_modules/make-me-discover-a-symlink/index.d.ts
+//// /// <reference types="lib" />
+
+// @Filename: /packages/app/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     },
+////     "references": [
+////         { "path": "../lib" }
+////     ]
+//// }
+
+// @Filename: /packages/app/package.json
+//// { "dependencies": { "make-me-discover-a-symlink": "*" } }
+
+// @Filename: /packages/app/index.ts
+//// util/**/
+
+// Test that the ModuleSpecifierResolutionHost used for resolving the specifier
+// for a file in the referenced project knows that lib/src/index.ts is a source
+// of a project reference redirect.
+
+goTo.marker("");
+
+verify.importFixAtPosition(
+  [`import { util } from "lib";\r\n\r\nutil`],
+  /*errorCode*/ undefined);
+
+const expectedData: ts.CompletionEntryData = {
+  source: ts.AutoImportSourceKind.PackageJson,
+  exportName: "util",
+  fileName: "/packages/lib/src/index.ts",
+  moduleSpecifier: "lib"
+};
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "util",
+    source: "lib",
+    sourceDisplay: "lib",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+    data: expectedData,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeProjectReferenceAutoImports: "on",
+  },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "util",
+  source: "../lib",
+  description: `Add import from "lib"`,
+  data: expectedData,
+  newFileContent: `import { util } from "lib";\r\n\r\nutil`,
+  preferences: {
+    includeProjectReferenceAutoImports: "on"
+  },
+});

--- a/tests/cases/fourslash/server/autoImportProvider_projectReferences1.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_projectReferences1.ts
@@ -1,0 +1,40 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////     "files": [],
+////     "references": [
+////         { "path": "packages/lib" },
+////         { "path": "packages/app" }
+////     ]
+//// }
+
+// @Filename: /packages/lib/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     }
+//// }
+
+// @Filename: /packages/lib/index.ts
+//// export const x = 0;
+
+// @Filename: /packages/app/tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "composite": true,
+////         "module": "commonjs"
+////     },
+////     "references": [
+////         { "path": "../lib" }
+////     ]
+//// }
+
+// @Filename: /packages/app/index.ts
+//// x/**/
+
+goTo.marker("");
+verify.importFixModuleSpecifiers("", ["../lib"]);
+
+verify.completions()

--- a/tests/cases/fourslash/server/autoImportProvider_projectReferences1.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_projectReferences1.ts
@@ -35,6 +35,35 @@
 //// x/**/
 
 goTo.marker("");
-verify.importFixModuleSpecifiers("", ["../lib"]);
+verify.importFixModuleSpecifiers("", ["../lib"], { includeProjectReferenceAutoImports: "on" });
 
-verify.completions()
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus([{
+    name: "x",
+    source: "../lib",
+    sourceDisplay: "../lib",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeProjectReferenceAutoImports: "on",
+  },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "x",
+  source: "../lib",
+  description: `Add import from "../lib"`,
+  data: {
+    source: "/packages/lib/tsconfig.json",
+    exportName: "x",
+    fileName: "/packages/lib/index.ts",
+  },
+  newFileContent: `import { x } from "../lib";\r\n\r\nx`,
+  preferences: {
+    includeProjectReferenceAutoImports: "on"
+  }
+});

--- a/tests/cases/fourslash/server/completionsImport_addToNamedWithDifferentCacheValue.ts
+++ b/tests/cases/fourslash/server/completionsImport_addToNamedWithDifferentCacheValue.ts
@@ -54,6 +54,7 @@ verify.applyCodeActionFromCompletion("1", {
   source: "../packages/mylib",
   description: `Add import from "../packages/mylib"`,
   data: {
+    source: ts.AutoImportSourceKind.Program,
     exportName: "MyClass",
     fileName: "/packages/mylib/index.ts",
   },

--- a/tests/cases/fourslash/server/completionsImport_defaultAndNamedConflict_server.ts
+++ b/tests/cases/fourslash/server/completionsImport_defaultAndNamedConflict_server.ts
@@ -44,7 +44,7 @@ verify.completions({
 verify.applyCodeActionFromCompletion("", {
   name: "someModule",
   source: "/someModule",
-  data: { exportName: "default", fileName: "/someModule.ts" },
+  data: { source: ts.AutoImportSourceKind.Program, exportName: "default", fileName: "/someModule.ts" },
   description: `Add import from "./someModule"`,
   newFileContent: `import someModule from "./someModule";\r\n\r\nsomeMo`
 });

--- a/tests/cases/fourslash/server/completionsImport_jsModuleExportsAssignment.ts
+++ b/tests/cases/fourslash/server/completionsImport_jsModuleExportsAssignment.ts
@@ -48,6 +48,7 @@ verify.applyCodeActionFromCompletion("", {
   source: "/third_party/marked/src/defaults",
   description: `Add import from "./third_party/marked/src/defaults"`,
   data: {
+    source: ts.AutoImportSourceKind.Program,
     exportName: "defaults",
     fileName: "/third_party/marked/src/defaults.js",
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Still to-do:

- [x] Deduplicate files from multiple programs
  - [x] How does this change based on `useSourceOfProjectReferenceRedirect`? Are there cases where the main program will directly contain `.d.ts` outputs but the referenced project will show us equivalent `.ts` inputs?
- [x] Audit which program should be used to create the module specifier resolution host—it probably should be the main program (look at `paths`)
- [ ] Test cache invalidation (I think it should be working without changes based on conversation with @amcasey. If it doesn’t, this PR is likely not worth it.)
- [ ] Consider limiting how many total files/projects we put into the ExportInfoMap
- [x] Test `paths` module specifier resolution
- [ ] Add perf telemetry

Fixes #39778
