### PR TITLE
Don't crash on non-literal computed property names during getPropertyAssignment

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -987,7 +987,9 @@ namespace ts {
         return name.kind === SyntaxKind.ComputedPropertyName && !isStringOrNumericLiteralLike(name.expression);
     }
 
-    export function getTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral): __String {
+    export function getTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral): __String;
+    export function getTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral, undefinedIfNotLiteral: boolean): __String | undefined;
+    export function getTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral, undefinedIfNotLiteral?: boolean): __String | undefined {
         switch (name.kind) {
             case SyntaxKind.Identifier:
             case SyntaxKind.PrivateIdentifier:
@@ -998,6 +1000,9 @@ namespace ts {
                 return escapeLeadingUnderscores(name.text);
             case SyntaxKind.ComputedPropertyName:
                 if (isStringOrNumericLiteralLike(name.expression)) return escapeLeadingUnderscores(name.expression.text);
+                if (undefinedIfNotLiteral) {
+                    return undefined;
+                }
                 return Debug.fail("Text of property name cannot be read from non-literal-valued ComputedPropertyNames");
             default:
                 return Debug.assertNever(name);
@@ -1573,7 +1578,7 @@ namespace ts {
     export function getPropertyAssignment(objectLiteral: ObjectLiteralExpression, key: string, key2?: string): readonly PropertyAssignment[] {
         return objectLiteral.properties.filter((property): property is PropertyAssignment => {
             if (property.kind === SyntaxKind.PropertyAssignment) {
-                const propName = getTextOfPropertyName(property.name);
+                const propName = getTextOfPropertyName(property.name, /*undefinedIfNotLiteral*/ true);
                 return key === propName || (!!key2 && key2 === propName);
             }
             return false;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1005,9 +1005,7 @@ namespace ts {
     }
 
     export function getTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral): __String {
-        const text = tryGetTextOfPropertyName(name);
-        Debug.assertIsDefined(text);
-        return text;
+        return Debug.checkDefined(tryGetTextOfPropertyName(name));
     }
 
     export function entityNameToString(name: EntityNameOrEntityNameExpression | JSDocMemberName | JsxTagNameExpression | PrivateIdentifier): string {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -987,9 +987,7 @@ namespace ts {
         return name.kind === SyntaxKind.ComputedPropertyName && !isStringOrNumericLiteralLike(name.expression);
     }
 
-    export function getTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral): __String;
-    export function getTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral, undefinedIfNotLiteral: boolean): __String | undefined;
-    export function getTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral, undefinedIfNotLiteral?: boolean): __String | undefined {
+    export function tryGetTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral): __String | undefined {
         switch (name.kind) {
             case SyntaxKind.Identifier:
             case SyntaxKind.PrivateIdentifier:
@@ -1000,13 +998,16 @@ namespace ts {
                 return escapeLeadingUnderscores(name.text);
             case SyntaxKind.ComputedPropertyName:
                 if (isStringOrNumericLiteralLike(name.expression)) return escapeLeadingUnderscores(name.expression.text);
-                if (undefinedIfNotLiteral) {
-                    return undefined;
-                }
-                return Debug.fail("Text of property name cannot be read from non-literal-valued ComputedPropertyNames");
+                return undefined;
             default:
                 return Debug.assertNever(name);
         }
+    }
+
+    export function getTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral): __String {
+        const text = tryGetTextOfPropertyName(name);
+        Debug.assertIsDefined(text);
+        return text;
     }
 
     export function entityNameToString(name: EntityNameOrEntityNameExpression | JSDocMemberName | JsxTagNameExpression | PrivateIdentifier): string {
@@ -1578,7 +1579,7 @@ namespace ts {
     export function getPropertyAssignment(objectLiteral: ObjectLiteralExpression, key: string, key2?: string): readonly PropertyAssignment[] {
         return objectLiteral.properties.filter((property): property is PropertyAssignment => {
             if (property.kind === SyntaxKind.PropertyAssignment) {
-                const propName = getTextOfPropertyName(property.name, /*undefinedIfNotLiteral*/ true);
+                const propName = tryGetTextOfPropertyName(property.name);
                 return key === propName || (!!key2 && key2 === propName);
             }
             return false;

--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -110,14 +110,12 @@ namespace ts.server {
                 }
             }
 
-            // verify the sequence numbers
-            Debug.assert(response.request_seq === request.seq, "Malformed response: response sequence number did not match request sequence number.");
-
             // unmarshal errors
             if (!response.success) {
                 throw new Error("Error " + response.message);
             }
 
+            Debug.assert(response.request_seq === request.seq, "Malformed response: response sequence number did not match request sequence number.");
             Debug.assert(expectEmptyBody || !!response.body, "Malformed response: Unexpected empty response body.");
             Debug.assert(!expectEmptyBody || !response.body, "Malformed response: Unexpected non-empty response body.");
 

--- a/tests/cases/fourslash/server/tsconfigComputedPropertyError.ts
+++ b/tests/cases/fourslash/server/tsconfigComputedPropertyError.ts
@@ -1,0 +1,12 @@
+/// <reference path="../fourslash.ts"/>
+
+// @filename: tsconfig.json
+////{
+////    ["oops!" + 42]: "true",
+////    "files": [
+////        "nonexistentfile.ts"
+////    ],
+////    "compileOnSave": true
+////}
+
+verify.getSemanticDiagnostics([]);


### PR DESCRIPTION
`getPropertyAssignment` is searching for a property with a given text; when it encounters a bad property name, it crashes. Just skip over the bad property name, as it can't be equal to the key being searched for anyway.

This test is weird; the failure mode doesn't look like the bug in this particular harness (but it works).

```
Test failure:
fourslash-server test tsconfigComputedPropertyError.ts runs correctly
  [.................................................................]

  0 passing (2s)
  1 failing

  1) fourslash-server tests
       tests/cases/fourslash/server/tsconfigComputedPropertyError.ts
         fourslash-server test tsconfigComputedPropertyError.ts runs correctly:
     Error: Debug Failure. False expression: Malformed response: response sequence number did not match request sequence number.
```

Fixes #47989
