### PR TITLE
Add support for formatRange to Intl.DateTimeFormat 

### DIFF
--- a/src/lib/esnext.intl.d.ts
+++ b/src/lib/esnext.intl.d.ts
@@ -1,3 +1,6 @@
 declare namespace Intl {
-   // Empty for now
+   
+   interface DateTimeFormat {
+      formatRange(startName: Date, endNumber: Date): string;
+   }
 }

--- a/src/lib/esnext.intl.d.ts
+++ b/src/lib/esnext.intl.d.ts
@@ -1,5 +1,5 @@
 declare namespace Intl {
-   
+
    interface DateTimeFormat {
       formatRange(startName: Date, endNumber: Date): string;
    }


### PR DESCRIPTION
Fixes #46905

Follows the specification described here: https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formatRange

Note: I ran `gulp LKG` locally and it generated a lot of changes (looks like `lib/` isn't up to date). Is that something I should run or something the the maintainers take care of?