### PR TITLE
Fix Intl.Locale.language cannot be undefined

### DIFF
--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -254,6 +254,8 @@ declare namespace Intl {
     }
 
     interface Locale extends LocaleOptions {
+        /** The primary language subtag associated with the locale. */
+        language: string;
         /** Gets the most likely values for the language, script, and region of the locale based on existing values. */
         maximize(): Locale;
         /** Attempts to remove information about the locale that would be added by calling `Locale.maximize()`. */
@@ -277,7 +279,7 @@ declare namespace Intl {
      * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale).
      */
     const Locale: {
-        new (tag?: BCP47LanguageTag, options?: LocaleOptions): Locale;
+        new (tag: BCP47LanguageTag, options?: LocaleOptions): Locale;
     };
 
      interface DisplayNamesOptions {

--- a/tests/baselines/reference/es2020IntlAPIs.errors.txt
+++ b/tests/baselines/reference/es2020IntlAPIs.errors.txt
@@ -1,0 +1,55 @@
+tests/cases/conformance/es2020/es2020IntlAPIs.ts(47,1): error TS2554: Expected 1-2 arguments, but got 0.
+
+
+==== tests/cases/conformance/es2020/es2020IntlAPIs.ts (1 errors) ====
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation
+    const count = 26254.39;
+    const date = new Date("2012-05-24");
+    
+    function log(locale: string) {
+      console.log(
+        `${new Intl.DateTimeFormat(locale).format(date)} ${new Intl.NumberFormat(locale).format(count)}`
+      );
+    }
+    
+    log("en-US");
+    // expected output: 5/24/2012 26,254.39
+    
+    log("de-DE");
+    // expected output: 24.5.2012 26.254,39
+    
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat
+    const rtf1 = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
+    
+    console.log(rtf1.format(3, 'quarter'));
+    //expected output: "in 3 qtrs."
+    
+    console.log(rtf1.format(-1, 'day'));
+    //expected output: "1 day ago"
+    
+    const rtf2 = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
+    
+    console.log(rtf2.format(2, 'day'));
+    //expected output: "pasado mañana"
+    
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames
+    const regionNamesInEnglish = new Intl.DisplayNames(['en'], { type: 'region' });
+    const regionNamesInTraditionalChinese = new Intl.DisplayNames(['zh-Hant'], { type: 'region' });
+    
+    console.log(regionNamesInEnglish.of('US'));
+    // expected output: "United States"
+    
+    console.log(regionNamesInTraditionalChinese.of('US'));
+    // expected output: "美國"
+    
+    const locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
+    const options1 = { localeMatcher: 'lookup' } as const;
+    console.log(Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', '));
+    
+    const language = (new Intl.Locale('en-US')).language;
+    
+    new Intl.Locale(); // should error
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2554: Expected 1-2 arguments, but got 0.
+!!! related TS6210 /.ts/lib.es2020.intl.d.ts:302:14: An argument for 'tag' was not provided.
+    

--- a/tests/baselines/reference/es2020IntlAPIs.js
+++ b/tests/baselines/reference/es2020IntlAPIs.js
@@ -43,6 +43,11 @@ const locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
 const options1 = { localeMatcher: 'lookup' } as const;
 console.log(Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', '));
 
+const language = (new Intl.Locale('en-US')).language;
+
+new Intl.Locale(); // should error
+
+
 //// [es2020IntlAPIs.js]
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation
 const count = 26254.39;
@@ -73,3 +78,5 @@ console.log(regionNamesInTraditionalChinese.of('US'));
 const locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
 const options1 = { localeMatcher: 'lookup' };
 console.log(Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', '));
+const language = (new Intl.Locale('en-US')).language;
+new Intl.Locale(); // should error

--- a/tests/baselines/reference/es2020IntlAPIs.symbols
+++ b/tests/baselines/reference/es2020IntlAPIs.symbols
@@ -147,3 +147,16 @@ console.log(Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', '))
 >options1 : Symbol(options1, Decl(es2020IntlAPIs.ts, 41, 5))
 >join : Symbol(Array.join, Decl(lib.es5.d.ts, --, --))
 
+const language = (new Intl.Locale('en-US')).language;
+>language : Symbol(language, Decl(es2020IntlAPIs.ts, 44, 5))
+>(new Intl.Locale('en-US')).language : Symbol(Intl.Locale.language, Decl(lib.es2020.intl.d.ts, --, --))
+>Intl.Locale : Symbol(Intl.Locale, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Locale : Symbol(Intl.Locale, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>language : Symbol(Intl.Locale.language, Decl(lib.es2020.intl.d.ts, --, --))
+
+new Intl.Locale(); // should error
+>Intl.Locale : Symbol(Intl.Locale, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Locale : Symbol(Intl.Locale, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+

--- a/tests/baselines/reference/es2020IntlAPIs.types
+++ b/tests/baselines/reference/es2020IntlAPIs.types
@@ -207,3 +207,20 @@ console.log(Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', '))
 >join : (separator?: string) => string
 >', ' : ", "
 
+const language = (new Intl.Locale('en-US')).language;
+>language : string
+>(new Intl.Locale('en-US')).language : string
+>(new Intl.Locale('en-US')) : Intl.Locale
+>new Intl.Locale('en-US') : Intl.Locale
+>Intl.Locale : new (tag: string, options?: Intl.LocaleOptions) => Intl.Locale
+>Intl : typeof Intl
+>Locale : new (tag: string, options?: Intl.LocaleOptions) => Intl.Locale
+>'en-US' : "en-US"
+>language : string
+
+new Intl.Locale(); // should error
+>new Intl.Locale() : Intl.Locale
+>Intl.Locale : new (tag: string, options?: Intl.LocaleOptions) => Intl.Locale
+>Intl : typeof Intl
+>Locale : new (tag: string, options?: Intl.LocaleOptions) => Intl.Locale
+

--- a/tests/cases/conformance/es2020/es2020IntlAPIs.ts
+++ b/tests/cases/conformance/es2020/es2020IntlAPIs.ts
@@ -43,3 +43,7 @@ console.log(regionNamesInTraditionalChinese.of('US'));
 const locales1 = ['ban', 'id-u-co-pinyin', 'de-ID'];
 const options1 = { localeMatcher: 'lookup' } as const;
 console.log(Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', '));
+
+const language = (new Intl.Locale('en-US')).language;
+
+new Intl.Locale(); // should error


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #47169

Also includes an additional fix where the `tag` parameter in `Intl.Locale` constructor's signature has been changed to non-optional, because:
* [ECMA-402](https://tc39.es/ecma402/#sec-Intl.Locale) doesn't mention `tag` as optional.
* Calling an empty constructor throws TypeError. Tested on Node v12, v14, and v16, and on Chrome.
* formatjs's polyfill also has the [`tag` parameter as non-optional](https://github.com/formatjs/formatjs/blob/d5a7b900f806f0ca51007ca86a13a42918db3a1c/packages/intl-locale/index.ts#L296).
