### PR TITLE
Use full `isReadonlySymbol` check rather than declaration flags

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19747,8 +19747,9 @@ namespace ts {
                 // This ensures the subtype relationship is ordered, and preventing declaration order
                 // from deciding which type "wins" in union subtype reduction.
                 // They're still assignable to one another, since `readonly` doesn't affect assignability.
+                // This is only applied during the strictSubtypeRelation for compatability's sake in control flow
                 if (
-                    (relation === subtypeRelation || relation === strictSubtypeRelation) &&
+                    relation === strictSubtypeRelation &&
                     isReadonlySymbol(sourceProp) && !isReadonlySymbol(targetProp)
                 ) {
                     return Ternary.False;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19749,7 +19749,7 @@ namespace ts {
                 // They're still assignable to one another, since `readonly` doesn't affect assignability.
                 if (
                     (relation === subtypeRelation || relation === strictSubtypeRelation) &&
-                    !!(sourcePropFlags & ModifierFlags.Readonly) && !(targetPropFlags & ModifierFlags.Readonly)
+                    isReadonlySymbol(sourceProp) && !isReadonlySymbol(targetProp)
                 ) {
                     return Ternary.False;
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19747,7 +19747,7 @@ namespace ts {
                 // This ensures the subtype relationship is ordered, and preventing declaration order
                 // from deciding which type "wins" in union subtype reduction.
                 // They're still assignable to one another, since `readonly` doesn't affect assignability.
-                // This is only applied during the strictSubtypeRelation for compatability's sake in control flow
+                // This is only applied during the strictSubtypeRelation -- currently used in subtype reduction
                 if (
                     relation === strictSubtypeRelation &&
                     isReadonlySymbol(sourceProp) && !isReadonlySymbol(targetProp)

--- a/tests/baselines/reference/typeGuardNarrowByMutableUntypedField.js
+++ b/tests/baselines/reference/typeGuardNarrowByMutableUntypedField.js
@@ -1,0 +1,11 @@
+//// [typeGuardNarrowByMutableUntypedField.ts]
+declare function hasOwnProperty<P extends PropertyKey>(target: {}, property: P): target is { [K in P]: unknown };
+declare const arrayLikeOrIterable: ArrayLike<any> | Iterable<any>;
+if (hasOwnProperty(arrayLikeOrIterable, 'length')) {
+    let x: number = arrayLikeOrIterable.length;
+}
+
+//// [typeGuardNarrowByMutableUntypedField.js]
+if (hasOwnProperty(arrayLikeOrIterable, 'length')) {
+    var x = arrayLikeOrIterable.length;
+}

--- a/tests/baselines/reference/typeGuardNarrowByMutableUntypedField.symbols
+++ b/tests/baselines/reference/typeGuardNarrowByMutableUntypedField.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts ===
+declare function hasOwnProperty<P extends PropertyKey>(target: {}, property: P): target is { [K in P]: unknown };
+>hasOwnProperty : Symbol(hasOwnProperty, Decl(typeGuardNarrowByMutableUntypedField.ts, 0, 0))
+>P : Symbol(P, Decl(typeGuardNarrowByMutableUntypedField.ts, 0, 32))
+>PropertyKey : Symbol(PropertyKey, Decl(lib.es5.d.ts, --, --))
+>target : Symbol(target, Decl(typeGuardNarrowByMutableUntypedField.ts, 0, 55))
+>property : Symbol(property, Decl(typeGuardNarrowByMutableUntypedField.ts, 0, 66))
+>P : Symbol(P, Decl(typeGuardNarrowByMutableUntypedField.ts, 0, 32))
+>target : Symbol(target, Decl(typeGuardNarrowByMutableUntypedField.ts, 0, 55))
+>K : Symbol(K, Decl(typeGuardNarrowByMutableUntypedField.ts, 0, 94))
+>P : Symbol(P, Decl(typeGuardNarrowByMutableUntypedField.ts, 0, 32))
+
+declare const arrayLikeOrIterable: ArrayLike<any> | Iterable<any>;
+>arrayLikeOrIterable : Symbol(arrayLikeOrIterable, Decl(typeGuardNarrowByMutableUntypedField.ts, 1, 13))
+>ArrayLike : Symbol(ArrayLike, Decl(lib.es5.d.ts, --, --))
+>Iterable : Symbol(Iterable, Decl(lib.es2015.iterable.d.ts, --, --))
+
+if (hasOwnProperty(arrayLikeOrIterable, 'length')) {
+>hasOwnProperty : Symbol(hasOwnProperty, Decl(typeGuardNarrowByMutableUntypedField.ts, 0, 0))
+>arrayLikeOrIterable : Symbol(arrayLikeOrIterable, Decl(typeGuardNarrowByMutableUntypedField.ts, 1, 13))
+
+    let x: number = arrayLikeOrIterable.length;
+>x : Symbol(x, Decl(typeGuardNarrowByMutableUntypedField.ts, 3, 7))
+>arrayLikeOrIterable.length : Symbol(ArrayLike.length, Decl(lib.es5.d.ts, --, --))
+>arrayLikeOrIterable : Symbol(arrayLikeOrIterable, Decl(typeGuardNarrowByMutableUntypedField.ts, 1, 13))
+>length : Symbol(ArrayLike.length, Decl(lib.es5.d.ts, --, --))
+}

--- a/tests/baselines/reference/typeGuardNarrowByMutableUntypedField.types
+++ b/tests/baselines/reference/typeGuardNarrowByMutableUntypedField.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts ===
+declare function hasOwnProperty<P extends PropertyKey>(target: {}, property: P): target is { [K in P]: unknown };
+>hasOwnProperty : <P extends PropertyKey>(target: {}, property: P) => target is { [K in P]: unknown; }
+>target : {}
+>property : P
+
+declare const arrayLikeOrIterable: ArrayLike<any> | Iterable<any>;
+>arrayLikeOrIterable : ArrayLike<any> | Iterable<any>
+
+if (hasOwnProperty(arrayLikeOrIterable, 'length')) {
+>hasOwnProperty(arrayLikeOrIterable, 'length') : boolean
+>hasOwnProperty : <P extends PropertyKey>(target: {}, property: P) => target is { [K in P]: unknown; }
+>arrayLikeOrIterable : ArrayLike<any> | Iterable<any>
+>'length' : "length"
+
+    let x: number = arrayLikeOrIterable.length;
+>x : number
+>arrayLikeOrIterable.length : number
+>arrayLikeOrIterable : ArrayLike<any>
+>length : number
+}

--- a/tests/baselines/reference/typeGuardNarrowByUntypedField.js
+++ b/tests/baselines/reference/typeGuardNarrowByUntypedField.js
@@ -1,0 +1,11 @@
+//// [typeGuardNarrowByUntypedField.ts]
+declare function hasOwnProperty<P extends PropertyKey>(target: {}, property: P): target is { readonly [K in P]: unknown };
+declare const arrayLikeOrIterable: ArrayLike<any> | Iterable<any>;
+if (hasOwnProperty(arrayLikeOrIterable, 'length')) {
+    let x: number = arrayLikeOrIterable.length;
+}
+
+//// [typeGuardNarrowByUntypedField.js]
+if (hasOwnProperty(arrayLikeOrIterable, 'length')) {
+    var x = arrayLikeOrIterable.length;
+}

--- a/tests/baselines/reference/typeGuardNarrowByUntypedField.symbols
+++ b/tests/baselines/reference/typeGuardNarrowByUntypedField.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/typeGuardNarrowByUntypedField.ts ===
+declare function hasOwnProperty<P extends PropertyKey>(target: {}, property: P): target is { readonly [K in P]: unknown };
+>hasOwnProperty : Symbol(hasOwnProperty, Decl(typeGuardNarrowByUntypedField.ts, 0, 0))
+>P : Symbol(P, Decl(typeGuardNarrowByUntypedField.ts, 0, 32))
+>PropertyKey : Symbol(PropertyKey, Decl(lib.es5.d.ts, --, --))
+>target : Symbol(target, Decl(typeGuardNarrowByUntypedField.ts, 0, 55))
+>property : Symbol(property, Decl(typeGuardNarrowByUntypedField.ts, 0, 66))
+>P : Symbol(P, Decl(typeGuardNarrowByUntypedField.ts, 0, 32))
+>target : Symbol(target, Decl(typeGuardNarrowByUntypedField.ts, 0, 55))
+>K : Symbol(K, Decl(typeGuardNarrowByUntypedField.ts, 0, 103))
+>P : Symbol(P, Decl(typeGuardNarrowByUntypedField.ts, 0, 32))
+
+declare const arrayLikeOrIterable: ArrayLike<any> | Iterable<any>;
+>arrayLikeOrIterable : Symbol(arrayLikeOrIterable, Decl(typeGuardNarrowByUntypedField.ts, 1, 13))
+>ArrayLike : Symbol(ArrayLike, Decl(lib.es5.d.ts, --, --))
+>Iterable : Symbol(Iterable, Decl(lib.es2015.iterable.d.ts, --, --))
+
+if (hasOwnProperty(arrayLikeOrIterable, 'length')) {
+>hasOwnProperty : Symbol(hasOwnProperty, Decl(typeGuardNarrowByUntypedField.ts, 0, 0))
+>arrayLikeOrIterable : Symbol(arrayLikeOrIterable, Decl(typeGuardNarrowByUntypedField.ts, 1, 13))
+
+    let x: number = arrayLikeOrIterable.length;
+>x : Symbol(x, Decl(typeGuardNarrowByUntypedField.ts, 3, 7))
+>arrayLikeOrIterable.length : Symbol(ArrayLike.length, Decl(lib.es5.d.ts, --, --))
+>arrayLikeOrIterable : Symbol(arrayLikeOrIterable, Decl(typeGuardNarrowByUntypedField.ts, 1, 13))
+>length : Symbol(ArrayLike.length, Decl(lib.es5.d.ts, --, --))
+}

--- a/tests/baselines/reference/typeGuardNarrowByUntypedField.types
+++ b/tests/baselines/reference/typeGuardNarrowByUntypedField.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/typeGuardNarrowByUntypedField.ts ===
+declare function hasOwnProperty<P extends PropertyKey>(target: {}, property: P): target is { readonly [K in P]: unknown };
+>hasOwnProperty : <P extends PropertyKey>(target: {}, property: P) => target is { readonly [K in P]: unknown; }
+>target : {}
+>property : P
+
+declare const arrayLikeOrIterable: ArrayLike<any> | Iterable<any>;
+>arrayLikeOrIterable : ArrayLike<any> | Iterable<any>
+
+if (hasOwnProperty(arrayLikeOrIterable, 'length')) {
+>hasOwnProperty(arrayLikeOrIterable, 'length') : boolean
+>hasOwnProperty : <P extends PropertyKey>(target: {}, property: P) => target is { readonly [K in P]: unknown; }
+>arrayLikeOrIterable : ArrayLike<any> | Iterable<any>
+>'length' : "length"
+
+    let x: number = arrayLikeOrIterable.length;
+>x : number
+>arrayLikeOrIterable.length : number
+>arrayLikeOrIterable : ArrayLike<any>
+>length : number
+}

--- a/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
+++ b/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
@@ -1,0 +1,6 @@
+// @lib: es6
+declare function hasOwnProperty<P extends PropertyKey>(target: {}, property: P): target is { [K in P]: unknown };
+declare const arrayLikeOrIterable: ArrayLike<any> | Iterable<any>;
+if (hasOwnProperty(arrayLikeOrIterable, 'length')) {
+    let x: number = arrayLikeOrIterable.length;
+}

--- a/tests/cases/compiler/typeGuardNarrowByUntypedField.ts
+++ b/tests/cases/compiler/typeGuardNarrowByUntypedField.ts
@@ -1,0 +1,6 @@
+// @lib: es6
+declare function hasOwnProperty<P extends PropertyKey>(target: {}, property: P): target is { readonly [K in P]: unknown };
+declare const arrayLikeOrIterable: ArrayLike<any> | Iterable<any>;
+if (hasOwnProperty(arrayLikeOrIterable, 'length')) {
+    let x: number = arrayLikeOrIterable.length;
+}


### PR DESCRIPTION
When comparing property readonly-ness for subtype checks. This fixes comparing a mapped type `readonly` prop (which gets a `Readonly` check flag) with a declared `readonly` prop (which has a `Readonly` modifier flag, but no check flag).

That alone fixes #47940 with the caveat that the type guard should look for a `readonly` field rather than a mutable one (since narrowing is by subtype and not assignability, and `ArrayLike` has a `readonly` length property).

In addition, I also limit the new subtype check to only the `strictSubtypeRelation`, as used by subtype reduction, so as to not change behavior in control flow, and thus fixes #47940 completely.