### PR TITLE
Treat intersection types as potential `never`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17815,6 +17815,8 @@ namespace ts {
             const t = target.flags;
             if (t & TypeFlags.AnyOrUnknown || s & TypeFlags.Never || source === wildcardType) return true;
             if (t & TypeFlags.Never) return false;
+            // Intersection types that would be reduced to never may be passed as `target`, thus returning early.
+            if (t & TypeFlags.Intersection) return false;
             if (s & TypeFlags.StringLike && t & TypeFlags.String) return true;
             if (s & TypeFlags.StringLiteral && s & TypeFlags.EnumLiteral &&
                 t & TypeFlags.StringLiteral && !(t & TypeFlags.EnumLiteral) &&

--- a/tests/baselines/reference/intersectionReductionInFunctionReturnType.errors.txt
+++ b/tests/baselines/reference/intersectionReductionInFunctionReturnType.errors.txt
@@ -1,0 +1,60 @@
+tests/cases/compiler/intersectionReductionInFunctionReturnType.ts(15,5): error TS2322: Type 'undefined[]' is not assignable to type 'never[]'.
+  Type 'undefined' is not assignable to type 'never'.
+    The intersection 'C' was reduced to 'never' because property 'p' has conflicting types in some constituents.
+tests/cases/compiler/intersectionReductionInFunctionReturnType.ts(23,3): error TS2322: Type 'undefined' is not assignable to type 'never'.
+tests/cases/compiler/intersectionReductionInFunctionReturnType.ts(27,3): error TS2322: Type 'undefined' is not assignable to type 'never'.
+  The intersection 'C' was reduced to 'never' because property 'p' has conflicting types in some constituents.
+tests/cases/compiler/intersectionReductionInFunctionReturnType.ts(30,16): error TS2534: A function returning 'never' cannot have a reachable end point.
+tests/cases/compiler/intersectionReductionInFunctionReturnType.ts(32,16): error TS2534: A function returning 'never' cannot have a reachable end point.
+  The intersection 'C' was reduced to 'never' because property 'p' has conflicting types in some constituents.
+
+
+==== tests/cases/compiler/intersectionReductionInFunctionReturnType.ts (5 errors) ====
+    // repro from #46032
+    
+    interface A {
+      p: "a";
+    }
+    
+    interface B {
+      p: "b";
+    }
+    
+    type C = A & B;
+    
+    function func(): { value: C[] } {
+      return {
+        value: [],
+        ~~~~~
+!!! error TS2322: Type 'undefined[]' is not assignable to type 'never[]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'never'.
+!!! error TS2322:     The intersection 'C' was reduced to 'never' because property 'p' has conflicting types in some constituents.
+!!! related TS6500 tests/cases/compiler/intersectionReductionInFunctionReturnType.ts:13:20: The expected type comes from property 'value' which is declared here on type '{ value: never[]; }'
+      };
+    }
+    
+    // other tests
+    // Using `C` in place of `never` shouldn't change the errors other than elaboration
+    
+    function f1(): never {
+      return;
+      ~~~~~~~
+!!! error TS2322: Type 'undefined' is not assignable to type 'never'.
+    }
+    
+    function f2(): C {
+      return;
+      ~~~~~~~
+!!! error TS2322: Type 'undefined' is not assignable to type 'never'.
+!!! error TS2322:   The intersection 'C' was reduced to 'never' because property 'p' has conflicting types in some constituents.
+    }
+    
+    function g1(): never {}
+                   ~~~~~
+!!! error TS2534: A function returning 'never' cannot have a reachable end point.
+    
+    function g2(): C {}
+                   ~
+!!! error TS2534: A function returning 'never' cannot have a reachable end point.
+!!! error TS2534:   The intersection 'C' was reduced to 'never' because property 'p' has conflicting types in some constituents.
+    

--- a/tests/baselines/reference/intersectionReductionInFunctionReturnType.js
+++ b/tests/baselines/reference/intersectionReductionInFunctionReturnType.js
@@ -1,0 +1,52 @@
+//// [intersectionReductionInFunctionReturnType.ts]
+// repro from #46032
+
+interface A {
+  p: "a";
+}
+
+interface B {
+  p: "b";
+}
+
+type C = A & B;
+
+function func(): { value: C[] } {
+  return {
+    value: [],
+  };
+}
+
+// other tests
+// Using `C` in place of `never` shouldn't change the errors other than elaboration
+
+function f1(): never {
+  return;
+}
+
+function f2(): C {
+  return;
+}
+
+function g1(): never {}
+
+function g2(): C {}
+
+
+//// [intersectionReductionInFunctionReturnType.js]
+// repro from #46032
+function func() {
+    return {
+        value: []
+    };
+}
+// other tests
+// Using `C` in place of `never` shouldn't change the errors other than elaboration
+function f1() {
+    return;
+}
+function f2() {
+    return;
+}
+function g1() { }
+function g2() { }

--- a/tests/baselines/reference/intersectionReductionInFunctionReturnType.symbols
+++ b/tests/baselines/reference/intersectionReductionInFunctionReturnType.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/compiler/intersectionReductionInFunctionReturnType.ts ===
+// repro from #46032
+
+interface A {
+>A : Symbol(A, Decl(intersectionReductionInFunctionReturnType.ts, 0, 0))
+
+  p: "a";
+>p : Symbol(A.p, Decl(intersectionReductionInFunctionReturnType.ts, 2, 13))
+}
+
+interface B {
+>B : Symbol(B, Decl(intersectionReductionInFunctionReturnType.ts, 4, 1))
+
+  p: "b";
+>p : Symbol(B.p, Decl(intersectionReductionInFunctionReturnType.ts, 6, 13))
+}
+
+type C = A & B;
+>C : Symbol(C, Decl(intersectionReductionInFunctionReturnType.ts, 8, 1))
+>A : Symbol(A, Decl(intersectionReductionInFunctionReturnType.ts, 0, 0))
+>B : Symbol(B, Decl(intersectionReductionInFunctionReturnType.ts, 4, 1))
+
+function func(): { value: C[] } {
+>func : Symbol(func, Decl(intersectionReductionInFunctionReturnType.ts, 10, 15))
+>value : Symbol(value, Decl(intersectionReductionInFunctionReturnType.ts, 12, 18))
+>C : Symbol(C, Decl(intersectionReductionInFunctionReturnType.ts, 8, 1))
+
+  return {
+    value: [],
+>value : Symbol(value, Decl(intersectionReductionInFunctionReturnType.ts, 13, 10))
+
+  };
+}
+
+// other tests
+// Using `C` in place of `never` shouldn't change the errors other than elaboration
+
+function f1(): never {
+>f1 : Symbol(f1, Decl(intersectionReductionInFunctionReturnType.ts, 16, 1))
+
+  return;
+}
+
+function f2(): C {
+>f2 : Symbol(f2, Decl(intersectionReductionInFunctionReturnType.ts, 23, 1))
+>C : Symbol(C, Decl(intersectionReductionInFunctionReturnType.ts, 8, 1))
+
+  return;
+}
+
+function g1(): never {}
+>g1 : Symbol(g1, Decl(intersectionReductionInFunctionReturnType.ts, 27, 1))
+
+function g2(): C {}
+>g2 : Symbol(g2, Decl(intersectionReductionInFunctionReturnType.ts, 29, 23))
+>C : Symbol(C, Decl(intersectionReductionInFunctionReturnType.ts, 8, 1))
+

--- a/tests/baselines/reference/intersectionReductionInFunctionReturnType.types
+++ b/tests/baselines/reference/intersectionReductionInFunctionReturnType.types
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/intersectionReductionInFunctionReturnType.ts ===
+// repro from #46032
+
+interface A {
+  p: "a";
+>p : "a"
+}
+
+interface B {
+  p: "b";
+>p : "b"
+}
+
+type C = A & B;
+>C : never
+
+function func(): { value: C[] } {
+>func : () => {    value: C[];}
+>value : never[]
+
+  return {
+>{    value: [],  } : { value: undefined[]; }
+
+    value: [],
+>value : undefined[]
+>[] : undefined[]
+
+  };
+}
+
+// other tests
+// Using `C` in place of `never` shouldn't change the errors other than elaboration
+
+function f1(): never {
+>f1 : () => never
+
+  return;
+}
+
+function f2(): C {
+>f2 : () => C
+
+  return;
+}
+
+function g1(): never {}
+>g1 : () => never
+
+function g2(): C {}
+>g2 : () => C
+

--- a/tests/cases/compiler/intersectionReductionInFunctionReturnType.ts
+++ b/tests/cases/compiler/intersectionReductionInFunctionReturnType.ts
@@ -1,0 +1,34 @@
+// @strict: false
+
+// repro from #46032
+
+interface A {
+  p: "a";
+}
+
+interface B {
+  p: "b";
+}
+
+type C = A & B;
+
+function func(): { value: C[] } {
+  return {
+    value: [],
+  };
+}
+
+// other tests
+// Using `C` in place of `never` shouldn't change the errors other than elaboration
+
+function f1(): never {
+  return;
+}
+
+function f2(): C {
+  return;
+}
+
+function g1(): never {}
+
+function g2(): C {}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #46032

This PR fixes crashes and improves error messages when a function is declared to return a type alias that names an intersection type of object-like types that reduces to `never`.

Besides #46032, there have been certain circumstances under which using such type aliases as functions' return type emits error messages different from using `never` directly ([playground](https://www.typescriptlang.org/play?strict=false&noImplicitAny=false&strictNullChecks=false&strictFunctionTypes=false&strictPropertyInitialization=false&strictBindCallApply=false&noImplicitThis=false&noImplicitReturns=false&alwaysStrict=false&ts=4.6.0-dev.20220116#code/C4TwDgpgBAglC8UDeUwC4oCIaagXwG4AoUSKAIQWVQ03N0JPGgGEq4AyC4ogMwFcAdgGNgASwD2gqLwCMACgCUGQRABuEAE7IiUKJojB+mwcTxE+Q0ZOm8ATEoxsku-YeOmi5yyPFSoAOYKylCqGtpI3gK+NoEOIc54QA)). This PR improves error messages so that they emit the same errors (aside from elaboration of `never` intersections). This is actually not really related to #46032, so let me know if I should open a separate issue/PR.