### PR TITLE
Fix incorrect parser error assumption in semicolon handling leading to incremental parser brokenness

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1680,19 +1680,8 @@ namespace ts {
                 return;
             }
 
-            // If an initializer was parsed but there is still an error in finding the next semicolon,
-            // we generally know there was an error already reported in the initializer...
-            //   class Example { a = new Map([), ) }
-            //                                ~
             if (initializer) {
-                // ...unless we've found the start of a block after a property declaration, in which
-                // case we can know that regardless of the initializer we should complain on the block.
-                //   class Example { a = 0 {} }
-                //                         ~
-                if (token() === SyntaxKind.OpenBraceToken) {
-                    parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(SyntaxKind.SemicolonToken));
-                }
-
+                parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(SyntaxKind.SemicolonToken));
                 return;
             }
 

--- a/tests/baselines/reference/parser0_004152.errors.txt
+++ b/tests/baselines/reference/parser0_004152.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts(2,28): error TS2304: Cannot find name 'DisplayPosition'.
 tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts(2,45): error TS1137: Expression or comma expected.
-tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts(2,46): error TS1068: Unexpected token. A constructor, method, accessor, or property was expected.
+tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts(2,46): error TS1005: ';' expected.
 tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts(2,49): error TS1005: ';' expected.
 tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts(2,51): error TS2300: Duplicate identifier '3'.
 tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts(2,52): error TS1005: ';' expected.
@@ -41,7 +41,7 @@ tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts(3,25): error T
                                                 ~
 !!! error TS1137: Expression or comma expected.
                                                  ~
-!!! error TS1068: Unexpected token. A constructor, method, accessor, or property was expected.
+!!! error TS1005: ';' expected.
                                                     ~
 !!! error TS1005: ';' expected.
                                                       ~

--- a/tests/cases/fourslash/parserCorruptionAfterMapInClass.ts
+++ b/tests/cases/fourslash/parserCorruptionAfterMapInClass.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+
+//// class C {
+////     map = new Set<string, number>/*$*/
+////
+////     foo() {
+////
+////     }
+//// }
+
+goTo.marker('$');
+edit.insert('()');
+verify.getSyntacticDiagnostics([]);


### PR DESCRIPTION
#43005 added special handling for missing semicolons to attempt to produce better errors. Unfortunately, it made an incorrect assumption about when the tokenizer would have already reported an error. This led to a class node with a syntax error being created without the flag noting that it contained an error (there's an initializer, but there's not a brace after it), which then led to the incremental parser trying to use that node rather than deciding it was unsafe.

Just remove this assumption; this fixes the new test case, and only reverts one error change introduced in #43005 (which doesn't seem correct to me anyway).

Fixes #47895
