### PR TITLE
Fix modifier order for class member completions

### DIFF
--- a/tests/cases/fourslash/completionsOverridingMethod.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod.ts
@@ -93,7 +93,7 @@
 ////
 ////class HSub extends HBase {
 ////    /*h1*/
-////    static /*h2*/
+////    [|static|] /*h2*/
 ////}
 
 // @Filename: i.ts
@@ -124,11 +124,6 @@ verify.completions({
         {
             name: "foo",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "foo(param1: string, param2: boolean): Promise<void> {\n}",
         }
     ],
@@ -146,11 +141,6 @@ verify.completions({
         {
             name: "foo",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "foo(a: string, b: string): string {\n}",
         }
     ],
@@ -168,11 +158,6 @@ verify.completions({
         {
             name: "foo",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -190,11 +175,6 @@ verify.completions({
         {
             name: "foo",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -212,11 +192,6 @@ verify.completions({
         {
             name: "foo",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -234,11 +209,6 @@ verify.completions({
         {
             name: "foo",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -256,11 +226,6 @@ verify.completions({
         {
             name: "foo",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText:
 `foo(a: string): string;
 foo(a: undefined, b: number): string;
@@ -292,12 +257,8 @@ verify.completions({
         {
             name: "met",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
-            insertText: "met(n: number): number {\n}",
+            replacementSpan: test.ranges()[0],
+            insertText: "static met(n: number): number {\n}",
         }
     ],
 });
@@ -314,21 +275,11 @@ verify.completions({
         {
             name: "met",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "met<T>(t: T): T {\n}",
         },
         {
             name: "metcons",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "metcons<T extends string | number>(t: T): T {\n}",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod1.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod1.ts
@@ -25,11 +25,6 @@ verify.completions({
         {
             name: "foo",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "override foo(a: string): void {\n}",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod10.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod10.ts
@@ -26,21 +26,11 @@ verify.completions({
         {
             name: "a",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "a: string;",
         },
         {
             name: "b",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText:
 `b(a: string): void {
 }`,
@@ -48,11 +38,6 @@ verify.completions({
         {
             name: "c",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText:
 `c(a: string): string;
 c(a: number): number;

--- a/tests/cases/fourslash/completionsOverridingMethod11.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod11.ts
@@ -32,21 +32,11 @@ verify.completions({
         {
             name: "a",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "a: string",
         },
         {
             name: "b",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText:
 `b(a: string): void {
 }`,
@@ -54,11 +44,6 @@ verify.completions({
         {
             name: "c",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText:
 `c(a: string): string
 c(a: number): number

--- a/tests/cases/fourslash/completionsOverridingMethod12.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod12.ts
@@ -1,0 +1,54 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: a.ts
+// @newline: LF
+// Case: modifier order
+////abstract class A {
+////    public get P(): string {
+////        return "";
+////    }
+////}
+////
+////abstract class B extends A {
+////    [|abstract|] /*a*/
+////}
+////
+////abstract class B1 extends A {
+////    [|abstract override|] /*b*/
+////}
+
+verify.completions({
+    marker: "a",
+    isNewIdentifierLocation: true,
+    preferences: {
+        includeCompletionsWithInsertText: true,
+        includeCompletionsWithSnippetText: false,
+        includeCompletionsWithClassMemberSnippets: true,
+    },
+    includes: [
+        {
+            name: "P",
+            sortText: completion.SortText.LocationPriority,
+            replacementSpan: test.ranges()[0],
+            insertText: "public abstract get P(): string;",
+        },
+    ],
+});
+
+verify.completions({
+    marker: "b",
+    isNewIdentifierLocation: true,
+    preferences: {
+        includeCompletionsWithInsertText: true,
+        includeCompletionsWithSnippetText: false,
+        includeCompletionsWithClassMemberSnippets: true,
+    },
+    includes: [
+        {
+            name: "P",
+            sortText: completion.SortText.LocationPriority,
+            replacementSpan: test.ranges()[1],
+            insertText: "public abstract override get P(): string;",
+        },
+    ],
+});

--- a/tests/cases/fourslash/completionsOverridingMethod2.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod2.ts
@@ -23,11 +23,6 @@ verify.completions({
         {
             name: "$usd",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             isSnippet: true,
             insertText: "\"\\$usd\"(a: number): number {\n    $0\n}",
         }

--- a/tests/cases/fourslash/completionsOverridingMethod3.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod3.ts
@@ -24,11 +24,6 @@ verify.completions({
         {
             name: "boo",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "boo(): string;",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod4.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod4.ts
@@ -43,21 +43,11 @@ verify.completions({
         {
             name: "hint",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "protected hint(): string {\n}",
         },
         {
             name: "refuse",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "public refuse(): string {\n}",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod5.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod5.ts
@@ -12,8 +12,8 @@
 ////
 ////abstract class Abc extends Ab {
 ////    /*a*/
-////    abstract /*b*/
-////    abstract m/*c*/
+////    [|abstract|] /*b*/
+////    [|abstract m|]/*c*/
 ////}
 
 
@@ -29,21 +29,11 @@ verify.completions({
         {
             name: "met",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "met(n: string): void {\n}",
         },
         {
             name: "met2",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "met2(n: number): void {\n}",
         }
     ],
@@ -61,22 +51,14 @@ verify.completions({
         {
             name: "met",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
-            insertText: "met(n: string): void;",
+            replacementSpan: test.ranges()[0],
+            insertText: "abstract met(n: string): void;",
         },
         {
             name: "met2",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
-            insertText: "met2(n: number): void;",
+            replacementSpan: test.ranges()[0],
+            insertText: "abstract met2(n: number): void;",
         }
     ],
 });
@@ -93,22 +75,14 @@ verify.completions({
         {
             name: "met",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
-            insertText: "met(n: string): void;",
+            replacementSpan: test.ranges()[1],
+            insertText: "abstract met(n: string): void;",
         },
         {
             name: "met2",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
-            insertText: "met2(n: number): void;",
+            replacementSpan: test.ranges()[1],
+            insertText: "abstract met2(n: number): void;",
         }
     ],
 });

--- a/tests/cases/fourslash/completionsOverridingMethod6.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod6.ts
@@ -10,11 +10,11 @@
 ////}
 ////
 ////abstract class B extends A {
-////    public abstract /*b*/
+////    [|public abstract|] /*b*/
 ////}
 ////
 ////class C extends A {
-////    public override m/*a*/
+////    [|public override m|]/*a*/
 ////}
 ////
 ////interface D {
@@ -23,7 +23,7 @@
 ////}
 ////
 ////class E implements D {
-////    public f/*c*/
+////    [|public f|]/*c*/
 ////}
 
 verify.completions({
@@ -38,12 +38,8 @@ verify.completions({
         {
             name: "method",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
-            insertText: "method(): number {\n}",
+            replacementSpan: test.ranges()[1],
+            insertText: "public override method(): number {\n}",
         },
     ],
 });
@@ -60,12 +56,8 @@ verify.completions({
         {
             name: "method",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
-            insertText: "method(): number;",
+            replacementSpan: test.ranges()[0],
+            insertText: "public abstract method(): number;",
         },
     ],
 });
@@ -82,13 +74,9 @@ verify.completions({
         {
             name: "fun",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
+            replacementSpan: test.ranges()[2],
             insertText:
-`fun(a: number): number;
+`public fun(a: number): number;
 public fun(a: undefined, b: string): number;
 public fun(a: unknown, b?: unknown): number {
 }`,

--- a/tests/cases/fourslash/completionsOverridingMethod7.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod7.ts
@@ -9,7 +9,7 @@
 ////}
 ////
 ////abstract class Derived extends Base {
-////    abstract /*a*/
+////    [|abstract|] /*a*/
 ////}
 
 verify.completions({
@@ -24,13 +24,9 @@ verify.completions({
         {
             name: "M",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
+            replacementSpan: test.ranges()[0],
             insertText:
-`M<T>(t: T): void;
+`abstract M<T>(t: T): void;
 abstract M<T>(t: T, x: number): void;`,
         },
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod8.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod8.ts
@@ -27,11 +27,6 @@ verify.completions({
   includes: [{
     name: "method",
     sortText: completion.SortText.LocationPriority,
-    replacementSpan: {
-      fileName: "",
-      pos: 0,
-      end: 0,
-    },
     insertText: "method(p: I): void {\n}",
     hasAction: true,
     source: completion.CompletionSource.ClassMemberSnippet,

--- a/tests/cases/fourslash/completionsOverridingMethod9.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod9.ts
@@ -23,21 +23,11 @@ verify.completions({
         {
             name: "a",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "a?: number;"
         },
         {
             name: "b",
             sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
             insertText: "b(x: number): void {\n}"
         },
     ],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #46568 (third item).

This PR makes it so that, when the user has already typed in some modifiers (e.g. `abstract`, `override`), we replace those already present modifiers, and then insert the class member signature (which will contain the already present modifiers). Before, we were not replacing the already present modifier, and instead just adding the new modifiers after those, causing the modifier order to be wrong in some cases (e.g. if the user had already typed `abstract` but we needed to insert `private` along with the signature, we'd get `abstract private foo`, but the correct order is `private abstract foo`).

I also removed `replacementSpan`s of length 0 from some fourslash tests, as [those are useless](https://github.com/microsoft/TypeScript/pull/42013).

