### PR TITLE
Prevent crash on code fixes on default keyword 

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -847,9 +847,10 @@ namespace ts.codefix {
         const checker = program.getTypeChecker();
         const compilerOptions = program.getCompilerOptions();
         const symbolName = getSymbolName(sourceFile, checker, symbolToken, compilerOptions);
-        // "default" is a keyword and not a legal identifier for the import, so we don't expect it here
-        Debug.assert(symbolName !== InternalSymbolName.Default, "'default' isn't a legal identifier and couldn't occur here");
-
+        // "default" is a keyword and not a legal identifier for the import, but appears as an identifier.
+        if (symbolName === InternalSymbolName.Default) {
+            return undefined;
+        }
         const isValidTypeOnlyUseSite = isValidTypeOnlyAliasUseSite(symbolToken);
         const useRequire = shouldUseRequire(sourceFile, program);
         const exportInfo = getExportInfos(symbolName, isJSXTagName(symbolToken), getMeaningFromLocation(symbolToken), cancellationToken, sourceFile, program, useAutoImportProvider, host, preferences);

--- a/tests/cases/fourslash/addAllMissingImportsNoCrash2.ts
+++ b/tests/cases/fourslash/addAllMissingImportsNoCrash2.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: file1.ts
+//// export { /**/default };
+
+goTo.marker();
+
+verify.codeFixAll({
+    fixId: "fixMissingImport",
+    fixAllDescription: "Add all missing imports",
+    newFileContent: 
+`import { Test1, Test2, Test3, Test4 } from './file1';
+interface Testing {
+    test1: Test1;
+    test2: Test2;
+    test3: Test3;
+    test4: Test4;
+}`
+});

--- a/tests/cases/fourslash/addAllMissingImportsNoCrash2.ts
+++ b/tests/cases/fourslash/addAllMissingImportsNoCrash2.ts
@@ -5,15 +5,4 @@
 
 goTo.marker();
 
-verify.codeFixAll({
-    fixId: "fixMissingImport",
-    fixAllDescription: "Add all missing imports",
-    newFileContent: 
-`import { Test1, Test2, Test3, Test4 } from './file1';
-interface Testing {
-    test1: Test1;
-    test2: Test2;
-    test3: Test3;
-    test4: Test4;
-}`
-});
+verify.not.codeFixAllAvailable("fixMissingImport");


### PR DESCRIPTION
Fixes #48008

`default` appears as an identifier in the AST, which appears to be expected. Just return `undefined` to skip the symbol rather than asserting that it's not legal.