### PR TITLE
fix(47949): Unexpected error in param jsdoc tags for methods containing arguments - 4.6 RC regression

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13688,10 +13688,12 @@ namespace ts {
                     if (!type) {
                         symbol = resolveTypeReferenceName(node, meaning, /*ignoreErrors*/ true);
                         if (symbol === unknownSymbol) {
-                            symbol = resolveTypeReferenceName(node, meaning | SymbolFlags.Value);
+                            symbol = resolveTypeReferenceName(node, meaning | SymbolFlags.Value, /*ignoreErrors*/ !isInJSFile(node));
                         }
                         else {
-                            resolveTypeReferenceName(node, meaning); // Resolve again to mark errors, if any
+                            if (isInJSFile(node)) {
+                                resolveTypeReferenceName(node, meaning); // Resolve again to mark errors, if any
+                            }
                         }
                         type = getTypeReferenceType(node, symbol);
                     }

--- a/tests/baselines/reference/paramTagOnFunctionUsingArguments2.js
+++ b/tests/baselines/reference/paramTagOnFunctionUsingArguments2.js
@@ -1,0 +1,23 @@
+//// [paramTagOnFunctionUsingArguments2.ts]
+class Foo {
+  /**
+   * @param {foo-module.Foo} foo
+   */
+  m(foo: unknown): void {
+      arguments;
+  }
+}
+
+
+//// [paramTagOnFunctionUsingArguments2.js]
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    /**
+     * @param {foo-module.Foo} foo
+     */
+    Foo.prototype.m = function (foo) {
+        arguments;
+    };
+    return Foo;
+}());

--- a/tests/baselines/reference/paramTagOnFunctionUsingArguments2.symbols
+++ b/tests/baselines/reference/paramTagOnFunctionUsingArguments2.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/jsdoc/paramTagOnFunctionUsingArguments2.ts ===
+class Foo {
+>Foo : Symbol(Foo, Decl(paramTagOnFunctionUsingArguments2.ts, 0, 0))
+
+  /**
+   * @param {foo-module.Foo} foo
+   */
+  m(foo: unknown): void {
+>m : Symbol(Foo.m, Decl(paramTagOnFunctionUsingArguments2.ts, 0, 11))
+>foo : Symbol(foo, Decl(paramTagOnFunctionUsingArguments2.ts, 4, 4))
+
+      arguments;
+>arguments : Symbol(arguments)
+  }
+}
+

--- a/tests/baselines/reference/paramTagOnFunctionUsingArguments2.types
+++ b/tests/baselines/reference/paramTagOnFunctionUsingArguments2.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/jsdoc/paramTagOnFunctionUsingArguments2.ts ===
+class Foo {
+>Foo : Foo
+
+  /**
+   * @param {foo-module.Foo} foo
+   */
+  m(foo: unknown): void {
+>m : (foo: unknown) => void
+>foo : unknown
+
+      arguments;
+>arguments : IArguments
+  }
+}
+

--- a/tests/cases/conformance/jsdoc/paramTagOnFunctionUsingArguments2.ts
+++ b/tests/cases/conformance/jsdoc/paramTagOnFunctionUsingArguments2.ts
@@ -1,0 +1,8 @@
+class Foo {
+  /**
+   * @param {foo-module.Foo} foo
+   */
+  m(foo: unknown): void {
+      arguments;
+  }
+}

--- a/tests/cases/fourslash/jsdocParamTagOnFunctionUsingArguments.ts
+++ b/tests/cases/fourslash/jsdocParamTagOnFunctionUsingArguments.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+// @strict: true
+
+////class Foo {
+////    /**
+////     * @param {string} [|foo|]
+////     */
+////    m(): void {
+////        arguments;
+////    }
+////}
+
+verify.getSuggestionDiagnostics([
+    { message: "JSDoc '@param' tag has name 'foo', but there is no parameter with that name. It would match 'arguments' if it had an array type.", code: 8029 },
+])


### PR DESCRIPTION
Fixes #47949