### PR TITLE
fix(47794): Fix incorrect substitution on index access on generic mapped type with key remapping

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15567,8 +15567,10 @@ namespace ts {
         }
 
         function substituteIndexedMappedType(objectType: MappedType, index: Type) {
-            const mapper = createTypeMapper([getTypeParameterFromMappedType(objectType)], [index]);
-            const templateMapper = combineTypeMappers(objectType.mapper, mapper);
+            let templateMapper = objectType.mapper;
+            if (!objectType.declaration.nameType) {
+                templateMapper = combineTypeMappers(templateMapper, createTypeMapper([getTypeParameterFromMappedType(objectType)], [index]));
+            }
             return instantiateType(getTemplateTypeFromMappedType(objectType), templateMapper);
         }
 

--- a/tests/baselines/reference/indexAccessOnGenericMappedTypeWithKeyRemapping.js
+++ b/tests/baselines/reference/indexAccessOnGenericMappedTypeWithKeyRemapping.js
@@ -1,0 +1,9 @@
+//// [indexAccessOnGenericMappedTypeWithKeyRemapping.ts]
+type Foo<T extends string> = {
+    [RemappedT in T as `get${RemappedT}`]: RemappedT;
+};
+const get = <T extends string>(t: T, foo: Foo<T>): T => foo[`get${t}`];
+
+
+//// [indexAccessOnGenericMappedTypeWithKeyRemapping.js]
+var get = function (t, foo) { return foo["get".concat(t)]; };

--- a/tests/baselines/reference/indexAccessOnGenericMappedTypeWithKeyRemapping.symbols
+++ b/tests/baselines/reference/indexAccessOnGenericMappedTypeWithKeyRemapping.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/indexAccessOnGenericMappedTypeWithKeyRemapping.ts ===
+type Foo<T extends string> = {
+>Foo : Symbol(Foo, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 0, 0))
+>T : Symbol(T, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 0, 9))
+
+    [RemappedT in T as `get${RemappedT}`]: RemappedT;
+>RemappedT : Symbol(RemappedT, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 1, 5))
+>T : Symbol(T, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 0, 9))
+>RemappedT : Symbol(RemappedT, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 1, 5))
+>RemappedT : Symbol(RemappedT, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 1, 5))
+
+};
+const get = <T extends string>(t: T, foo: Foo<T>): T => foo[`get${t}`];
+>get : Symbol(get, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 3, 5))
+>T : Symbol(T, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 3, 13))
+>t : Symbol(t, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 3, 31))
+>T : Symbol(T, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 3, 13))
+>foo : Symbol(foo, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 3, 36))
+>Foo : Symbol(Foo, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 0, 0))
+>T : Symbol(T, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 3, 13))
+>T : Symbol(T, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 3, 13))
+>foo : Symbol(foo, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 3, 36))
+>t : Symbol(t, Decl(indexAccessOnGenericMappedTypeWithKeyRemapping.ts, 3, 31))
+

--- a/tests/baselines/reference/indexAccessOnGenericMappedTypeWithKeyRemapping.types
+++ b/tests/baselines/reference/indexAccessOnGenericMappedTypeWithKeyRemapping.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/indexAccessOnGenericMappedTypeWithKeyRemapping.ts ===
+type Foo<T extends string> = {
+>Foo : Foo<T>
+
+    [RemappedT in T as `get${RemappedT}`]: RemappedT;
+};
+const get = <T extends string>(t: T, foo: Foo<T>): T => foo[`get${t}`];
+>get : <T extends string>(t: T, foo: Foo<T>) => T
+><T extends string>(t: T, foo: Foo<T>): T => foo[`get${t}`] : <T extends string>(t: T, foo: Foo<T>) => T
+>t : T
+>foo : Foo<T>
+>foo[`get${t}`] : Foo<T>[`get${T}`]
+>foo : Foo<T>
+>`get${t}` : `get${T}`
+>t : T
+

--- a/tests/cases/compiler/indexAccessOnGenericMappedTypeWithKeyRemapping.ts
+++ b/tests/cases/compiler/indexAccessOnGenericMappedTypeWithKeyRemapping.ts
@@ -1,0 +1,4 @@
+type Foo<T extends string> = {
+    [RemappedT in T as `get${RemappedT}`]: RemappedT;
+};
+const get = <T extends string>(t: T, foo: Foo<T>): T => foo[`get${t}`];


### PR DESCRIPTION
Fixes #47794 