### PR TITLE
Fix incorrect rest element type inside contextually typed parameter

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26061,12 +26061,17 @@ namespace ts {
                 links.resolvedSignature = cached;
                 return type;
             }
+
             const contextualSignature = getContextualSignature(func);
             if (contextualSignature) {
+                // const inferenceContext = getInferenceContext(func); // >> Changed here
+                // const signature = inferenceContext ?
+                //                 instantiateSignature(contextualSignature, inferenceContext.mapper) : contextualSignature;
+                const signature = contextualSignature;
                 const index = func.parameters.indexOf(parameter) - (getThisParameter(func) ? 1 : 0);
                 return parameter.dotDotDotToken && lastOrUndefined(func.parameters) === parameter ?
-                    getRestTypeAtPosition(contextualSignature, index) :
-                    tryGetTypeAtPosition(contextualSignature, index);
+                    getRestTypeAtPosition(signature, index) :
+                    tryGetTypeAtPosition(signature, index);
             }
         }
 
@@ -31858,21 +31863,23 @@ namespace ts {
                     if (links.type === unknownType) {
                         links.type = getTypeFromBindingPattern(declaration.name);
                     }
-                    assignBindingElementTypes(declaration.name);
+                    assignBindingElementTypes(declaration.name, links.type);
                 }
             }
         }
 
         // When contextual typing assigns a type to a parameter that contains a binding pattern, we also need to push
         // the destructured type into the contained binding elements.
-        function assignBindingElementTypes(pattern: BindingPattern) {
+        function assignBindingElementTypes(pattern: BindingPattern, parentType: Type) {
             for (const element of pattern.elements) {
                 if (!isOmittedExpression(element)) {
+                    const type = getBindingElementTypeFromParentType(element, parentType); // >> Changed here
                     if (element.name.kind === SyntaxKind.Identifier) {
-                        getSymbolLinks(getSymbolOfNode(element)).type = getTypeForBindingElement(element);
+                        // getSymbolLinks(getSymbolOfNode(element)).type = getTypeForBindingElement(element);
+                        getSymbolLinks(getSymbolOfNode(element)).type = type;
                     }
                     else {
-                        assignBindingElementTypes(element.name);
+                        assignBindingElementTypes(element.name, type);
                     }
                 }
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26061,14 +26061,12 @@ namespace ts {
                 links.resolvedSignature = cached;
                 return type;
             }
-
             const contextualSignature = getContextualSignature(func);
             if (contextualSignature) {
-                const signature = contextualSignature;
                 const index = func.parameters.indexOf(parameter) - (getThisParameter(func) ? 1 : 0);
                 return parameter.dotDotDotToken && lastOrUndefined(func.parameters) === parameter ?
-                    getRestTypeAtPosition(signature, index) :
-                    tryGetTypeAtPosition(signature, index);
+                    getRestTypeAtPosition(contextualSignature, index) :
+                    tryGetTypeAtPosition(contextualSignature, index);
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26064,9 +26064,6 @@ namespace ts {
 
             const contextualSignature = getContextualSignature(func);
             if (contextualSignature) {
-                // const inferenceContext = getInferenceContext(func); // >> Changed here
-                // const signature = inferenceContext ?
-                //                 instantiateSignature(contextualSignature, inferenceContext.mapper) : contextualSignature;
                 const signature = contextualSignature;
                 const index = func.parameters.indexOf(parameter) - (getThisParameter(func) ? 1 : 0);
                 return parameter.dotDotDotToken && lastOrUndefined(func.parameters) === parameter ?
@@ -31873,9 +31870,8 @@ namespace ts {
         function assignBindingElementTypes(pattern: BindingPattern, parentType: Type) {
             for (const element of pattern.elements) {
                 if (!isOmittedExpression(element)) {
-                    const type = getBindingElementTypeFromParentType(element, parentType); // >> Changed here
+                    const type = getBindingElementTypeFromParentType(element, parentType);
                     if (element.name.kind === SyntaxKind.Identifier) {
-                        // getSymbolLinks(getSymbolOfNode(element)).type = getTypeForBindingElement(element);
                         getSymbolLinks(getSymbolOfNode(element)).type = type;
                     }
                     else {

--- a/tests/baselines/reference/narrowingRestGenericCall.js
+++ b/tests/baselines/reference/narrowingRestGenericCall.js
@@ -1,0 +1,36 @@
+//// [narrowingRestGenericCall.ts]
+interface Slugs {
+  foo: string;
+  bar: string;
+}
+
+function call<T extends object>(obj: T, cb: (val: T) => void) {
+  cb(obj);
+}
+
+declare let obj: Slugs;
+call(obj, ({foo, ...rest}) => {
+  console.log(rest.bar);
+  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)
+});
+
+//// [narrowingRestGenericCall.js]
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
+function call(obj, cb) {
+    cb(obj);
+}
+call(obj, function (_a) {
+    var foo = _a.foo, rest = __rest(_a, ["foo"]);
+    console.log(rest.bar);
+    //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)
+});

--- a/tests/baselines/reference/narrowingRestGenericCall.js
+++ b/tests/baselines/reference/narrowingRestGenericCall.js
@@ -11,7 +11,6 @@ function call<T extends object>(obj: T, cb: (val: T) => void) {
 declare let obj: Slugs;
 call(obj, ({foo, ...rest}) => {
   console.log(rest.bar);
-  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)
 });
 
 //// [narrowingRestGenericCall.js]
@@ -32,5 +31,4 @@ function call(obj, cb) {
 call(obj, function (_a) {
     var foo = _a.foo, rest = __rest(_a, ["foo"]);
     console.log(rest.bar);
-    //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)
 });

--- a/tests/baselines/reference/narrowingRestGenericCall.symbols
+++ b/tests/baselines/reference/narrowingRestGenericCall.symbols
@@ -1,0 +1,45 @@
+=== tests/cases/compiler/narrowingRestGenericCall.ts ===
+interface Slugs {
+>Slugs : Symbol(Slugs, Decl(narrowingRestGenericCall.ts, 0, 0))
+
+  foo: string;
+>foo : Symbol(Slugs.foo, Decl(narrowingRestGenericCall.ts, 0, 17))
+
+  bar: string;
+>bar : Symbol(Slugs.bar, Decl(narrowingRestGenericCall.ts, 1, 14))
+}
+
+function call<T extends object>(obj: T, cb: (val: T) => void) {
+>call : Symbol(call, Decl(narrowingRestGenericCall.ts, 3, 1))
+>T : Symbol(T, Decl(narrowingRestGenericCall.ts, 5, 14))
+>obj : Symbol(obj, Decl(narrowingRestGenericCall.ts, 5, 32))
+>T : Symbol(T, Decl(narrowingRestGenericCall.ts, 5, 14))
+>cb : Symbol(cb, Decl(narrowingRestGenericCall.ts, 5, 39))
+>val : Symbol(val, Decl(narrowingRestGenericCall.ts, 5, 45))
+>T : Symbol(T, Decl(narrowingRestGenericCall.ts, 5, 14))
+
+  cb(obj);
+>cb : Symbol(cb, Decl(narrowingRestGenericCall.ts, 5, 39))
+>obj : Symbol(obj, Decl(narrowingRestGenericCall.ts, 5, 32))
+}
+
+declare let obj: Slugs;
+>obj : Symbol(obj, Decl(narrowingRestGenericCall.ts, 9, 11))
+>Slugs : Symbol(Slugs, Decl(narrowingRestGenericCall.ts, 0, 0))
+
+call(obj, ({foo, ...rest}) => {
+>call : Symbol(call, Decl(narrowingRestGenericCall.ts, 3, 1))
+>obj : Symbol(obj, Decl(narrowingRestGenericCall.ts, 9, 11))
+>foo : Symbol(foo, Decl(narrowingRestGenericCall.ts, 10, 12))
+>rest : Symbol(rest, Decl(narrowingRestGenericCall.ts, 10, 16))
+
+  console.log(rest.bar);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>rest.bar : Symbol(Slugs.bar, Decl(narrowingRestGenericCall.ts, 1, 14))
+>rest : Symbol(rest, Decl(narrowingRestGenericCall.ts, 10, 16))
+>bar : Symbol(Slugs.bar, Decl(narrowingRestGenericCall.ts, 1, 14))
+
+  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)
+});

--- a/tests/baselines/reference/narrowingRestGenericCall.symbols
+++ b/tests/baselines/reference/narrowingRestGenericCall.symbols
@@ -41,5 +41,4 @@ call(obj, ({foo, ...rest}) => {
 >rest : Symbol(rest, Decl(narrowingRestGenericCall.ts, 10, 16))
 >bar : Symbol(Slugs.bar, Decl(narrowingRestGenericCall.ts, 1, 14))
 
-  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)
 });

--- a/tests/baselines/reference/narrowingRestGenericCall.types
+++ b/tests/baselines/reference/narrowingRestGenericCall.types
@@ -23,10 +23,10 @@ declare let obj: Slugs;
 >obj : Slugs
 
 call(obj, ({foo, ...rest}) => {
->call(obj, ({foo, ...rest}) => {  console.log(rest.bar);  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)}) : void
+>call(obj, ({foo, ...rest}) => {  console.log(rest.bar);}) : void
 >call : <T extends object>(obj: T, cb: (val: T) => void) => void
 >obj : Slugs
->({foo, ...rest}) => {  console.log(rest.bar);  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)} : ({ foo, ...rest }: Slugs) => void
+>({foo, ...rest}) => {  console.log(rest.bar);} : ({ foo, ...rest }: Slugs) => void
 >foo : string
 >rest : { bar: string; }
 
@@ -39,5 +39,4 @@ call(obj, ({foo, ...rest}) => {
 >rest : { bar: string; }
 >bar : string
 
-  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)
 });

--- a/tests/baselines/reference/narrowingRestGenericCall.types
+++ b/tests/baselines/reference/narrowingRestGenericCall.types
@@ -1,0 +1,43 @@
+=== tests/cases/compiler/narrowingRestGenericCall.ts ===
+interface Slugs {
+  foo: string;
+>foo : string
+
+  bar: string;
+>bar : string
+}
+
+function call<T extends object>(obj: T, cb: (val: T) => void) {
+>call : <T extends object>(obj: T, cb: (val: T) => void) => void
+>obj : T
+>cb : (val: T) => void
+>val : T
+
+  cb(obj);
+>cb(obj) : void
+>cb : (val: T) => void
+>obj : T
+}
+
+declare let obj: Slugs;
+>obj : Slugs
+
+call(obj, ({foo, ...rest}) => {
+>call(obj, ({foo, ...rest}) => {  console.log(rest.bar);  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)}) : void
+>call : <T extends object>(obj: T, cb: (val: T) => void) => void
+>obj : Slugs
+>({foo, ...rest}) => {  console.log(rest.bar);  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)} : ({ foo, ...rest }: Slugs) => void
+>foo : string
+>rest : { bar: string; }
+
+  console.log(rest.bar);
+>console.log(rest.bar) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>rest.bar : string
+>rest : { bar: string; }
+>bar : string
+
+  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)
+});

--- a/tests/cases/compiler/narrowingRestGenericCall.ts
+++ b/tests/cases/compiler/narrowingRestGenericCall.ts
@@ -10,5 +10,4 @@ function call<T extends object>(obj: T, cb: (val: T) => void) {
 declare let obj: Slugs;
 call(obj, ({foo, ...rest}) => {
   console.log(rest.bar);
-  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)
 });

--- a/tests/cases/compiler/narrowingRestGenericCall.ts
+++ b/tests/cases/compiler/narrowingRestGenericCall.ts
@@ -1,0 +1,14 @@
+interface Slugs {
+  foo: string;
+  bar: string;
+}
+
+function call<T extends object>(obj: T, cb: (val: T) => void) {
+  cb(obj);
+}
+
+declare let obj: Slugs;
+call(obj, ({foo, ...rest}) => {
+  console.log(rest.bar);
+  //               ~~~ Property 'bar' does not exist on type 'Omit<T, "foo">'. ts(2339)
+});


### PR DESCRIPTION
Fixes #47865.

When pushing down the instantiated contextual type from a parameter to its binding elements (i.e. a parameter that is a binding pattern), we relied on storing this parameter type in our type cache (`symbolLinks.type`), and retrieving this cached type when computing the type of its binding elements (in `assignBindingElementTypes`). However, if the binding element is a rest binding element, as of #47337 we skip looking for its parent type in the cache, because `checkMode` is going to have `CheckMode.RestBindingElement` set, and we compute the wrong (uninstantiated) type for the parent.
This fix makes it so we explicitly pass the parent type in `assignBindingElementTypes`, avoiding the need to rely on getting the cached type.
