### PR TITLE
fix(47733): JSDoc comment template incorrectly returned for element that already has JSDoc comment

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -333,7 +333,8 @@ namespace ts.JsDoc {
         }
 
         const { commentOwner, parameters, hasReturn } = commentOwnerInfo;
-        if (commentOwner.getStart(sourceFile) < position) {
+        const commentOwnerJSDoc = hasJSDocNodes(commentOwner) && commentOwner.jsDoc ? lastOrUndefined(commentOwner.jsDoc) : undefined;
+        if (commentOwner.getStart(sourceFile) < position || commentOwnerJSDoc && commentOwnerJSDoc !== existingDocComment) {
             return undefined;
         }
 

--- a/tests/cases/fourslash/docCommentTemplateWithExistingJSDoc.ts
+++ b/tests/cases/fourslash/docCommentTemplateWithExistingJSDoc.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+/////** /**/ */
+////
+/////**
+//// * @param {string} a
+//// * @param {string} b
+//// */
+////function foo(a, b) {
+////    return a + b;
+////}
+
+verify.noDocCommentTemplateAt("");


### PR DESCRIPTION
Fixes #47733