### PR TITLE
[GH Actions] Implicitly use AUTHORIZATION header instead of PAT-in-URL

### DIFF
--- a/.github/workflows/ensure-related-repos-run-crons.yml
+++ b/.github/workflows/ensure-related-repos-run-crons.yml
@@ -20,6 +20,7 @@ jobs:
       run: |
         git config --global user.email "typescriptbot@microsoft.com"
         git config --global user.name "TypeScript Bot"
+        git config --unset-all http.https://github.com/.extraheader
 
     - uses: actions/checkout@v2
       with: 
@@ -30,9 +31,7 @@ jobs:
       run:  |
         cd ts-site
         git commit --allow-empty -m "Monthly Bump"
-        git push https://github.com/microsoft/TypeScript-Website.git
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        git push https://${{ secrets.TS_BOT_GITHUB_TOKEN }}@github.com/microsoft/TypeScript-Website.git
 
     - uses: actions/checkout@v2
       with: 
@@ -43,6 +42,4 @@ jobs:
       run:  |
         cd monaco-builds
         git commit --allow-empty -m "Monthly Bump"
-        git push https://github.com/microsoft/TypeScript-Make-Monaco-Builds.git
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        git push https://${{ secrets.TS_BOT_GITHUB_TOKEN }}@github.com/microsoft/TypeScript-Make-Monaco-Builds.git

--- a/.github/workflows/ensure-related-repos-run-crons.yml
+++ b/.github/workflows/ensure-related-repos-run-crons.yml
@@ -16,11 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Configure git and update package-lock.json
+    - name: Configure git
       run: |
         git config --global user.email "typescriptbot@microsoft.com"
         git config --global user.name "TypeScript Bot"
-        git config --unset-all http.https://github.com/.extraheader
 
     - uses: actions/checkout@v2
       with: 
@@ -31,6 +30,7 @@ jobs:
       run:  |
         cd ts-site
         git commit --allow-empty -m "Monthly Bump"
+        git config --unset-all http.https://github.com/.extraheader
         git push https://${{ secrets.TS_BOT_GITHUB_TOKEN }}@github.com/microsoft/TypeScript-Website.git
 
     - uses: actions/checkout@v2
@@ -42,4 +42,5 @@ jobs:
       run:  |
         cd monaco-builds
         git commit --allow-empty -m "Monthly Bump"
+        git config --unset-all http.https://github.com/.extraheader
         git push https://${{ secrets.TS_BOT_GITHUB_TOKEN }}@github.com/microsoft/TypeScript-Make-Monaco-Builds.git

--- a/.github/workflows/ensure-related-repos-run-crons.yml
+++ b/.github/workflows/ensure-related-repos-run-crons.yml
@@ -32,7 +32,7 @@ jobs:
         git commit --allow-empty -m "Monthly Bump"
         git push https://github.com/microsoft/TypeScript-Website.git
       env:
-        GITHUB_TOKEN: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/checkout@v2
       with: 
@@ -45,4 +45,4 @@ jobs:
         git commit --allow-empty -m "Monthly Bump"
         git push https://github.com/microsoft/TypeScript-Make-Monaco-Builds.git
       env:
-        GITHUB_TOKEN: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ensure-related-repos-run-crons.yml
+++ b/.github/workflows/ensure-related-repos-run-crons.yml
@@ -30,7 +30,9 @@ jobs:
       run:  |
         cd ts-site
         git commit --allow-empty -m "Monthly Bump"
-        git push https://${{ secrets.TS_BOT_GITHUB_TOKEN }}@github.com/microsoft/TypeScript-Website.git
+        git push https://github.com/microsoft/TypeScript-Website.git
+      env:
+        GITHUB_TOKEN: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
 
     - uses: actions/checkout@v2
       with: 
@@ -41,4 +43,6 @@ jobs:
       run:  |
         cd monaco-builds
         git commit --allow-empty -m "Monthly Bump"
-        git push https://${{ secrets.TS_BOT_GITHUB_TOKEN }}@github.com/microsoft/TypeScript-Make-Monaco-Builds.git
+        git push https://github.com/microsoft/TypeScript-Make-Monaco-Builds.git
+      env:
+        GITHUB_TOKEN: ${{ secrets.TS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes [all this red](https://github.com/microsoft/TypeScript/actions/workflows/ensure-related-repos-run-crons.yml) hopefully

According to https://stackoverflow.com/questions/64374179/how-to-push-to-another-repository-in-github-actions, GH Actions agents are configured to send `$GITHUB_TOKEN` as the `AUTHORIZATION` HTTP header on git requests to GitHub, which would thwart the attempt to pass the PAT as part of the remote URL.
