### PR TITLE
Allow extensionless `main`s for cjs mode packages even from an esm import

### DIFF
--- a/tests/baselines/reference/nodeNextEsmImportsOfPackagesWithExtensionlessMains.js
+++ b/tests/baselines/reference/nodeNextEsmImportsOfPackagesWithExtensionlessMains.js
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/nodeNextEsmImportsOfPackagesWithExtensionlessMains.ts] ////
+
+//// [package.json]
+{
+    "name": "@types/ip",
+    "version": "1.1.0",
+    "main": "",
+    "types": "index"
+}
+//// [index.d.ts]
+export function address(): string;
+//// [package.json]
+{
+    "name": "nullthrows",
+    "version": "1.1.1",
+    "main": "nullthrows.js",
+    "types": "nullthrows.d.ts"
+}
+//// [nullthrows.d.ts]
+declare function nullthrows(x: any): any;
+declare namespace nullthrows {
+    export {nullthrows as default};
+}
+export = nullthrows;
+//// [package.json]
+{
+    "type": "module"
+}
+//// [index.ts]
+import * as ip from 'ip';
+import nullthrows from 'nullthrows'; // shouldn't be callable, `nullthrows` is a cjs package, so the `default` is the module itself
+
+export function getAddress(): string {
+  return nullthrows(ip.address());
+}
+
+//// [index.js]
+import * as ip from 'ip';
+import nullthrows from 'nullthrows'; // shouldn't be callable, `nullthrows` is a cjs package, so the `default` is the module itself
+export function getAddress() {
+    return nullthrows(ip.address());
+}

--- a/tests/baselines/reference/nodeNextEsmImportsOfPackagesWithExtensionlessMains.symbols
+++ b/tests/baselines/reference/nodeNextEsmImportsOfPackagesWithExtensionlessMains.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/index.ts ===
+import * as ip from 'ip';
+>ip : Symbol(ip, Decl(index.ts, 0, 6))
+
+import nullthrows from 'nullthrows'; // shouldn't be callable, `nullthrows` is a cjs package, so the `default` is the module itself
+>nullthrows : Symbol(nullthrows, Decl(index.ts, 1, 6))
+
+export function getAddress(): string {
+>getAddress : Symbol(getAddress, Decl(index.ts, 1, 36))
+
+  return nullthrows(ip.address());
+>nullthrows : Symbol(nullthrows, Decl(index.ts, 1, 6))
+>ip.address : Symbol(ip.address, Decl(index.d.ts, 0, 0))
+>ip : Symbol(ip, Decl(index.ts, 0, 6))
+>address : Symbol(ip.address, Decl(index.d.ts, 0, 0))
+}
+=== tests/cases/compiler/node_modules/@types/ip/index.d.ts ===
+export function address(): string;
+>address : Symbol(address, Decl(index.d.ts, 0, 0))
+
+=== tests/cases/compiler/node_modules/nullthrows/nullthrows.d.ts ===
+declare function nullthrows(x: any): any;
+>nullthrows : Symbol(nullthrows, Decl(nullthrows.d.ts, 0, 0), Decl(nullthrows.d.ts, 0, 41))
+>x : Symbol(x, Decl(nullthrows.d.ts, 0, 28))
+
+declare namespace nullthrows {
+>nullthrows : Symbol(nullthrows, Decl(nullthrows.d.ts, 0, 0), Decl(nullthrows.d.ts, 0, 41))
+
+    export {nullthrows as default};
+>nullthrows : Symbol(nullthrows, Decl(nullthrows.d.ts, 0, 0), Decl(nullthrows.d.ts, 0, 41))
+>default : Symbol(default, Decl(nullthrows.d.ts, 2, 12))
+}
+export = nullthrows;
+>nullthrows : Symbol(nullthrows, Decl(nullthrows.d.ts, 0, 0), Decl(nullthrows.d.ts, 0, 41))
+

--- a/tests/baselines/reference/nodeNextEsmImportsOfPackagesWithExtensionlessMains.types
+++ b/tests/baselines/reference/nodeNextEsmImportsOfPackagesWithExtensionlessMains.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/index.ts ===
+import * as ip from 'ip';
+>ip : typeof ip
+
+import nullthrows from 'nullthrows'; // shouldn't be callable, `nullthrows` is a cjs package, so the `default` is the module itself
+>nullthrows : typeof nullthrows
+
+export function getAddress(): string {
+>getAddress : () => string
+
+  return nullthrows(ip.address());
+>nullthrows(ip.address()) : any
+>nullthrows : typeof nullthrows
+>ip.address() : string
+>ip.address : () => string
+>ip : typeof ip
+>address : () => string
+}
+=== tests/cases/compiler/node_modules/@types/ip/index.d.ts ===
+export function address(): string;
+>address : () => string
+
+=== tests/cases/compiler/node_modules/nullthrows/nullthrows.d.ts ===
+declare function nullthrows(x: any): any;
+>nullthrows : typeof nullthrows
+>x : any
+
+declare namespace nullthrows {
+>nullthrows : typeof nullthrows
+
+    export {nullthrows as default};
+>nullthrows : typeof nullthrows
+>default : typeof nullthrows
+}
+export = nullthrows;
+>nullthrows : typeof nullthrows
+

--- a/tests/cases/compiler/nodeNextEsmImportsOfPackagesWithExtensionlessMains.ts
+++ b/tests/cases/compiler/nodeNextEsmImportsOfPackagesWithExtensionlessMains.ts
@@ -1,0 +1,36 @@
+// @noImplicitReferences: true
+// @module: nodenext
+// @outDir: esm
+// @filename: node_modules/@types/ip/package.json
+{
+    "name": "@types/ip",
+    "version": "1.1.0",
+    "main": "",
+    "types": "index"
+}
+// @filename: node_modules/@types/ip/index.d.ts
+export function address(): string;
+// @filename: node_modules/nullthrows/package.json
+{
+    "name": "nullthrows",
+    "version": "1.1.1",
+    "main": "nullthrows.js",
+    "types": "nullthrows.d.ts"
+}
+// @filename: node_modules/nullthrows/nullthrows.d.ts
+declare function nullthrows(x: any): any;
+declare namespace nullthrows {
+    export {nullthrows as default};
+}
+export = nullthrows;
+// @filename: package.json
+{
+    "type": "module"
+}
+// @filename: index.ts
+import * as ip from 'ip';
+import nullthrows from 'nullthrows'; // shouldn't be callable, `nullthrows` is a cjs package, so the `default` is the module itself
+
+export function getAddress(): string {
+  return nullthrows(ip.address());
+}


### PR DESCRIPTION
Do note that `type: module` package do still require the extension on `main`; if you actually try to author an esm package with an extensionless `main` in `node` you'll get a deprecation warning saying the extension is required.

Fixes #46770
