### PR TITLE
Refactor named imports to default instead of namespace when esModuleInterop is on and module is an `export=`

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1252,11 +1252,11 @@ namespace ts {
         return result;
     }
 
-    export function getOwnValues<T>(sparseArray: T[]): T[] {
+    export function getOwnValues<T>(collection: MapLike<T> | T[]): T[] {
         const values: T[] = [];
-        for (const key in sparseArray) {
-            if (hasOwnProperty.call(sparseArray, key)) {
-                values.push(sparseArray[key]);
+        for (const key in collection) {
+            if (hasOwnProperty.call(collection, key)) {
+                values.push((collection as MapLike<T>)[key]);
             }
         }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -7131,6 +7131,10 @@
         "category": "Message",
         "code": 95169
     },
+    "Convert named imports to default import": {
+        "category": "Message",
+        "code": 95170
+    },
 
     "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer.": {
         "category": "Error",

--- a/tests/cases/fourslash/refactorConvertImport_namedToDefault1.ts
+++ b/tests/cases/fourslash/refactorConvertImport_namedToDefault1.ts
@@ -1,0 +1,50 @@
+/// <reference path="fourslash.ts" />
+
+// @esModuleInterop: true
+
+// @Filename: /process.d.ts
+//// declare module "process" {
+////   interface Process {
+////     pid: number;
+////     addListener(event: string, listener: (...args: any[]) => void): void;
+////   }
+////   var process: Process;
+////   export = process;
+//// }
+
+// @Filename: /url.d.ts
+//// declare module "url" {
+////   export function parse(urlStr: string): any;
+//// }
+
+// @Filename: /index.ts
+//// [|import { pid, addListener } from "process";|]
+//// addListener("message", (m) => {
+////   console.log(pid);
+//// });
+
+// @Filename: /a.ts
+//// [|import { parse } from "url";|]
+//// parse("https://www.typescriptlang.org");
+
+goTo.selectRange(test.ranges()[0]);
+edit.applyRefactor({
+  refactorName: "Convert import",
+  actionName: "Convert named imports to default import",
+  actionDescription: "Convert named imports to default import",
+  newContent: `import process from "process";
+process.addListener("message", (m) => {
+  console.log(process.pid);
+});`,
+});
+verify.not.refactorAvailable("Convert import", "Convert named imports to namespace import");
+
+goTo.selectRange(test.ranges()[1]);
+edit.applyRefactor({
+  refactorName: "Convert import",
+  actionName: "Convert named imports to namespace import",
+  actionDescription: "Convert named imports to namespace import",
+  newContent: `import * as url from "url";
+url.parse("https://www.typescriptlang.org");`,
+});
+verify.not.refactorAvailable("Convert import", "Convert named imports to default import");


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

If a module declares an `export =`, we let you import the resolved export’s members with named imports, but this is generally asking for a bad time. If you have `esModuleInterop` enabled, the best thing to do with an `export =` is to default-import it. However, the refactor we offer is to convert the named imports to a namespace (`import *`) import. That’s definitely the most correct translation from named imports, but if you were _already_ doing something super sketchy by using named imports, we can nudge you in the direction of doing something better by replacing them with a default import instead a namespace import.

Closes #46047
