### PR TITLE
fix(7410): Support JSX Element as JSX Attribute Value

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -435,6 +435,10 @@
         "category": "Error",
         "code": 1144
     },
+    "'{' or JSX element expected.": {
+        "category": "Error",
+        "code": 1145
+    },
     "Declaration expected.": {
         "category": "Error",
         "code": 1146

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -4856,7 +4856,7 @@ namespace ts {
         }
 
         // @api
-        function createJsxAttribute(name: Identifier, initializer: StringLiteral | JsxExpression | undefined) {
+        function createJsxAttribute(name: Identifier, initializer: JsxAttributeValue | undefined) {
             const node = createBaseNode<JsxAttribute>(SyntaxKind.JsxAttribute);
             node.name = name;
             node.initializer = initializer;
@@ -4868,7 +4868,7 @@ namespace ts {
         }
 
         // @api
-        function updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined) {
+        function updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: JsxAttributeValue | undefined) {
             return node.name !== name
                 || node.initializer !== initializer
                 ? update(createJsxAttribute(name, initializer), node)

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5284,15 +5284,23 @@ namespace ts {
 
             scanJsxIdentifier();
             const pos = getNodePos();
-            return finishNode(
-                factory.createJsxAttribute(
-                    parseIdentifierName(),
-                    token() !== SyntaxKind.EqualsToken ? undefined :
-                    scanJsxAttributeValue() === SyntaxKind.StringLiteral ? parseLiteralNode() as StringLiteral :
-                    parseJsxExpression(/*inExpressionContext*/ true)
-                ),
-                pos
-            );
+            return finishNode(factory.createJsxAttribute(parseIdentifierName(), parseJsxAttributeValue()), pos);
+        }
+
+        function parseJsxAttributeValue(): JsxAttributeValue | undefined {
+            if (token() === SyntaxKind.EqualsToken) {
+                if (scanJsxAttributeValue() === SyntaxKind.StringLiteral) {
+                    return parseLiteralNode() as StringLiteral;
+                }
+                if (token() === SyntaxKind.OpenBraceToken) {
+                    return parseJsxExpression(/*inExpressionContext*/ true);
+                }
+                if (token() === SyntaxKind.LessThanToken) {
+                    return parseJsxElementOrSelfClosingElementOrFragment(/*inExpressionContext*/ true);
+                }
+                parseErrorAtCurrentToken(Diagnostics.or_JSX_element_expected);
+            }
+            return undefined;
         }
 
         function parseJsxSpreadAttribute(): JsxSpreadAttribute {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2590,8 +2590,15 @@ namespace ts {
         readonly parent: JsxAttributes;
         readonly name: Identifier;
         /// JSX attribute initializers are optional; <X y /> is sugar for <X y={true} />
-        readonly initializer?: StringLiteral | JsxExpression;
+        readonly initializer?: JsxAttributeValue;
     }
+
+    export type JsxAttributeValue =
+        | StringLiteral
+        | JsxExpression
+        | JsxElement
+        | JsxSelfClosingElement
+        | JsxFragment;
 
     export interface JsxSpreadAttribute extends ObjectLiteralElement {
         readonly kind: SyntaxKind.JsxSpreadAttribute;
@@ -7583,8 +7590,8 @@ namespace ts {
         createJsxOpeningFragment(): JsxOpeningFragment;
         createJsxJsxClosingFragment(): JsxClosingFragment;
         updateJsxFragment(node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment): JsxFragment;
-        createJsxAttribute(name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
-        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
+        createJsxAttribute(name: Identifier, initializer: JsxAttributeValue | undefined): JsxAttribute;
+        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: JsxAttributeValue | undefined): JsxAttribute;
         createJsxAttributes(properties: readonly JsxAttributeLike[]): JsxAttributes;
         updateJsxAttributes(node: JsxAttributes, properties: readonly JsxAttributeLike[]): JsxAttributes;
         createJsxSpreadAttribute(expression: Expression): JsxSpreadAttribute;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1372,8 +1372,9 @@ declare namespace ts {
         readonly kind: SyntaxKind.JsxAttribute;
         readonly parent: JsxAttributes;
         readonly name: Identifier;
-        readonly initializer?: StringLiteral | JsxExpression;
+        readonly initializer?: JsxAttributeValue;
     }
+    export type JsxAttributeValue = StringLiteral | JsxExpression | JsxElement | JsxSelfClosingElement | JsxFragment;
     export interface JsxSpreadAttribute extends ObjectLiteralElement {
         readonly kind: SyntaxKind.JsxSpreadAttribute;
         readonly parent: JsxAttributes;
@@ -3691,8 +3692,8 @@ declare namespace ts {
         createJsxOpeningFragment(): JsxOpeningFragment;
         createJsxJsxClosingFragment(): JsxClosingFragment;
         updateJsxFragment(node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment): JsxFragment;
-        createJsxAttribute(name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
-        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
+        createJsxAttribute(name: Identifier, initializer: JsxAttributeValue | undefined): JsxAttribute;
+        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: JsxAttributeValue | undefined): JsxAttribute;
         createJsxAttributes(properties: readonly JsxAttributeLike[]): JsxAttributes;
         updateJsxAttributes(node: JsxAttributes, properties: readonly JsxAttributeLike[]): JsxAttributes;
         createJsxSpreadAttribute(expression: Expression): JsxSpreadAttribute;
@@ -11189,9 +11190,9 @@ declare namespace ts {
     /** @deprecated Use `factory.updateJsxFragment` or the factory supplied by your transformation context instead. */
     const updateJsxFragment: (node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment) => JsxFragment;
     /** @deprecated Use `factory.createJsxAttribute` or the factory supplied by your transformation context instead. */
-    const createJsxAttribute: (name: Identifier, initializer: StringLiteral | JsxExpression | undefined) => JsxAttribute;
+    const createJsxAttribute: (name: Identifier, initializer: JsxAttributeValue | undefined) => JsxAttribute;
     /** @deprecated Use `factory.updateJsxAttribute` or the factory supplied by your transformation context instead. */
-    const updateJsxAttribute: (node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined) => JsxAttribute;
+    const updateJsxAttribute: (node: JsxAttribute, name: Identifier, initializer: JsxAttributeValue | undefined) => JsxAttribute;
     /** @deprecated Use `factory.createJsxAttributes` or the factory supplied by your transformation context instead. */
     const createJsxAttributes: (properties: readonly JsxAttributeLike[]) => JsxAttributes;
     /** @deprecated Use `factory.updateJsxAttributes` or the factory supplied by your transformation context instead. */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1372,8 +1372,9 @@ declare namespace ts {
         readonly kind: SyntaxKind.JsxAttribute;
         readonly parent: JsxAttributes;
         readonly name: Identifier;
-        readonly initializer?: StringLiteral | JsxExpression;
+        readonly initializer?: JsxAttributeValue;
     }
+    export type JsxAttributeValue = StringLiteral | JsxExpression | JsxElement | JsxSelfClosingElement | JsxFragment;
     export interface JsxSpreadAttribute extends ObjectLiteralElement {
         readonly kind: SyntaxKind.JsxSpreadAttribute;
         readonly parent: JsxAttributes;
@@ -3691,8 +3692,8 @@ declare namespace ts {
         createJsxOpeningFragment(): JsxOpeningFragment;
         createJsxJsxClosingFragment(): JsxClosingFragment;
         updateJsxFragment(node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment): JsxFragment;
-        createJsxAttribute(name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
-        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined): JsxAttribute;
+        createJsxAttribute(name: Identifier, initializer: JsxAttributeValue | undefined): JsxAttribute;
+        updateJsxAttribute(node: JsxAttribute, name: Identifier, initializer: JsxAttributeValue | undefined): JsxAttribute;
         createJsxAttributes(properties: readonly JsxAttributeLike[]): JsxAttributes;
         updateJsxAttributes(node: JsxAttributes, properties: readonly JsxAttributeLike[]): JsxAttributes;
         createJsxSpreadAttribute(expression: Expression): JsxSpreadAttribute;
@@ -7371,9 +7372,9 @@ declare namespace ts {
     /** @deprecated Use `factory.updateJsxFragment` or the factory supplied by your transformation context instead. */
     const updateJsxFragment: (node: JsxFragment, openingFragment: JsxOpeningFragment, children: readonly JsxChild[], closingFragment: JsxClosingFragment) => JsxFragment;
     /** @deprecated Use `factory.createJsxAttribute` or the factory supplied by your transformation context instead. */
-    const createJsxAttribute: (name: Identifier, initializer: StringLiteral | JsxExpression | undefined) => JsxAttribute;
+    const createJsxAttribute: (name: Identifier, initializer: JsxAttributeValue | undefined) => JsxAttribute;
     /** @deprecated Use `factory.updateJsxAttribute` or the factory supplied by your transformation context instead. */
-    const updateJsxAttribute: (node: JsxAttribute, name: Identifier, initializer: StringLiteral | JsxExpression | undefined) => JsxAttribute;
+    const updateJsxAttribute: (node: JsxAttribute, name: Identifier, initializer: JsxAttributeValue | undefined) => JsxAttribute;
     /** @deprecated Use `factory.createJsxAttributes` or the factory supplied by your transformation context instead. */
     const createJsxAttributes: (properties: readonly JsxAttributeLike[]) => JsxAttributes;
     /** @deprecated Use `factory.updateJsxAttributes` or the factory supplied by your transformation context instead. */

--- a/tests/baselines/reference/jsxAttributeInitializer(jsx=preserve).errors.txt
+++ b/tests/baselines/reference/jsxAttributeInitializer(jsx=preserve).errors.txt
@@ -1,0 +1,15 @@
+tests/cases/conformance/jsx/a.tsx(7,16): error TS1145: '{' or JSX element expected.
+
+
+==== tests/cases/conformance/jsx/a.tsx (1 errors) ====
+    declare var React: any;
+    
+    <div>
+        <div attr=<div /> />
+        <div attr=<div>foo</div> />
+        <div attr=<><div>foo</div></> />
+        <div attr= />
+                   ~
+!!! error TS1145: '{' or JSX element expected.
+    </div>
+    

--- a/tests/baselines/reference/jsxAttributeInitializer(jsx=preserve).js
+++ b/tests/baselines/reference/jsxAttributeInitializer(jsx=preserve).js
@@ -1,0 +1,18 @@
+//// [a.tsx]
+declare var React: any;
+
+<div>
+    <div attr=<div /> />
+    <div attr=<div>foo</div> />
+    <div attr=<><div>foo</div></> />
+    <div attr= />
+</div>
+
+
+//// [a.jsx]
+<div>
+    <div attr=<div />/>
+    <div attr=<div>foo</div>/>
+    <div attr=<><div>foo</div></>/>
+    <div attr/>
+</div>;

--- a/tests/baselines/reference/jsxAttributeInitializer(jsx=preserve).symbols
+++ b/tests/baselines/reference/jsxAttributeInitializer(jsx=preserve).symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsx/a.tsx ===
+declare var React: any;
+>React : Symbol(React, Decl(a.tsx, 0, 11))
+
+<div>
+    <div attr=<div /> />
+>attr : Symbol(attr, Decl(a.tsx, 3, 8))
+
+    <div attr=<div>foo</div> />
+>attr : Symbol(attr, Decl(a.tsx, 4, 8))
+
+    <div attr=<><div>foo</div></> />
+>attr : Symbol(attr, Decl(a.tsx, 5, 8))
+
+    <div attr= />
+>attr : Symbol(attr, Decl(a.tsx, 6, 8))
+
+</div>
+

--- a/tests/baselines/reference/jsxAttributeInitializer(jsx=preserve).types
+++ b/tests/baselines/reference/jsxAttributeInitializer(jsx=preserve).types
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/jsx/a.tsx ===
+declare var React: any;
+>React : any
+
+<div>
+><div>    <div attr=<div /> />    <div attr=<div>foo</div> />    <div attr=<><div>foo</div></> />    <div attr= /></div> : any
+>div : any
+
+    <div attr=<div /> />
+><div attr=<div /> /> : any
+>div : any
+>attr : any
+><div /> : any
+>div : any
+
+    <div attr=<div>foo</div> />
+><div attr=<div>foo</div> /> : any
+>div : any
+>attr : any
+><div>foo</div> : any
+>div : any
+>div : any
+
+    <div attr=<><div>foo</div></> />
+><div attr=<><div>foo</div></> /> : any
+>div : any
+>attr : any
+><><div>foo</div></> : any
+><div>foo</div> : any
+>div : any
+>div : any
+
+    <div attr= />
+><div attr= /> : any
+>div : any
+>attr : true
+
+</div>
+>div : any
+

--- a/tests/baselines/reference/jsxAttributeInitializer(jsx=react).errors.txt
+++ b/tests/baselines/reference/jsxAttributeInitializer(jsx=react).errors.txt
@@ -1,0 +1,15 @@
+tests/cases/conformance/jsx/a.tsx(7,16): error TS1145: '{' or JSX element expected.
+
+
+==== tests/cases/conformance/jsx/a.tsx (1 errors) ====
+    declare var React: any;
+    
+    <div>
+        <div attr=<div /> />
+        <div attr=<div>foo</div> />
+        <div attr=<><div>foo</div></> />
+        <div attr= />
+                   ~
+!!! error TS1145: '{' or JSX element expected.
+    </div>
+    

--- a/tests/baselines/reference/jsxAttributeInitializer(jsx=react).js
+++ b/tests/baselines/reference/jsxAttributeInitializer(jsx=react).js
@@ -1,0 +1,18 @@
+//// [a.tsx]
+declare var React: any;
+
+<div>
+    <div attr=<div /> />
+    <div attr=<div>foo</div> />
+    <div attr=<><div>foo</div></> />
+    <div attr= />
+</div>
+
+
+//// [a.js]
+React.createElement("div", null,
+    React.createElement("div", { attr: React.createElement("div", null) }),
+    React.createElement("div", { attr: React.createElement("div", null, "foo") }),
+    React.createElement("div", { attr: React.createElement(React.Fragment, null,
+            React.createElement("div", null, "foo")) }),
+    React.createElement("div", { attr: true }));

--- a/tests/baselines/reference/jsxAttributeInitializer(jsx=react).symbols
+++ b/tests/baselines/reference/jsxAttributeInitializer(jsx=react).symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsx/a.tsx ===
+declare var React: any;
+>React : Symbol(React, Decl(a.tsx, 0, 11))
+
+<div>
+    <div attr=<div /> />
+>attr : Symbol(attr, Decl(a.tsx, 3, 8))
+
+    <div attr=<div>foo</div> />
+>attr : Symbol(attr, Decl(a.tsx, 4, 8))
+
+    <div attr=<><div>foo</div></> />
+>attr : Symbol(attr, Decl(a.tsx, 5, 8))
+
+    <div attr= />
+>attr : Symbol(attr, Decl(a.tsx, 6, 8))
+
+</div>
+

--- a/tests/baselines/reference/jsxAttributeInitializer(jsx=react).types
+++ b/tests/baselines/reference/jsxAttributeInitializer(jsx=react).types
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/jsx/a.tsx ===
+declare var React: any;
+>React : any
+
+<div>
+><div>    <div attr=<div /> />    <div attr=<div>foo</div> />    <div attr=<><div>foo</div></> />    <div attr= /></div> : any
+>div : any
+
+    <div attr=<div /> />
+><div attr=<div /> /> : any
+>div : any
+>attr : any
+><div /> : any
+>div : any
+
+    <div attr=<div>foo</div> />
+><div attr=<div>foo</div> /> : any
+>div : any
+>attr : any
+><div>foo</div> : any
+>div : any
+>div : any
+
+    <div attr=<><div>foo</div></> />
+><div attr=<><div>foo</div></> /> : any
+>div : any
+>attr : any
+><><div>foo</div></> : any
+><div>foo</div> : any
+>div : any
+>div : any
+
+    <div attr= />
+><div attr= /> : any
+>div : any
+>attr : true
+
+</div>
+>div : any
+

--- a/tests/baselines/reference/jsxAttributeMissingInitializer.errors.txt
+++ b/tests/baselines/reference/jsxAttributeMissingInitializer.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/jsxAttributeMissingInitializer.tsx(1,21): error TS1005: '{' expected.
+tests/cases/compiler/jsxAttributeMissingInitializer.tsx(1,21): error TS1145: '{' or JSX element expected.
 
 
 ==== tests/cases/compiler/jsxAttributeMissingInitializer.tsx (1 errors) ====
     const x = <div foo= ></div>;
                         ~
-!!! error TS1005: '{' expected.
+!!! error TS1145: '{' or JSX element expected.
     const y = 0;
     

--- a/tests/baselines/reference/jsxEsprimaFbTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxEsprimaFbTestSuite.errors.txt
@@ -1,13 +1,7 @@
-tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(40,1): error TS2657: JSX expressions must have one parent element.
-tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(40,17): error TS1005: '{' expected.
-tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(40,23): error TS1005: ';' expected.
-tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(40,23): error TS2304: Cannot find name 'right'.
 tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(40,41): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
-tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(40,57): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(40,58): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx (7 errors) ====
+==== tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx (1 errors) ====
     declare var React: any;
     declare var 日本語;
     declare var AbC_def;
@@ -48,20 +42,8 @@ tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(40,58): error TS1109: Expr
     <div><br />7x invalid-js-identifier</div>;
     
     <LeftRight left=<a /> right=<b>monkeys /> gorillas</b> />;
-    ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2657: JSX expressions must have one parent element.
-                    ~
-!!! error TS1005: '{' expected.
-                          ~~~~~
-!!! error TS1005: ';' expected.
-                          ~~~~~
-!!! error TS2304: Cannot find name 'right'.
                                             ~
 !!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
-                                                            ~
-!!! error TS1109: Expression expected.
-                                                             ~
-!!! error TS1109: Expression expected.
     
     <a.b></a.b>;
     

--- a/tests/baselines/reference/jsxEsprimaFbTestSuite.js
+++ b/tests/baselines/reference/jsxEsprimaFbTestSuite.js
@@ -72,8 +72,7 @@ baz
 <a>{/* this is a comment */}</a>;
 <div>@test content</div>;
 <div><br />7x invalid-js-identifier</div>;
-<LeftRight left/>, <a />;
-right = <b>monkeys /> gorillas</b> /  > ;
+<LeftRight left=<a /> right=<b>monkeys /> gorillas</b>/>;
 <a.b></a.b>;
 <a.b.c></a.b.c>;
 (<div />) < x;

--- a/tests/baselines/reference/jsxEsprimaFbTestSuite.symbols
+++ b/tests/baselines/reference/jsxEsprimaFbTestSuite.symbols
@@ -77,6 +77,7 @@ baz
 <LeftRight left=<a /> right=<b>monkeys /> gorillas</b> />;
 >LeftRight : Symbol(LeftRight, Decl(jsxEsprimaFbTestSuite.tsx, 3, 11))
 >left : Symbol(left, Decl(jsxEsprimaFbTestSuite.tsx, 39, 10))
+>right : Symbol(right, Decl(jsxEsprimaFbTestSuite.tsx, 39, 21))
 
 <a.b></a.b>;
 >a : Symbol(a, Decl(jsxEsprimaFbTestSuite.tsx, 5, 11))

--- a/tests/baselines/reference/jsxEsprimaFbTestSuite.types
+++ b/tests/baselines/reference/jsxEsprimaFbTestSuite.types
@@ -118,21 +118,15 @@ baz
 >div : any
 
 <LeftRight left=<a /> right=<b>monkeys /> gorillas</b> />;
-><LeftRight left=<a /> : any
-><LeftRight left= : any
+><LeftRight left=<a /> right=<b>monkeys /> gorillas</b> /> : any
 >LeftRight : any
->left : true
+>left : any
 ><a /> : any
 >a : any
->right=<b>monkeys /> gorillas</b> /> : boolean
 >right : any
-><b>monkeys /> gorillas</b> /> : boolean
-><b>monkeys /> gorillas</b> / : number
 ><b>monkeys /> gorillas</b> : any
 >b : any
 >b : any
-> : any
-> : any
 
 <a.b></a.b>;
 ><a.b></a.b> : any

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
@@ -57,10 +57,8 @@ tests/cases/conformance/jsx/25.tsx(1,39): error TS1109: Expression expected.
 tests/cases/conformance/jsx/26.tsx(1,4): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
 tests/cases/conformance/jsx/27.tsx(1,5): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
 tests/cases/conformance/jsx/28.tsx(1,2): error TS17008: JSX element 'a' has no corresponding closing tag.
-tests/cases/conformance/jsx/28.tsx(1,6): error TS1005: '{' expected.
+tests/cases/conformance/jsx/28.tsx(1,6): error TS1145: '{' or JSX element expected.
 tests/cases/conformance/jsx/28.tsx(2,1): error TS1005: '</' expected.
-tests/cases/conformance/jsx/29.tsx(1,1): error TS2657: JSX expressions must have one parent element.
-tests/cases/conformance/jsx/29.tsx(1,6): error TS1005: '{' expected.
 tests/cases/conformance/jsx/29.tsx(1,7): error TS1003: Identifier expected.
 tests/cases/conformance/jsx/29.tsx(2,1): error TS1005: '</' expected.
 tests/cases/conformance/jsx/3.tsx(1,1): error TS1109: Expression expected.
@@ -70,7 +68,7 @@ tests/cases/conformance/jsx/3.tsx(1,6): error TS1109: Expression expected.
 tests/cases/conformance/jsx/3.tsx(1,7): error TS1109: Expression expected.
 tests/cases/conformance/jsx/30.tsx(1,4): error TS1381: Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
 tests/cases/conformance/jsx/31.tsx(1,4): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/4.tsx(1,6): error TS1005: '{' expected.
+tests/cases/conformance/jsx/4.tsx(1,6): error TS1145: '{' or JSX element expected.
 tests/cases/conformance/jsx/5.tsx(1,2): error TS17008: JSX element 'a' has no corresponding closing tag.
 tests/cases/conformance/jsx/5.tsx(1,5): error TS1005: '</' expected.
 tests/cases/conformance/jsx/6.tsx(1,6): error TS17002: Expected corresponding JSX closing tag for 'a'.
@@ -110,7 +108,7 @@ tests/cases/conformance/jsx/9.tsx(1,10): error TS2304: Cannot find name 'a:b'.
 ==== tests/cases/conformance/jsx/4.tsx (1 errors) ====
     <a b=d />;
          ~
-!!! error TS1005: '{' expected.
+!!! error TS1145: '{' or JSX element expected.
 ==== tests/cases/conformance/jsx/5.tsx (2 errors) ====
     <a>;
      ~
@@ -292,20 +290,15 @@ tests/cases/conformance/jsx/9.tsx(1,10): error TS2304: Cannot find name 'a:b'.
      ~
 !!! error TS17008: JSX element 'a' has no corresponding closing tag.
          ~
-!!! error TS1005: '{' expected.
+!!! error TS1145: '{' or JSX element expected.
     
     
 !!! error TS1005: '</' expected.
-==== tests/cases/conformance/jsx/29.tsx (4 errors) ====
+==== tests/cases/conformance/jsx/29.tsx (2 errors) ====
     <a b=<}>;
-    ~~~~~~~~~
-         ~
-!!! error TS1005: '{' expected.
           ~
 !!! error TS1003: Identifier expected.
     
-    
-!!! error TS2657: JSX expressions must have one parent element.
     
 !!! error TS1005: '</' expected.
 ==== tests/cases/conformance/jsx/30.tsx (1 errors) ====

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.js
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.js
@@ -150,8 +150,8 @@ var x = <div>one</div> /* intervening comment */, /* intervening comment */ <div
 <a b>;
 </>;
 //// [29.jsx]
-<a b/>, <>;
-</>;
+<a b=<>;
+</>/>;
 //// [30.jsx]
 <a>}</a>;
 //// [31.jsx]

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.types
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.types
@@ -250,9 +250,8 @@ var x = <div>one</div> /* intervening comment */ <div>two</div>;;
 === tests/cases/conformance/jsx/29.tsx ===
 <a b=<}>;
 ><a b=<}>; : any
-><a b= : any
 >a : any
->b : true
+>b : any
 ><}>; : any
 > : any
 

--- a/tests/cases/conformance/jsx/jsxAttributeInitializer.ts
+++ b/tests/cases/conformance/jsx/jsxAttributeInitializer.ts
@@ -1,0 +1,10 @@
+// @jsx: preserve, react
+// @filename: a.tsx
+declare var React: any;
+
+<div>
+    <div attr=<div /> />
+    <div attr=<div>foo</div> />
+    <div attr=<><div>foo</div></> />
+    <div attr= />
+</div>


### PR DESCRIPTION
Fixes #7410

```md
JSXAttributeValue:
    " JSXDoubleStringCharactersopt "
    ' JSXSingleStringCharactersopt '
    { AssignmentExpression }
    JSXElement
    JSXFragment
```

- [JSX spec](https://facebook.github.io/jsx/)
- https://github.com/babel/babel/pull/6006 / [Example](https://babeljs.io/repl/#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.6&spec=false&loose=false&code_lz=DwEwlgbgfAUAkKSACAhgFzQJwLyIkgeikNgXH3S13KgDMB7e4AmkmZmoA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact%2Cstage-2&prettier=false&targets=&version=7.17.6&externalPlugins=&assumptions=%7B%7D)

