### PR TITLE
Triple-slash reference type directives can override the import mode used for their resolution

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -42120,11 +42120,11 @@ namespace ts {
             // this variable and functions that use it are deliberately moved here from the outer scope
             // to avoid scope pollution
             const resolvedTypeReferenceDirectives = host.getResolvedTypeReferenceDirectives();
-            let fileToDirective: ESMap<string, string>;
+            let fileToDirective: ESMap<string, [specifier: string, mode: SourceFile["impliedNodeFormat"] | undefined]>;
             if (resolvedTypeReferenceDirectives) {
                 // populate reverse mapping: file path -> type reference directive that was resolved to this file
-                fileToDirective = new Map<string, string>();
-                resolvedTypeReferenceDirectives.forEach((resolvedDirective, key) => {
+                fileToDirective = new Map<string, [specifier: string, mode: SourceFile["impliedNodeFormat"] | undefined]>();
+                resolvedTypeReferenceDirectives.forEach((resolvedDirective, key, mode) => {
                     if (!resolvedDirective || !resolvedDirective.resolvedFileName) {
                         return;
                     }
@@ -42132,7 +42132,7 @@ namespace ts {
                     if (file) {
                         // Add the transitive closure of path references loaded by this file (as long as they are not)
                         // part of an existing type reference.
-                        addReferencedFilesToTypeDirective(file, key);
+                        addReferencedFilesToTypeDirective(file, key, mode);
                     }
                 });
             }
@@ -42255,7 +42255,7 @@ namespace ts {
             }
 
             // defined here to avoid outer scope pollution
-            function getTypeReferenceDirectivesForEntityName(node: EntityNameOrEntityNameExpression): string[] | undefined {
+            function getTypeReferenceDirectivesForEntityName(node: EntityNameOrEntityNameExpression): [specifier: string, mode: SourceFile["impliedNodeFormat"] | undefined][] | undefined {
                 // program does not have any files with type reference directives - bail out
                 if (!fileToDirective) {
                     return undefined;
@@ -42273,13 +42273,13 @@ namespace ts {
             }
 
             // defined here to avoid outer scope pollution
-            function getTypeReferenceDirectivesForSymbol(symbol: Symbol, meaning?: SymbolFlags): string[] | undefined {
+            function getTypeReferenceDirectivesForSymbol(symbol: Symbol, meaning?: SymbolFlags): [specifier: string, mode: SourceFile["impliedNodeFormat"] | undefined][] | undefined {
                 // program does not have any files with type reference directives - bail out
                 if (!fileToDirective || !isSymbolFromTypeDeclarationFile(symbol)) {
                     return undefined;
                 }
                 // check what declarations in the symbol can contribute to the target meaning
-                let typeReferenceDirectives: string[] | undefined;
+                let typeReferenceDirectives: [specifier: string, mode: SourceFile["impliedNodeFormat"] | undefined][] | undefined;
                 for (const decl of symbol.declarations!) {
                     // check meaning of the local symbol to see if declaration needs to be analyzed further
                     if (decl.symbol && decl.symbol.flags & meaning!) {
@@ -42330,14 +42330,14 @@ namespace ts {
                 return false;
             }
 
-            function addReferencedFilesToTypeDirective(file: SourceFile, key: string) {
+            function addReferencedFilesToTypeDirective(file: SourceFile, key: string, mode: SourceFile["impliedNodeFormat"] | undefined) {
                 if (fileToDirective.has(file.path)) return;
-                fileToDirective.set(file.path, key);
-                for (const { fileName } of file.referencedFiles) {
+                fileToDirective.set(file.path, [key, mode]);
+                for (const { fileName, resolutionMode } of file.referencedFiles) {
                     const resolvedFile = resolveTripleslashReference(fileName, file.fileName);
                     const referencedFile = host.getSourceFile(resolvedFile);
                     if (referencedFile) {
-                        addReferencedFilesToTypeDirective(referencedFile, key);
+                        addReferencedFilesToTypeDirective(referencedFile, key, resolutionMode || file.impliedNodeFormat);
                     }
                 }
             }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1400,6 +1400,14 @@
         "category": "Error",
         "code": 1451
     },
+    "Resolution modes are only supported when `moduleResolution` is `node12` or `nodenext`.": {
+        "category": "Error",
+        "code": 1452
+    },
+    "`resolution-mode` should be either `require` or `import`.": {
+        "category": "Error",
+        "code": 1453
+    },
 
     "The 'import.meta' meta-property is not allowed in files which will build into CommonJS output.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3993,8 +3993,10 @@ namespace ts {
             }
             for (const directive of types) {
                 const pos = writer.getTextPos();
-                // Should we elide `resolution-mode` if it matches the mode the currentSourceFile defaults to?
-                writeComment(`/// <reference types="${directive.fileName}" ${directive.resolutionMode && directive.resolutionMode !== currentSourceFile?.impliedNodeFormat ? `resolution-mode="${directive.resolutionMode === ModuleKind.ESNext ? "import" : "require"}"` : ""}/>`);
+                const resolutionMode = directive.resolutionMode && directive.resolutionMode !== currentSourceFile?.impliedNodeFormat
+                    ? `resolution-mode="${directive.resolutionMode === ModuleKind.ESNext ? "import" : "require"}"`
+                    : "";
+                writeComment(`/// <reference types="${directive.fileName}" ${resolutionMode}/>`);
                 if (bundleFileInfo) bundleFileInfo.sections.push({ pos, end: writer.getTextPos(), kind: !directive.resolutionMode ? BundleFileSectionKind.Type : directive.resolutionMode === ModuleKind.ESNext ? BundleFileSectionKind.TypeResolutionModeImport : BundleFileSectionKind.TypeResolutionModeRequire, data: directive.fileName });
                 writeLine();
             }

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3993,8 +3993,9 @@ namespace ts {
             }
             for (const directive of types) {
                 const pos = writer.getTextPos();
-                writeComment(`/// <reference types="${directive.fileName}" />`);
-                if (bundleFileInfo) bundleFileInfo.sections.push({ pos, end: writer.getTextPos(), kind: BundleFileSectionKind.Type, data: directive.fileName });
+                // Should we elide `resolution-mode` if it matches the mode the currentSourceFile defaults to?
+                writeComment(`/// <reference types="${directive.fileName}" ${directive.resolutionMode ? `resolution-mode="${directive.resolutionMode === ModuleKind.ESNext ? "import" : "require"}"` : ""}/>`);
+                if (bundleFileInfo) bundleFileInfo.sections.push({ pos, end: writer.getTextPos(), kind: !directive.resolutionMode ? BundleFileSectionKind.Type : directive.resolutionMode === ModuleKind.ESNext ? BundleFileSectionKind.TypeResolutionModeImport : BundleFileSectionKind.TypeResolutionModeRequire, data: directive.fileName });
                 writeLine();
             }
             for (const directive of libs) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3994,7 +3994,7 @@ namespace ts {
             for (const directive of types) {
                 const pos = writer.getTextPos();
                 // Should we elide `resolution-mode` if it matches the mode the currentSourceFile defaults to?
-                writeComment(`/// <reference types="${directive.fileName}" ${directive.resolutionMode ? `resolution-mode="${directive.resolutionMode === ModuleKind.ESNext ? "import" : "require"}"` : ""}/>`);
+                writeComment(`/// <reference types="${directive.fileName}" ${directive.resolutionMode && directive.resolutionMode !== currentSourceFile?.impliedNodeFormat ? `resolution-mode="${directive.resolutionMode === ModuleKind.ESNext ? "import" : "require"}"` : ""}/>`);
                 if (bundleFileInfo) bundleFileInfo.sections.push({ pos, end: writer.getTextPos(), kind: !directive.resolutionMode ? BundleFileSectionKind.Type : directive.resolutionMode === ModuleKind.ESNext ? BundleFileSectionKind.TypeResolutionModeImport : BundleFileSectionKind.TypeResolutionModeRequire, data: directive.fileName });
                 writeLine();
             }

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -6414,7 +6414,7 @@ namespace ts {
         let prologues: UnparsedPrologue[] | undefined;
         let helpers: UnscopedEmitHelper[] | undefined;
         let referencedFiles: FileReference[] | undefined;
-        let typeReferenceDirectives: string[] | undefined;
+        let typeReferenceDirectives: FileReference[] | undefined;
         let libReferenceDirectives: FileReference[] | undefined;
         let prependChildren: UnparsedTextLike[] | undefined;
         let texts: UnparsedSourceText[] | undefined;
@@ -6435,7 +6435,13 @@ namespace ts {
                     referencedFiles = append(referencedFiles, { pos: -1, end: -1, fileName: section.data });
                     break;
                 case BundleFileSectionKind.Type:
-                    typeReferenceDirectives = append(typeReferenceDirectives, section.data);
+                    typeReferenceDirectives = append(typeReferenceDirectives, { pos: -1, end: -1, fileName: section.data });
+                    break;
+                case BundleFileSectionKind.TypeResolutionModeImport:
+                    typeReferenceDirectives = append(typeReferenceDirectives, { pos: -1, end: -1, fileName: section.data, resolutionMode: ModuleKind.ESNext });
+                    break;
+                case BundleFileSectionKind.TypeResolutionModeRequire:
+                    typeReferenceDirectives = append(typeReferenceDirectives, { pos: -1, end: -1, fileName: section.data, resolutionMode: ModuleKind.CommonJS });
                     break;
                 case BundleFileSectionKind.Lib:
                     libReferenceDirectives = append(libReferenceDirectives, { pos: -1, end: -1, fileName: section.data });
@@ -6496,6 +6502,8 @@ namespace ts {
                 case BundleFileSectionKind.NoDefaultLib:
                 case BundleFileSectionKind.Reference:
                 case BundleFileSectionKind.Type:
+                case BundleFileSectionKind.TypeResolutionModeImport:
+                case BundleFileSectionKind.TypeResolutionModeRequire:
                 case BundleFileSectionKind.Lib:
                     syntheticReferences = append(syntheticReferences, setTextRange(factory.createUnparsedSyntheticReference(section), section));
                     break;

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -347,7 +347,7 @@ namespace ts {
         // are present in a non-modal project; while in theory we'd like to either ignore the mode or provide faithful modern resolution, depending on what we feel is best,
         // in practice, not every cache has the options available to intelligently make the choice to ignore the mode request, and it's unclear how modern "faithful modern
         // resolution" should be (`node12`? `nodenext`?). As such, witnessing a mode-overriding triple-slash reference in a non-modal module resolution
-        // context should _probably_ be an error - and that should likely be handled by the `Program`.
+        // context should _probably_ be an error - and that should likely be handled by the `Program` (which is what we do).
         if (resolutionMode === ModuleKind.ESNext && (getEmitModuleResolutionKind(options) === ModuleResolutionKind.Node12 || getEmitModuleResolutionKind(options) === ModuleResolutionKind.NodeNext)) {
             features |= NodeResolutionFeatures.EsmMode;
         }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -9305,6 +9305,20 @@ namespace ts {
         moduleName?: string;
     }
 
+    function parseResolutionMode(mode: string | undefined, pos: number, end: number, reportDiagnostic: PragmaDiagnosticReporter): ModuleKind.ESNext | ModuleKind.CommonJS | undefined {
+        if (!mode) {
+            return undefined;
+        }
+        if (mode === "import") {
+            return ModuleKind.ESNext;
+        }
+        if (mode === "require") {
+            return ModuleKind.CommonJS;
+        }
+        reportDiagnostic(pos, end - pos, Diagnostics.resolution_mode_should_be_either_require_or_import);
+        return undefined;
+    }
+
     /*@internal*/
     export function processCommentPragmas(context: PragmaContext, sourceText: string): void {
         const pragmas: PragmaPseudoMapEntry[] = [];
@@ -9350,12 +9364,13 @@ namespace ts {
                     const typeReferenceDirectives = context.typeReferenceDirectives;
                     const libReferenceDirectives = context.libReferenceDirectives;
                     forEach(toArray(entryOrList) as PragmaPseudoMap["reference"][], arg => {
-                        const { types, lib, path } = arg.arguments;
+                        const { types, lib, path, ["resolution-mode"]: res } = arg.arguments;
                         if (arg.arguments["no-default-lib"]) {
                             context.hasNoDefaultLib = true;
                         }
                         else if (types) {
-                            typeReferenceDirectives.push({ pos: types.pos, end: types.end, fileName: types.value });
+                            const parsed = parseResolutionMode(res, types.pos, types.end, reportDiagnostic);
+                            typeReferenceDirectives.push({ pos: types.pos, end: types.end, fileName: types.value, ...(parsed ? { resolutionMode: parsed } : {}) });
                         }
                         else if (lib) {
                             libReferenceDirectives.push({ pos: lib.pos, end: lib.end, fileName: lib.value });

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -510,7 +510,7 @@ namespace ts {
     }
 
     /* @internal */
-    export function loadWithLocalCache<T>(names: string[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, loader: (name: string, containingFile: string, redirectedReference: ResolvedProjectReference | undefined) => T): T[] {
+    export function loadWithTypeDirectiveCache<T>(names: string[] | readonly FileReference[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, containingFileMode: SourceFile["impliedNodeFormat"], loader: (name: string, containingFile: string, redirectedReference: ResolvedProjectReference | undefined, resolutionMode: SourceFile["impliedNodeFormat"]) => T): T[] {
         if (names.length === 0) {
             return [];
         }
@@ -518,11 +518,15 @@ namespace ts {
         const cache = new Map<string, T>();
         for (const name of names) {
             let result: T;
-            if (cache.has(name)) {
-                result = cache.get(name)!;
+            const mode = (!isString(name) ? name.resolutionMode : undefined) || containingFileMode;
+            // We lower-case all type references because npm automatically lowercases all packages. See GH#9824.
+            const strName = isString(name) ? name : name.fileName.toLowerCase();
+            const cacheKey = mode !== undefined ? `${mode}|${strName}` : strName;
+            if (cache.has(cacheKey)) {
+                result = cache.get(cacheKey)!;
             }
             else {
-                cache.set(name, result = loader(name, containingFile, redirectedReference));
+                cache.set(cacheKey, result = loader(strName, containingFile, redirectedReference, mode));
             }
             resolutions.push(result);
         }
@@ -671,7 +675,7 @@ namespace ts {
     export function getReferencedFileLocation(getSourceFileByPath: (path: Path) => SourceFile | undefined, ref: ReferencedFile): ReferenceFileLocation | SyntheticReferenceFileLocation {
         const file = Debug.checkDefined(getSourceFileByPath(ref.file));
         const { kind, index } = ref;
-        let pos: number | undefined, end: number | undefined, packageId: PackageId | undefined;
+        let pos: number | undefined, end: number | undefined, packageId: PackageId | undefined, resolutionMode: FileReference["resolutionMode"] | undefined;
         switch (kind) {
             case FileIncludeKind.Import:
                 const importLiteral = getModuleNameStringLiteralAt(file, index);
@@ -684,8 +688,8 @@ namespace ts {
                 ({ pos, end } = file.referencedFiles[index]);
                 break;
             case FileIncludeKind.TypeReferenceDirective:
-                ({ pos, end } = file.typeReferenceDirectives[index]);
-                packageId = file.resolvedTypeReferenceDirectiveNames?.get(toFileNameLowerCase(file.typeReferenceDirectives[index].fileName), file.impliedNodeFormat)?.packageId;
+                ({ pos, end, resolutionMode } = file.typeReferenceDirectives[index]);
+                packageId = file.resolvedTypeReferenceDirectiveNames?.get(toFileNameLowerCase(file.typeReferenceDirectives[index].fileName), resolutionMode || file.impliedNodeFormat)?.packageId;
                 break;
             case FileIncludeKind.LibReferenceDirective:
                 ({ pos, end } = file.libReferenceDirectives[index]);
@@ -977,7 +981,7 @@ namespace ts {
         const cachedBindAndCheckDiagnosticsForFile: DiagnosticCache<Diagnostic> = {};
         const cachedDeclarationDiagnosticsForFile: DiagnosticCache<DiagnosticWithLocation> = {};
 
-        let resolvedTypeReferenceDirectives = new Map<string, ResolvedTypeReferenceDirective | undefined>();
+        let resolvedTypeReferenceDirectives = createModeAwareCache<ResolvedTypeReferenceDirective | undefined>();
         let fileProcessingDiagnostics: FilePreprocessingDiagnostics[] | undefined;
 
         // The below settings are to track if a .js file should be add to the program if loaded via searching under node_modules.
@@ -1037,21 +1041,22 @@ namespace ts {
             actualResolveModuleNamesWorker = (moduleNames, containingFile, containingFileName, _reusedNames, redirectedReference) => loadWithModeAwareCache<ResolvedModuleFull>(Debug.checkEachDefined(moduleNames), containingFile, containingFileName, redirectedReference, loader);
         }
 
-        let actualResolveTypeReferenceDirectiveNamesWorker: (typeDirectiveNames: string[], containingFile: string, redirectedReference?: ResolvedProjectReference) => (ResolvedTypeReferenceDirective | undefined)[];
+        let actualResolveTypeReferenceDirectiveNamesWorker: (typeDirectiveNames: string[] | readonly FileReference[], containingFile: string, redirectedReference?: ResolvedProjectReference, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined) => (ResolvedTypeReferenceDirective | undefined)[];
         if (host.resolveTypeReferenceDirectives) {
-            actualResolveTypeReferenceDirectiveNamesWorker = (typeDirectiveNames, containingFile, redirectedReference) => host.resolveTypeReferenceDirectives!(Debug.checkEachDefined(typeDirectiveNames), containingFile, redirectedReference, options);
+            actualResolveTypeReferenceDirectiveNamesWorker = (typeDirectiveNames, containingFile, redirectedReference, containingFileMode) => host.resolveTypeReferenceDirectives!(Debug.checkEachDefined(typeDirectiveNames), containingFile, redirectedReference, options, containingFileMode);
         }
         else {
             typeReferenceDirectiveResolutionCache = createTypeReferenceDirectiveResolutionCache(currentDirectory, getCanonicalFileName, /*options*/ undefined, moduleResolutionCache?.getPackageJsonInfoCache());
-            const loader = (typesRef: string, containingFile: string, redirectedReference: ResolvedProjectReference | undefined) => resolveTypeReferenceDirective(
+            const loader = (typesRef: string, containingFile: string, redirectedReference: ResolvedProjectReference | undefined, resolutionMode: SourceFile["impliedNodeFormat"] | undefined) => resolveTypeReferenceDirective(
                 typesRef,
                 containingFile,
                 options,
                 host,
                 redirectedReference,
                 typeReferenceDirectiveResolutionCache,
+                resolutionMode,
             ).resolvedTypeReferenceDirective!; // TODO: GH#18217
-            actualResolveTypeReferenceDirectiveNamesWorker = (typeReferenceDirectiveNames, containingFile, redirectedReference) => loadWithLocalCache<ResolvedTypeReferenceDirective>(Debug.checkEachDefined(typeReferenceDirectiveNames), containingFile, redirectedReference, loader);
+            actualResolveTypeReferenceDirectiveNamesWorker = (typeReferenceDirectiveNames, containingFile, redirectedReference, containingFileMode) => loadWithTypeDirectiveCache<ResolvedTypeReferenceDirective>(Debug.checkEachDefined(typeReferenceDirectiveNames), containingFile, redirectedReference, containingFileMode, loader);
         }
 
         // Map from a stringified PackageId to the source file with that id.
@@ -1154,7 +1159,8 @@ namespace ts {
                 const containingFilename = combinePaths(containingDirectory, inferredTypesContainingFile);
                 const resolutions = resolveTypeReferenceDirectiveNamesWorker(typeReferences, containingFilename);
                 for (let i = 0; i < typeReferences.length; i++) {
-                    processTypeReferenceDirective(typeReferences[i], resolutions[i], { kind: FileIncludeKind.AutomaticTypeDirectiveFile, typeReference: typeReferences[i], packageId: resolutions[i]?.packageId });
+                    // under node12/nodenext module resolution, load `types`/ata include names as cjs resolution results by passing an `undefined` mode
+                    processTypeReferenceDirective(typeReferences[i], /*mode*/ undefined, resolutions[i], { kind: FileIncludeKind.AutomaticTypeDirectiveFile, typeReference: typeReferences[i], packageId: resolutions[i]?.packageId });
                 }
                 tracing?.pop();
             }
@@ -1322,13 +1328,14 @@ namespace ts {
             return result;
         }
 
-        function resolveTypeReferenceDirectiveNamesWorker(typeDirectiveNames: string[], containingFile: string | SourceFile): readonly (ResolvedTypeReferenceDirective | undefined)[] {
+        function resolveTypeReferenceDirectiveNamesWorker(typeDirectiveNames: string[] | readonly FileReference[], containingFile: string | SourceFile): readonly (ResolvedTypeReferenceDirective | undefined)[] {
             if (!typeDirectiveNames.length) return [];
             const containingFileName = !isString(containingFile) ? getNormalizedAbsolutePath(containingFile.originalFileName, currentDirectory) : containingFile;
             const redirectedReference = !isString(containingFile) ? getRedirectReferenceForResolution(containingFile) : undefined;
+            const containingFileMode = !isString(containingFile) ? containingFile.impliedNodeFormat : undefined;
             tracing?.push(tracing.Phase.Program, "resolveTypeReferenceDirectiveNamesWorker", { containingFileName });
             performance.mark("beforeResolveTypeReference");
-            const result = actualResolveTypeReferenceDirectiveNamesWorker(typeDirectiveNames, containingFileName, redirectedReference);
+            const result = actualResolveTypeReferenceDirectiveNamesWorker(typeDirectiveNames, containingFileName, redirectedReference, containingFileMode);
             performance.mark("afterResolveTypeReference");
             performance.measure("ResolveTypeReference", "beforeResolveTypeReference", "afterResolveTypeReference");
             tracing?.pop();
@@ -1766,8 +1773,7 @@ namespace ts {
                 else {
                     newSourceFile.resolvedModules = oldSourceFile.resolvedModules;
                 }
-                // We lower-case all type references because npm automatically lowercases all packages. See GH#9824.
-                const typesReferenceDirectives = map(newSourceFile.typeReferenceDirectives, ref => toFileNameLowerCase(ref.fileName));
+                const typesReferenceDirectives = newSourceFile.typeReferenceDirectives;
                 const typeReferenceResolutions = resolveTypeReferenceDirectiveNamesWorker(typesReferenceDirectives, newSourceFile);
                 // ensure that types resolutions are still correct
                 const typeReferenceResolutionsChanged = hasChangesInResolutions(typesReferenceDirectives, typeReferenceResolutions, oldSourceFile.resolvedTypeReferenceDirectiveNames, oldSourceFile, typeDirectiveIsEqualTo);
@@ -3002,8 +3008,7 @@ namespace ts {
         }
 
         function processTypeReferenceDirectives(file: SourceFile) {
-            // We lower-case all type references because npm automatically lowercases all packages. See GH#9824.
-            const typeDirectives = map(file.typeReferenceDirectives, ref => toFileNameLowerCase(ref.fileName));
+            const typeDirectives = file.typeReferenceDirectives;
             if (!typeDirectives) {
                 return;
             }
@@ -3015,28 +3020,34 @@ namespace ts {
                 // store resolved type directive on the file
                 const fileName = toFileNameLowerCase(ref.fileName);
                 setResolvedTypeReferenceDirective(file, fileName, resolvedTypeReferenceDirective);
-                processTypeReferenceDirective(fileName, resolvedTypeReferenceDirective, { kind: FileIncludeKind.TypeReferenceDirective, file: file.path, index, });
+                const mode = ref.resolutionMode || file.impliedNodeFormat;
+                if (mode && getEmitModuleResolutionKind(options) !== ModuleResolutionKind.Node12 && getEmitModuleResolutionKind(options) !== ModuleResolutionKind.NodeNext) {
+                    programDiagnostics.add(createDiagnosticForRange(file, ref, Diagnostics.Resolution_modes_are_only_supported_when_moduleResolution_is_node12_or_nodenext));
+                }
+                processTypeReferenceDirective(fileName, mode, resolvedTypeReferenceDirective, { kind: FileIncludeKind.TypeReferenceDirective, file: file.path, index, });
             }
         }
 
         function processTypeReferenceDirective(
             typeReferenceDirective: string,
+            mode: SourceFile["impliedNodeFormat"] | undefined,
             resolvedTypeReferenceDirective: ResolvedTypeReferenceDirective | undefined,
             reason: FileIncludeReason
         ): void {
             tracing?.push(tracing.Phase.Program, "processTypeReferenceDirective", { directive: typeReferenceDirective, hasResolved: !!resolveModuleNamesReusingOldState, refKind: reason.kind, refPath: isReferencedFile(reason) ? reason.file : undefined });
-            processTypeReferenceDirectiveWorker(typeReferenceDirective, resolvedTypeReferenceDirective, reason);
+            processTypeReferenceDirectiveWorker(typeReferenceDirective, mode, resolvedTypeReferenceDirective, reason);
             tracing?.pop();
         }
 
         function processTypeReferenceDirectiveWorker(
             typeReferenceDirective: string,
+            mode: SourceFile["impliedNodeFormat"] | undefined,
             resolvedTypeReferenceDirective: ResolvedTypeReferenceDirective | undefined,
             reason: FileIncludeReason
         ): void {
 
             // If we already found this library as a primary reference - nothing to do
-            const previousResolution = resolvedTypeReferenceDirectives.get(typeReferenceDirective);
+            const previousResolution = resolvedTypeReferenceDirectives.get(typeReferenceDirective, mode);
             if (previousResolution && previousResolution.primary) {
                 return;
             }
@@ -3081,7 +3092,7 @@ namespace ts {
             }
 
             if (saveResolution) {
-                resolvedTypeReferenceDirectives.set(typeReferenceDirective, resolvedTypeReferenceDirective);
+                resolvedTypeReferenceDirectives.set(typeReferenceDirective, mode, resolvedTypeReferenceDirective);
             }
         }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -518,7 +518,7 @@ namespace ts {
         const cache = new Map<string, T>();
         for (const name of names) {
             let result: T;
-            const mode = (!isString(name) ? name.resolutionMode : undefined) || containingFileMode;
+            const mode = getModeForFileReference(name, containingFileMode);
             // We lower-case all type references because npm automatically lowercases all packages. See GH#9824.
             const strName = isString(name) ? name : name.fileName.toLowerCase();
             const cacheKey = mode !== undefined ? `${mode}|${strName}` : strName;
@@ -539,6 +539,11 @@ namespace ts {
         moduleAugmentations: SourceFile["moduleAugmentations"];
         impliedNodeFormat?: SourceFile["impliedNodeFormat"];
     };
+
+    /* @internal */
+    export function getModeForFileReference(ref: FileReference | string, containingFileMode: SourceFile["impliedNodeFormat"]) {
+        return (isString(ref) ? containingFileMode : ref.resolutionMode) || containingFileMode;
+    }
 
     /* @internal */
     export function getModeForResolutionAtIndex(file: SourceFileImportsList, index: number) {

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -347,8 +347,8 @@ namespace ts {
             return primaryResult;
         }
 
-        function resolveTypeReferenceDirective(typeReferenceDirectiveName: string, containingFile: string | undefined, options: CompilerOptions, host: ModuleResolutionHost, redirectedReference?: ResolvedProjectReference): CachedResolvedTypeReferenceDirectiveWithFailedLookupLocations {
-            return ts.resolveTypeReferenceDirective(typeReferenceDirectiveName, containingFile, options, host, redirectedReference, typeReferenceDirectiveResolutionCache);
+        function resolveTypeReferenceDirective(typeReferenceDirectiveName: string, containingFile: string | undefined, options: CompilerOptions, host: ModuleResolutionHost, redirectedReference?: ResolvedProjectReference, _containingSourceFile?: SourceFile, resolutionMode?: SourceFile["impliedNodeFormat"] | undefined): CachedResolvedTypeReferenceDirectiveWithFailedLookupLocations {
+            return ts.resolveTypeReferenceDirective(typeReferenceDirectiveName, containingFile, options, host, redirectedReference, typeReferenceDirectiveResolutionCache, resolutionMode);
         }
 
         interface ResolveNamesWithLocalCacheInput<T extends ResolutionWithFailedLookupLocations, R extends ResolutionWithResolvedFileName> {

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -400,7 +400,7 @@ namespace ts {
                 // import's syntax may override the file's default mode.
                 // Type references instead supply a `containingSourceFileMode` and a non-string entry which contains
                 // a default file mode override if applicable.
-                const mode = !isString(entry) ? entry.resolutionMode || containingSourceFileMode :
+                const mode = !isString(entry) ? getModeForFileReference(entry, containingSourceFileMode) :
                     containingSourceFile ? getModeForResolutionAtIndex(containingSourceFile, i) : undefined;
                 i++;
                 let resolution = resolutionsInFile.get(name, mode);

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -7,7 +7,7 @@ namespace ts {
 
         resolveModuleNames(moduleNames: string[], containingFile: string, reusedNames: string[] | undefined, redirectedReference?: ResolvedProjectReference, containingSourceFile?: SourceFile): (ResolvedModuleFull | undefined)[];
         getResolvedModuleWithFailedLookupLocationsFromCache(moduleName: string, containingFile: string, resolutionMode?: ModuleKind.CommonJS | ModuleKind.ESNext): CachedResolvedModuleWithFailedLookupLocations | undefined;
-        resolveTypeReferenceDirectives(typeDirectiveNames: string[], containingFile: string, redirectedReference?: ResolvedProjectReference): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives(typeDirectiveNames: string[] | readonly FileReference[], containingFile: string, redirectedReference?: ResolvedProjectReference, containingFileMode?: SourceFile["impliedNodeFormat"]): (ResolvedTypeReferenceDirective | undefined)[];
 
         invalidateResolutionsOfFailedLookupLocations(): boolean;
         invalidateResolutionOfFile(filePath: Path): void;
@@ -315,8 +315,8 @@ namespace ts {
             hasChangedAutomaticTypeDirectiveNames = false;
         }
 
-        function resolveModuleName(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, redirectedReference?: ResolvedProjectReference): CachedResolvedModuleWithFailedLookupLocations {
-            const primaryResult = ts.resolveModuleName(moduleName, containingFile, compilerOptions, host, moduleResolutionCache, redirectedReference);
+        function resolveModuleName(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, redirectedReference?: ResolvedProjectReference, _containingSourceFile?: never, mode?: ModuleKind.CommonJS | ModuleKind.ESNext | undefined): CachedResolvedModuleWithFailedLookupLocations {
+            const primaryResult = ts.resolveModuleName(moduleName, containingFile, compilerOptions, host, moduleResolutionCache, redirectedReference, mode);
             // return result immediately only if global cache support is not enabled or if it is .ts, .tsx or .d.ts
             if (!resolutionHost.getGlobalCache) {
                 return primaryResult;
@@ -352,23 +352,24 @@ namespace ts {
         }
 
         interface ResolveNamesWithLocalCacheInput<T extends ResolutionWithFailedLookupLocations, R extends ResolutionWithResolvedFileName> {
-            names: readonly string[];
+            names: readonly string[] | readonly FileReference[];
             containingFile: string;
             redirectedReference: ResolvedProjectReference | undefined;
             cache: ESMap<Path, ModeAwareCache<T>>;
             perDirectoryCacheWithRedirects: CacheWithRedirects<ModeAwareCache<T>>;
-            loader: (name: string, containingFile: string, options: CompilerOptions, host: ModuleResolutionHost, redirectedReference?: ResolvedProjectReference, containingSourceFile?: SourceFile) => T;
+            loader: (name: string, containingFile: string, options: CompilerOptions, host: ModuleResolutionHost, redirectedReference?: ResolvedProjectReference, containingSourceFile?: SourceFile, resolutionMode?: ModuleKind.CommonJS | ModuleKind.ESNext | undefined) => T;
             getResolutionWithResolvedFileName: GetResolutionWithResolvedFileName<T, R>;
             shouldRetryResolution: (t: T) => boolean;
             reusedNames?: readonly string[];
             logChanges?: boolean;
             containingSourceFile?: SourceFile;
+            containingSourceFileMode?: SourceFile["impliedNodeFormat"];
         }
         function resolveNamesWithLocalCache<T extends ResolutionWithFailedLookupLocations, R extends ResolutionWithResolvedFileName>({
             names, containingFile, redirectedReference,
             cache, perDirectoryCacheWithRedirects,
             loader, getResolutionWithResolvedFileName,
-            shouldRetryResolution, reusedNames, logChanges, containingSourceFile
+            shouldRetryResolution, reusedNames, logChanges, containingSourceFile, containingSourceFileMode
         }: ResolveNamesWithLocalCacheInput<T, R>): (R | undefined)[] {
             const path = resolutionHost.toPath(containingFile);
             const resolutionsInFile = cache.get(path) || cache.set(path, createModeAwareCache()).get(path)!;
@@ -392,8 +393,15 @@ namespace ts {
 
             const seenNamesInFile = createModeAwareCache<true>();
             let i = 0;
-            for (const name of names) {
-                const mode = containingSourceFile ? getModeForResolutionAtIndex(containingSourceFile, i) : undefined;
+            for (const entry of names) {
+                const name = isString(entry) ? entry : entry.fileName.toLowerCase();
+                // Imports supply a `containingSourceFile` but no `containingSourceFileMode` - it would be redundant
+                // they require calculating the mode for a given import from it's position in the resolution table, since a given
+                // import's syntax may override the file's default mode.
+                // Type references instead supply a `containingSourceFileMode` and a non-string entry which contains
+                // a default file mode override if applicable.
+                const mode = !isString(entry) ? entry.resolutionMode || containingSourceFileMode :
+                    containingSourceFile ? getModeForResolutionAtIndex(containingSourceFile, i) : undefined;
                 i++;
                 let resolution = resolutionsInFile.get(name, mode);
                 // Resolution is valid if it is present and not invalidated
@@ -430,7 +438,7 @@ namespace ts {
                         }
                     }
                     else {
-                        resolution = loader(name, containingFile, compilerOptions, resolutionHost.getCompilerHost?.() || resolutionHost, redirectedReference, containingSourceFile);
+                        resolution = loader(name, containingFile, compilerOptions, resolutionHost.getCompilerHost?.() || resolutionHost, redirectedReference, containingSourceFile, mode);
                         perDirectoryResolution.set(name, mode, resolution);
                         if (resolutionHost.onDiscoveredSymlink && resolutionIsSymlink(resolution)) {
                             resolutionHost.onDiscoveredSymlink();
@@ -506,7 +514,7 @@ namespace ts {
             }
         }
 
-        function resolveTypeReferenceDirectives(typeDirectiveNames: string[], containingFile: string, redirectedReference?: ResolvedProjectReference): (ResolvedTypeReferenceDirective | undefined)[] {
+        function resolveTypeReferenceDirectives(typeDirectiveNames: string[] | readonly FileReference[], containingFile: string, redirectedReference?: ResolvedProjectReference, containingFileMode?: SourceFile["impliedNodeFormat"]): (ResolvedTypeReferenceDirective | undefined)[] {
             return resolveNamesWithLocalCache<CachedResolvedTypeReferenceDirectiveWithFailedLookupLocations, ResolvedTypeReferenceDirective>({
                 names: typeDirectiveNames,
                 containingFile,
@@ -516,6 +524,7 @@ namespace ts {
                 loader: resolveTypeReferenceDirective,
                 getResolutionWithResolvedFileName: getResolvedTypeReferenceDirective,
                 shouldRetryResolution: resolution => resolution.resolvedTypeReferenceDirective === undefined,
+                containingSourceFileMode: containingFileMode
             });
         }
 

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -292,9 +292,9 @@ namespace ts {
             compilerHost.getModuleResolutionCache = () => moduleResolutionCache;
         }
         if (!compilerHost.resolveTypeReferenceDirectives) {
-            const loader = (moduleName: string, containingFile: string, redirectedReference: ResolvedProjectReference | undefined) => resolveTypeReferenceDirective(moduleName, containingFile, state.projectCompilerOptions, compilerHost, redirectedReference, state.typeReferenceDirectiveResolutionCache).resolvedTypeReferenceDirective!;
-            compilerHost.resolveTypeReferenceDirectives = (typeReferenceDirectiveNames, containingFile, redirectedReference) =>
-                loadWithLocalCache<ResolvedTypeReferenceDirective>(Debug.checkEachDefined(typeReferenceDirectiveNames), containingFile, redirectedReference, loader);
+            const loader = (moduleName: string, containingFile: string, redirectedReference: ResolvedProjectReference | undefined, containingFileMode: SourceFile["impliedNodeFormat"] | undefined) => resolveTypeReferenceDirective(moduleName, containingFile, state.projectCompilerOptions, compilerHost, redirectedReference, state.typeReferenceDirectiveResolutionCache, containingFileMode).resolvedTypeReferenceDirective!;
+            compilerHost.resolveTypeReferenceDirectives = (typeReferenceDirectiveNames, containingFile, redirectedReference, _options, containingFileMode) =>
+                loadWithTypeDirectiveCache<ResolvedTypeReferenceDirective>(Debug.checkEachDefined(typeReferenceDirectiveNames), containingFile, redirectedReference, containingFileMode, loader);
         }
 
         const { watchFile, watchDirectory, writeLog } = createWatchFactory<ResolvedConfigFileName>(hostWithWatch, options);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3159,6 +3159,7 @@ namespace ts {
 
     export interface FileReference extends TextRange {
         fileName: string;
+        resolutionMode?: SourceFile["impliedNodeFormat"];
     }
 
     export interface CheckJsDirective extends TextRange {
@@ -3712,7 +3713,7 @@ namespace ts {
 
         // References and noDefaultLibAre Dts only
         referencedFiles: readonly FileReference[];
-        typeReferenceDirectives: readonly string[] | undefined;
+        typeReferenceDirectives: readonly FileReference[] | undefined;
         libReferenceDirectives: readonly FileReference[];
         hasNoDefaultLib?: boolean;
 
@@ -4005,7 +4006,7 @@ namespace ts {
         getRelationCacheSizes(): { assignable: number, identity: number, subtype: number, strictSubtype: number };
 
         /* @internal */ getFileProcessingDiagnostics(): FilePreprocessingDiagnostics[] | undefined;
-        /* @internal */ getResolvedTypeReferenceDirectives(): ESMap<string, ResolvedTypeReferenceDirective | undefined>;
+        /* @internal */ getResolvedTypeReferenceDirectives(): ModeAwareCache<ResolvedTypeReferenceDirective | undefined>;
         isSourceFileFromExternalLibrary(file: SourceFile): boolean;
         isSourceFileDefaultLibrary(file: SourceFile): boolean;
 
@@ -4145,7 +4146,7 @@ namespace ts {
 
         getSourceFiles(): readonly SourceFile[];
         getSourceFile(fileName: string): SourceFile | undefined;
-        getResolvedTypeReferenceDirectives(): ReadonlyESMap<string, ResolvedTypeReferenceDirective | undefined>;
+        getResolvedTypeReferenceDirectives(): ModeAwareCache<ResolvedTypeReferenceDirective | undefined>;
         getProjectReferenceRedirect(fileName: string): string | undefined;
         isSourceOfProjectReferenceRedirect(fileName: string): boolean;
 
@@ -4788,8 +4789,8 @@ namespace ts {
         moduleExportsSomeValue(moduleReferenceExpression: Expression): boolean;
         isArgumentsLocalBinding(node: Identifier): boolean;
         getExternalModuleFileFromDeclaration(declaration: ImportEqualsDeclaration | ImportDeclaration | ExportDeclaration | ModuleDeclaration | ImportTypeNode | ImportCall): SourceFile | undefined;
-        getTypeReferenceDirectivesForEntityName(name: EntityNameOrEntityNameExpression): string[] | undefined;
-        getTypeReferenceDirectivesForSymbol(symbol: Symbol, meaning?: SymbolFlags): string[] | undefined;
+        getTypeReferenceDirectivesForEntityName(name: EntityNameOrEntityNameExpression): [specifier: string, mode: SourceFile["impliedNodeFormat"] | undefined][] | undefined;
+        getTypeReferenceDirectivesForSymbol(symbol: Symbol, meaning?: SymbolFlags): [specifier: string, mode: SourceFile["impliedNodeFormat"] | undefined][] | undefined;
         isLiteralConstDeclaration(node: VariableDeclaration | PropertyDeclaration | PropertySignature | ParameterDeclaration): boolean;
         getJsxFactoryEntity(location?: Node): EntityName | undefined;
         getJsxFragmentFactoryEntity(location?: Node): EntityName | undefined;
@@ -6694,7 +6695,7 @@ namespace ts {
         /**
          * This method is a companion for 'resolveModuleNames' and is used to resolve 'types' references to actual type declaration files
          */
-        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[] | readonly FileReference[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[];
         getEnvironmentVariable?(name: string): string | undefined;
         /* @internal */ onReleaseOldSourceFile?(oldSourceFile: SourceFile, oldOptions: CompilerOptions, hasSourceFileByPath: boolean): void;
         /* @internal */ onReleaseParsedCommandLine?(configFileName: string, oldResolvedRef: ResolvedProjectReference | undefined, optionOptions: CompilerOptions): void;
@@ -8048,6 +8049,8 @@ namespace ts {
         NoDefaultLib = "no-default-lib",
         Reference = "reference",
         Type = "type",
+        TypeResolutionModeRequire = "type-require",
+        TypeResolutionModeImport = "type-import",
         Lib = "lib",
         Prepend = "prepend",
         Text = "text",
@@ -8080,7 +8083,7 @@ namespace ts {
 
     /*@internal*/
     export interface BundleFileReference extends BundleFileSectionBase {
-        kind: BundleFileSectionKind.Reference | BundleFileSectionKind.Type | BundleFileSectionKind.Lib;
+        kind: BundleFileSectionKind.Reference | BundleFileSectionKind.Type | BundleFileSectionKind.Lib | BundleFileSectionKind.TypeResolutionModeImport | BundleFileSectionKind.TypeResolutionModeRequire;
         data: string;
     }
 
@@ -8571,7 +8574,8 @@ namespace ts {
                 { name: "types", optional: true, captureSpan: true },
                 { name: "lib", optional: true, captureSpan: true },
                 { name: "path", optional: true, captureSpan: true },
-                { name: "no-default-lib", optional: true }
+                { name: "no-default-lib", optional: true },
+                { name: "resolution-mode", optional: true }
             ],
             kind: PragmaKindFlags.TripleSlashXML
         },

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -219,7 +219,7 @@ namespace ts {
             const entry = names[i];
             // We lower-case all type references because npm automatically lowercases all packages. See GH#9824.
             const name = !isString(entry) ? entry.fileName.toLowerCase() : entry;
-            const mode = !isString(entry) ? entry.resolutionMode || oldSourceFile?.impliedNodeFormat : oldSourceFile && getModeForResolutionAtIndex(oldSourceFile, i);
+            const mode = !isString(entry) ? getModeForFileReference(entry, oldSourceFile?.impliedNodeFormat) : oldSourceFile && getModeForResolutionAtIndex(oldSourceFile, i);
             const oldResolution = oldResolutions && oldResolutions.get(name, mode);
             const changed =
                 oldResolution

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -207,7 +207,7 @@ namespace ts {
     }
 
     export function hasChangesInResolutions<T>(
-        names: readonly string[],
+        names: readonly string[] | readonly FileReference[],
         newResolutions: readonly T[],
         oldResolutions: ModeAwareCache<T> | undefined,
         oldSourceFile: SourceFile | undefined,
@@ -216,7 +216,11 @@ namespace ts {
 
         for (let i = 0; i < names.length; i++) {
             const newResolution = newResolutions[i];
-            const oldResolution = oldResolutions && oldResolutions.get(names[i], oldSourceFile && getModeForResolutionAtIndex(oldSourceFile, i));
+            const entry = names[i];
+            // We lower-case all type references because npm automatically lowercases all packages. See GH#9824.
+            const name = !isString(entry) ? entry.fileName.toLowerCase() : entry;
+            const mode = !isString(entry) ? entry.resolutionMode || oldSourceFile?.impliedNodeFormat : oldSourceFile && getModeForResolutionAtIndex(oldSourceFile, i);
+            const oldResolution = oldResolutions && oldResolutions.get(name, mode);
             const changed =
                 oldResolution
                     ? !newResolution || !comparer(oldResolution, newResolution)
@@ -6376,7 +6380,7 @@ namespace ts {
          * don't include automatic type reference directives. Must be called only when
          * `hasProcessedResolutions` returns false (once per cache instance).
          */
-        setSymlinksFromResolutions(files: readonly SourceFile[], typeReferenceDirectives: ReadonlyESMap<string, ResolvedTypeReferenceDirective | undefined> | undefined): void;
+        setSymlinksFromResolutions(files: readonly SourceFile[], typeReferenceDirectives: ModeAwareCache<ResolvedTypeReferenceDirective | undefined> | undefined): void;
         /**
          * @internal
          * Whether `setSymlinksFromResolutions` has already been called.

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -103,7 +103,7 @@ namespace ts {
         /** If provided, used to resolve the module names, otherwise typescript's default module resolution */
         resolveModuleNames?(moduleNames: string[], containingFile: string, reusedNames: string[] | undefined, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingSourceFile?: SourceFile): (ResolvedModule | undefined)[];
         /** If provided, used to resolve type reference directives, otherwise typescript's default resolution */
-        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[] | readonly FileReference[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[];
     }
     /** Internal interface used to wire emit through same host */
 
@@ -353,7 +353,7 @@ namespace ts {
             ((moduleNames, containingFile, reusedNames, redirectedReference, _options, sourceFile) => resolutionCache.resolveModuleNames(moduleNames, containingFile, reusedNames, redirectedReference, sourceFile));
         compilerHost.resolveTypeReferenceDirectives = host.resolveTypeReferenceDirectives ?
             ((...args) => host.resolveTypeReferenceDirectives!(...args)) :
-            ((typeDirectiveNames, containingFile, redirectedReference) => resolutionCache.resolveTypeReferenceDirectives(typeDirectiveNames, containingFile, redirectedReference));
+            ((typeDirectiveNames, containingFile, redirectedReference, _options, containingFileMode) => resolutionCache.resolveTypeReferenceDirectives(typeDirectiveNames, containingFile, redirectedReference, containingFileMode));
         const userProvidedResolution = !!host.resolveModuleNames || !!host.resolveTypeReferenceDirectives;
 
         builderProgram = readBuilderProgram(compilerOptions, compilerHost) as any as T;

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -484,8 +484,8 @@ namespace ts.server {
             return this.resolutionCache.getResolvedModuleWithFailedLookupLocationsFromCache(moduleName, containingFile, resolutionMode);
         }
 
-        resolveTypeReferenceDirectives(typeDirectiveNames: string[], containingFile: string, redirectedReference?: ResolvedProjectReference): (ResolvedTypeReferenceDirective | undefined)[] {
-            return this.resolutionCache.resolveTypeReferenceDirectives(typeDirectiveNames, containingFile, redirectedReference);
+        resolveTypeReferenceDirectives(typeDirectiveNames: string[] | FileReference[], containingFile: string, redirectedReference?: ResolvedProjectReference, _options?: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[] {
+            return this.resolutionCache.resolveTypeReferenceDirectives(typeDirectiveNames, containingFile, redirectedReference, containingFileMode);
         }
 
         directoryExists(path: string): boolean {

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -159,7 +159,7 @@ namespace ts.GoToDefinition {
 
         const typeReferenceDirective = findReferenceInPosition(sourceFile.typeReferenceDirectives, position);
         if (typeReferenceDirective) {
-            const reference = program.getResolvedTypeReferenceDirectives().get(typeReferenceDirective.fileName);
+            const reference = program.getResolvedTypeReferenceDirectives().get(typeReferenceDirective.fileName, typeReferenceDirective.resolutionMode || sourceFile.impliedNodeFormat);
             const file = reference && program.getSourceFile(reference.resolvedFileName!); // TODO:GH#18217
             return file && { reference: typeReferenceDirective, fileName: file.fileName, file, unverified: false };
         }

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -367,7 +367,7 @@ namespace ts.FindAllReferences {
                     }
                 }
                 for (const ref of referencingFile.typeReferenceDirectives) {
-                    const referenced = program.getResolvedTypeReferenceDirectives().get(ref.fileName);
+                    const referenced = program.getResolvedTypeReferenceDirectives().get(ref.fileName, ref.resolutionMode || referencingFile.impliedNodeFormat);
                     if (referenced !== undefined && referenced.resolvedFileName === (searchSourceFile as SourceFile).fileName) {
                         refs.push({ kind: "reference", referencingFile, ref });
                     }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -351,7 +351,7 @@ namespace ts {
         private tracingEnabled = false;
 
         public resolveModuleNames: ((moduleName: string[], containingFile: string) => (ResolvedModuleFull | undefined)[]) | undefined;
-        public resolveTypeReferenceDirectives: ((typeDirectiveNames: string[], containingFile: string) => (ResolvedTypeReferenceDirective | undefined)[]) | undefined;
+        public resolveTypeReferenceDirectives: ((typeDirectiveNames: string[] | readonly FileReference[], containingFile: string) => (ResolvedTypeReferenceDirective | undefined)[]) | undefined;
         public directoryExists: ((directoryName: string) => boolean) | undefined;
 
         constructor(private shimHost: LanguageServiceShimHost) {
@@ -372,7 +372,7 @@ namespace ts {
             if ("getTypeReferenceDirectiveResolutionsForFile" in this.shimHost) {
                 this.resolveTypeReferenceDirectives = (typeDirectiveNames, containingFile) => {
                     const typeDirectivesForFile = JSON.parse(this.shimHost.getTypeReferenceDirectiveResolutionsForFile!(containingFile)) as MapLike<ResolvedTypeReferenceDirective>; // TODO: GH#18217
-                    return map(typeDirectiveNames, name => getProperty(typeDirectivesForFile, name));
+                    return map(typeDirectiveNames as (string | FileReference)[], name => getProperty(typeDirectivesForFile, isString(name) ? name : name.fileName.toLowerCase()));
                 };
             }
         }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -281,7 +281,7 @@ namespace ts {
          */
         resolveModuleNames?(moduleNames: string[], containingFile: string, reusedNames: string[] | undefined, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingSourceFile?: SourceFile): (ResolvedModule | undefined)[];
         getResolvedModuleWithFailedLookupLocationsFromCache?(modulename: string, containingFile: string, resolutionMode?: ModuleKind.CommonJS | ModuleKind.ESNext): ResolvedModuleWithFailedLookupLocations | undefined;
-        resolveTypeReferenceDirectives?(typeDirectiveNames: string[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives?(typeDirectiveNames: string[] | FileReference[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[];
         /* @internal */ hasInvalidatedResolution?: HasInvalidatedResolution;
         /* @internal */ hasChangedAutomaticTypeDirectiveNames?: HasChangedAutomaticTypeDirectiveNames;
         /* @internal */ getGlobalTypingsCacheLocation?(): string | undefined;

--- a/src/testRunner/unittests/tsserver/symlinkCache.ts
+++ b/src/testRunner/unittests/tsserver/symlinkCache.ts
@@ -61,11 +61,13 @@ namespace ts.projectSystem {
         it("works for paths close to the root", () => {
             const cache = createSymlinkCache("/", createGetCanonicalFileName(/*useCaseSensitiveFileNames*/ false));
             // Used to crash, #44953
-            cache.setSymlinksFromResolutions([], new Map([["foo", {
+            const map = createModeAwareCache<ResolvedTypeReferenceDirective | undefined>();
+            map.set("foo", /*mode*/ undefined, {
                 primary: true,
                 originalPath: "/foo",
                 resolvedFileName: "/one/two/foo",
-            }]]));
+            });
+            cache.setSymlinksFromResolutions([], map);
         });
     });
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1749,6 +1749,7 @@ declare namespace ts {
     }
     export interface FileReference extends TextRange {
         fileName: string;
+        resolutionMode?: SourceFile["impliedNodeFormat"];
     }
     export interface CheckJsDirective extends TextRange {
         enabled: boolean;
@@ -2074,7 +2075,7 @@ declare namespace ts {
         readonly prologues: readonly UnparsedPrologue[];
         helpers: readonly UnscopedEmitHelper[] | undefined;
         referencedFiles: readonly FileReference[];
-        typeReferenceDirectives: readonly string[] | undefined;
+        typeReferenceDirectives: readonly FileReference[] | undefined;
         libReferenceDirectives: readonly FileReference[];
         hasNoDefaultLib?: boolean;
         sourceMapPath?: string;
@@ -3223,7 +3224,7 @@ declare namespace ts {
         /**
          * This method is a companion for 'resolveModuleNames' and is used to resolve 'types' references to actual type declaration files
          */
-        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[] | readonly FileReference[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[];
         getEnvironmentVariable?(name: string): string | undefined;
         createHash?(data: string): string;
         getParsedCommandLine?(fileName: string): ParsedCommandLine | undefined;
@@ -4855,7 +4856,7 @@ declare namespace ts {
      * This is possible in case if resolution is performed for directives specified via 'types' parameter. In this case initial path for secondary lookups
      * is assumed to be the same as root directory of the project.
      */
-    export function resolveTypeReferenceDirective(typeReferenceDirectiveName: string, containingFile: string | undefined, options: CompilerOptions, host: ModuleResolutionHost, redirectedReference?: ResolvedProjectReference, cache?: TypeReferenceDirectiveResolutionCache): ResolvedTypeReferenceDirectiveWithFailedLookupLocations;
+    export function resolveTypeReferenceDirective(typeReferenceDirectiveName: string, containingFile: string | undefined, options: CompilerOptions, host: ModuleResolutionHost, redirectedReference?: ResolvedProjectReference, cache?: TypeReferenceDirectiveResolutionCache, resolutionMode?: SourceFile["impliedNodeFormat"]): ResolvedTypeReferenceDirectiveWithFailedLookupLocations;
     /**
      * Given a set of options, returns the set of type directive names
      *   that should be included for this program automatically.
@@ -5276,7 +5277,7 @@ declare namespace ts {
         /** If provided, used to resolve the module names, otherwise typescript's default module resolution */
         resolveModuleNames?(moduleNames: string[], containingFile: string, reusedNames: string[] | undefined, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingSourceFile?: SourceFile): (ResolvedModule | undefined)[];
         /** If provided, used to resolve type reference directives, otherwise typescript's default resolution */
-        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[] | readonly FileReference[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[];
     }
     interface WatchCompilerHost<T extends BuilderProgram> extends ProgramHost<T>, WatchHost {
         /** Instead of using output d.ts file from project reference, use its source file */
@@ -5672,7 +5673,7 @@ declare namespace ts {
         getTypeRootsVersion?(): number;
         resolveModuleNames?(moduleNames: string[], containingFile: string, reusedNames: string[] | undefined, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingSourceFile?: SourceFile): (ResolvedModule | undefined)[];
         getResolvedModuleWithFailedLookupLocationsFromCache?(modulename: string, containingFile: string, resolutionMode?: ModuleKind.CommonJS | ModuleKind.ESNext): ResolvedModuleWithFailedLookupLocations | undefined;
-        resolveTypeReferenceDirectives?(typeDirectiveNames: string[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives?(typeDirectiveNames: string[] | FileReference[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[];
         getDirectories?(directoryName: string): string[];
         /**
          * Gets a set of custom transformers to use during emit.
@@ -9881,7 +9882,7 @@ declare namespace ts.server {
         resolveModuleNames(moduleNames: string[], containingFile: string, reusedNames?: string[], redirectedReference?: ResolvedProjectReference, _options?: CompilerOptions, containingSourceFile?: SourceFile): (ResolvedModuleFull | undefined)[];
         getModuleResolutionCache(): ModuleResolutionCache | undefined;
         getResolvedModuleWithFailedLookupLocationsFromCache(moduleName: string, containingFile: string, resolutionMode?: ModuleKind.CommonJS | ModuleKind.ESNext): ResolvedModuleWithFailedLookupLocations | undefined;
-        resolveTypeReferenceDirectives(typeDirectiveNames: string[], containingFile: string, redirectedReference?: ResolvedProjectReference): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives(typeDirectiveNames: string[] | FileReference[], containingFile: string, redirectedReference?: ResolvedProjectReference, _options?: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[];
         directoryExists(path: string): boolean;
         getDirectories(path: string): string[];
         log(s: string): void;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1749,6 +1749,7 @@ declare namespace ts {
     }
     export interface FileReference extends TextRange {
         fileName: string;
+        resolutionMode?: SourceFile["impliedNodeFormat"];
     }
     export interface CheckJsDirective extends TextRange {
         enabled: boolean;
@@ -2074,7 +2075,7 @@ declare namespace ts {
         readonly prologues: readonly UnparsedPrologue[];
         helpers: readonly UnscopedEmitHelper[] | undefined;
         referencedFiles: readonly FileReference[];
-        typeReferenceDirectives: readonly string[] | undefined;
+        typeReferenceDirectives: readonly FileReference[] | undefined;
         libReferenceDirectives: readonly FileReference[];
         hasNoDefaultLib?: boolean;
         sourceMapPath?: string;
@@ -3223,7 +3224,7 @@ declare namespace ts {
         /**
          * This method is a companion for 'resolveModuleNames' and is used to resolve 'types' references to actual type declaration files
          */
-        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[] | readonly FileReference[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[];
         getEnvironmentVariable?(name: string): string | undefined;
         createHash?(data: string): string;
         getParsedCommandLine?(fileName: string): ParsedCommandLine | undefined;
@@ -4855,7 +4856,7 @@ declare namespace ts {
      * This is possible in case if resolution is performed for directives specified via 'types' parameter. In this case initial path for secondary lookups
      * is assumed to be the same as root directory of the project.
      */
-    export function resolveTypeReferenceDirective(typeReferenceDirectiveName: string, containingFile: string | undefined, options: CompilerOptions, host: ModuleResolutionHost, redirectedReference?: ResolvedProjectReference, cache?: TypeReferenceDirectiveResolutionCache): ResolvedTypeReferenceDirectiveWithFailedLookupLocations;
+    export function resolveTypeReferenceDirective(typeReferenceDirectiveName: string, containingFile: string | undefined, options: CompilerOptions, host: ModuleResolutionHost, redirectedReference?: ResolvedProjectReference, cache?: TypeReferenceDirectiveResolutionCache, resolutionMode?: SourceFile["impliedNodeFormat"]): ResolvedTypeReferenceDirectiveWithFailedLookupLocations;
     /**
      * Given a set of options, returns the set of type directive names
      *   that should be included for this program automatically.
@@ -5276,7 +5277,7 @@ declare namespace ts {
         /** If provided, used to resolve the module names, otherwise typescript's default module resolution */
         resolveModuleNames?(moduleNames: string[], containingFile: string, reusedNames: string[] | undefined, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingSourceFile?: SourceFile): (ResolvedModule | undefined)[];
         /** If provided, used to resolve type reference directives, otherwise typescript's default resolution */
-        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[] | readonly FileReference[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[];
     }
     interface WatchCompilerHost<T extends BuilderProgram> extends ProgramHost<T>, WatchHost {
         /** Instead of using output d.ts file from project reference, use its source file */
@@ -5672,7 +5673,7 @@ declare namespace ts {
         getTypeRootsVersion?(): number;
         resolveModuleNames?(moduleNames: string[], containingFile: string, reusedNames: string[] | undefined, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingSourceFile?: SourceFile): (ResolvedModule | undefined)[];
         getResolvedModuleWithFailedLookupLocationsFromCache?(modulename: string, containingFile: string, resolutionMode?: ModuleKind.CommonJS | ModuleKind.ESNext): ResolvedModuleWithFailedLookupLocations | undefined;
-        resolveTypeReferenceDirectives?(typeDirectiveNames: string[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions): (ResolvedTypeReferenceDirective | undefined)[];
+        resolveTypeReferenceDirectives?(typeDirectiveNames: string[] | FileReference[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingFileMode?: SourceFile["impliedNodeFormat"] | undefined): (ResolvedTypeReferenceDirective | undefined)[];
         getDirectories?(directoryName: string): string[];
         /**
          * Gets a set of custom transformers to use during emit.

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=node12).js
@@ -30,6 +30,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 
 //// [index.d.ts]
-/// <reference types="pkg" resolution-mode="require"/>
+/// <reference types="pkg" />
 export interface LocalInterface extends RequireInterface {
 }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=node12).js
@@ -1,0 +1,35 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit1.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+}
+//// [index.ts]
+/// <reference types="pkg" />
+export interface LocalInterface extends RequireInterface {}
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" />
+
+
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends RequireInterface {
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=node12).symbols
@@ -1,0 +1,14 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+export interface LocalInterface extends RequireInterface {}
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    interface RequireInterface {}
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=node12).types
@@ -1,0 +1,10 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+No type information for this code.export interface LocalInterface extends RequireInterface {}
+No type information for this code.=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface RequireInterface {}
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=nodenext).js
@@ -30,6 +30,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 
 //// [index.d.ts]
-/// <reference types="pkg" resolution-mode="require"/>
+/// <reference types="pkg" />
 export interface LocalInterface extends RequireInterface {
 }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=nodenext).js
@@ -1,0 +1,35 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit1.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+}
+//// [index.ts]
+/// <reference types="pkg" />
+export interface LocalInterface extends RequireInterface {}
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" />
+
+
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends RequireInterface {
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=nodenext).symbols
@@ -1,0 +1,14 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+export interface LocalInterface extends RequireInterface {}
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    interface RequireInterface {}
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit1(module=nodenext).types
@@ -1,0 +1,10 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+No type information for this code.export interface LocalInterface extends RequireInterface {}
+No type information for this code.=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface RequireInterface {}
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=node12).js
@@ -34,6 +34,6 @@ export {};
 
 
 //// [index.d.ts]
-/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" />
 export interface LocalInterface extends ImportInterface {
 }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=node12).js
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit2.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+}
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [index.ts]
+/// <reference types="pkg" />
+export interface LocalInterface extends ImportInterface {}
+
+//// [index.js]
+/// <reference types="pkg" />
+export {};
+
+
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+export interface LocalInterface extends ImportInterface {
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=node12).symbols
@@ -1,0 +1,14 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+export interface LocalInterface extends ImportInterface {}
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    interface ImportInterface {}
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=node12).types
@@ -1,0 +1,10 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+No type information for this code.export interface LocalInterface extends ImportInterface {}
+No type information for this code.=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface ImportInterface {}
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=nodenext).js
@@ -34,6 +34,6 @@ export {};
 
 
 //// [index.d.ts]
-/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" />
 export interface LocalInterface extends ImportInterface {
 }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=nodenext).js
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit2.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+}
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [index.ts]
+/// <reference types="pkg" />
+export interface LocalInterface extends ImportInterface {}
+
+//// [index.js]
+/// <reference types="pkg" />
+export {};
+
+
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+export interface LocalInterface extends ImportInterface {
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=nodenext).symbols
@@ -1,0 +1,14 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+export interface LocalInterface extends ImportInterface {}
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    interface ImportInterface {}
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit2(module=nodenext).types
@@ -1,0 +1,10 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+No type information for this code.export interface LocalInterface extends ImportInterface {}
+No type information for this code.=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface ImportInterface {}
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=node12).js
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit3.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+}
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends RequireInterface {}
+
+//// [index.js]
+/// <reference types="pkg" resolution-mode="require"/>
+export {};
+
+
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends RequireInterface {
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=node12).symbols
@@ -1,0 +1,14 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends RequireInterface {}
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    interface RequireInterface {}
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=node12).types
@@ -1,0 +1,10 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="require"/>
+No type information for this code.export interface LocalInterface extends RequireInterface {}
+No type information for this code.=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface RequireInterface {}
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=nodenext).js
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit3.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+}
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends RequireInterface {}
+
+//// [index.js]
+/// <reference types="pkg" resolution-mode="require"/>
+export {};
+
+
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends RequireInterface {
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=nodenext).symbols
@@ -1,0 +1,14 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends RequireInterface {}
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    interface RequireInterface {}
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit3(module=nodenext).types
@@ -1,0 +1,10 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="require"/>
+No type information for this code.export interface LocalInterface extends RequireInterface {}
+No type information for this code.=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface RequireInterface {}
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=node12).js
@@ -1,0 +1,35 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit4.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+export interface LocalInterface extends ImportInterface {}
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" resolution-mode="import"/>
+
+
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+export interface LocalInterface extends ImportInterface {
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=node12).symbols
@@ -1,0 +1,14 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import"/>
+export interface LocalInterface extends ImportInterface {}
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    interface ImportInterface {}
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=node12).types
@@ -1,0 +1,10 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import"/>
+No type information for this code.export interface LocalInterface extends ImportInterface {}
+No type information for this code.=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface ImportInterface {}
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=nodenext).js
@@ -1,0 +1,35 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit4.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+export interface LocalInterface extends ImportInterface {}
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" resolution-mode="import"/>
+
+
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+export interface LocalInterface extends ImportInterface {
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=nodenext).symbols
@@ -1,0 +1,14 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import"/>
+export interface LocalInterface extends ImportInterface {}
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    interface ImportInterface {}
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit4(module=nodenext).types
@@ -1,0 +1,10 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import"/>
+No type information for this code.export interface LocalInterface extends ImportInterface {}
+No type information for this code.=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface ImportInterface {}
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=node12).js
@@ -1,0 +1,38 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit5.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends ImportInterface, RequireInterface {}
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+
+
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends ImportInterface, RequireInterface {
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=node12).js
@@ -33,6 +33,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [index.d.ts]
 /// <reference types="pkg" resolution-mode="import"/>
-/// <reference types="pkg" resolution-mode="require"/>
+/// <reference types="pkg" />
 export interface LocalInterface extends ImportInterface, RequireInterface {
 }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=node12).symbols
@@ -1,0 +1,24 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends ImportInterface, RequireInterface {}
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    interface ImportInterface {}
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    interface RequireInterface {}
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=node12).types
@@ -1,0 +1,18 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import"/>
+No type information for this code./// <reference types="pkg" resolution-mode="require"/>
+No type information for this code.export interface LocalInterface extends ImportInterface, RequireInterface {}
+No type information for this code.=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface ImportInterface {}
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface RequireInterface {}
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=nodenext).js
@@ -1,0 +1,38 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit5.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends ImportInterface, RequireInterface {}
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+
+
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends ImportInterface, RequireInterface {
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=nodenext).js
@@ -33,6 +33,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 //// [index.d.ts]
 /// <reference types="pkg" resolution-mode="import"/>
-/// <reference types="pkg" resolution-mode="require"/>
+/// <reference types="pkg" />
 export interface LocalInterface extends ImportInterface, RequireInterface {
 }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=nodenext).symbols
@@ -1,0 +1,24 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends ImportInterface, RequireInterface {}
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    interface ImportInterface {}
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    interface RequireInterface {}
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit5(module=nodenext).types
@@ -1,0 +1,18 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import"/>
+No type information for this code./// <reference types="pkg" resolution-mode="require"/>
+No type information for this code.export interface LocalInterface extends ImportInterface, RequireInterface {}
+No type information for this code.=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface ImportInterface {}
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : any
+
+    interface RequireInterface {}
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=node12).js
@@ -1,0 +1,53 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit6.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+    function getInterI(): ImportInterface;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+    function getInterR(): RequireInterface;
+}
+//// [uses.ts]
+/// <reference types="pkg" />
+export default getInterR();
+//// [index.ts]
+import obj from "./uses.js"
+export default (obj as typeof obj);
+
+//// [uses.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" />
+exports.default = getInterR();
+//// [index.js]
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const uses_js_1 = __importDefault(require("./uses.js"));
+exports.default = uses_js_1.default;
+
+
+//// [uses.d.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+declare const _default: RequireInterface;
+export default _default;
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+declare const _default: RequireInterface;
+export default _default;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=node12).js
@@ -44,10 +44,10 @@ exports.default = uses_js_1.default;
 
 
 //// [uses.d.ts]
-/// <reference types="pkg" resolution-mode="require"/>
+/// <reference types="pkg" />
 declare const _default: RequireInterface;
 export default _default;
 //// [index.d.ts]
-/// <reference types="pkg" resolution-mode="require"/>
+/// <reference types="pkg" />
 declare const _default: RequireInterface;
 export default _default;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=node12).symbols
@@ -1,0 +1,25 @@
+=== /index.ts ===
+import obj from "./uses.js"
+>obj : Symbol(obj, Decl(index.ts, 0, 6))
+
+export default (obj as typeof obj);
+>obj : Symbol(obj, Decl(index.ts, 0, 6))
+>obj : Symbol(obj, Decl(index.ts, 0, 6))
+
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    interface RequireInterface {}
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+
+    function getInterR(): RequireInterface;
+>getInterR : Symbol(getInterR, Decl(require.d.ts, 2, 33))
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+}
+=== /uses.ts ===
+/// <reference types="pkg" />
+export default getInterR();
+>getInterR : Symbol(getInterR, Decl(require.d.ts, 2, 33))
+

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=node12).types
@@ -1,0 +1,25 @@
+=== /index.ts ===
+import obj from "./uses.js"
+>obj : RequireInterface
+
+export default (obj as typeof obj);
+>(obj as typeof obj) : RequireInterface
+>obj as typeof obj : RequireInterface
+>obj : RequireInterface
+>obj : RequireInterface
+
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    interface RequireInterface {}
+    function getInterR(): RequireInterface;
+>getInterR : () => RequireInterface
+}
+=== /uses.ts ===
+/// <reference types="pkg" />
+export default getInterR();
+>getInterR() : RequireInterface
+>getInterR : () => RequireInterface
+

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=nodenext).js
@@ -1,0 +1,53 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit6.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface {}
+    function getInterI(): ImportInterface;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface {}
+    function getInterR(): RequireInterface;
+}
+//// [uses.ts]
+/// <reference types="pkg" />
+export default getInterR();
+//// [index.ts]
+import obj from "./uses.js"
+export default (obj as typeof obj);
+
+//// [uses.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" />
+exports.default = getInterR();
+//// [index.js]
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const uses_js_1 = __importDefault(require("./uses.js"));
+exports.default = uses_js_1.default;
+
+
+//// [uses.d.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+declare const _default: RequireInterface;
+export default _default;
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+declare const _default: RequireInterface;
+export default _default;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=nodenext).js
@@ -44,10 +44,10 @@ exports.default = uses_js_1.default;
 
 
 //// [uses.d.ts]
-/// <reference types="pkg" resolution-mode="require"/>
+/// <reference types="pkg" />
 declare const _default: RequireInterface;
 export default _default;
 //// [index.d.ts]
-/// <reference types="pkg" resolution-mode="require"/>
+/// <reference types="pkg" />
 declare const _default: RequireInterface;
 export default _default;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=nodenext).symbols
@@ -1,0 +1,25 @@
+=== /index.ts ===
+import obj from "./uses.js"
+>obj : Symbol(obj, Decl(index.ts, 0, 6))
+
+export default (obj as typeof obj);
+>obj : Symbol(obj, Decl(index.ts, 0, 6))
+>obj : Symbol(obj, Decl(index.ts, 0, 6))
+
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    interface RequireInterface {}
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+
+    function getInterR(): RequireInterface;
+>getInterR : Symbol(getInterR, Decl(require.d.ts, 2, 33))
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+}
+=== /uses.ts ===
+/// <reference types="pkg" />
+export default getInterR();
+>getInterR : Symbol(getInterR, Decl(require.d.ts, 2, 33))
+

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit6(module=nodenext).types
@@ -1,0 +1,25 @@
+=== /index.ts ===
+import obj from "./uses.js"
+>obj : RequireInterface
+
+export default (obj as typeof obj);
+>(obj as typeof obj) : RequireInterface
+>obj as typeof obj : RequireInterface
+>obj : RequireInterface
+>obj : RequireInterface
+
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    interface RequireInterface {}
+    function getInterR(): RequireInterface;
+>getInterR : () => RequireInterface
+}
+=== /uses.ts ===
+/// <reference types="pkg" />
+export default getInterR();
+>getInterR() : RequireInterface
+>getInterR : () => RequireInterface
+

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=node12).js
@@ -1,0 +1,78 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface { _i: any; }
+    function getInterI(): ImportInterface;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface { _r: any; }
+    function getInterR(): RequireInterface;
+}
+//// [uses.ts]
+/// <reference types="pkg" />
+export default getInterI();
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [uses.ts]
+/// <reference types="pkg" />
+export default getInterR();
+//// [package.json]
+{
+    "private": true,
+    "type": "commonjs"
+}
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [index.ts]
+// only an esm file can `import` both kinds of files
+import obj1 from "./sub1/uses.js"
+import obj2 from "./sub2/uses.js"
+export default [obj1, obj2.default] as const;
+
+//// [uses.js]
+/// <reference types="pkg" />
+export default getInterI();
+//// [uses.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" />
+exports.default = getInterR();
+//// [index.js]
+// only an esm file can `import` both kinds of files
+import obj1 from "./sub1/uses.js";
+import obj2 from "./sub2/uses.js";
+export default [obj1, obj2.default];
+
+
+//// [uses.d.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+declare const _default: ImportInterface;
+export default _default;
+//// [uses.d.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+declare const _default: RequireInterface;
+export default _default;
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+declare const _default: readonly [ImportInterface, RequireInterface];
+export default _default;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=node12).js
@@ -64,15 +64,15 @@ export default [obj1, obj2.default];
 
 
 //// [uses.d.ts]
-/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" />
 declare const _default: ImportInterface;
 export default _default;
 //// [uses.d.ts]
-/// <reference types="pkg" resolution-mode="require"/>
+/// <reference types="pkg" />
 declare const _default: RequireInterface;
 export default _default;
 //// [index.d.ts]
-/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" />
 /// <reference types="pkg" resolution-mode="require"/>
 declare const _default: readonly [ImportInterface, RequireInterface];
 export default _default;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=node12).symbols
@@ -1,0 +1,51 @@
+=== /index.ts ===
+// only an esm file can `import` both kinds of files
+import obj1 from "./sub1/uses.js"
+>obj1 : Symbol(obj1, Decl(index.ts, 1, 6))
+
+import obj2 from "./sub2/uses.js"
+>obj2 : Symbol(obj2, Decl(index.ts, 2, 6))
+
+export default [obj1, obj2.default] as const;
+>obj1 : Symbol(obj1, Decl(index.ts, 1, 6))
+>obj2.default : Symbol(obj2.default, Decl(uses.ts, 0, 0))
+>obj2 : Symbol(obj2, Decl(index.ts, 2, 6))
+>default : Symbol(obj2.default, Decl(uses.ts, 0, 0))
+>const : Symbol(const)
+
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    interface ImportInterface { _i: any; }
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+>_i : Symbol(ImportInterface._i, Decl(import.d.ts, 2, 31))
+
+    function getInterI(): ImportInterface;
+>getInterI : Symbol(getInterI, Decl(import.d.ts, 2, 42))
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    interface RequireInterface { _r: any; }
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+>_r : Symbol(RequireInterface._r, Decl(require.d.ts, 2, 32))
+
+    function getInterR(): RequireInterface;
+>getInterR : Symbol(getInterR, Decl(require.d.ts, 2, 43))
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+}
+=== /sub1/uses.ts ===
+/// <reference types="pkg" />
+export default getInterI();
+>getInterI : Symbol(getInterI, Decl(import.d.ts, 2, 42))
+
+=== /sub2/uses.ts ===
+/// <reference types="pkg" />
+export default getInterR();
+>getInterR : Symbol(getInterR, Decl(require.d.ts, 2, 43))
+

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=node12).types
@@ -1,0 +1,50 @@
+=== /index.ts ===
+// only an esm file can `import` both kinds of files
+import obj1 from "./sub1/uses.js"
+>obj1 : ImportInterface
+
+import obj2 from "./sub2/uses.js"
+>obj2 : typeof obj2
+
+export default [obj1, obj2.default] as const;
+>[obj1, obj2.default] as const : readonly [ImportInterface, RequireInterface]
+>[obj1, obj2.default] : readonly [ImportInterface, RequireInterface]
+>obj1 : ImportInterface
+>obj2.default : RequireInterface
+>obj2 : typeof obj2
+>default : RequireInterface
+
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    interface ImportInterface { _i: any; }
+>_i : any
+
+    function getInterI(): ImportInterface;
+>getInterI : () => ImportInterface
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    interface RequireInterface { _r: any; }
+>_r : any
+
+    function getInterR(): RequireInterface;
+>getInterR : () => RequireInterface
+}
+=== /sub1/uses.ts ===
+/// <reference types="pkg" />
+export default getInterI();
+>getInterI() : ImportInterface
+>getInterI : () => ImportInterface
+
+=== /sub2/uses.ts ===
+/// <reference types="pkg" />
+export default getInterR();
+>getInterR() : RequireInterface
+>getInterR : () => RequireInterface
+

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=nodenext).js
@@ -1,0 +1,78 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    interface ImportInterface { _i: any; }
+    function getInterI(): ImportInterface;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    interface RequireInterface { _r: any; }
+    function getInterR(): RequireInterface;
+}
+//// [uses.ts]
+/// <reference types="pkg" />
+export default getInterI();
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [uses.ts]
+/// <reference types="pkg" />
+export default getInterR();
+//// [package.json]
+{
+    "private": true,
+    "type": "commonjs"
+}
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [index.ts]
+// only an esm file can `import` both kinds of files
+import obj1 from "./sub1/uses.js"
+import obj2 from "./sub2/uses.js"
+export default [obj1, obj2.default] as const;
+
+//// [uses.js]
+/// <reference types="pkg" />
+export default getInterI();
+//// [uses.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" />
+exports.default = getInterR();
+//// [index.js]
+// only an esm file can `import` both kinds of files
+import obj1 from "./sub1/uses.js";
+import obj2 from "./sub2/uses.js";
+export default [obj1, obj2.default];
+
+
+//// [uses.d.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+declare const _default: ImportInterface;
+export default _default;
+//// [uses.d.ts]
+/// <reference types="pkg" resolution-mode="require"/>
+declare const _default: RequireInterface;
+export default _default;
+//// [index.d.ts]
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+declare const _default: readonly [ImportInterface, RequireInterface];
+export default _default;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=nodenext).js
@@ -64,15 +64,15 @@ export default [obj1, obj2.default];
 
 
 //// [uses.d.ts]
-/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" />
 declare const _default: ImportInterface;
 export default _default;
 //// [uses.d.ts]
-/// <reference types="pkg" resolution-mode="require"/>
+/// <reference types="pkg" />
 declare const _default: RequireInterface;
 export default _default;
 //// [index.d.ts]
-/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" />
 /// <reference types="pkg" resolution-mode="require"/>
 declare const _default: readonly [ImportInterface, RequireInterface];
 export default _default;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=nodenext).symbols
@@ -1,0 +1,51 @@
+=== /index.ts ===
+// only an esm file can `import` both kinds of files
+import obj1 from "./sub1/uses.js"
+>obj1 : Symbol(obj1, Decl(index.ts, 1, 6))
+
+import obj2 from "./sub2/uses.js"
+>obj2 : Symbol(obj2, Decl(index.ts, 2, 6))
+
+export default [obj1, obj2.default] as const;
+>obj1 : Symbol(obj1, Decl(index.ts, 1, 6))
+>obj2.default : Symbol(obj2.default, Decl(uses.ts, 0, 0))
+>obj2 : Symbol(obj2, Decl(index.ts, 2, 6))
+>default : Symbol(obj2.default, Decl(uses.ts, 0, 0))
+>const : Symbol(const)
+
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    interface ImportInterface { _i: any; }
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+>_i : Symbol(ImportInterface._i, Decl(import.d.ts, 2, 31))
+
+    function getInterI(): ImportInterface;
+>getInterI : Symbol(getInterI, Decl(import.d.ts, 2, 42))
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 1, 16))
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    interface RequireInterface { _r: any; }
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+>_r : Symbol(RequireInterface._r, Decl(require.d.ts, 2, 32))
+
+    function getInterR(): RequireInterface;
+>getInterR : Symbol(getInterR, Decl(require.d.ts, 2, 43))
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 1, 16))
+}
+=== /sub1/uses.ts ===
+/// <reference types="pkg" />
+export default getInterI();
+>getInterI : Symbol(getInterI, Decl(import.d.ts, 2, 42))
+
+=== /sub2/uses.ts ===
+/// <reference types="pkg" />
+export default getInterR();
+>getInterR : Symbol(getInterR, Decl(require.d.ts, 2, 43))
+

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeDeclarationEmit7(module=nodenext).types
@@ -1,0 +1,50 @@
+=== /index.ts ===
+// only an esm file can `import` both kinds of files
+import obj1 from "./sub1/uses.js"
+>obj1 : ImportInterface
+
+import obj2 from "./sub2/uses.js"
+>obj2 : typeof obj2
+
+export default [obj1, obj2.default] as const;
+>[obj1, obj2.default] as const : readonly [ImportInterface, RequireInterface]
+>[obj1, obj2.default] : readonly [ImportInterface, RequireInterface]
+>obj1 : ImportInterface
+>obj2.default : RequireInterface
+>obj2 : typeof obj2
+>default : RequireInterface
+
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    interface ImportInterface { _i: any; }
+>_i : any
+
+    function getInterI(): ImportInterface;
+>getInterI : () => ImportInterface
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    interface RequireInterface { _r: any; }
+>_r : any
+
+    function getInterR(): RequireInterface;
+>getInterR : () => RequireInterface
+}
+=== /sub1/uses.ts ===
+/// <reference types="pkg" />
+export default getInterI();
+>getInterI() : ImportInterface
+>getInterI : () => ImportInterface
+
+=== /sub2/uses.ts ===
+/// <reference types="pkg" />
+export default getInterR();
+>getInterR() : RequireInterface
+>getInterR : () => RequireInterface
+

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=node12).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=node12).errors.txt
@@ -1,0 +1,29 @@
+/index.ts(2,1): error TS2304: Cannot find name 'foo'.
+
+
+==== /index.ts (1 errors) ====
+    /// <reference types="pkg" />
+    foo;
+    ~~~
+!!! error TS2304: Cannot find name 'foo'.
+    bar; // bar should resolve while foo should not, since index.js is cjs
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=node12).js
@@ -1,0 +1,33 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride1.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [index.ts]
+/// <reference types="pkg" />
+foo;
+bar; // bar should resolve while foo should not, since index.js is cjs
+export {};
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" />
+foo;
+bar; // bar should resolve while foo should not, since index.js is cjs

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=node12).symbols
@@ -1,0 +1,15 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+foo;
+bar; // bar should resolve while foo should not, since index.js is cjs
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    var bar: number;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=node12).types
@@ -1,0 +1,17 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+foo;
+>foo : any
+
+bar; // bar should resolve while foo should not, since index.js is cjs
+>bar : number
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var bar: number;
+>bar : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=nodenext).errors.txt
@@ -1,0 +1,29 @@
+/index.ts(2,1): error TS2304: Cannot find name 'foo'.
+
+
+==== /index.ts (1 errors) ====
+    /// <reference types="pkg" />
+    foo;
+    ~~~
+!!! error TS2304: Cannot find name 'foo'.
+    bar; // bar should resolve while foo should not, since index.js is cjs
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=nodenext).js
@@ -1,0 +1,33 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride1.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [index.ts]
+/// <reference types="pkg" />
+foo;
+bar; // bar should resolve while foo should not, since index.js is cjs
+export {};
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" />
+foo;
+bar; // bar should resolve while foo should not, since index.js is cjs

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=nodenext).symbols
@@ -1,0 +1,15 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+foo;
+bar; // bar should resolve while foo should not, since index.js is cjs
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    var bar: number;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride1(module=nodenext).types
@@ -1,0 +1,17 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+foo;
+>foo : any
+
+bar; // bar should resolve while foo should not, since index.js is cjs
+>bar : number
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var bar: number;
+>bar : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=node12).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=node12).errors.txt
@@ -1,0 +1,34 @@
+/index.ts(3,1): error TS2304: Cannot find name 'bar'.
+
+
+==== /index.ts (1 errors) ====
+    /// <reference types="pkg" />
+    foo; // foo should resolve while bar should not, since index.js is esm
+    bar;
+    ~~~
+!!! error TS2304: Cannot find name 'bar'.
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }
+==== /package.json (0 errors) ====
+    {
+        "private": true,
+        "type": "module"
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=node12).js
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride2.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [index.ts]
+/// <reference types="pkg" />
+foo; // foo should resolve while bar should not, since index.js is esm
+bar;
+export {};
+
+//// [index.js]
+/// <reference types="pkg" />
+foo; // foo should resolve while bar should not, since index.js is esm
+bar;
+export {};

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=node12).symbols
@@ -1,0 +1,15 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+foo; // foo should resolve while bar should not, since index.js is esm
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+
+bar;
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    var foo: number;
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=node12).types
@@ -1,0 +1,17 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+foo; // foo should resolve while bar should not, since index.js is esm
+>foo : number
+
+bar;
+>bar : any
+
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var foo: number;
+>foo : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=nodenext).errors.txt
@@ -1,0 +1,34 @@
+/index.ts(3,1): error TS2304: Cannot find name 'bar'.
+
+
+==== /index.ts (1 errors) ====
+    /// <reference types="pkg" />
+    foo; // foo should resolve while bar should not, since index.js is esm
+    bar;
+    ~~~
+!!! error TS2304: Cannot find name 'bar'.
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }
+==== /package.json (0 errors) ====
+    {
+        "private": true,
+        "type": "module"
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=nodenext).js
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride2.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [index.ts]
+/// <reference types="pkg" />
+foo; // foo should resolve while bar should not, since index.js is esm
+bar;
+export {};
+
+//// [index.js]
+/// <reference types="pkg" />
+foo; // foo should resolve while bar should not, since index.js is esm
+bar;
+export {};

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=nodenext).symbols
@@ -1,0 +1,15 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+foo; // foo should resolve while bar should not, since index.js is esm
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+
+bar;
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    var foo: number;
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride2(module=nodenext).types
@@ -1,0 +1,17 @@
+=== /index.ts ===
+/// <reference types="pkg" />
+foo; // foo should resolve while bar should not, since index.js is esm
+>foo : number
+
+bar;
+>bar : any
+
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var foo: number;
+>foo : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).errors.txt
@@ -1,0 +1,34 @@
+/index.ts(2,1): error TS2304: Cannot find name 'foo'.
+
+
+==== /index.ts (1 errors) ====
+    /// <reference types="pkg" resolution-mode="require" />
+    foo;
+    ~~~
+!!! error TS2304: Cannot find name 'foo'.
+    bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }
+==== /package.json (0 errors) ====
+    {
+        "private": true,
+        "type": "module"
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).errors.txt
@@ -6,7 +6,7 @@
     foo;
     ~~~
 !!! error TS2304: Cannot find name 'foo'.
-    bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+    bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
     export {};
 ==== /node_modules/pkg/package.json (0 errors) ====
     {

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).js
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride3.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="require" />
+foo;
+bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+export {};
+
+//// [index.js]
+/// <reference types="pkg" resolution-mode="require" />
+foo;
+bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+export {};

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).js
@@ -27,11 +27,11 @@ declare global {
 //// [index.ts]
 /// <reference types="pkg" resolution-mode="require" />
 foo;
-bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
 export {};
 
 //// [index.js]
 /// <reference types="pkg" resolution-mode="require" />
 foo;
-bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
 export {};

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).symbols
@@ -1,0 +1,15 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="require" />
+foo;
+bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    var bar: number;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).symbols
@@ -1,7 +1,7 @@
 === /index.ts ===
 /// <reference types="pkg" resolution-mode="require" />
 foo;
-bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
 >bar : Symbol(bar, Decl(require.d.ts, 2, 7))
 
 export {};

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).types
@@ -3,7 +3,7 @@
 foo;
 >foo : any
 
-bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
 >bar : number
 
 export {};

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=node12).types
@@ -1,0 +1,17 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="require" />
+foo;
+>foo : any
+
+bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+>bar : number
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var bar: number;
+>bar : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).errors.txt
@@ -1,0 +1,34 @@
+/index.ts(2,1): error TS2304: Cannot find name 'foo'.
+
+
+==== /index.ts (1 errors) ====
+    /// <reference types="pkg" resolution-mode="require" />
+    foo;
+    ~~~
+!!! error TS2304: Cannot find name 'foo'.
+    bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }
+==== /package.json (0 errors) ====
+    {
+        "private": true,
+        "type": "module"
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).errors.txt
@@ -6,7 +6,7 @@
     foo;
     ~~~
 !!! error TS2304: Cannot find name 'foo'.
-    bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+    bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
     export {};
 ==== /node_modules/pkg/package.json (0 errors) ====
     {

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).js
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride3.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [package.json]
+{
+    "private": true,
+    "type": "module"
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="require" />
+foo;
+bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+export {};
+
+//// [index.js]
+/// <reference types="pkg" resolution-mode="require" />
+foo;
+bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+export {};

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).js
@@ -27,11 +27,11 @@ declare global {
 //// [index.ts]
 /// <reference types="pkg" resolution-mode="require" />
 foo;
-bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
 export {};
 
 //// [index.js]
 /// <reference types="pkg" resolution-mode="require" />
 foo;
-bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
 export {};

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).symbols
@@ -1,0 +1,15 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="require" />
+foo;
+bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    var bar: number;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).symbols
@@ -1,7 +1,7 @@
 === /index.ts ===
 /// <reference types="pkg" resolution-mode="require" />
 foo;
-bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
 >bar : Symbol(bar, Decl(require.d.ts, 2, 7))
 
 export {};

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).types
@@ -3,7 +3,7 @@
 foo;
 >foo : any
 
-bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
 >bar : number
 
 export {};

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride3(module=nodenext).types
@@ -1,0 +1,17 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="require" />
+foo;
+>foo : any
+
+bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+>bar : number
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var bar: number;
+>bar : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=node12).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=node12).errors.txt
@@ -1,0 +1,29 @@
+/index.ts(3,1): error TS2304: Cannot find name 'bar'.
+
+
+==== /index.ts (1 errors) ====
+    /// <reference types="pkg" resolution-mode="import" />
+    foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+    bar;
+    ~~~
+!!! error TS2304: Cannot find name 'bar'.
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=node12).js
@@ -1,0 +1,33 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride4.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="import" />
+foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+bar;
+export {};
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" resolution-mode="import" />
+foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+bar;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=node12).symbols
@@ -1,0 +1,15 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import" />
+foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+
+bar;
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    var foo: number;
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=node12).types
@@ -1,0 +1,17 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import" />
+foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+>foo : number
+
+bar;
+>bar : any
+
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var foo: number;
+>foo : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=nodenext).errors.txt
@@ -1,0 +1,29 @@
+/index.ts(3,1): error TS2304: Cannot find name 'bar'.
+
+
+==== /index.ts (1 errors) ====
+    /// <reference types="pkg" resolution-mode="import" />
+    foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+    bar;
+    ~~~
+!!! error TS2304: Cannot find name 'bar'.
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=nodenext).js
@@ -1,0 +1,33 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride4.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="import" />
+foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+bar;
+export {};
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" resolution-mode="import" />
+foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+bar;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=nodenext).symbols
@@ -1,0 +1,15 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import" />
+foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+
+bar;
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    var foo: number;
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride4(module=nodenext).types
@@ -1,0 +1,17 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import" />
+foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+>foo : number
+
+bar;
+>bar : any
+
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var foo: number;
+>foo : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=node12).js
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride5.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="import" />
+/// <reference types="pkg" resolution-mode="require" />
+// Both `foo` and `bar` should resolve, as _both_ entrypoints are included by the two
+// references above.
+foo;
+bar;
+export {};
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" resolution-mode="import" />
+/// <reference types="pkg" resolution-mode="require" />
+// Both `foo` and `bar` should resolve, as _both_ entrypoints are included by the two
+// references above.
+foo;
+bar;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=node12).symbols
@@ -1,0 +1,28 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import" />
+/// <reference types="pkg" resolution-mode="require" />
+// Both `foo` and `bar` should resolve, as _both_ entrypoints are included by the two
+// references above.
+foo;
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+
+bar;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    var foo: number;
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    var bar: number;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=node12).types
@@ -1,0 +1,28 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import" />
+/// <reference types="pkg" resolution-mode="require" />
+// Both `foo` and `bar` should resolve, as _both_ entrypoints are included by the two
+// references above.
+foo;
+>foo : number
+
+bar;
+>bar : number
+
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var foo: number;
+>foo : number
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var bar: number;
+>bar : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=nodenext).js
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride5.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="import" />
+/// <reference types="pkg" resolution-mode="require" />
+// Both `foo` and `bar` should resolve, as _both_ entrypoints are included by the two
+// references above.
+foo;
+bar;
+export {};
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" resolution-mode="import" />
+/// <reference types="pkg" resolution-mode="require" />
+// Both `foo` and `bar` should resolve, as _both_ entrypoints are included by the two
+// references above.
+foo;
+bar;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=nodenext).symbols
@@ -1,0 +1,28 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import" />
+/// <reference types="pkg" resolution-mode="require" />
+// Both `foo` and `bar` should resolve, as _both_ entrypoints are included by the two
+// references above.
+foo;
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+
+bar;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(import.d.ts, 0, 10))
+
+    var foo: number;
+>foo : Symbol(foo, Decl(import.d.ts, 2, 7))
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    var bar: number;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverride5(module=nodenext).types
@@ -1,0 +1,28 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="import" />
+/// <reference types="pkg" resolution-mode="require" />
+// Both `foo` and `bar` should resolve, as _both_ entrypoints are included by the two
+// references above.
+foo;
+>foo : number
+
+bar;
+>bar : number
+
+export {};
+=== /node_modules/pkg/import.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var foo: number;
+>foo : number
+}
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var bar: number;
+>bar : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=node12).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=node12).errors.txt
@@ -1,0 +1,32 @@
+/index.ts(1,23): error TS1453: `resolution-mode` should be either `require` or `import`.
+/index.ts(2,1): error TS2304: Cannot find name 'foo'.
+
+
+==== /index.ts (2 errors) ====
+    /// <reference types="pkg" resolution-mode="esm"/>
+                          ~~~
+!!! error TS1453: `resolution-mode` should be either `require` or `import`.
+    foo; // bad resolution mode, which resolves is arbitrary
+    ~~~
+!!! error TS2304: Cannot find name 'foo'.
+    bar;
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=node12).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=node12).js
@@ -1,0 +1,33 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverrideModeError.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="esm"/>
+foo; // bad resolution mode, which resolves is arbitrary
+bar;
+export {};
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" resolution-mode="esm"/>
+foo; // bad resolution mode, which resolves is arbitrary
+bar;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=node12).symbols
@@ -1,0 +1,15 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="esm"/>
+foo; // bad resolution mode, which resolves is arbitrary
+bar;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    var bar: number;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=node12).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=node12).types
@@ -1,0 +1,17 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="esm"/>
+foo; // bad resolution mode, which resolves is arbitrary
+>foo : any
+
+bar;
+>bar : number
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var bar: number;
+>bar : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=nodenext).errors.txt
@@ -1,0 +1,32 @@
+/index.ts(1,23): error TS1453: `resolution-mode` should be either `require` or `import`.
+/index.ts(2,1): error TS2304: Cannot find name 'foo'.
+
+
+==== /index.ts (2 errors) ====
+    /// <reference types="pkg" resolution-mode="esm"/>
+                          ~~~
+!!! error TS1453: `resolution-mode` should be either `require` or `import`.
+    foo; // bad resolution mode, which resolves is arbitrary
+    ~~~
+!!! error TS2304: Cannot find name 'foo'.
+    bar;
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=nodenext).js
@@ -1,0 +1,33 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverrideModeError.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="esm"/>
+foo; // bad resolution mode, which resolves is arbitrary
+bar;
+export {};
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="pkg" resolution-mode="esm"/>
+foo; // bad resolution mode, which resolves is arbitrary
+bar;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=nodenext).symbols
@@ -1,0 +1,15 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="esm"/>
+foo; // bad resolution mode, which resolves is arbitrary
+bar;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : Symbol(global, Decl(require.d.ts, 0, 10))
+
+    var bar: number;
+>bar : Symbol(bar, Decl(require.d.ts, 2, 7))
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideModeError(module=nodenext).types
@@ -1,0 +1,17 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="esm"/>
+foo; // bad resolution mode, which resolves is arbitrary
+>foo : any
+
+bar;
+>bar : number
+
+export {};
+=== /node_modules/pkg/require.d.ts ===
+export {};
+declare global {
+>global : typeof global
+
+    var bar: number;
+>bar : number
+}

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.errors.txt
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.errors.txt
@@ -1,0 +1,45 @@
+/index.ts(1,23): error TS1452: Resolution modes are only supported when `moduleResolution` is `node12` or `nodenext`.
+/index.ts(1,23): error TS2688: Cannot find type definition file for 'pkg'.
+/index.ts(2,23): error TS1452: Resolution modes are only supported when `moduleResolution` is `node12` or `nodenext`.
+/index.ts(2,23): error TS2688: Cannot find type definition file for 'pkg'.
+/index.ts(3,1): error TS2304: Cannot find name 'foo'.
+/index.ts(4,1): error TS2304: Cannot find name 'bar'.
+
+
+==== /index.ts (6 errors) ====
+    /// <reference types="pkg" resolution-mode="require" />
+                          ~~~
+!!! error TS1452: Resolution modes are only supported when `moduleResolution` is `node12` or `nodenext`.
+                          ~~~
+!!! error TS2688: Cannot find type definition file for 'pkg'.
+    /// <reference types="pkg" resolution-mode="import" />
+                          ~~~
+!!! error TS1452: Resolution modes are only supported when `moduleResolution` is `node12` or `nodenext`.
+                          ~~~
+!!! error TS2688: Cannot find type definition file for 'pkg'.
+    foo; // `resolution-mode` is an error in old resolution settings, which resolves is arbitrary
+    ~~~
+!!! error TS2304: Cannot find name 'foo'.
+    bar;
+    ~~~
+!!! error TS2304: Cannot find name 'bar'.
+    export {};
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var foo: number;
+    }
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export {};
+    declare global {
+        var bar: number;
+    }

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.js
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.js
@@ -1,0 +1,35 @@
+//// [tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export {};
+declare global {
+    var foo: number;
+}
+//// [require.d.ts]
+export {};
+declare global {
+    var bar: number;
+}
+//// [index.ts]
+/// <reference types="pkg" resolution-mode="require" />
+/// <reference types="pkg" resolution-mode="import" />
+foo; // `resolution-mode` is an error in old resolution settings, which resolves is arbitrary
+bar;
+export {};
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+/// <reference types="pkg" resolution-mode="require" />
+/// <reference types="pkg" resolution-mode="import" />
+foo; // `resolution-mode` is an error in old resolution settings, which resolves is arbitrary
+bar;

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.symbols
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.symbols
@@ -1,0 +1,7 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="require" />
+No type information for this code./// <reference types="pkg" resolution-mode="import" />
+No type information for this code.foo; // `resolution-mode` is an error in old resolution settings, which resolves is arbitrary
+No type information for this code.bar;
+No type information for this code.export {};
+No type information for this code.

--- a/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.types
+++ b/tests/baselines/reference/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.types
@@ -1,0 +1,10 @@
+=== /index.ts ===
+/// <reference types="pkg" resolution-mode="require" />
+/// <reference types="pkg" resolution-mode="import" />
+foo; // `resolution-mode` is an error in old resolution settings, which resolves is arbitrary
+>foo : any
+
+bar;
+>bar : any
+
+export {};

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit1.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit1.ts
@@ -1,0 +1,26 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @declaration: true
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    interface ImportInterface {}
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    interface RequireInterface {}
+}
+// @filename: /index.ts
+/// <reference types="pkg" />
+export interface LocalInterface extends RequireInterface {}

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit2.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit2.ts
@@ -1,0 +1,31 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @declaration: true
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    interface ImportInterface {}
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    interface RequireInterface {}
+}
+// @filename: /package.json
+{
+    "private": true,
+    "type": "module"
+}
+// @filename: /index.ts
+/// <reference types="pkg" />
+export interface LocalInterface extends ImportInterface {}

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit3.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit3.ts
@@ -1,0 +1,31 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @declaration: true
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    interface ImportInterface {}
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    interface RequireInterface {}
+}
+// @filename: /package.json
+{
+    "private": true,
+    "type": "module"
+}
+// @filename: /index.ts
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends RequireInterface {}

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit4.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit4.ts
@@ -1,0 +1,26 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @declaration: true
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    interface ImportInterface {}
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    interface RequireInterface {}
+}
+// @filename: /index.ts
+/// <reference types="pkg" resolution-mode="import"/>
+export interface LocalInterface extends ImportInterface {}

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit5.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit5.ts
@@ -1,0 +1,27 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @declaration: true
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    interface ImportInterface {}
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    interface RequireInterface {}
+}
+// @filename: /index.ts
+/// <reference types="pkg" resolution-mode="import"/>
+/// <reference types="pkg" resolution-mode="require"/>
+export interface LocalInterface extends ImportInterface, RequireInterface {}

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit6.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit6.ts
@@ -1,0 +1,31 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @declaration: true
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    interface ImportInterface {}
+    function getInterI(): ImportInterface;
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    interface RequireInterface {}
+    function getInterR(): RequireInterface;
+}
+// @filename: /uses.ts
+/// <reference types="pkg" />
+export default getInterR();
+// @filename: /index.ts
+import obj from "./uses.js"
+export default (obj as typeof obj);

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts
@@ -1,0 +1,51 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @declaration: true
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    interface ImportInterface { _i: any; }
+    function getInterI(): ImportInterface;
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    interface RequireInterface { _r: any; }
+    function getInterR(): RequireInterface;
+}
+// @filename: /sub1/uses.ts
+/// <reference types="pkg" />
+export default getInterI();
+// @filename: /sub1/package.json
+{
+    "private": true,
+    "type": "module"
+}
+// @filename: /sub2/uses.ts
+/// <reference types="pkg" />
+export default getInterR();
+// @filename: /sub2/package.json
+{
+    "private": true,
+    "type": "commonjs"
+}
+// @filename: /package.json
+{
+    "private": true,
+    "type": "module"
+}
+// @filename: /index.ts
+// only an esm file can `import` both kinds of files
+import obj1 from "./sub1/uses.js"
+import obj2 from "./sub2/uses.js"
+export default [obj1, obj2.default] as const;

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride1.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride1.ts
@@ -1,0 +1,27 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    var foo: number;
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    var bar: number;
+}
+// @filename: /index.ts
+/// <reference types="pkg" />
+foo;
+bar; // bar should resolve while foo should not, since index.js is cjs
+export {};

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride2.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride2.ts
@@ -1,0 +1,32 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    var foo: number;
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    var bar: number;
+}
+// @filename: /package.json
+{
+    "private": true,
+    "type": "module"
+}
+// @filename: /index.ts
+/// <reference types="pkg" />
+foo; // foo should resolve while bar should not, since index.js is esm
+bar;
+export {};

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride3.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride3.ts
@@ -1,0 +1,32 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    var foo: number;
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    var bar: number;
+}
+// @filename: /package.json
+{
+    "private": true,
+    "type": "module"
+}
+// @filename: /index.ts
+/// <reference types="pkg" resolution-mode="require" />
+foo;
+bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+export {};

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride3.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride3.ts
@@ -28,5 +28,5 @@ declare global {
 // @filename: /index.ts
 /// <reference types="pkg" resolution-mode="require" />
 foo;
-bar; // bar should resolve while foo should not, since even though index.js is esm, the refernce is cjs
+bar; // bar should resolve while foo should not, since even though index.js is esm, the reference is cjs
 export {};

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride4.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride4.ts
@@ -1,0 +1,27 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    var foo: number;
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    var bar: number;
+}
+// @filename: /index.ts
+/// <reference types="pkg" resolution-mode="import" />
+foo; // foo should resolve while bar should not, since even though index.js is cjs, the refernce is esm
+bar;
+export {};

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride5.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverride5.ts
@@ -1,0 +1,30 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    var foo: number;
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    var bar: number;
+}
+// @filename: /index.ts
+/// <reference types="pkg" resolution-mode="import" />
+/// <reference types="pkg" resolution-mode="require" />
+// Both `foo` and `bar` should resolve, as _both_ entrypoints are included by the two
+// references above.
+foo;
+bar;
+export {};

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverrideModeError.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverrideModeError.ts
@@ -1,0 +1,27 @@
+// @noImplicitReferences: true
+// @module: node12,nodenext
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    var foo: number;
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    var bar: number;
+}
+// @filename: /index.ts
+/// <reference types="pkg" resolution-mode="esm"/>
+foo; // bad resolution mode, which resolves is arbitrary
+bar;
+export {};

--- a/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.ts
+++ b/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeOverrideOldResolutionError.ts
@@ -1,0 +1,28 @@
+// @noImplicitReferences: true
+// @module: commonjs
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export {};
+declare global {
+    var foo: number;
+}
+// @filename: /node_modules/pkg/require.d.ts
+export {};
+declare global {
+    var bar: number;
+}
+// @filename: /index.ts
+/// <reference types="pkg" resolution-mode="require" />
+/// <reference types="pkg" resolution-mode="import" />
+foo; // `resolution-mode` is an error in old resolution settings, which resolves is arbitrary
+bar;
+export {};

--- a/tests/cases/fourslash/server/nodeNextModuleKindCaching1.ts
+++ b/tests/cases/fourslash/server/nodeNextModuleKindCaching1.ts
@@ -1,0 +1,35 @@
+/// <reference path="../fourslash.ts"/>
+
+// @Filename: tsconfig.json
+////{
+////    "compilerOptions": {
+////      "rootDir": "src",
+////      "outDir": "dist",
+////      "target": "ES2020",
+////      "module": "NodeNext",
+////      "strict": true
+////    },
+////    "include": ["src\\**\\*.ts"]
+////}
+
+// @Filename: package.json
+////{
+////    "type": "module",
+////    "private": true
+////}
+
+// @Filename: src/index.ts
+////// The line below should show a "Relative import paths need explicit file
+////// extensions..." error in VS Code, but it doesn't. The error is only picked up
+////// by `tsc` which seems to properly infer the module type.
+////import { helloWorld } from './example'
+/////**/
+////helloWorld()
+
+// @Filename: src/example.ts
+////export function helloWorld() {
+////    console.log('Hello, world!')
+////}
+
+goTo.marker();
+verify.numberOfErrorsInCurrentFile(1);

--- a/tests/cases/fourslash/server/tripleSlashReferenceResolutionMode.ts
+++ b/tests/cases/fourslash/server/tripleSlashReferenceResolutionMode.ts
@@ -1,0 +1,28 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "nodenext", "declaration": true, "strict": true, "outDir": "out" }, "files": ["./index.ts"] }
+
+// @Filename: /package.json
+//// { "private": true, "type": "commonjs" }
+
+// @Filename: /node_modules/pkg/package.json
+////{ "name": "pkg", "version": "0.0.1", "exports": { "require": "./require.cjs", "default": "./import.js" }, "type": "module" }
+
+// @Filename: /node_modules/pkg/require.d.cts
+////export {};
+////export interface PkgRequireInterface { member: any; }
+////declare global { const pkgRequireGlobal: PkgRequireInterface; }
+
+// @Filename: /node_modules/pkg/import.d.ts
+////export {};
+////export interface PkgImportInterface { field: any; }
+////declare global { const pkgImportGlobal: PkgImportInterface; }
+
+// @Filename: /index.ts
+/////// <reference types="pkg" resolution-mode="import" />
+////pkgImportGlobal;
+////export {};
+
+goTo.file("/index.ts");
+verify.numberOfErrorsInCurrentFile(0);


### PR DESCRIPTION
They now use the file's default mode by default, rather than always using commonjs. The new arguments to the
reference directive look like:

```ts
///<reference types="pkg" resolution-mode="require" />
```

or

```ts
///<reference types="pkg" resolution-mode="import" />
```

We consider it an error to see these kinds of references outside of `node12` or `nodenext` resolution. This change is separate from the change adding similar configurability for type-only imports (and import types), as the plumbing work to support multi-modal type reference directives is much more extensive (since the API changes to support modality for them was not yet in place), so is probably best reviewed on its own.


Fixes #47795
Fixes #47806