### PR TITLE
[Do not merge] Remove TNext from Iterators

### DIFF
--- a/lib/lib.es2015.generator.d.ts
+++ b/lib/lib.es2015.generator.d.ts
@@ -20,7 +20,7 @@ and limitations under the License.
 
 /// <reference lib="es2015.iterable" />
 
-interface Generator<T = unknown, TReturn = any, TNext = unknown> extends Iterator<T, TReturn, TNext> {
+interface Generator<T = unknown, TReturn = any, TNext = unknown> extends Iterator<T, TReturn>, IterableIterator<T> {
     // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
     next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
     return(value: TReturn): IteratorResult<T, TReturn>;

--- a/lib/lib.es2015.iterable.d.ts
+++ b/lib/lib.es2015.iterable.d.ts
@@ -40,11 +40,9 @@ interface IteratorReturnResult<TReturn> {
 
 type IteratorResult<T, TReturn = any> = IteratorYieldResult<T> | IteratorReturnResult<TReturn>;
 
-interface Iterator<T, TReturn = any, TNext = undefined> {
+interface Iterator<T, TReturn = any> {
     // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
-    next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
-    return?(value?: TReturn): IteratorResult<T, TReturn>;
-    throw?(e?: any): IteratorResult<T, TReturn>;
+    next(): IteratorResult<T, TReturn>;
 }
 
 interface Iterable<T> {

--- a/lib/lib.es2018.asyncgenerator.d.ts
+++ b/lib/lib.es2018.asyncgenerator.d.ts
@@ -20,7 +20,7 @@ and limitations under the License.
 
 /// <reference lib="es2018.asynciterable" />
 
-interface AsyncGenerator<T = unknown, TReturn = any, TNext = unknown> extends AsyncIterator<T, TReturn, TNext> {
+interface AsyncGenerator<T = unknown, TReturn = any, TNext = unknown> extends AsyncIterator<T, TReturn>, AsyncIterableIterator<T> {
     // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
     next(...args: [] | [TNext]): Promise<IteratorResult<T, TReturn>>;
     return(value: TReturn | PromiseLike<TReturn>): Promise<IteratorResult<T, TReturn>>;

--- a/lib/lib.es2018.asynciterable.d.ts
+++ b/lib/lib.es2018.asynciterable.d.ts
@@ -29,11 +29,9 @@ interface SymbolConstructor {
     readonly asyncIterator: unique symbol;
 }
 
-interface AsyncIterator<T, TReturn = any, TNext = undefined> {
+interface AsyncIterator<T, TReturn = any> {
     // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
-    next(...args: [] | [TNext]): Promise<IteratorResult<T, TReturn>>;
-    return?(value?: TReturn | PromiseLike<TReturn>): Promise<IteratorResult<T, TReturn>>;
-    throw?(e?: any): Promise<IteratorResult<T, TReturn>>;
+    next(): Promise<IteratorResult<T, TReturn>>;
 }
 
 interface AsyncIterable<T> {

--- a/src/harness/collectionsImpl.ts
+++ b/src/harness/collectionsImpl.ts
@@ -239,9 +239,9 @@ namespace collections {
         return result.done ? undefined : result;
     }
 
-    export function closeIterator<T>(iterator: Iterator<T>) {
-        const fn = iterator.return;
-        if (typeof fn === "function") fn.call(iterator);
+    export function closeIterator<T>(_: Iterator<T>) {
+        // const fn = iterator.return;
+        // if (typeof fn === "function") fn.call(iterator);
     }
 
     /**


### PR DESCRIPTION
Doesn't look like it is actually needed anywhere?


## notes irrelevant to the proposal

Stubbed out `src/harness/collectionsImpl.ts::closeIterator` (which doesn't fail a single test lol) because whenever I tried to do something like
```ts
export function closeIterator<T>(iterator: Iterator<T> | Generator<T>) {
    // Iterators don't have to have a return method
    // eslint-disable-next-line no-in-operator
    if ("return" in iterator && typeof iterator.return === "function") iterator.return.call(iterator);
}
```
I would get test timeouts (flaky?)

Actually not sure how this is meant to be written according to the enforced styles, since truthiness doesn't narrow it, and typeof is not allowed on the `| undefined` field.
`Object.prototype.hasOwnProperty` definitely isn't appropriate here.