### PR TITLE
feat(44956): jsdoc comments - remove hyphen separator

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -152,12 +152,21 @@ namespace ts.JsDoc {
 
     function getDisplayPartsFromComment(comment: string | readonly JSDocComment[], checker: TypeChecker | undefined): SymbolDisplayPart[] {
         if (typeof comment === "string") {
-            return [textPart(comment)];
+            return [textPart(skipSeparatorFromComment(comment))];
         }
         return flatMap(
             comment,
-            node => node.kind === SyntaxKind.JSDocText ? [textPart(node.text)] : buildLinkParts(node, checker)
+            node => node.kind === SyntaxKind.JSDocText ? [textPart(skipSeparatorFromComment(node.text))] : buildLinkParts(node, checker)
         ) as SymbolDisplayPart[];
+    }
+
+    function skipSeparatorFromComment(text: string) {
+        let pos = 0;
+        if (text.charCodeAt(pos++) === CharacterCodes.minus) {
+            while (pos < text.length && text.charCodeAt(pos) === CharacterCodes.space) pos++;
+            return text.slice(pos);
+        }
+        return text;
     }
 
     function getCommentDisplayParts(tag: JSDocTag, checker?: TypeChecker): SymbolDisplayPart[] | undefined {

--- a/src/testRunner/unittests/tsserver/jsdocTag.ts
+++ b/src/testRunner/unittests/tsserver/jsdocTag.ts
@@ -386,11 +386,11 @@ x(1)`
                 displayPartsForJSDoc: false,
                 tags: [{
                     name: "param",
-                    text: "y - {@link C}"
+                    text: "y {@link C}"
                 }],
                 documentation: [{
                     kind: "text",
-                    text: "- "
+                    text: ""
                 }, {
                     kind: "link",
                     text: "{@link "
@@ -425,7 +425,7 @@ x(1)`
                     text: " "
                 }, {
                     kind: "text",
-                    text: "- "
+                    text: ""
                 }, {
                     kind: "link",
                     text: "{@link "
@@ -461,11 +461,11 @@ x(1)`
                 displayPartsForJSDoc: false,
                 tags: [{
                     name: "param",
-                    text: "y - {@link C}"
+                    text: "y {@link C}"
                 }],
                 documentation: [{
                     kind: "text",
-                    text: "- "
+                    text: ""
                 }, {
                     kind: "link",
                     text: "{@link "
@@ -496,7 +496,7 @@ x(1)`
                     text: " "
                 }, {
                     kind: "text",
-                    text: "- "
+                    text: ""
                 }, {
                     kind: "link",
                     text: "{@link "
@@ -610,7 +610,7 @@ foo`
                         text: " "
                     }, {
                         kind: "text",
-                        text: "- see "
+                        text: "see "
                     }, {
                         kind: "link",
                         text: "{@link "
@@ -641,7 +641,7 @@ foo`
                 displayPartsForJSDoc: false,
                 tags: [{
                     name: "param",
-                    text: "x - see {@link C}",
+                    text: "x see {@link C}",
                 }],
             });
         });
@@ -659,7 +659,7 @@ foo`
                         text: " "
                     }, {
                         kind: "text",
-                        text: "- see "
+                        text: "see "
                     }, {
                         kind: "link",
                         text: "{@link "
@@ -686,7 +686,7 @@ foo`
                 displayPartsForJSDoc: false,
                 tags: [{
                     name: "param",
-                    text: "x - see {@link C}",
+                    text: "x see {@link C}",
                 }],
             });
         });

--- a/tests/baselines/reference/jsDocFunctionSignatures6.baseline
+++ b/tests/baselines/reference/jsDocFunctionSignatures6.baseline
@@ -52,7 +52,7 @@
               "name": "p1",
               "documentation": [
                 {
-                  "text": "- A string param",
+                  "text": "A string param",
                   "kind": "text"
                 }
               ],
@@ -81,7 +81,7 @@
               "name": "p2",
               "documentation": [
                 {
-                  "text": "- An optional param",
+                  "text": "An optional param",
                   "kind": "text"
                 }
               ],
@@ -110,7 +110,7 @@
               "name": "p3",
               "documentation": [
                 {
-                  "text": "- Another optional param",
+                  "text": "Another optional param",
                   "kind": "text"
                 }
               ],
@@ -143,7 +143,7 @@
               "name": "p4",
               "documentation": [
                 {
-                  "text": "- An optional param with a default value",
+                  "text": "An optional param with a default value",
                   "kind": "text"
                 }
               ],
@@ -187,7 +187,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- A string param",
+                  "text": "A string param",
                   "kind": "text"
                 }
               ]
@@ -204,7 +204,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- An optional param",
+                  "text": "An optional param",
                   "kind": "text"
                 }
               ]
@@ -221,7 +221,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- Another optional param",
+                  "text": "Another optional param",
                   "kind": "text"
                 }
               ]
@@ -238,7 +238,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- An optional param with a default value",
+                  "text": "An optional param with a default value",
                   "kind": "text"
                 }
               ]
@@ -308,7 +308,7 @@
               "name": "p1",
               "documentation": [
                 {
-                  "text": "- A string param",
+                  "text": "A string param",
                   "kind": "text"
                 }
               ],
@@ -337,7 +337,7 @@
               "name": "p2",
               "documentation": [
                 {
-                  "text": "- An optional param",
+                  "text": "An optional param",
                   "kind": "text"
                 }
               ],
@@ -366,7 +366,7 @@
               "name": "p3",
               "documentation": [
                 {
-                  "text": "- Another optional param",
+                  "text": "Another optional param",
                   "kind": "text"
                 }
               ],
@@ -399,7 +399,7 @@
               "name": "p4",
               "documentation": [
                 {
-                  "text": "- An optional param with a default value",
+                  "text": "An optional param with a default value",
                   "kind": "text"
                 }
               ],
@@ -443,7 +443,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- A string param",
+                  "text": "A string param",
                   "kind": "text"
                 }
               ]
@@ -460,7 +460,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- An optional param",
+                  "text": "An optional param",
                   "kind": "text"
                 }
               ]
@@ -477,7 +477,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- Another optional param",
+                  "text": "Another optional param",
                   "kind": "text"
                 }
               ]
@@ -494,7 +494,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- An optional param with a default value",
+                  "text": "An optional param with a default value",
                   "kind": "text"
                 }
               ]
@@ -564,7 +564,7 @@
               "name": "p1",
               "documentation": [
                 {
-                  "text": "- A string param",
+                  "text": "A string param",
                   "kind": "text"
                 }
               ],
@@ -593,7 +593,7 @@
               "name": "p2",
               "documentation": [
                 {
-                  "text": "- An optional param",
+                  "text": "An optional param",
                   "kind": "text"
                 }
               ],
@@ -622,7 +622,7 @@
               "name": "p3",
               "documentation": [
                 {
-                  "text": "- Another optional param",
+                  "text": "Another optional param",
                   "kind": "text"
                 }
               ],
@@ -655,7 +655,7 @@
               "name": "p4",
               "documentation": [
                 {
-                  "text": "- An optional param with a default value",
+                  "text": "An optional param with a default value",
                   "kind": "text"
                 }
               ],
@@ -699,7 +699,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- A string param",
+                  "text": "A string param",
                   "kind": "text"
                 }
               ]
@@ -716,7 +716,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- An optional param",
+                  "text": "An optional param",
                   "kind": "text"
                 }
               ]
@@ -733,7 +733,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- Another optional param",
+                  "text": "Another optional param",
                   "kind": "text"
                 }
               ]
@@ -750,7 +750,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- An optional param with a default value",
+                  "text": "An optional param with a default value",
                   "kind": "text"
                 }
               ]
@@ -820,7 +820,7 @@
               "name": "p1",
               "documentation": [
                 {
-                  "text": "- A string param",
+                  "text": "A string param",
                   "kind": "text"
                 }
               ],
@@ -849,7 +849,7 @@
               "name": "p2",
               "documentation": [
                 {
-                  "text": "- An optional param",
+                  "text": "An optional param",
                   "kind": "text"
                 }
               ],
@@ -878,7 +878,7 @@
               "name": "p3",
               "documentation": [
                 {
-                  "text": "- Another optional param",
+                  "text": "Another optional param",
                   "kind": "text"
                 }
               ],
@@ -911,7 +911,7 @@
               "name": "p4",
               "documentation": [
                 {
-                  "text": "- An optional param with a default value",
+                  "text": "An optional param with a default value",
                   "kind": "text"
                 }
               ],
@@ -955,7 +955,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- A string param",
+                  "text": "A string param",
                   "kind": "text"
                 }
               ]
@@ -972,7 +972,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- An optional param",
+                  "text": "An optional param",
                   "kind": "text"
                 }
               ]
@@ -989,7 +989,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- Another optional param",
+                  "text": "Another optional param",
                   "kind": "text"
                 }
               ]
@@ -1006,7 +1006,7 @@
                   "kind": "space"
                 },
                 {
-                  "text": "- An optional param with a default value",
+                  "text": "An optional param with a default value",
                   "kind": "text"
                 }
               ]

--- a/tests/baselines/reference/quickInfoJsDocTags3.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags3.baseline
@@ -107,7 +107,7 @@
               "kind": "space"
             },
             {
-              "text": "- x comment",
+              "text": "x comment",
               "kind": "text"
             }
           ]
@@ -124,7 +124,7 @@
               "kind": "space"
             },
             {
-              "text": "- y comment",
+              "text": "y comment",
               "kind": "text"
             }
           ]

--- a/tests/baselines/reference/quickInfoJsDocTags4.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags4.baseline
@@ -147,7 +147,7 @@
               "kind": "space"
             },
             {
-              "text": "- x comment",
+              "text": "x comment",
               "kind": "text"
             }
           ]
@@ -164,7 +164,7 @@
               "kind": "space"
             },
             {
-              "text": "- y comment",
+              "text": "y comment",
               "kind": "text"
             }
           ]

--- a/tests/baselines/reference/quickInfoJsDocTags5.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags5.baseline
@@ -147,7 +147,7 @@
               "kind": "space"
             },
             {
-              "text": "- x comment",
+              "text": "x comment",
               "kind": "text"
             }
           ]
@@ -164,7 +164,7 @@
               "kind": "space"
             },
             {
-              "text": "- y comment",
+              "text": "y comment",
               "kind": "text"
             }
           ]

--- a/tests/baselines/reference/quickInfoJsDocTags6.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags6.baseline
@@ -147,7 +147,7 @@
               "kind": "space"
             },
             {
-              "text": "- x comment",
+              "text": "x comment",
               "kind": "text"
             }
           ]
@@ -164,7 +164,7 @@
               "kind": "space"
             },
             {
-              "text": "- y comment",
+              "text": "y comment",
               "kind": "text"
             }
           ]

--- a/tests/baselines/reference/signatureHelpJSDocCallbackTag.baseline
+++ b/tests/baselines/reference/signatureHelpJSDocCallbackTag.baseline
@@ -52,7 +52,7 @@
               "name": "eventName",
               "documentation": [
                 {
-                  "text": "- So many words",
+                  "text": "So many words",
                   "kind": "text"
                 }
               ],
@@ -81,7 +81,7 @@
               "name": "eventName2",
               "documentation": [
                 {
-                  "text": "- Silence is golden",
+                  "text": "Silence is golden",
                   "kind": "text"
                 }
               ],
@@ -126,7 +126,7 @@
               "name": "eventName3",
               "documentation": [
                 {
-                  "text": "- Osterreich mos def",
+                  "text": "Osterreich mos def",
                   "kind": "text"
                 }
               ],
@@ -234,7 +234,7 @@
               "name": "eventName",
               "documentation": [
                 {
-                  "text": "- So many words",
+                  "text": "So many words",
                   "kind": "text"
                 }
               ],
@@ -263,7 +263,7 @@
               "name": "eventName2",
               "documentation": [
                 {
-                  "text": "- Silence is golden",
+                  "text": "Silence is golden",
                   "kind": "text"
                 }
               ],
@@ -308,7 +308,7 @@
               "name": "eventName3",
               "documentation": [
                 {
-                  "text": "- Osterreich mos def",
+                  "text": "Osterreich mos def",
                   "kind": "text"
                 }
               ],
@@ -416,7 +416,7 @@
               "name": "eventName",
               "documentation": [
                 {
-                  "text": "- So many words",
+                  "text": "So many words",
                   "kind": "text"
                 }
               ],
@@ -445,7 +445,7 @@
               "name": "eventName2",
               "documentation": [
                 {
-                  "text": "- Silence is golden",
+                  "text": "Silence is golden",
                   "kind": "text"
                 }
               ],
@@ -490,7 +490,7 @@
               "name": "eventName3",
               "documentation": [
                 {
-                  "text": "- Osterreich mos def",
+                  "text": "Osterreich mos def",
                   "kind": "text"
                 }
               ],

--- a/tests/cases/fourslash/server/jsdocCallbackTag.ts
+++ b/tests/cases/fourslash/server/jsdocCallbackTag.ts
@@ -30,6 +30,6 @@ verify.quickInfoIs("var t: FooHandler");
 goTo.marker("2");
 verify.quickInfoIs("var t2: FooHandler2");
 goTo.marker("3");
-verify.quickInfoIs("type FooHandler2 = (eventName?: string | undefined, eventName2?: string) => any", "- What, another one?");
+verify.quickInfoIs("type FooHandler2 = (eventName?: string | undefined, eventName2?: string) => any", "What, another one?");
 goTo.marker("8");
-verify.quickInfoIs("type FooHandler = (eventName: string, eventName2: number | string, eventName3: any) => number", "- A kind of magic");
+verify.quickInfoIs("type FooHandler = (eventName: string, eventName2: number | string, eventName3: any) => number", "A kind of magic");

--- a/tests/cases/fourslash/server/jsdocTypedefTag.ts
+++ b/tests/cases/fourslash/server/jsdocTypedefTag.ts
@@ -71,4 +71,4 @@ verify.completions(
     { marker: "catAge", includes: "toExponential" },
 );
 
-verify.quickInfoAt("AnimalType", "type Animal = {\n    animalName: string;\n    animalAge: number;\n}", "- think Giraffes");
+verify.quickInfoAt("AnimalType", "type Animal = {\n    animalName: string;\n    animalAge: number;\n}", "think Giraffes");


### PR DESCRIPTION
Fixes #44956