### PR TITLE
fix(47946): Literal types cannot be used in JSDoc export default { } syntax

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9328,8 +9328,8 @@ namespace ts {
             return isPrivateWithinAmbient(memberDeclaration);
         }
 
-        function tryGetTypeFromEffectiveTypeNode(declaration: Declaration) {
-            const typeNode = getEffectiveTypeAnnotationNode(declaration);
+        function tryGetTypeFromEffectiveTypeNode(node: Node) {
+            const typeNode = getEffectiveTypeAnnotationNode(node);
             if (typeNode) {
                 return getTypeFromTypeNode(typeNode);
             }
@@ -26736,6 +26736,8 @@ namespace ts {
                 }
                 case SyntaxKind.NonNullExpression:
                     return getContextualType(parent as NonNullExpression, contextFlags);
+                case SyntaxKind.ExportAssignment:
+                    return tryGetTypeFromEffectiveTypeNode(parent as ExportAssignment);
                 case SyntaxKind.JsxExpression:
                     return getContextualTypeForJsxExpression(parent as JsxExpression);
                 case SyntaxKind.JsxAttribute:

--- a/tests/baselines/reference/checkJsdocTypeTagOnExportAssignment8.js
+++ b/tests/baselines/reference/checkJsdocTypeTagOnExportAssignment8.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/checkJsdocTypeTagOnExportAssignment8.ts] ////
+
+//// [checkJsdocTypeTagOnExportAssignment8.js]
+
+//// [a.js]
+/**
+ * @typedef Foo
+ * @property {string} a
+ * @property {'b'} b
+ */
+
+/** @type {Foo} */
+export default {
+    a: 'a',
+    b: 'b'
+}
+
+
+//// [checkJsdocTypeTagOnExportAssignment8.js]
+//// [a.js]
+"use strict";
+/**
+ * @typedef Foo
+ * @property {string} a
+ * @property {'b'} b
+ */
+exports.__esModule = true;
+/** @type {Foo} */
+exports["default"] = {
+    a: 'a',
+    b: 'b'
+};

--- a/tests/baselines/reference/checkJsdocTypeTagOnExportAssignment8.symbols
+++ b/tests/baselines/reference/checkJsdocTypeTagOnExportAssignment8.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/checkJsdocTypeTagOnExportAssignment8.js ===
+
+No type information for this code.=== tests/cases/compiler/a.js ===
+/**
+ * @typedef Foo
+ * @property {string} a
+ * @property {'b'} b
+ */
+
+/** @type {Foo} */
+export default {
+    a: 'a',
+>a : Symbol(a, Decl(a.js, 7, 16))
+
+    b: 'b'
+>b : Symbol(b, Decl(a.js, 8, 11))
+}
+

--- a/tests/baselines/reference/checkJsdocTypeTagOnExportAssignment8.types
+++ b/tests/baselines/reference/checkJsdocTypeTagOnExportAssignment8.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/checkJsdocTypeTagOnExportAssignment8.js ===
+
+No type information for this code.=== tests/cases/compiler/a.js ===
+/**
+ * @typedef Foo
+ * @property {string} a
+ * @property {'b'} b
+ */
+
+/** @type {Foo} */
+export default {
+>{    a: 'a',    b: 'b'} : { a: string; b: "b"; }
+
+    a: 'a',
+>a : string
+>'a' : "a"
+
+    b: 'b'
+>b : "b"
+>'b' : "b"
+}
+

--- a/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment8.ts
+++ b/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment8.ts
@@ -1,0 +1,17 @@
+// @allowJs: true
+// @checkJs: true
+// @outDir: ./out
+// @filename: checkJsdocTypeTagOnExportAssignment8.js
+
+// @Filename: a.js
+/**
+ * @typedef Foo
+ * @property {string} a
+ * @property {'b'} b
+ */
+
+/** @type {Foo} */
+export default {
+    a: 'a',
+    b: 'b'
+}


### PR DESCRIPTION
Fixes #47946


