### PR TITLE
preserveValueImports + isolatedModules -> type-only ambient const enums

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -39882,7 +39882,7 @@ namespace ts {
                     && !(node.flags & NodeFlags.Ambient)) {
                     const typeOnlyAlias = getTypeOnlyAliasDeclaration(symbol);
                     const isType = !(target.flags & SymbolFlags.Value);
-                    if (isType || typeOnlyAlias) {
+                    if (isType || typeOnlyAlias || target.valueDeclaration?.flags! & NodeFlags.Ambient && isConstEnumOrConstEnumOnlyModule(target)) {
                         switch (node.kind) {
                             case SyntaxKind.ImportClause:
                             case SyntaxKind.ImportSpecifier:


### PR DESCRIPTION
Currently, if you compile `import Big, { RoundingMode } from "big.js"` with `preserveValueImports` and `isolatedModules` the import name is preserved and you get at runtime:
```sh
import Big, { RoundingMode } from "big.js";
              ^^^^^^^^^^^^
SyntaxError: Named export 'RoundingMode' not found. The requested module 'big.js' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'big.js';
const { RoundingMode } = pkg;
```

`RoundingMode` is an ambient const enum, defined in [@types/big.js](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7467038c60726c43ccfc0f084cd8d5d8f062d234/types/big.js/index.d.ts). There's [no corresponding runtime value](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58523#pullrequestreview-873686805) in big.js.

This PR extends the existing `preserveValueImports` + `isolatedModules` requirement, that [imported types *must* be marked type-only](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#:~:text=Note%20that%20this,a%20runtime%20crash.), to ambient const enums.

If you add the type modifier (`import Big, { type RoundingMode } from "big.js"`), the compiler does remove the import name, solving the runtime error.

This PR specifically excludes *non-ambient* const enums, because they don't lead to runtime errors. (The import name is preserved, but the const enum is also preserved, so not an error at runtime.)