### PR TITLE
fix(48024) Scanner optimizations based on character frecuency

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -518,7 +518,7 @@ namespace ts {
     }
 
     function isHexDigit(ch: number): boolean {
-        return isDigit(ch) || ch >= CharacterCodes.A && ch <= CharacterCodes.F || ch >= CharacterCodes.a && ch <= CharacterCodes.f;
+        return isDigit(ch) || ch >= CharacterCodes.a && ch <= CharacterCodes.f || ch >= CharacterCodes.A && ch <= CharacterCodes.F;
     }
 
     function isCodePoint(code: number): boolean {
@@ -896,13 +896,13 @@ namespace ts {
     }
 
     export function isIdentifierStart(ch: number, languageVersion: ScriptTarget | undefined): boolean {
-        return ch >= CharacterCodes.A && ch <= CharacterCodes.Z || ch >= CharacterCodes.a && ch <= CharacterCodes.z ||
+        return ch >= CharacterCodes.a && ch <= CharacterCodes.z || ch >= CharacterCodes.A && ch <= CharacterCodes.Z ||
             ch === CharacterCodes.$ || ch === CharacterCodes._ ||
             ch > CharacterCodes.maxAsciiCharacter && isUnicodeIdentifierStart(ch, languageVersion);
     }
 
     export function isIdentifierPart(ch: number, languageVersion: ScriptTarget | undefined, identifierVariant?: LanguageVariant): boolean {
-        return ch >= CharacterCodes.A && ch <= CharacterCodes.Z || ch >= CharacterCodes.a && ch <= CharacterCodes.z ||
+        return ch >= CharacterCodes.a && ch <= CharacterCodes.z || ch >= CharacterCodes.A && ch <= CharacterCodes.Z ||
             ch >= CharacterCodes._0 && ch <= CharacterCodes._9 || ch === CharacterCodes.$ || ch === CharacterCodes._ ||
             // "-" and ":" are valid in JSX Identifiers
             (identifierVariant === LanguageVariant.JSX ? (ch === CharacterCodes.minus || ch === CharacterCodes.colon) : false) ||

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1617,6 +1617,11 @@ namespace ts {
                 }
                 const ch = codePointAt(text, pos);
 
+                const identifierKind = scanIdentifier(ch, languageVersion);
+                if (identifierKind) {
+                    return token = identifierKind;
+                }
+
                 switch (ch) {
                     case CharacterCodes.lineFeed:
                     case CharacterCodes.carriageReturn:
@@ -2059,11 +2064,7 @@ namespace ts {
                         }
                         return token = SyntaxKind.PrivateIdentifier;
                     default:
-                        const identifierKind = scanIdentifier(ch, languageVersion);
-                        if (identifierKind) {
-                            return token = identifierKind;
-                        }
-                        else if (isWhiteSpaceSingleLine(ch)) {
+                        if (isWhiteSpaceSingleLine(ch)) {
                             pos += charSize(ch);
                             continue;
                         }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1782,45 +1782,21 @@ namespace ts {
                         pos++;
                         return token = SyntaxKind.SlashToken;
 
-                    case CharacterCodes.exclamation:
-                        if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
-                            if (text.charCodeAt(pos + 2) === CharacterCodes.equals) {
-                                return pos += 3, token = SyntaxKind.ExclamationEqualsEqualsToken;
-                            }
-                            return pos += 2, token = SyntaxKind.ExclamationEqualsToken;
+                    case CharacterCodes.dot:
+                        if (isDigit(text.charCodeAt(pos + 1))) {
+                            tokenValue = scanNumber().value;
+                            return token = SyntaxKind.NumericLiteral;
+                        }
+                        if (text.charCodeAt(pos + 1) === CharacterCodes.dot && text.charCodeAt(pos + 2) === CharacterCodes.dot) {
+                            return pos += 3, token = SyntaxKind.DotDotDotToken;
                         }
                         pos++;
-                        return token = SyntaxKind.ExclamationToken;
-                    case CharacterCodes.doubleQuote:
-                    case CharacterCodes.singleQuote:
-                        tokenValue = scanString();
-                        return token = SyntaxKind.StringLiteral;
-                    case CharacterCodes.backtick:
-                        return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ false);
-                    case CharacterCodes.percent:
-                        if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
-                            return pos += 2, token = SyntaxKind.PercentEqualsToken;
-                        }
+                        return token = SyntaxKind.DotToken;
+
+                    case CharacterCodes.comma:
                         pos++;
-                        return token = SyntaxKind.PercentToken;
-                    case CharacterCodes.ampersand:
-                        if (text.charCodeAt(pos + 1) === CharacterCodes.ampersand) {
-                            if (text.charCodeAt(pos + 2) === CharacterCodes.equals) {
-                                return pos += 3, token = SyntaxKind.AmpersandAmpersandEqualsToken;
-                            }
-                            return pos += 2, token = SyntaxKind.AmpersandAmpersandToken;
-                        }
-                        if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
-                            return pos += 2, token = SyntaxKind.AmpersandEqualsToken;
-                        }
-                        pos++;
-                        return token = SyntaxKind.AmpersandToken;
-                    case CharacterCodes.openParen:
-                        pos++;
-                        return token = SyntaxKind.OpenParenToken;
-                    case CharacterCodes.closeParen:
-                        pos++;
-                        return token = SyntaxKind.CloseParenToken;
+                        return token = SyntaxKind.CommaToken;
+
                     case CharacterCodes.asterisk:
                         if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
                             return pos += 2, token = SyntaxKind.AsteriskEqualsToken;
@@ -1838,18 +1814,58 @@ namespace ts {
                             continue;
                         }
                         return token = SyntaxKind.AsteriskToken;
-                    case CharacterCodes.plus:
-                        if (text.charCodeAt(pos + 1) === CharacterCodes.plus) {
-                            return pos += 2, token = SyntaxKind.PlusPlusToken;
+
+                    case CharacterCodes.openParen:
+                        pos++;
+                        return token = SyntaxKind.OpenParenToken;
+
+                    case CharacterCodes.closeParen:
+                        pos++;
+                        return token = SyntaxKind.CloseParenToken;
+
+                    case CharacterCodes.colon:
+                        pos++;
+                        return token = SyntaxKind.ColonToken;
+
+                    case CharacterCodes.semicolon:
+                        pos++;
+                        return token = SyntaxKind.SemicolonToken;
+
+                    case CharacterCodes.doubleQuote:
+                    case CharacterCodes.singleQuote:
+                        tokenValue = scanString();
+                        return token = SyntaxKind.StringLiteral;
+
+                    case CharacterCodes.equals:
+                        if (isConflictMarkerTrivia(text, pos)) {
+                            pos = scanConflictMarkerTrivia(text, pos, error);
+                            if (skipTrivia) {
+                                continue;
+                            }
+                            else {
+                                return token = SyntaxKind.ConflictMarkerTrivia;
+                            }
                         }
+
                         if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
-                            return pos += 2, token = SyntaxKind.PlusEqualsToken;
+                            if (text.charCodeAt(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.EqualsEqualsEqualsToken;
+                            }
+                            return pos += 2, token = SyntaxKind.EqualsEqualsToken;
+                        }
+                        if (text.charCodeAt(pos + 1) === CharacterCodes.greaterThan) {
+                            return pos += 2, token = SyntaxKind.EqualsGreaterThanToken;
                         }
                         pos++;
-                        return token = SyntaxKind.PlusToken;
-                    case CharacterCodes.comma:
+                        return token = SyntaxKind.EqualsToken;
+
+                    case CharacterCodes.openBrace:
                         pos++;
-                        return token = SyntaxKind.CommaToken;
+                        return token = SyntaxKind.OpenBraceToken;
+                    case CharacterCodes.closeBrace:
+                        pos++;
+                        return token = SyntaxKind.CloseBraceToken;
+
                     case CharacterCodes.minus:
                         if (text.charCodeAt(pos + 1) === CharacterCodes.minus) {
                             return pos += 2, token = SyntaxKind.MinusMinusToken;
@@ -1859,23 +1875,51 @@ namespace ts {
                         }
                         pos++;
                         return token = SyntaxKind.MinusToken;
-                    case CharacterCodes.dot:
-                        if (isDigit(text.charCodeAt(pos + 1))) {
-                            tokenValue = scanNumber().value;
-                            return token = SyntaxKind.NumericLiteral;
-                        }
-                        if (text.charCodeAt(pos + 1) === CharacterCodes.dot && text.charCodeAt(pos + 2) === CharacterCodes.dot) {
-                            return pos += 3, token = SyntaxKind.DotDotDotToken;
-                        }
-                        pos++;
-                        return token = SyntaxKind.DotToken;
 
-                    case CharacterCodes.colon:
+                    case CharacterCodes.greaterThan:
+                        if (isConflictMarkerTrivia(text, pos)) {
+                            pos = scanConflictMarkerTrivia(text, pos, error);
+                            if (skipTrivia) {
+                                continue;
+                            }
+                            else {
+                                return token = SyntaxKind.ConflictMarkerTrivia;
+                            }
+                        }
+
                         pos++;
-                        return token = SyntaxKind.ColonToken;
-                    case CharacterCodes.semicolon:
+                        return token = SyntaxKind.GreaterThanToken;
+
+                    case CharacterCodes.bar:
+                        if (isConflictMarkerTrivia(text, pos)) {
+                            pos = scanConflictMarkerTrivia(text, pos, error);
+                            if (skipTrivia) {
+                                continue;
+                            }
+                            else {
+                                return token = SyntaxKind.ConflictMarkerTrivia;
+                            }
+                        }
+
+                        if (text.charCodeAt(pos + 1) === CharacterCodes.bar) {
+                            if (text.charCodeAt(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.BarBarEqualsToken;
+                            }
+                            return pos += 2, token = SyntaxKind.BarBarToken;
+                        }
+                        if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.BarEqualsToken;
+                        }
                         pos++;
-                        return token = SyntaxKind.SemicolonToken;
+                        return token = SyntaxKind.BarToken;
+
+                    case CharacterCodes.openBracket:
+                        pos++;
+                        return token = SyntaxKind.OpenBracketToken;
+                    case CharacterCodes.closeBracket:
+                        pos++;
+                        return token = SyntaxKind.CloseBracketToken;
+
                     case CharacterCodes.lessThan:
                         if (isConflictMarkerTrivia(text, pos)) {
                             pos = scanConflictMarkerTrivia(text, pos, error);
@@ -1903,41 +1947,10 @@ namespace ts {
                         }
                         pos++;
                         return token = SyntaxKind.LessThanToken;
-                    case CharacterCodes.equals:
-                        if (isConflictMarkerTrivia(text, pos)) {
-                            pos = scanConflictMarkerTrivia(text, pos, error);
-                            if (skipTrivia) {
-                                continue;
-                            }
-                            else {
-                                return token = SyntaxKind.ConflictMarkerTrivia;
-                            }
-                        }
 
-                        if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
-                            if (text.charCodeAt(pos + 2) === CharacterCodes.equals) {
-                                return pos += 3, token = SyntaxKind.EqualsEqualsEqualsToken;
-                            }
-                            return pos += 2, token = SyntaxKind.EqualsEqualsToken;
-                        }
-                        if (text.charCodeAt(pos + 1) === CharacterCodes.greaterThan) {
-                            return pos += 2, token = SyntaxKind.EqualsGreaterThanToken;
-                        }
-                        pos++;
-                        return token = SyntaxKind.EqualsToken;
-                    case CharacterCodes.greaterThan:
-                        if (isConflictMarkerTrivia(text, pos)) {
-                            pos = scanConflictMarkerTrivia(text, pos, error);
-                            if (skipTrivia) {
-                                continue;
-                            }
-                            else {
-                                return token = SyntaxKind.ConflictMarkerTrivia;
-                            }
-                        }
+                    case CharacterCodes.backtick:
+                        return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ false);
 
-                        pos++;
-                        return token = SyntaxKind.GreaterThanToken;
                     case CharacterCodes.question:
                         if (text.charCodeAt(pos + 1) === CharacterCodes.dot && !isDigit(text.charCodeAt(pos + 2))) {
                             return pos += 2, token = SyntaxKind.QuestionDotToken;
@@ -1950,52 +1963,41 @@ namespace ts {
                         }
                         pos++;
                         return token = SyntaxKind.QuestionToken;
-                    case CharacterCodes.openBracket:
+
+                    case CharacterCodes.plus:
+                        if (text.charCodeAt(pos + 1) === CharacterCodes.plus) {
+                            return pos += 2, token = SyntaxKind.PlusPlusToken;
+                        }
+                        if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.PlusEqualsToken;
+                        }
                         pos++;
-                        return token = SyntaxKind.OpenBracketToken;
-                    case CharacterCodes.closeBracket:
+                        return token = SyntaxKind.PlusToken;
+
+                    case CharacterCodes.at:
                         pos++;
-                        return token = SyntaxKind.CloseBracketToken;
+                        return token = SyntaxKind.AtToken;
+
+                    case CharacterCodes.ampersand:
+                        if (text.charCodeAt(pos + 1) === CharacterCodes.ampersand) {
+                            if (text.charCodeAt(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.AmpersandAmpersandEqualsToken;
+                            }
+                            return pos += 2, token = SyntaxKind.AmpersandAmpersandToken;
+                        }
+                        if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.AmpersandEqualsToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.AmpersandToken;
+
                     case CharacterCodes.caret:
                         if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
                             return pos += 2, token = SyntaxKind.CaretEqualsToken;
                         }
                         pos++;
                         return token = SyntaxKind.CaretToken;
-                    case CharacterCodes.openBrace:
-                        pos++;
-                        return token = SyntaxKind.OpenBraceToken;
-                    case CharacterCodes.bar:
-                        if (isConflictMarkerTrivia(text, pos)) {
-                            pos = scanConflictMarkerTrivia(text, pos, error);
-                            if (skipTrivia) {
-                                continue;
-                            }
-                            else {
-                                return token = SyntaxKind.ConflictMarkerTrivia;
-                            }
-                        }
 
-                        if (text.charCodeAt(pos + 1) === CharacterCodes.bar) {
-                            if (text.charCodeAt(pos + 2) === CharacterCodes.equals) {
-                                return pos += 3, token = SyntaxKind.BarBarEqualsToken;
-                            }
-                            return pos += 2, token = SyntaxKind.BarBarToken;
-                        }
-                        if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
-                            return pos += 2, token = SyntaxKind.BarEqualsToken;
-                        }
-                        pos++;
-                        return token = SyntaxKind.BarToken;
-                    case CharacterCodes.closeBrace:
-                        pos++;
-                        return token = SyntaxKind.CloseBraceToken;
-                    case CharacterCodes.tilde:
-                        pos++;
-                        return token = SyntaxKind.TildeToken;
-                    case CharacterCodes.at:
-                        pos++;
-                        return token = SyntaxKind.AtToken;
                     case CharacterCodes.backslash:
                         const extendedCookedChar = peekExtendedUnicodeEscape();
                         if (extendedCookedChar >= 0 && isIdentifierStart(extendedCookedChar, languageVersion)) {
@@ -2016,6 +2018,24 @@ namespace ts {
                         error(Diagnostics.Invalid_character);
                         pos++;
                         return token = SyntaxKind.Unknown;
+
+                    case CharacterCodes.exclamation:
+                        if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
+                            if (text.charCodeAt(pos + 2) === CharacterCodes.equals) {
+                                return pos += 3, token = SyntaxKind.ExclamationEqualsEqualsToken;
+                            }
+                            return pos += 2, token = SyntaxKind.ExclamationEqualsToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.ExclamationToken;
+
+                    case CharacterCodes.percent:
+                        if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
+                            return pos += 2, token = SyntaxKind.PercentEqualsToken;
+                        }
+                        pos++;
+                        return token = SyntaxKind.PercentToken;
+
                     case CharacterCodes.hash:
                         // Special handling for shebang
                         if (pos === 0) {
@@ -2044,6 +2064,11 @@ namespace ts {
                             error(Diagnostics.Invalid_character, pos++, charSize(ch));
                         }
                         return token = SyntaxKind.PrivateIdentifier;
+
+                    case CharacterCodes.tilde:
+                        pos++;
+                        return token = SyntaxKind.TildeToken;
+
                     default:
                         if (isWhiteSpaceSingleLine(ch)) {
                             const isWhiteSpace = handleWhiteSpaceLike();

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1617,17 +1617,6 @@ namespace ts {
                 }
                 const ch = codePointAt(text, pos);
 
-                // Special handling for shebang
-                if (ch === CharacterCodes.hash && pos === 0 && isShebangTrivia(text, pos)) {
-                    pos = scanShebangTrivia(text, pos);
-                    if (skipTrivia) {
-                        continue;
-                    }
-                    else {
-                        return token = SyntaxKind.ShebangTrivia;
-                    }
-                }
-
                 switch (ch) {
                     case CharacterCodes.lineFeed:
                     case CharacterCodes.carriageReturn:
@@ -2043,7 +2032,18 @@ namespace ts {
                         pos++;
                         return token = SyntaxKind.Unknown;
                     case CharacterCodes.hash:
-                        if (pos !== 0 && text[pos + 1] === "!") {
+                        // Special handling for shebang
+                        if (pos === 0) {
+                            if (isShebangTrivia(text, pos)) {
+                                pos = scanShebangTrivia(text, pos);
+                                if (skipTrivia) {
+                                    continue;
+                                }
+                                else {
+                                    return token = SyntaxKind.ShebangTrivia;
+                                }
+                            }
+                        } else if (text[pos + 1] === "!") {
                             error(Diagnostics.can_only_be_used_at_the_start_of_a_file);
                             pos++;
                             return token = SyntaxKind.Unknown;

--- a/src/services/patternMatcher.ts
+++ b/src/services/patternMatcher.ts
@@ -420,7 +420,7 @@ namespace ts {
     }
 
     function isWordChar(ch: number) {
-        return isUpperCaseLetter(ch) || isLowerCaseLetter(ch) || isDigit(ch) || ch === CharacterCodes._ || ch === CharacterCodes.$;
+        return  isLowerCaseLetter(ch) || isUpperCaseLetter(ch) || isDigit(ch) || ch === CharacterCodes._ || ch === CharacterCodes.$;
     }
 
     function breakPatternIntoTextChunks(pattern: string): TextChunk[] {
@@ -553,8 +553,8 @@ namespace ts {
         // programs.
         return index !== wordStart
             && index + 1 < identifier.length
-            && isUpperCaseLetter(identifier.charCodeAt(index))
             && isLowerCaseLetter(identifier.charCodeAt(index + 1))
+            && isUpperCaseLetter(identifier.charCodeAt(index))
             && every(identifier, isUpperCaseLetter, wordStart, index);
     }
 

--- a/src/services/patternMatcher.ts
+++ b/src/services/patternMatcher.ts
@@ -420,7 +420,7 @@ namespace ts {
     }
 
     function isWordChar(ch: number) {
-        return  isLowerCaseLetter(ch) || isUpperCaseLetter(ch) || isDigit(ch) || ch === CharacterCodes._ || ch === CharacterCodes.$;
+        return isLowerCaseLetter(ch) || isUpperCaseLetter(ch) || isDigit(ch) || ch === CharacterCodes._ || ch === CharacterCodes.$;
     }
 
     function breakPatternIntoTextChunks(pattern: string): TextChunk[] {


### PR DESCRIPTION
Fixes #48024 

A peer-commit review is recommended:
- `b24034f`: Merges shebang check with hash check.
- `59e0c4f`: Make identifier check the first thing to execute.
- `f7e363e`: Create a fast path for whitespace (`32`). Also, defer the other whitespace like character to the `default` block, since there was a call to `isWhiteSpaceSingleLine` there already and that cover all the removed character checks. Minor note, that function also checks for `CharacterCodes.nextLine` which wasn't checked before but after running all the test suite I found that nothing broke.
- `a790e00`: Move digits check up.
- `f2b4439` & `29e8f74`: Are just copying and pasting the checks in the order of occurrence.
- `0e07955` & `ed5d47e`: I tried to search every meaningful function that would check for either lowercase or uppercase letters and ensure that lowercases were checked first.
