### PR TITLE
Explicitly annotate return type of getCommentRange

### DIFF
--- a/src/compiler/factory/emitNode.ts
+++ b/src/compiler/factory/emitNode.ts
@@ -127,7 +127,7 @@ namespace ts {
     /**
      * Gets a custom text range to use when emitting comments.
      */
-    export function getCommentRange(node: Node) {
+    export function getCommentRange(node: Node): TextRange {
         return node.emitNode?.commentRange ?? node;
     }
 


### PR DESCRIPTION
Fixes the nightly publish. Post-LKG, `Node | TextRange` no longer subtype reduces due to a change involving total ordering of `readonly` properties in subtyping (`node`'s fields are `readonly`, `TextRange`'s are not), which, in turn, causes an API diff. This remedies that by annotating the old type explicitly.