### PR TITLE
Enable path completions for node12/nodenext

### DIFF
--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -368,9 +368,15 @@ namespace ts.Completions.StringCompletions {
         }
     }
 
+    function isEmitResolutionKindUsingNodeModules(compilerOptions: CompilerOptions): boolean {
+        return getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.NodeJs ||
+            getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Node12 ||
+            getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.NodeNext;
+    }
+
     function getSupportedExtensionsForModuleResolution(compilerOptions: CompilerOptions): readonly Extension[][] {
         const extensions = getSupportedExtensions(compilerOptions);
-        return getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.NodeJs ?
+        return isEmitResolutionKindUsingNodeModules(compilerOptions) ?
             getSupportedExtensionsWithJsonIfResolveJsonModule(compilerOptions, extensions) :
             extensions;
     }
@@ -549,7 +555,7 @@ namespace ts.Completions.StringCompletions {
 
         getCompletionEntriesFromTypings(host, compilerOptions, scriptPath, fragmentDirectory, extensionOptions, result);
 
-        if (getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.NodeJs) {
+        if (isEmitResolutionKindUsingNodeModules(compilerOptions)) {
             // If looking for a global package name, don't just include everything in `node_modules` because that includes dependencies' own dependencies.
             // (But do if we didn't find anything, e.g. 'package.json' missing.)
             let foundGlobal = false;

--- a/tests/baselines/reference/nodeNextPathCompletions.baseline
+++ b/tests/baselines/reference/nodeNextPathCompletions.baseline
@@ -1,0 +1,29 @@
+[
+  {
+    "marker": {
+      "fileName": "/src/foo.ts",
+      "position": 30,
+      "name": ""
+    },
+    "completionList": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": true,
+      "entries": [
+        {
+          "name": "dependency",
+          "kind": "external module name",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "dependency",
+              "kind": "text"
+            }
+          ],
+          "tags": []
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/server/nodeNextPathCompletions.ts
+++ b/tests/cases/fourslash/server/nodeNextPathCompletions.ts
@@ -11,7 +11,8 @@
 ////         },
 ////         "./lol": {
 ////             "types": "./lib/lol.d.ts"
-////         }
+////         },
+////        "./dir/*": "./lib/*"
 ////     }
 //// }
 
@@ -37,6 +38,6 @@
 
 verify.baselineCompletions();
 edit.insert("dependency/");
-verify.completions({ exact: ["lol"], isNewIdentifierLocation: true });
+verify.completions({ exact: ["lol", "dir/"], isNewIdentifierLocation: true });
 edit.insert("l");
 verify.completions({ exact: ["lol"], isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/server/nodeNextPathCompletions.ts
+++ b/tests/cases/fourslash/server/nodeNextPathCompletions.ts
@@ -1,3 +1,5 @@
+/// <reference path="../fourslash.ts" />
+
 // @Filename: /node_modules/dependency/package.json
 //// {
 ////     "type": "module",
@@ -34,3 +36,7 @@
 //// import { fooFromIndex } from "/**/";
 
 verify.baselineCompletions();
+edit.insert("dependency/");
+verify.completions({ exact: ["lol"], isNewIdentifierLocation: true });
+edit.insert("l");
+verify.completions({ exact: ["lol"], isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/server/nodeNextPathCompletions.ts
+++ b/tests/cases/fourslash/server/nodeNextPathCompletions.ts
@@ -1,0 +1,36 @@
+// @Filename: /node_modules/dependency/package.json
+//// {
+////     "type": "module",
+////     "name": "dependency",
+////     "version": "1.0.0",
+////     "exports": {
+////         ".": {
+////             "types": "./lib/index.d.ts"
+////         },
+////         "./lol": {
+////             "types": "./lib/lol.d.ts"
+////         }
+////     }
+//// }
+
+// @Filename: /node_modules/dependency/lib/index.d.ts
+//// export function fooFromIndex(): void;
+
+// @Filename: /node_modules/dependency/lib/lol.d.ts
+//// export function fooFromLol(): void;
+
+// @Filename: /package.json
+//// {
+////     "type": "module",
+////     "dependencies": {
+////         "dependency": "^1.0.0"
+////     }
+//// }
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "nodenext" }, "files": ["./src/foo.ts"] }
+
+// @Filename: /src/foo.ts
+//// import { fooFromIndex } from "/**/";
+
+verify.baselineCompletions();


### PR DESCRIPTION
Fixes #47011

Just a matter of swapping some checks in `stringCompletions` to look for any node-like mode rather than just `node`. Did a quick check, and there don't seem to be any other resolution-mode dependent codepaths in services.