### PR TITLE
ESM mode nonrelative imports should assume index.js entrypoints even …

### DIFF
--- a/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution.errors.txt
+++ b/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution.errors.txt
@@ -1,0 +1,31 @@
+tests/cases/compiler/index.ts(2,31): error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node12' or 'nodenext'. Consider adding an extension to the import path.
+tests/cases/compiler/index.ts(3,31): error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node12' or 'nodenext'. Consider adding an extension to the import path.
+
+
+==== tests/cases/compiler/node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1"
+    }
+==== tests/cases/compiler/node_modules/pkg/index.d.ts (0 errors) ====
+    export const item = 4;
+==== tests/cases/compiler/pkg/package.json (0 errors) ====
+    {
+        "private": true
+    }
+==== tests/cases/compiler/pkg/index.d.ts (0 errors) ====
+    export const item = 4;
+==== tests/cases/compiler/package.json (0 errors) ====
+    {
+        "type": "module",
+        "private": true
+    }
+==== tests/cases/compiler/index.ts (2 errors) ====
+    import { item } from "pkg"; // should work (`index.js` is assumed to be the entrypoint for packages found via nonrelative import)
+    import { item as item2 } from "./pkg";  // shouldn't work (`index.js` is _not_ assumed to be the entrypoint for packages found via relative import)
+                                  ~~~~~~~
+!!! error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node12' or 'nodenext'. Consider adding an extension to the import path.
+    import { item as item3 } from "./node_modules/pkg" // _even if they're in a node_modules folder_
+                                  ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node12' or 'nodenext'. Consider adding an extension to the import path.
+    

--- a/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution.js
+++ b/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/nodeNextImportModeImplicitIndexResolution.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1"
+}
+//// [index.d.ts]
+export const item = 4;
+//// [package.json]
+{
+    "private": true
+}
+//// [index.d.ts]
+export const item = 4;
+//// [package.json]
+{
+    "type": "module",
+    "private": true
+}
+//// [index.ts]
+import { item } from "pkg"; // should work (`index.js` is assumed to be the entrypoint for packages found via nonrelative import)
+import { item as item2 } from "./pkg";  // shouldn't work (`index.js` is _not_ assumed to be the entrypoint for packages found via relative import)
+import { item as item3 } from "./node_modules/pkg" // _even if they're in a node_modules folder_
+
+
+//// [index.js]
+export {};

--- a/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution.symbols
+++ b/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/node_modules/pkg/index.d.ts ===
+export const item = 4;
+>item : Symbol(item, Decl(index.d.ts, 0, 12))
+
+=== tests/cases/compiler/pkg/index.d.ts ===
+export const item = 4;
+>item : Symbol(item, Decl(index.d.ts, 0, 12))
+
+=== tests/cases/compiler/index.ts ===
+import { item } from "pkg"; // should work (`index.js` is assumed to be the entrypoint for packages found via nonrelative import)
+>item : Symbol(item, Decl(index.ts, 0, 8))
+
+import { item as item2 } from "./pkg";  // shouldn't work (`index.js` is _not_ assumed to be the entrypoint for packages found via relative import)
+>item2 : Symbol(item2, Decl(index.ts, 1, 8))
+
+import { item as item3 } from "./node_modules/pkg" // _even if they're in a node_modules folder_
+>item3 : Symbol(item3, Decl(index.ts, 2, 8))
+

--- a/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution.types
+++ b/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/node_modules/pkg/index.d.ts ===
+export const item = 4;
+>item : 4
+>4 : 4
+
+=== tests/cases/compiler/pkg/index.d.ts ===
+export const item = 4;
+>item : 4
+>4 : 4
+
+=== tests/cases/compiler/index.ts ===
+import { item } from "pkg"; // should work (`index.js` is assumed to be the entrypoint for packages found via nonrelative import)
+>item : 4
+
+import { item as item2 } from "./pkg";  // shouldn't work (`index.js` is _not_ assumed to be the entrypoint for packages found via relative import)
+>item : any
+>item2 : any
+
+import { item as item3 } from "./node_modules/pkg" // _even if they're in a node_modules folder_
+>item : any
+>item3 : any
+

--- a/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution.ts
+++ b/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution.ts
@@ -1,0 +1,23 @@
+// @module: nodenext
+// @filename: node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1"
+}
+// @filename: node_modules/pkg/index.d.ts
+export const item = 4;
+// @filename: pkg/package.json
+{
+    "private": true
+}
+// @filename: pkg/index.d.ts
+export const item = 4;
+// @filename: package.json
+{
+    "type": "module",
+    "private": true
+}
+// @filename: index.ts
+import { item } from "pkg"; // should work (`index.js` is assumed to be the entrypoint for packages found via nonrelative import)
+import { item as item2 } from "./pkg";  // shouldn't work (`index.js` is _not_ assumed to be the entrypoint for packages found via relative import)
+import { item as item3 } from "./node_modules/pkg" // _even if they're in a node_modules folder_


### PR DESCRIPTION
…if no package `main` is present

In addition, esm-mode relative directory imports no longer attempt to read entrypoints from a directory's `package.json`, per `node`'s runtime behavior.

Fixes #47848
