### PR TITLE
Esm imports of cjs files should unconditionally have a default patched on

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3687,12 +3687,18 @@ namespace ts {
                         return cloneTypeAsModuleType(symbol, defaultOnlyType, referenceParent);
                     }
 
-                    if (getESModuleInterop(compilerOptions)) {
+                    const targetFile = moduleSymbol?.declarations?.find(isSourceFile);
+                    const isEsmCjsRef = targetFile && isESMFormatImportImportingCommonjsFormatFile(getUsageModeForExpression(reference), targetFile.impliedNodeFormat);
+                    if (getESModuleInterop(compilerOptions) || isEsmCjsRef) {
                         let sigs = getSignaturesOfStructuredType(type, SignatureKind.Call);
                         if (!sigs || !sigs.length) {
                             sigs = getSignaturesOfStructuredType(type, SignatureKind.Construct);
                         }
-                        if ((sigs && sigs.length) || getPropertyOfType(type, InternalSymbolName.Default, /*skipObjectFunctionPropertyAugment*/ true)) {
+                        if (
+                            (sigs && sigs.length) ||
+                            getPropertyOfType(type, InternalSymbolName.Default, /*skipObjectFunctionPropertyAugment*/ true) ||
+                            isEsmCjsRef
+                        ) {
                             const moduleType = getTypeWithSyntheticDefaultImportType(type, symbol, moduleSymbol!, reference);
                             return cloneTypeAsModuleType(symbol, moduleType, referenceParent);
                         }

--- a/tests/baselines/reference/nodeModules1(module=node12).types
+++ b/tests/baselines/reference/nodeModules1(module=node12).types
@@ -250,22 +250,22 @@ import m25 = require("./index");
 >m25 : typeof m1
 
 import m26 = require("./subfolder");
->m26 : typeof m4
+>m26 : typeof m26
 
 import m27 = require("./subfolder/");
->m27 : typeof m4
+>m27 : typeof m26
 
 import m28 = require("./subfolder/index");
->m28 : typeof m4
+>m28 : typeof m26
 
 import m29 = require("./subfolder2");
->m29 : typeof m7
+>m29 : typeof m29
 
 import m30 = require("./subfolder2/");
->m30 : typeof m7
+>m30 : typeof m29
 
 import m31 = require("./subfolder2/index");
->m31 : typeof m7
+>m31 : typeof m29
 
 import m32 = require("./subfolder2/another");
 >m32 : typeof m10
@@ -286,27 +286,27 @@ void m25;
 
 void m26;
 >void m26 : undefined
->m26 : typeof m4
+>m26 : typeof m26
 
 void m27;
 >void m27 : undefined
->m27 : typeof m4
+>m27 : typeof m26
 
 void m28;
 >void m28 : undefined
->m28 : typeof m4
+>m28 : typeof m26
 
 void m29;
 >void m29 : undefined
->m29 : typeof m7
+>m29 : typeof m29
 
 void m30;
 >void m30 : undefined
->m30 : typeof m7
+>m30 : typeof m29
 
 void m31;
 >void m31 : undefined
->m31 : typeof m7
+>m31 : typeof m29
 
 void m32;
 >void m32 : undefined
@@ -861,22 +861,22 @@ import m25 = require("./index");
 >m25 : typeof m1
 
 import m26 = require("./subfolder");
->m26 : typeof m4
+>m26 : typeof m26
 
 import m27 = require("./subfolder/");
->m27 : typeof m4
+>m27 : typeof m26
 
 import m28 = require("./subfolder/index");
->m28 : typeof m4
+>m28 : typeof m26
 
 import m29 = require("./subfolder2");
->m29 : typeof m7
+>m29 : typeof m29
 
 import m30 = require("./subfolder2/");
->m30 : typeof m7
+>m30 : typeof m29
 
 import m31 = require("./subfolder2/index");
->m31 : typeof m7
+>m31 : typeof m29
 
 import m32 = require("./subfolder2/another");
 >m32 : typeof m10
@@ -897,27 +897,27 @@ void m25;
 
 void m26;
 >void m26 : undefined
->m26 : typeof m4
+>m26 : typeof m26
 
 void m27;
 >void m27 : undefined
->m27 : typeof m4
+>m27 : typeof m26
 
 void m28;
 >void m28 : undefined
->m28 : typeof m4
+>m28 : typeof m26
 
 void m29;
 >void m29 : undefined
->m29 : typeof m7
+>m29 : typeof m29
 
 void m30;
 >void m30 : undefined
->m30 : typeof m7
+>m30 : typeof m29
 
 void m31;
 >void m31 : undefined
->m31 : typeof m7
+>m31 : typeof m29
 
 void m32;
 >void m32 : undefined

--- a/tests/baselines/reference/nodeModules1(module=nodenext).types
+++ b/tests/baselines/reference/nodeModules1(module=nodenext).types
@@ -250,22 +250,22 @@ import m25 = require("./index");
 >m25 : typeof m1
 
 import m26 = require("./subfolder");
->m26 : typeof m4
+>m26 : typeof m26
 
 import m27 = require("./subfolder/");
->m27 : typeof m4
+>m27 : typeof m26
 
 import m28 = require("./subfolder/index");
->m28 : typeof m4
+>m28 : typeof m26
 
 import m29 = require("./subfolder2");
->m29 : typeof m7
+>m29 : typeof m29
 
 import m30 = require("./subfolder2/");
->m30 : typeof m7
+>m30 : typeof m29
 
 import m31 = require("./subfolder2/index");
->m31 : typeof m7
+>m31 : typeof m29
 
 import m32 = require("./subfolder2/another");
 >m32 : typeof m10
@@ -286,27 +286,27 @@ void m25;
 
 void m26;
 >void m26 : undefined
->m26 : typeof m4
+>m26 : typeof m26
 
 void m27;
 >void m27 : undefined
->m27 : typeof m4
+>m27 : typeof m26
 
 void m28;
 >void m28 : undefined
->m28 : typeof m4
+>m28 : typeof m26
 
 void m29;
 >void m29 : undefined
->m29 : typeof m7
+>m29 : typeof m29
 
 void m30;
 >void m30 : undefined
->m30 : typeof m7
+>m30 : typeof m29
 
 void m31;
 >void m31 : undefined
->m31 : typeof m7
+>m31 : typeof m29
 
 void m32;
 >void m32 : undefined
@@ -861,22 +861,22 @@ import m25 = require("./index");
 >m25 : typeof m1
 
 import m26 = require("./subfolder");
->m26 : typeof m4
+>m26 : typeof m26
 
 import m27 = require("./subfolder/");
->m27 : typeof m4
+>m27 : typeof m26
 
 import m28 = require("./subfolder/index");
->m28 : typeof m4
+>m28 : typeof m26
 
 import m29 = require("./subfolder2");
->m29 : typeof m7
+>m29 : typeof m29
 
 import m30 = require("./subfolder2/");
->m30 : typeof m7
+>m30 : typeof m29
 
 import m31 = require("./subfolder2/index");
->m31 : typeof m7
+>m31 : typeof m29
 
 import m32 = require("./subfolder2/another");
 >m32 : typeof m10
@@ -897,27 +897,27 @@ void m25;
 
 void m26;
 >void m26 : undefined
->m26 : typeof m4
+>m26 : typeof m26
 
 void m27;
 >void m27 : undefined
->m27 : typeof m4
+>m27 : typeof m26
 
 void m28;
 >void m28 : undefined
->m28 : typeof m4
+>m28 : typeof m26
 
 void m29;
 >void m29 : undefined
->m29 : typeof m7
+>m29 : typeof m29
 
 void m30;
 >void m30 : undefined
->m30 : typeof m7
+>m30 : typeof m29
 
 void m31;
 >void m31 : undefined
->m31 : typeof m7
+>m31 : typeof m29
 
 void m32;
 >void m32 : undefined

--- a/tests/baselines/reference/nodeModulesAllowJs1(module=node12).types
+++ b/tests/baselines/reference/nodeModulesAllowJs1(module=node12).types
@@ -250,22 +250,22 @@ import m25 = require("./index");
 >m25 : typeof m1
 
 import m26 = require("./subfolder");
->m26 : typeof m4
+>m26 : typeof m26
 
 import m27 = require("./subfolder/");
->m27 : typeof m4
+>m27 : typeof m26
 
 import m28 = require("./subfolder/index");
->m28 : typeof m4
+>m28 : typeof m26
 
 import m29 = require("./subfolder2");
->m29 : typeof m7
+>m29 : typeof m29
 
 import m30 = require("./subfolder2/");
->m30 : typeof m7
+>m30 : typeof m29
 
 import m31 = require("./subfolder2/index");
->m31 : typeof m7
+>m31 : typeof m29
 
 import m32 = require("./subfolder2/another");
 >m32 : typeof m10
@@ -286,27 +286,27 @@ void m25;
 
 void m26;
 >void m26 : undefined
->m26 : typeof m4
+>m26 : typeof m26
 
 void m27;
 >void m27 : undefined
->m27 : typeof m4
+>m27 : typeof m26
 
 void m28;
 >void m28 : undefined
->m28 : typeof m4
+>m28 : typeof m26
 
 void m29;
 >void m29 : undefined
->m29 : typeof m7
+>m29 : typeof m29
 
 void m30;
 >void m30 : undefined
->m30 : typeof m7
+>m30 : typeof m29
 
 void m31;
 >void m31 : undefined
->m31 : typeof m7
+>m31 : typeof m29
 
 void m32;
 >void m32 : undefined
@@ -861,22 +861,22 @@ import m25 = require("./index");
 >m25 : typeof m1
 
 import m26 = require("./subfolder");
->m26 : typeof m4
+>m26 : typeof m26
 
 import m27 = require("./subfolder/");
->m27 : typeof m4
+>m27 : typeof m26
 
 import m28 = require("./subfolder/index");
->m28 : typeof m4
+>m28 : typeof m26
 
 import m29 = require("./subfolder2");
->m29 : typeof m7
+>m29 : typeof m29
 
 import m30 = require("./subfolder2/");
->m30 : typeof m7
+>m30 : typeof m29
 
 import m31 = require("./subfolder2/index");
->m31 : typeof m7
+>m31 : typeof m29
 
 import m32 = require("./subfolder2/another");
 >m32 : typeof m10
@@ -897,27 +897,27 @@ void m25;
 
 void m26;
 >void m26 : undefined
->m26 : typeof m4
+>m26 : typeof m26
 
 void m27;
 >void m27 : undefined
->m27 : typeof m4
+>m27 : typeof m26
 
 void m28;
 >void m28 : undefined
->m28 : typeof m4
+>m28 : typeof m26
 
 void m29;
 >void m29 : undefined
->m29 : typeof m7
+>m29 : typeof m29
 
 void m30;
 >void m30 : undefined
->m30 : typeof m7
+>m30 : typeof m29
 
 void m31;
 >void m31 : undefined
->m31 : typeof m7
+>m31 : typeof m29
 
 void m32;
 >void m32 : undefined

--- a/tests/baselines/reference/nodeModulesAllowJs1(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesAllowJs1(module=nodenext).types
@@ -250,22 +250,22 @@ import m25 = require("./index");
 >m25 : typeof m1
 
 import m26 = require("./subfolder");
->m26 : typeof m4
+>m26 : typeof m26
 
 import m27 = require("./subfolder/");
->m27 : typeof m4
+>m27 : typeof m26
 
 import m28 = require("./subfolder/index");
->m28 : typeof m4
+>m28 : typeof m26
 
 import m29 = require("./subfolder2");
->m29 : typeof m7
+>m29 : typeof m29
 
 import m30 = require("./subfolder2/");
->m30 : typeof m7
+>m30 : typeof m29
 
 import m31 = require("./subfolder2/index");
->m31 : typeof m7
+>m31 : typeof m29
 
 import m32 = require("./subfolder2/another");
 >m32 : typeof m10
@@ -286,27 +286,27 @@ void m25;
 
 void m26;
 >void m26 : undefined
->m26 : typeof m4
+>m26 : typeof m26
 
 void m27;
 >void m27 : undefined
->m27 : typeof m4
+>m27 : typeof m26
 
 void m28;
 >void m28 : undefined
->m28 : typeof m4
+>m28 : typeof m26
 
 void m29;
 >void m29 : undefined
->m29 : typeof m7
+>m29 : typeof m29
 
 void m30;
 >void m30 : undefined
->m30 : typeof m7
+>m30 : typeof m29
 
 void m31;
 >void m31 : undefined
->m31 : typeof m7
+>m31 : typeof m29
 
 void m32;
 >void m32 : undefined
@@ -861,22 +861,22 @@ import m25 = require("./index");
 >m25 : typeof m1
 
 import m26 = require("./subfolder");
->m26 : typeof m4
+>m26 : typeof m26
 
 import m27 = require("./subfolder/");
->m27 : typeof m4
+>m27 : typeof m26
 
 import m28 = require("./subfolder/index");
->m28 : typeof m4
+>m28 : typeof m26
 
 import m29 = require("./subfolder2");
->m29 : typeof m7
+>m29 : typeof m29
 
 import m30 = require("./subfolder2/");
->m30 : typeof m7
+>m30 : typeof m29
 
 import m31 = require("./subfolder2/index");
->m31 : typeof m7
+>m31 : typeof m29
 
 import m32 = require("./subfolder2/another");
 >m32 : typeof m10
@@ -897,27 +897,27 @@ void m25;
 
 void m26;
 >void m26 : undefined
->m26 : typeof m4
+>m26 : typeof m26
 
 void m27;
 >void m27 : undefined
->m27 : typeof m4
+>m27 : typeof m26
 
 void m28;
 >void m28 : undefined
->m28 : typeof m4
+>m28 : typeof m26
 
 void m29;
 >void m29 : undefined
->m29 : typeof m7
+>m29 : typeof m29
 
 void m30;
 >void m30 : undefined
->m30 : typeof m7
+>m30 : typeof m29
 
 void m31;
 >void m31 : undefined
->m31 : typeof m7
+>m31 : typeof m29
 
 void m32;
 >void m32 : undefined

--- a/tests/baselines/reference/nodeModulesAllowJsPackageExports(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsPackageExports(module=node12).symbols
@@ -124,13 +124,13 @@ import * as type from "inner";
 >type : Symbol(type, Decl(index.d.ts, 3, 6))
 
 export { cjs };
->cjs : Symbol(mjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
 
 export { mjs };
->mjs : Symbol(mjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
 
 export { type };
->type : Symbol(mjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.mts ===
 // esm format file
@@ -144,13 +144,13 @@ import * as type from "inner";
 >type : Symbol(type, Decl(index.d.mts, 3, 6))
 
 export { cjs };
->cjs : Symbol(cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
 
 export { mjs };
->mjs : Symbol(cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
 
 export { type };
->type : Symbol(cjs.mjs.type, Decl(index.d.mts, 6, 8))
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesAllowJsPackageExports(module=node12).types
+++ b/tests/baselines/reference/nodeModulesAllowJsPackageExports(module=node12).types
@@ -22,19 +22,19 @@ import * as cjsi from "inner/cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/allowJs/index.mjs ===
 // esm format file
@@ -60,19 +60,19 @@ import * as cjsi from "inner/cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/allowJs/index.cjs ===
 // cjs format file
@@ -101,7 +101,7 @@ import * as mjsi from "inner/mjs";
 >mjsi : typeof cjsi.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 cjsi;
 >cjsi : typeof cjsi
@@ -110,7 +110,7 @@ mjsi;
 >mjsi : typeof cjsi.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.ts ===
 // cjs format file
@@ -121,7 +121,7 @@ import * as mjs from "inner/mjs";
 >mjs : typeof mjs
 
 import * as type from "inner";
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 export { cjs };
 >cjs : any
@@ -130,7 +130,7 @@ export { mjs };
 >mjs : typeof mjs
 
 export { type };
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.mts ===
 // esm format file
@@ -138,19 +138,19 @@ import * as cjs from "inner/cjs";
 >cjs : typeof cjs
 
 import * as mjs from "inner/mjs";
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 import * as type from "inner";
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 export { cjs };
 >cjs : typeof cjs
 
 export { mjs };
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.cts ===
 // cjs format file
@@ -161,7 +161,7 @@ import * as mjs from "inner/mjs";
 >mjs : typeof cjs.mjs
 
 import * as type from "inner";
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 
 export { cjs };
 >cjs : typeof cjs
@@ -170,5 +170,5 @@ export { mjs };
 >mjs : typeof cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 

--- a/tests/baselines/reference/nodeModulesAllowJsPackageExports(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsPackageExports(module=nodenext).symbols
@@ -124,13 +124,13 @@ import * as type from "inner";
 >type : Symbol(type, Decl(index.d.ts, 3, 6))
 
 export { cjs };
->cjs : Symbol(mjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
 
 export { mjs };
->mjs : Symbol(mjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
 
 export { type };
->type : Symbol(mjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.mts ===
 // esm format file
@@ -144,13 +144,13 @@ import * as type from "inner";
 >type : Symbol(type, Decl(index.d.mts, 3, 6))
 
 export { cjs };
->cjs : Symbol(cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
 
 export { mjs };
->mjs : Symbol(cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
 
 export { type };
->type : Symbol(cjs.mjs.type, Decl(index.d.mts, 6, 8))
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesAllowJsPackageExports(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesAllowJsPackageExports(module=nodenext).types
@@ -22,19 +22,19 @@ import * as cjsi from "inner/cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/allowJs/index.mjs ===
 // esm format file
@@ -60,19 +60,19 @@ import * as cjsi from "inner/cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/allowJs/index.cjs ===
 // cjs format file
@@ -101,7 +101,7 @@ import * as mjsi from "inner/mjs";
 >mjsi : typeof cjsi.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 cjsi;
 >cjsi : typeof cjsi
@@ -110,7 +110,7 @@ mjsi;
 >mjsi : typeof cjsi.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.ts ===
 // cjs format file
@@ -121,7 +121,7 @@ import * as mjs from "inner/mjs";
 >mjs : typeof mjs
 
 import * as type from "inner";
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 export { cjs };
 >cjs : any
@@ -130,7 +130,7 @@ export { mjs };
 >mjs : typeof mjs
 
 export { type };
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.mts ===
 // esm format file
@@ -138,19 +138,19 @@ import * as cjs from "inner/cjs";
 >cjs : typeof cjs
 
 import * as mjs from "inner/mjs";
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 import * as type from "inner";
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 export { cjs };
 >cjs : typeof cjs
 
 export { mjs };
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.cts ===
 // cjs format file
@@ -161,7 +161,7 @@ import * as mjs from "inner/mjs";
 >mjs : typeof cjs.mjs
 
 import * as type from "inner";
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 
 export { cjs };
 >cjs : typeof cjs
@@ -170,5 +170,5 @@ export { mjs };
 >mjs : typeof cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExports(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExports(module=node12).symbols
@@ -70,13 +70,13 @@ import * as type from "inner/js/index";
 >type : Symbol(type, Decl(index.d.ts, 3, 6))
 
 export { cjs };
->cjs : Symbol(mjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
 
 export { mjs };
->mjs : Symbol(mjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
 
 export { type };
->type : Symbol(mjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.mts ===
 // esm format file
@@ -90,13 +90,13 @@ import * as type from "inner/js/index";
 >type : Symbol(type, Decl(index.d.mts, 3, 6))
 
 export { cjs };
->cjs : Symbol(cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
 
 export { mjs };
->mjs : Symbol(cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
 
 export { type };
->type : Symbol(cjs.mjs.type, Decl(index.d.mts, 6, 8))
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExports(module=node12).types
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExports(module=node12).types
@@ -4,19 +4,19 @@ import * as cjsi from "inner/cjs/index";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/allowJs/index.mjs ===
 // esm format file
@@ -24,19 +24,19 @@ import * as cjsi from "inner/cjs/index";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/allowJs/index.cjs ===
 // cjs format file
@@ -47,7 +47,7 @@ import * as mjsi from "inner/mjs/index";
 >mjsi : typeof cjsi.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 cjsi;
 >cjsi : typeof cjsi
@@ -56,7 +56,7 @@ mjsi;
 >mjsi : typeof cjsi.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.ts ===
 // cjs format file
@@ -67,7 +67,7 @@ import * as mjs from "inner/mjs/index";
 >mjs : typeof mjs
 
 import * as type from "inner/js/index";
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 export { cjs };
 >cjs : any
@@ -76,7 +76,7 @@ export { mjs };
 >mjs : typeof mjs
 
 export { type };
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.mts ===
 // esm format file
@@ -84,19 +84,19 @@ import * as cjs from "inner/cjs/index";
 >cjs : typeof cjs
 
 import * as mjs from "inner/mjs/index";
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 import * as type from "inner/js/index";
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 export { cjs };
 >cjs : typeof cjs
 
 export { mjs };
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.cts ===
 // cjs format file
@@ -107,7 +107,7 @@ import * as mjs from "inner/mjs/index";
 >mjs : typeof cjs.mjs
 
 import * as type from "inner/js/index";
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 
 export { cjs };
 >cjs : typeof cjs
@@ -116,5 +116,5 @@ export { mjs };
 >mjs : typeof cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExports(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExports(module=nodenext).symbols
@@ -70,13 +70,13 @@ import * as type from "inner/js/index";
 >type : Symbol(type, Decl(index.d.ts, 3, 6))
 
 export { cjs };
->cjs : Symbol(mjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
 
 export { mjs };
->mjs : Symbol(mjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
 
 export { type };
->type : Symbol(mjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.mts ===
 // esm format file
@@ -90,13 +90,13 @@ import * as type from "inner/js/index";
 >type : Symbol(type, Decl(index.d.mts, 3, 6))
 
 export { cjs };
->cjs : Symbol(cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
 
 export { mjs };
->mjs : Symbol(cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
 
 export { type };
->type : Symbol(cjs.mjs.type, Decl(index.d.mts, 6, 8))
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExports(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExports(module=nodenext).types
@@ -4,19 +4,19 @@ import * as cjsi from "inner/cjs/index";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/allowJs/index.mjs ===
 // esm format file
@@ -24,19 +24,19 @@ import * as cjsi from "inner/cjs/index";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/allowJs/index.cjs ===
 // cjs format file
@@ -47,7 +47,7 @@ import * as mjsi from "inner/mjs/index";
 >mjsi : typeof cjsi.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 cjsi;
 >cjsi : typeof cjsi
@@ -56,7 +56,7 @@ mjsi;
 >mjsi : typeof cjsi.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.ts ===
 // cjs format file
@@ -67,7 +67,7 @@ import * as mjs from "inner/mjs/index";
 >mjs : typeof mjs
 
 import * as type from "inner/js/index";
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 export { cjs };
 >cjs : any
@@ -76,7 +76,7 @@ export { mjs };
 >mjs : typeof mjs
 
 export { type };
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.mts ===
 // esm format file
@@ -84,19 +84,19 @@ import * as cjs from "inner/cjs/index";
 >cjs : typeof cjs
 
 import * as mjs from "inner/mjs/index";
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 import * as type from "inner/js/index";
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 export { cjs };
 >cjs : typeof cjs
 
 export { mjs };
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.cts ===
 // cjs format file
@@ -107,7 +107,7 @@ import * as mjs from "inner/mjs/index";
 >mjs : typeof cjs.mjs
 
 import * as type from "inner/js/index";
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 
 export { cjs };
 >cjs : typeof cjs
@@ -116,5 +116,5 @@ export { mjs };
 >mjs : typeof cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsTrailers(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsTrailers(module=nodenext).symbols
@@ -70,13 +70,13 @@ import * as type from "inner/js/index.js";
 >type : Symbol(type, Decl(index.d.ts, 3, 6))
 
 export { cjs };
->cjs : Symbol(mjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
 
 export { mjs };
->mjs : Symbol(mjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
 
 export { type };
->type : Symbol(mjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.mts ===
 // esm format file
@@ -90,13 +90,13 @@ import * as type from "inner/js/index.js";
 >type : Symbol(type, Decl(index.d.mts, 3, 6))
 
 export { cjs };
->cjs : Symbol(cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
 
 export { mjs };
->mjs : Symbol(cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
 
 export { type };
->type : Symbol(cjs.mjs.type, Decl(index.d.mts, 6, 8))
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsTrailers(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsTrailers(module=nodenext).types
@@ -4,19 +4,19 @@ import * as cjsi from "inner/cjs/index.cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index.mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index.js";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/allowJs/index.mjs ===
 // esm format file
@@ -24,19 +24,19 @@ import * as cjsi from "inner/cjs/index.cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index.mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index.js";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/allowJs/index.cjs ===
 // cjs format file
@@ -47,7 +47,7 @@ import * as mjsi from "inner/mjs/index.mjs";
 >mjsi : typeof cjsi.mjs
 
 import * as typei from "inner/js/index.js";
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 cjsi;
 >cjsi : typeof cjsi
@@ -56,7 +56,7 @@ mjsi;
 >mjsi : typeof cjsi.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.ts ===
 // cjs format file
@@ -67,7 +67,7 @@ import * as mjs from "inner/mjs/index.mjs";
 >mjs : typeof mjs
 
 import * as type from "inner/js/index.js";
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 export { cjs };
 >cjs : any
@@ -76,7 +76,7 @@ export { mjs };
 >mjs : typeof mjs
 
 export { type };
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.mts ===
 // esm format file
@@ -84,19 +84,19 @@ import * as cjs from "inner/cjs/index.cjs";
 >cjs : typeof cjs
 
 import * as mjs from "inner/mjs/index.mjs";
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 import * as type from "inner/js/index.js";
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 export { cjs };
 >cjs : typeof cjs
 
 export { mjs };
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 === tests/cases/conformance/node/allowJs/node_modules/inner/index.d.cts ===
 // cjs format file
@@ -107,7 +107,7 @@ import * as mjs from "inner/mjs/index.mjs";
 >mjs : typeof cjs.mjs
 
 import * as type from "inner/js/index.js";
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 
 export { cjs };
 >cjs : typeof cjs
@@ -116,5 +116,5 @@ export { mjs };
 >mjs : typeof cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 

--- a/tests/baselines/reference/nodeModulesPackageExports(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesPackageExports(module=node12).symbols
@@ -124,13 +124,13 @@ import * as type from "inner";
 >type : Symbol(type, Decl(index.d.ts, 3, 6))
 
 export { cjs };
->cjs : Symbol(mjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
 
 export { mjs };
->mjs : Symbol(mjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
 
 export { type };
->type : Symbol(mjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
 
 === tests/cases/conformance/node/node_modules/inner/index.d.mts ===
 // esm format file
@@ -144,13 +144,13 @@ import * as type from "inner";
 >type : Symbol(type, Decl(index.d.mts, 3, 6))
 
 export { cjs };
->cjs : Symbol(cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
 
 export { mjs };
->mjs : Symbol(cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
 
 export { type };
->type : Symbol(cjs.mjs.type, Decl(index.d.mts, 6, 8))
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
 
 === tests/cases/conformance/node/node_modules/inner/index.d.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesPackageExports(module=node12).types
+++ b/tests/baselines/reference/nodeModulesPackageExports(module=node12).types
@@ -22,19 +22,19 @@ import * as cjsi from "inner/cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/index.mts ===
 // esm format file
@@ -60,19 +60,19 @@ import * as cjsi from "inner/cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/index.cts ===
 // cjs format file
@@ -101,7 +101,7 @@ import * as mjsi from "inner/mjs";
 >mjsi : typeof cjsi.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 cjsi;
 >cjsi : typeof cjsi
@@ -110,7 +110,7 @@ mjsi;
 >mjsi : typeof cjsi.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.ts ===
 // cjs format file
@@ -121,7 +121,7 @@ import * as mjs from "inner/mjs";
 >mjs : typeof mjs
 
 import * as type from "inner";
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 export { cjs };
 >cjs : any
@@ -130,7 +130,7 @@ export { mjs };
 >mjs : typeof mjs
 
 export { type };
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.mts ===
 // esm format file
@@ -138,19 +138,19 @@ import * as cjs from "inner/cjs";
 >cjs : typeof cjs
 
 import * as mjs from "inner/mjs";
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 import * as type from "inner";
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 export { cjs };
 >cjs : typeof cjs
 
 export { mjs };
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.cts ===
 // cjs format file
@@ -161,7 +161,7 @@ import * as mjs from "inner/mjs";
 >mjs : typeof cjs.mjs
 
 import * as type from "inner";
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 
 export { cjs };
 >cjs : typeof cjs
@@ -170,5 +170,5 @@ export { mjs };
 >mjs : typeof cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 

--- a/tests/baselines/reference/nodeModulesPackageExports(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesPackageExports(module=nodenext).symbols
@@ -124,13 +124,13 @@ import * as type from "inner";
 >type : Symbol(type, Decl(index.d.ts, 3, 6))
 
 export { cjs };
->cjs : Symbol(mjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
 
 export { mjs };
->mjs : Symbol(mjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
 
 export { type };
->type : Symbol(mjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
 
 === tests/cases/conformance/node/node_modules/inner/index.d.mts ===
 // esm format file
@@ -144,13 +144,13 @@ import * as type from "inner";
 >type : Symbol(type, Decl(index.d.mts, 3, 6))
 
 export { cjs };
->cjs : Symbol(cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
 
 export { mjs };
->mjs : Symbol(cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
 
 export { type };
->type : Symbol(cjs.mjs.type, Decl(index.d.mts, 6, 8))
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
 
 === tests/cases/conformance/node/node_modules/inner/index.d.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesPackageExports(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesPackageExports(module=nodenext).types
@@ -22,19 +22,19 @@ import * as cjsi from "inner/cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/index.mts ===
 // esm format file
@@ -60,19 +60,19 @@ import * as cjsi from "inner/cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/index.cts ===
 // cjs format file
@@ -101,7 +101,7 @@ import * as mjsi from "inner/mjs";
 >mjsi : typeof cjsi.mjs
 
 import * as typei from "inner";
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 cjsi;
 >cjsi : typeof cjsi
@@ -110,7 +110,7 @@ mjsi;
 >mjsi : typeof cjsi.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.ts ===
 // cjs format file
@@ -121,7 +121,7 @@ import * as mjs from "inner/mjs";
 >mjs : typeof mjs
 
 import * as type from "inner";
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 export { cjs };
 >cjs : any
@@ -130,7 +130,7 @@ export { mjs };
 >mjs : typeof mjs
 
 export { type };
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.mts ===
 // esm format file
@@ -138,19 +138,19 @@ import * as cjs from "inner/cjs";
 >cjs : typeof cjs
 
 import * as mjs from "inner/mjs";
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 import * as type from "inner";
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 export { cjs };
 >cjs : typeof cjs
 
 export { mjs };
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.cts ===
 // cjs format file
@@ -161,7 +161,7 @@ import * as mjs from "inner/mjs";
 >mjs : typeof cjs.mjs
 
 import * as type from "inner";
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 
 export { cjs };
 >cjs : typeof cjs
@@ -170,5 +170,5 @@ export { mjs };
 >mjs : typeof cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 

--- a/tests/baselines/reference/nodeModulesPackagePatternExports(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesPackagePatternExports(module=node12).symbols
@@ -70,13 +70,13 @@ import * as type from "inner/js/index";
 >type : Symbol(type, Decl(index.d.ts, 3, 6))
 
 export { cjs };
->cjs : Symbol(mjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
 
 export { mjs };
->mjs : Symbol(mjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
 
 export { type };
->type : Symbol(mjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
 
 === tests/cases/conformance/node/node_modules/inner/index.d.mts ===
 // esm format file
@@ -90,13 +90,13 @@ import * as type from "inner/js/index";
 >type : Symbol(type, Decl(index.d.mts, 3, 6))
 
 export { cjs };
->cjs : Symbol(cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
 
 export { mjs };
->mjs : Symbol(cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
 
 export { type };
->type : Symbol(cjs.mjs.type, Decl(index.d.mts, 6, 8))
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
 
 === tests/cases/conformance/node/node_modules/inner/index.d.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesPackagePatternExports(module=node12).types
+++ b/tests/baselines/reference/nodeModulesPackagePatternExports(module=node12).types
@@ -4,19 +4,19 @@ import * as cjsi from "inner/cjs/index";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/index.mts ===
 // esm format file
@@ -24,19 +24,19 @@ import * as cjsi from "inner/cjs/index";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/index.cts ===
 // cjs format file
@@ -47,7 +47,7 @@ import * as mjsi from "inner/mjs/index";
 >mjsi : typeof cjsi.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 cjsi;
 >cjsi : typeof cjsi
@@ -56,7 +56,7 @@ mjsi;
 >mjsi : typeof cjsi.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.ts ===
 // cjs format file
@@ -67,7 +67,7 @@ import * as mjs from "inner/mjs/index";
 >mjs : typeof mjs
 
 import * as type from "inner/js/index";
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 export { cjs };
 >cjs : any
@@ -76,7 +76,7 @@ export { mjs };
 >mjs : typeof mjs
 
 export { type };
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.mts ===
 // esm format file
@@ -84,19 +84,19 @@ import * as cjs from "inner/cjs/index";
 >cjs : typeof cjs
 
 import * as mjs from "inner/mjs/index";
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 import * as type from "inner/js/index";
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 export { cjs };
 >cjs : typeof cjs
 
 export { mjs };
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.cts ===
 // cjs format file
@@ -107,7 +107,7 @@ import * as mjs from "inner/mjs/index";
 >mjs : typeof cjs.mjs
 
 import * as type from "inner/js/index";
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 
 export { cjs };
 >cjs : typeof cjs
@@ -116,5 +116,5 @@ export { mjs };
 >mjs : typeof cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 

--- a/tests/baselines/reference/nodeModulesPackagePatternExports(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesPackagePatternExports(module=nodenext).symbols
@@ -70,13 +70,13 @@ import * as type from "inner/js/index";
 >type : Symbol(type, Decl(index.d.ts, 3, 6))
 
 export { cjs };
->cjs : Symbol(mjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
 
 export { mjs };
->mjs : Symbol(mjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
 
 export { type };
->type : Symbol(mjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
 
 === tests/cases/conformance/node/node_modules/inner/index.d.mts ===
 // esm format file
@@ -90,13 +90,13 @@ import * as type from "inner/js/index";
 >type : Symbol(type, Decl(index.d.mts, 3, 6))
 
 export { cjs };
->cjs : Symbol(cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
 
 export { mjs };
->mjs : Symbol(cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
 
 export { type };
->type : Symbol(cjs.mjs.type, Decl(index.d.mts, 6, 8))
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
 
 === tests/cases/conformance/node/node_modules/inner/index.d.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesPackagePatternExports(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesPackagePatternExports(module=nodenext).types
@@ -4,19 +4,19 @@ import * as cjsi from "inner/cjs/index";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/index.mts ===
 // esm format file
@@ -24,19 +24,19 @@ import * as cjsi from "inner/cjs/index";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/index.cts ===
 // cjs format file
@@ -47,7 +47,7 @@ import * as mjsi from "inner/mjs/index";
 >mjsi : typeof cjsi.mjs
 
 import * as typei from "inner/js/index";
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 cjsi;
 >cjsi : typeof cjsi
@@ -56,7 +56,7 @@ mjsi;
 >mjsi : typeof cjsi.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.ts ===
 // cjs format file
@@ -67,7 +67,7 @@ import * as mjs from "inner/mjs/index";
 >mjs : typeof mjs
 
 import * as type from "inner/js/index";
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 export { cjs };
 >cjs : any
@@ -76,7 +76,7 @@ export { mjs };
 >mjs : typeof mjs
 
 export { type };
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.mts ===
 // esm format file
@@ -84,19 +84,19 @@ import * as cjs from "inner/cjs/index";
 >cjs : typeof cjs
 
 import * as mjs from "inner/mjs/index";
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 import * as type from "inner/js/index";
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 export { cjs };
 >cjs : typeof cjs
 
 export { mjs };
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.cts ===
 // cjs format file
@@ -107,7 +107,7 @@ import * as mjs from "inner/mjs/index";
 >mjs : typeof cjs.mjs
 
 import * as type from "inner/js/index";
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 
 export { cjs };
 >cjs : typeof cjs
@@ -116,5 +116,5 @@ export { mjs };
 >mjs : typeof cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 

--- a/tests/baselines/reference/nodeModulesPackagePatternExportsTrailers(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesPackagePatternExportsTrailers(module=nodenext).symbols
@@ -70,13 +70,13 @@ import * as type from "inner/js/index.js";
 >type : Symbol(type, Decl(index.d.ts, 3, 6))
 
 export { cjs };
->cjs : Symbol(mjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
 
 export { mjs };
->mjs : Symbol(mjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
 
 export { type };
->type : Symbol(mjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
 
 === tests/cases/conformance/node/node_modules/inner/index.d.mts ===
 // esm format file
@@ -90,13 +90,13 @@ import * as type from "inner/js/index.js";
 >type : Symbol(type, Decl(index.d.mts, 3, 6))
 
 export { cjs };
->cjs : Symbol(cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
 
 export { mjs };
->mjs : Symbol(cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
 
 export { type };
->type : Symbol(cjs.mjs.type, Decl(index.d.mts, 6, 8))
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
 
 === tests/cases/conformance/node/node_modules/inner/index.d.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesPackagePatternExportsTrailers(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesPackagePatternExportsTrailers(module=nodenext).types
@@ -4,19 +4,19 @@ import * as cjsi from "inner/cjs/index.cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index.mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index.js";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/index.mts ===
 // esm format file
@@ -24,19 +24,19 @@ import * as cjsi from "inner/cjs/index.cjs";
 >cjsi : typeof cjsi
 
 import * as mjsi from "inner/mjs/index.mjs";
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 import * as typei from "inner/js/index.js";
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 cjsi;
 >cjsi : typeof cjsi
 
 mjsi;
->mjsi : typeof cjsi.mjs
+>mjsi : typeof cjsi.cjs.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof typei
 
 === tests/cases/conformance/node/index.cts ===
 // cjs format file
@@ -47,7 +47,7 @@ import * as mjsi from "inner/mjs/index.mjs";
 >mjsi : typeof cjsi.mjs
 
 import * as typei from "inner/js/index.js";
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 cjsi;
 >cjsi : typeof cjsi
@@ -56,7 +56,7 @@ mjsi;
 >mjsi : typeof cjsi.mjs
 
 typei;
->typei : typeof cjsi.mjs.type
+>typei : typeof cjsi.mjs.cjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.ts ===
 // cjs format file
@@ -67,7 +67,7 @@ import * as mjs from "inner/mjs/index.mjs";
 >mjs : typeof mjs
 
 import * as type from "inner/js/index.js";
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 export { cjs };
 >cjs : any
@@ -76,7 +76,7 @@ export { mjs };
 >mjs : typeof mjs
 
 export { type };
->type : typeof mjs.cjs.type
+>type : typeof mjs.cjs.cjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.mts ===
 // esm format file
@@ -84,19 +84,19 @@ import * as cjs from "inner/cjs/index.cjs";
 >cjs : typeof cjs
 
 import * as mjs from "inner/mjs/index.mjs";
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 import * as type from "inner/js/index.js";
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 export { cjs };
 >cjs : typeof cjs
 
 export { mjs };
->mjs : typeof cjs.mjs
+>mjs : typeof cjs.cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.cjs.mjs.type
 
 === tests/cases/conformance/node/node_modules/inner/index.d.cts ===
 // cjs format file
@@ -107,7 +107,7 @@ import * as mjs from "inner/mjs/index.mjs";
 >mjs : typeof cjs.mjs
 
 import * as type from "inner/js/index.js";
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 
 export { cjs };
 >cjs : typeof cjs
@@ -116,5 +116,5 @@ export { mjs };
 >mjs : typeof cjs.mjs
 
 export { type };
->type : typeof cjs.mjs.type
+>type : typeof cjs.mjs.cjs.type
 

--- a/tests/baselines/reference/nodeModulesTypesVersionPackageExports(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesTypesVersionPackageExports(module=node12).symbols
@@ -4,9 +4,9 @@ import * as mod from "inner";
 >mod : Symbol(mod, Decl(index.ts, 1, 6))
 
 mod.correctVersionApplied;
->mod.correctVersionApplied : Symbol(mod.correctVersionApplied, Decl(new-types.d.ts, 0, 12))
+>mod.correctVersionApplied : Symbol(correctVersionApplied, Decl(new-types.d.ts, 0, 12))
 >mod : Symbol(mod, Decl(index.ts, 1, 6))
->correctVersionApplied : Symbol(mod.correctVersionApplied, Decl(new-types.d.ts, 0, 12))
+>correctVersionApplied : Symbol(correctVersionApplied, Decl(new-types.d.ts, 0, 12))
 
 === tests/cases/conformance/node/index.mts ===
 // esm format file
@@ -14,9 +14,9 @@ import * as mod from "inner";
 >mod : Symbol(mod, Decl(index.mts, 1, 6))
 
 mod.correctVersionApplied;
->mod.correctVersionApplied : Symbol(mod.correctVersionApplied, Decl(new-types.d.ts, 0, 12))
+>mod.correctVersionApplied : Symbol(correctVersionApplied, Decl(new-types.d.ts, 0, 12))
 >mod : Symbol(mod, Decl(index.mts, 1, 6))
->correctVersionApplied : Symbol(mod.correctVersionApplied, Decl(new-types.d.ts, 0, 12))
+>correctVersionApplied : Symbol(correctVersionApplied, Decl(new-types.d.ts, 0, 12))
 
 === tests/cases/conformance/node/index.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeModulesTypesVersionPackageExports(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesTypesVersionPackageExports(module=nodenext).symbols
@@ -4,9 +4,9 @@ import * as mod from "inner";
 >mod : Symbol(mod, Decl(index.ts, 1, 6))
 
 mod.correctVersionApplied;
->mod.correctVersionApplied : Symbol(mod.correctVersionApplied, Decl(new-types.d.ts, 0, 12))
+>mod.correctVersionApplied : Symbol(correctVersionApplied, Decl(new-types.d.ts, 0, 12))
 >mod : Symbol(mod, Decl(index.ts, 1, 6))
->correctVersionApplied : Symbol(mod.correctVersionApplied, Decl(new-types.d.ts, 0, 12))
+>correctVersionApplied : Symbol(correctVersionApplied, Decl(new-types.d.ts, 0, 12))
 
 === tests/cases/conformance/node/index.mts ===
 // esm format file
@@ -14,9 +14,9 @@ import * as mod from "inner";
 >mod : Symbol(mod, Decl(index.mts, 1, 6))
 
 mod.correctVersionApplied;
->mod.correctVersionApplied : Symbol(mod.correctVersionApplied, Decl(new-types.d.ts, 0, 12))
+>mod.correctVersionApplied : Symbol(correctVersionApplied, Decl(new-types.d.ts, 0, 12))
 >mod : Symbol(mod, Decl(index.mts, 1, 6))
->correctVersionApplied : Symbol(mod.correctVersionApplied, Decl(new-types.d.ts, 0, 12))
+>correctVersionApplied : Symbol(correctVersionApplied, Decl(new-types.d.ts, 0, 12))
 
 === tests/cases/conformance/node/index.cts ===
 // cjs format file

--- a/tests/baselines/reference/nodeNextCjsNamespaceImportDefault1.js
+++ b/tests/baselines/reference/nodeNextCjsNamespaceImportDefault1.js
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/nodeNextCjsNamespaceImportDefault1.ts] ////
+
+//// [a.cts]
+export const a: number = 1;
+//// [foo.mts]
+import d, {a} from './a.cjs';
+import * as ns from './a.cjs';
+export {d, a, ns};
+
+d.a;
+ns.default.a;
+
+//// [a.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.a = void 0;
+exports.a = 1;
+//// [foo.mjs]
+import d, { a } from './a.cjs';
+import * as ns from './a.cjs';
+export { d, a, ns };
+d.a;
+ns.default.a;
+
+
+//// [a.d.cts]
+export declare const a: number;
+//// [foo.d.mts]
+import d, { a } from './a.cjs';
+import * as ns from './a.cjs';
+export { d, a, ns };

--- a/tests/baselines/reference/nodeNextCjsNamespaceImportDefault1.symbols
+++ b/tests/baselines/reference/nodeNextCjsNamespaceImportDefault1.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/src/a.cts ===
+export const a: number = 1;
+>a : Symbol(a, Decl(a.cts, 0, 12))
+
+=== tests/cases/compiler/src/foo.mts ===
+import d, {a} from './a.cjs';
+>d : Symbol(d, Decl(foo.mts, 0, 6))
+>a : Symbol(a, Decl(foo.mts, 0, 11))
+
+import * as ns from './a.cjs';
+>ns : Symbol(ns, Decl(foo.mts, 1, 6))
+
+export {d, a, ns};
+>d : Symbol(d, Decl(foo.mts, 2, 8))
+>a : Symbol(a, Decl(foo.mts, 2, 10))
+>ns : Symbol(ns, Decl(foo.mts, 2, 13))
+
+d.a;
+>d.a : Symbol(d.a, Decl(a.cts, 0, 12))
+>d : Symbol(d, Decl(foo.mts, 0, 6))
+>a : Symbol(d.a, Decl(a.cts, 0, 12))
+
+ns.default.a;
+>ns.default.a : Symbol(d.a, Decl(a.cts, 0, 12))
+>ns.default : Symbol(d.default)
+>ns : Symbol(ns, Decl(foo.mts, 1, 6))
+>default : Symbol(d.default)
+>a : Symbol(d.a, Decl(a.cts, 0, 12))
+

--- a/tests/baselines/reference/nodeNextCjsNamespaceImportDefault1.types
+++ b/tests/baselines/reference/nodeNextCjsNamespaceImportDefault1.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/src/a.cts ===
+export const a: number = 1;
+>a : number
+>1 : 1
+
+=== tests/cases/compiler/src/foo.mts ===
+import d, {a} from './a.cjs';
+>d : typeof d
+>a : number
+
+import * as ns from './a.cjs';
+>ns : typeof ns
+
+export {d, a, ns};
+>d : typeof d
+>a : number
+>ns : typeof ns
+
+d.a;
+>d.a : number
+>d : typeof d
+>a : number
+
+ns.default.a;
+>ns.default.a : number
+>ns.default : typeof d
+>ns : typeof ns
+>default : typeof d
+>a : number
+

--- a/tests/baselines/reference/nodeNextCjsNamespaceImportDefault2.js
+++ b/tests/baselines/reference/nodeNextCjsNamespaceImportDefault2.js
@@ -1,0 +1,35 @@
+//// [tests/cases/compiler/nodeNextCjsNamespaceImportDefault2.ts] ////
+
+//// [a.cts]
+export const a: number = 1;
+export default 'string';
+//// [foo.mts]
+import d, {a} from './a.cjs';
+import * as ns from './a.cjs';
+export {d, a, ns};
+
+d.a;
+ns.default.a;
+
+//// [a.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.a = void 0;
+exports.a = 1;
+exports.default = 'string';
+//// [foo.mjs]
+import d, { a } from './a.cjs';
+import * as ns from './a.cjs';
+export { d, a, ns };
+d.a;
+ns.default.a;
+
+
+//// [a.d.cts]
+export declare const a: number;
+declare const _default: "string";
+export default _default;
+//// [foo.d.mts]
+import d, { a } from './a.cjs';
+import * as ns from './a.cjs';
+export { d, a, ns };

--- a/tests/baselines/reference/nodeNextCjsNamespaceImportDefault2.symbols
+++ b/tests/baselines/reference/nodeNextCjsNamespaceImportDefault2.symbols
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/src/a.cts ===
+export const a: number = 1;
+>a : Symbol(a, Decl(a.cts, 0, 12))
+
+export default 'string';
+=== tests/cases/compiler/src/foo.mts ===
+import d, {a} from './a.cjs';
+>d : Symbol(d, Decl(foo.mts, 0, 6))
+>a : Symbol(a, Decl(foo.mts, 0, 11))
+
+import * as ns from './a.cjs';
+>ns : Symbol(ns, Decl(foo.mts, 1, 6))
+
+export {d, a, ns};
+>d : Symbol(d, Decl(foo.mts, 2, 8))
+>a : Symbol(a, Decl(foo.mts, 2, 10))
+>ns : Symbol(ns, Decl(foo.mts, 2, 13))
+
+d.a;
+>d.a : Symbol(d.a, Decl(a.cts, 0, 12))
+>d : Symbol(d, Decl(foo.mts, 0, 6))
+>a : Symbol(d.a, Decl(a.cts, 0, 12))
+
+ns.default.a;
+>ns.default.a : Symbol(d.a, Decl(a.cts, 0, 12))
+>ns.default : Symbol(d.default)
+>ns : Symbol(ns, Decl(foo.mts, 1, 6))
+>default : Symbol(d.default)
+>a : Symbol(d.a, Decl(a.cts, 0, 12))
+

--- a/tests/baselines/reference/nodeNextCjsNamespaceImportDefault2.types
+++ b/tests/baselines/reference/nodeNextCjsNamespaceImportDefault2.types
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/src/a.cts ===
+export const a: number = 1;
+>a : number
+>1 : 1
+
+export default 'string';
+=== tests/cases/compiler/src/foo.mts ===
+import d, {a} from './a.cjs';
+>d : typeof d
+>a : number
+
+import * as ns from './a.cjs';
+>ns : typeof ns
+
+export {d, a, ns};
+>d : typeof d
+>a : number
+>ns : typeof ns
+
+d.a;
+>d.a : number
+>d : typeof d
+>a : number
+
+ns.default.a;
+>ns.default.a : number
+>ns.default : typeof d
+>ns : typeof ns
+>default : typeof d
+>a : number
+

--- a/tests/cases/compiler/nodeNextCjsNamespaceImportDefault1.ts
+++ b/tests/cases/compiler/nodeNextCjsNamespaceImportDefault1.ts
@@ -1,0 +1,13 @@
+// @module: nodenext
+// @moduleResolution: nodenext
+// @outDir: ./out
+// @declaration: true
+// @filename: src/a.cts
+export const a: number = 1;
+// @filename: src/foo.mts
+import d, {a} from './a.cjs';
+import * as ns from './a.cjs';
+export {d, a, ns};
+
+d.a;
+ns.default.a;

--- a/tests/cases/compiler/nodeNextCjsNamespaceImportDefault2.ts
+++ b/tests/cases/compiler/nodeNextCjsNamespaceImportDefault2.ts
@@ -1,0 +1,14 @@
+// @module: nodenext
+// @moduleResolution: nodenext
+// @outDir: ./out
+// @declaration: true
+// @filename: src/a.cts
+export const a: number = 1;
+export default 'string';
+// @filename: src/foo.mts
+import d, {a} from './a.cjs';
+import * as ns from './a.cjs';
+export {d, a, ns};
+
+d.a;
+ns.default.a;


### PR DESCRIPTION
Rather than only in the `esModuleInterop` detected case where the target file has a `default` of its own or call/construct signatures.

Fixes #47859
