### PR TITLE
fix(47783): Crash after case keyword outside of switch statement

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1680,7 +1680,8 @@ namespace ts.Completions {
             case SyntaxKind.NewKeyword:
                 return checker.getContextualType(parent as Expression);
             case SyntaxKind.CaseKeyword:
-                return getSwitchedType(cast(parent, isCaseClause), checker);
+                const caseClause = tryCast(parent, isCaseClause);
+                return caseClause ? getSwitchedType(caseClause, checker) : undefined;
             case SyntaxKind.OpenBraceToken:
                 return isJsxExpression(parent) && !isJsxElement(parent.parent) && !isJsxFragment(parent.parent) ? checker.getContextualTypeForJsxAttribute(parent.parent) : undefined;
             default:

--- a/tests/cases/fourslash/completionAtCaseClause.ts
+++ b/tests/cases/fourslash/completionAtCaseClause.ts
@@ -1,0 +1,6 @@
+/// <reference path="fourslash.ts" />
+
+////case /**/
+
+verify.completions({ marker: "", exact: completion.globals });
+


### PR DESCRIPTION
Fixes #47783