### PR TITLE
JSDoc @type tag optional parameters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12762,6 +12762,10 @@ namespace ts {
         }
 
         function getSignatureFromDeclaration(declaration: SignatureDeclaration | JSDocSignature): Signature {
+            if (isInJSFile(declaration)) {
+                const signature = getSignatureOfTypeTag(declaration);
+                if (signature) return signature;
+            }
             const links = getNodeLinks(declaration);
             if (!links.resolvedSignature) {
                 const parameters: Symbol[] = [];

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17212,8 +17212,7 @@ namespace ts {
         }
 
         function isContextSensitiveFunctionLikeDeclaration(node: FunctionLikeDeclaration): boolean {
-            return (!isFunctionDeclaration(node) || isInJSFile(node) && !!getTypeForDeclarationFromJSDocComment(node)) &&
-                (hasContextSensitiveParameters(node) || hasContextSensitiveReturnExpression(node));
+            return hasContextSensitiveParameters(node) || hasContextSensitiveReturnExpression(node);
         }
 
         function hasContextSensitiveReturnExpression(node: FunctionLikeDeclaration) {
@@ -17222,7 +17221,7 @@ namespace ts {
         }
 
         function isContextSensitiveFunctionOrObjectLiteralMethod(func: Node): func is FunctionExpression | ArrowFunction | MethodDeclaration {
-            return (isInJSFile(func) && isFunctionDeclaration(func) || isFunctionExpressionOrArrowFunction(func) || isObjectLiteralMethod(func)) &&
+            return (isFunctionExpressionOrArrowFunction(func) || isObjectLiteralMethod(func)) &&
                 isContextSensitiveFunctionLikeDeclaration(func);
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8873,10 +8873,8 @@ namespace ts {
                         return getReturnTypeOfSignature(getterSignature);
                     }
                 }
-                if (isInJSFile(declaration)) {
-                    const type = getParameterTypeOfTypeTag(func, declaration);
-                    if (type) return type;
-                }
+                const parameterTypeOfTypeTag = getParameterTypeOfTypeTag(func, declaration);
+                if (parameterTypeOfTypeTag) return parameterTypeOfTypeTag;
                 // Use contextual parameter type if one is available
                 const type = declaration.symbol.escapedName === InternalSymbolName.This ? getContextualThisParameterType(func) : getContextuallyTypedParameterType(declaration);
                 if (type) {
@@ -12762,10 +12760,8 @@ namespace ts {
         }
 
         function getSignatureFromDeclaration(declaration: SignatureDeclaration | JSDocSignature): Signature {
-            if (isInJSFile(declaration)) {
-                const signature = getSignatureOfTypeTag(declaration);
-                if (signature) return signature;
-            }
+            const signature = getSignatureOfTypeTag(declaration);
+            if (signature) return signature;
             const links = getNodeLinks(declaration);
             if (!links.resolvedSignature) {
                 const parameters: Symbol[] = [];
@@ -12980,7 +12976,7 @@ namespace ts {
                 else {
                     const type = signature.declaration && getEffectiveReturnTypeNode(signature.declaration);
                     let jsdocPredicate: TypePredicate | undefined;
-                    if (!type && isInJSFile(signature.declaration)) {
+                    if (!type) {
                         const jsdocSignature = getSignatureOfTypeTag(signature.declaration!);
                         if (jsdocSignature && signature !== jsdocSignature) {
                             jsdocPredicate = getTypePredicateOfSignature(jsdocSignature);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12760,8 +12760,6 @@ namespace ts {
         }
 
         function getSignatureFromDeclaration(declaration: SignatureDeclaration | JSDocSignature): Signature {
-            const signature = getSignatureOfTypeTag(declaration);
-            if (signature) return signature;
             const links = getNodeLinks(declaration);
             if (!links.resolvedSignature) {
                 const parameters: Symbol[] = [];
@@ -12941,7 +12939,15 @@ namespace ts {
                         continue;
                     }
                 }
-                result.push(getSignatureFromDeclaration(decl));
+                // If this is a function or method declaration, get the accurate minArgumentCount from the @type tag, if present.
+                // If this is a variable or property declaration, apply the @type tag to it
+                // (getTypeForVariableLikeDeclaration()), not to the initializer.
+                result.push(
+                    (!isFunctionExpressionOrArrowFunction(decl) &&
+                        !isObjectLiteralMethod(decl) &&
+                        getSignatureOfTypeTag(decl)) ||
+                        getSignatureFromDeclaration(decl)
+                );
             }
             return result;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12939,9 +12939,8 @@ namespace ts {
                         continue;
                     }
                 }
-                // If this is a function or method declaration, get the accurate minArgumentCount from the @type tag, if present.
-                // If this is a variable or property declaration, apply the @type tag to it
-                // (getTypeForVariableLikeDeclaration()), not to the initializer.
+                // If this is a function or method declaration, get the signature from the @type tag for the sake of optional parameters.
+                // Exclude contextually-typed kinds because we already apply the @type tag to the context, plus applying it here to the initializer would supress checks that the two are compatible.
                 result.push(
                     (!isFunctionExpressionOrArrowFunction(decl) &&
                         !isObjectLiteralMethod(decl) &&

--- a/tests/baselines/reference/checkJsdocTypeTag5.types
+++ b/tests/baselines/reference/checkJsdocTypeTag5.types
@@ -44,7 +44,7 @@ var k = function (x) { return x }
 /** @typedef {(x: 'hi' | 'bye') => 0 | 1 | 2} Argle */
 /** @type {Argle} */
 function blargle(s) {
->blargle : (s: "hi" | "bye") => 0 | 1 | 2
+>blargle : (x: 'hi' | 'bye') => 0 | 1 | 2
 >s : "hi" | "bye"
 
     return 0;
@@ -55,7 +55,7 @@ function blargle(s) {
 var zeroonetwo = blargle('hi')
 >zeroonetwo : 0 | 1 | 2
 >blargle('hi') : 0 | 1 | 2
->blargle : (s: "hi" | "bye") => 0 | 1 | 2
+>blargle : (x: "hi" | "bye") => 0 | 1 | 2
 >'hi' : "hi"
 
 /** @typedef {{(s: string): 0 | 1; (b: boolean): 2 | 3 }} Gioconda */

--- a/tests/baselines/reference/checkJsdocTypeTag6.errors.txt
+++ b/tests/baselines/reference/checkJsdocTypeTag6.errors.txt
@@ -1,9 +1,13 @@
 tests/cases/conformance/jsdoc/test.js(1,12): error TS8030: The type of a function declaration must match the function's signature.
 tests/cases/conformance/jsdoc/test.js(7,5): error TS2322: Type '(prop: any) => void' is not assignable to type '{ prop: string; }'.
 tests/cases/conformance/jsdoc/test.js(10,12): error TS8030: The type of a function declaration must match the function's signature.
+tests/cases/conformance/jsdoc/test.js(23,12): error TS8030: The type of a function declaration must match the function's signature.
+tests/cases/conformance/jsdoc/test.js(27,7): error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+tests/cases/conformance/jsdoc/test.js(30,7): error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+tests/cases/conformance/jsdoc/test.js(34,3): error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
 
 
-==== tests/cases/conformance/jsdoc/test.js (3 errors) ====
+==== tests/cases/conformance/jsdoc/test.js (7 errors) ====
     /** @type {number} */
                ~~~~~~
 !!! error TS8030: The type of a function declaration must match the function's signature.
@@ -28,4 +32,29 @@ tests/cases/conformance/jsdoc/test.js(10,12): error TS8030: The type of a functi
     // TODO: Should be an error since signature doesn't match.
     /** @type {(a: number, b: number, c: number) => number} */
     function add3(a, b) { return a + b; }
+    
+    // Confirm initializers are compatible.
+    // They can't have more parameters than the type/context.
+    
+    /** @type {() => void} */
+               ~~~~~~~~~~
+!!! error TS8030: The type of a function declaration must match the function's signature.
+    function funcWithMoreParameters(more) {} // error
+    
+    /** @type {() => void} */
+    const variableWithMoreParameters = function (more) {}; // error
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+    
+    /** @type {() => void} */
+    const arrowWithMoreParameters = (more) => {}; // error
+          ~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+    
+    ({
+      /** @type {() => void} */
+      methodWithMoreParameters(more) {}, // error
+      ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+    });
     

--- a/tests/baselines/reference/checkJsdocTypeTag6.symbols
+++ b/tests/baselines/reference/checkJsdocTypeTag6.symbols
@@ -37,3 +37,29 @@ function add3(a, b) { return a + b; }
 >a : Symbol(a, Decl(test.js, 17, 14))
 >b : Symbol(b, Decl(test.js, 17, 16))
 
+// Confirm initializers are compatible.
+// They can't have more parameters than the type/context.
+
+/** @type {() => void} */
+function funcWithMoreParameters(more) {} // error
+>funcWithMoreParameters : Symbol(funcWithMoreParameters, Decl(test.js, 17, 37))
+>more : Symbol(more, Decl(test.js, 23, 32))
+
+/** @type {() => void} */
+const variableWithMoreParameters = function (more) {}; // error
+>variableWithMoreParameters : Symbol(variableWithMoreParameters, Decl(test.js, 26, 5))
+>more : Symbol(more, Decl(test.js, 26, 45))
+
+/** @type {() => void} */
+const arrowWithMoreParameters = (more) => {}; // error
+>arrowWithMoreParameters : Symbol(arrowWithMoreParameters, Decl(test.js, 29, 5))
+>more : Symbol(more, Decl(test.js, 29, 33))
+
+({
+  /** @type {() => void} */
+  methodWithMoreParameters(more) {}, // error
+>methodWithMoreParameters : Symbol(methodWithMoreParameters, Decl(test.js, 31, 2))
+>more : Symbol(more, Decl(test.js, 33, 27))
+
+});
+

--- a/tests/baselines/reference/checkJsdocTypeTag6.types
+++ b/tests/baselines/reference/checkJsdocTypeTag6.types
@@ -16,7 +16,7 @@ var g = function (prop) {
 
 /** @type {(a: number) => number} */
 function add1(a, b) { return a + b; }
->add1 : (a: number, b: any) => number
+>add1 : (a: number) => number
 >a : number
 >b : any
 >a + b : any
@@ -35,10 +35,41 @@ function add2(a, b) { return a + b; }
 // TODO: Should be an error since signature doesn't match.
 /** @type {(a: number, b: number, c: number) => number} */
 function add3(a, b) { return a + b; }
->add3 : (a: number, b: number) => number
+>add3 : (a: number, b: number, c: number) => number
 >a : number
 >b : number
 >a + b : number
 >a : number
 >b : number
+
+// Confirm initializers are compatible.
+// They can't have more parameters than the type/context.
+
+/** @type {() => void} */
+function funcWithMoreParameters(more) {} // error
+>funcWithMoreParameters : () => void
+>more : any
+
+/** @type {() => void} */
+const variableWithMoreParameters = function (more) {}; // error
+>variableWithMoreParameters : () => void
+>function (more) {} : (more: any) => void
+>more : any
+
+/** @type {() => void} */
+const arrowWithMoreParameters = (more) => {}; // error
+>arrowWithMoreParameters : () => void
+>(more) => {} : (more: any) => void
+>more : any
+
+({
+>({  /** @type {() => void} */  methodWithMoreParameters(more) {}, // error}) : { methodWithMoreParameters(): void; }
+>{  /** @type {() => void} */  methodWithMoreParameters(more) {}, // error} : { methodWithMoreParameters(): void; }
+
+  /** @type {() => void} */
+  methodWithMoreParameters(more) {}, // error
+>methodWithMoreParameters : (more: any) => void
+>more : any
+
+});
 

--- a/tests/baselines/reference/checkJsdocTypeTag7.symbols
+++ b/tests/baselines/reference/checkJsdocTypeTag7.symbols
@@ -11,5 +11,9 @@ class C {
 >foo : Symbol(C.foo, Decl(test.js, 4, 9))
 >a : Symbol(a, Decl(test.js, 6, 8))
 >b : Symbol(b, Decl(test.js, 6, 10))
+
+    /** @type {(optional?) => void} */
+    methodWithOptionalParameters() {}
+>methodWithOptionalParameters : Symbol(C.methodWithOptionalParameters, Decl(test.js, 6, 16))
 }
 

--- a/tests/baselines/reference/checkJsdocTypeTag7.types
+++ b/tests/baselines/reference/checkJsdocTypeTag7.types
@@ -11,5 +11,9 @@ class C {
 >foo : (a: string, b: number) => void
 >a : string
 >b : number
+
+    /** @type {(optional?) => void} */
+    methodWithOptionalParameters() {}
+>methodWithOptionalParameters : (optional?: any) => void
 }
 

--- a/tests/baselines/reference/jsDocDontBreakWithNamespaces.baseline
+++ b/tests/baselines/reference/jsDocDontBreakWithNamespaces.baseline
@@ -181,19 +181,82 @@
               "kind": "space"
             }
           ],
-          "parameters": [],
-          "documentation": [],
-          "tags": [
+          "parameters": [
             {
-              "name": "type",
-              "text": [
+              "name": "arg0",
+              "documentation": [],
+              "displayParts": [
                 {
-                  "text": "{function(module:xxxx, module:xxxx): module:xxxxx}",
-                  "kind": "text"
+                  "text": "arg0",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "any",
+                  "kind": "keyword"
                 }
-              ]
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg1",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg1",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "any",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "arg2",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "arg2",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "any",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
             }
-          ]
+          ],
+          "documentation": [],
+          "tags": []
         }
       ],
       "applicableSpan": {

--- a/tests/baselines/reference/jsdocTypeTagRequiredParameters.errors.txt
+++ b/tests/baselines/reference/jsdocTypeTagRequiredParameters.errors.txt
@@ -21,9 +21,9 @@ tests/cases/conformance/jsdoc/a.js(13,1): error TS2554: Expected 1 arguments, bu
     g() // should error
     ~~~
 !!! error TS2554: Expected 1 arguments, but got 0.
-!!! related TS6210 tests/cases/conformance/jsdoc/a.js:5:12: An argument for 's' was not provided.
+!!! related TS6210 tests/cases/conformance/jsdoc/a.js:4:13: An argument for 's' was not provided.
     h()
     ~~~
 !!! error TS2554: Expected 1 arguments, but got 0.
-!!! related TS6210 tests/cases/conformance/jsdoc/a.js:8:12: An argument for 's' was not provided.
+!!! related TS6210 tests/cases/conformance/jsdoc/a.js:7:14: An argument for 's' was not provided.
     

--- a/tests/baselines/reference/typeTagWithGenericSignature.types
+++ b/tests/baselines/reference/typeTagWithGenericSignature.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/jsdoc/bug25618.js ===
 /** @type {<T>(param?: T) => T | undefined} */
 function typed(param) {
->typed : <T>(param: T | undefined) => T | undefined
+>typed : <T>(param?: T | undefined) => T | undefined
 >param : T | undefined
 
     return param;
@@ -11,7 +11,7 @@ function typed(param) {
 var n = typed(1);
 >n : number | undefined
 >typed(1) : 1 | undefined
->typed : <T>(param: T | undefined) => T | undefined
+>typed : <T>(param?: T | undefined) => T | undefined
 >1 : 1
 
 

--- a/tests/cases/conformance/jsdoc/checkJsdocTypeTag6.ts
+++ b/tests/cases/conformance/jsdoc/checkJsdocTypeTag6.ts
@@ -26,15 +26,15 @@ function add3(a, b) { return a + b; }
 // They can't have more parameters than the type/context.
 
 /** @type {() => void} */
-function func(more) {} // error
+function funcWithMoreParameters(more) {} // error
 
 /** @type {() => void} */
-const variable = function (more) {}; // error
+const variableWithMoreParameters = function (more) {}; // error
 
 /** @type {() => void} */
-const arrow = (more) => {}; // error
+const arrowWithMoreParameters = (more) => {}; // error
 
 ({
   /** @type {() => void} */
-  method(more) {}, // error
+  methodWithMoreParameters(more) {}, // error
 });

--- a/tests/cases/conformance/jsdoc/checkJsdocTypeTag6.ts
+++ b/tests/cases/conformance/jsdoc/checkJsdocTypeTag6.ts
@@ -21,3 +21,20 @@ function add2(a, b) { return a + b; }
 // TODO: Should be an error since signature doesn't match.
 /** @type {(a: number, b: number, c: number) => number} */
 function add3(a, b) { return a + b; }
+
+// Confirm initializers are compatible.
+// They can't have more parameters than the type/context.
+
+/** @type {() => void} */
+function func(more) {} // error
+
+/** @type {() => void} */
+const variable = function (more) {}; // error
+
+/** @type {() => void} */
+const arrow = (more) => {}; // error
+
+({
+  /** @type {() => void} */
+  method(more) {}, // error
+});

--- a/tests/cases/conformance/jsdoc/checkJsdocTypeTag7.ts
+++ b/tests/cases/conformance/jsdoc/checkJsdocTypeTag7.ts
@@ -10,4 +10,7 @@
 class C {
     /** @type {Foo} */
     foo(a, b) {}
+
+    /** @type {(optional?) => void} */
+    methodWithOptionalParameters() {}
 }


### PR DESCRIPTION
<!--
  Please fill in each section completely. Thank you!
-->
TS obeys JSDoc `@type` tag signatures, but not parameter optionality. Projects work around this by adding `| void` to parameters in `@type` tags, but this isn't strictly correct, and leads to problems later using those values, without `Exclude<param, void>`. e.g.
- https://github.com/remarkjs/remark-lint/blob/96e8c4f543a0b13d14470819b2a7278d11b4afe3/packages/unified-lint-rule/index.d.ts#L22
- https://github.com/remarkjs/remark-validate-links/blob/0489d132d2354af0ca29e37f4e88c6ce660587fe/lib/index.js#L54

### :monocle_face: Investigation

The signatures passed to `resolveCall()` ignore `@type` tags entirely, so they have the wrong `minArgumentCount`, so `hasCorrectArity()` fails. I think they obey `@param` tags?

Otherwise, the *applicability* checks obey `@type` tags, because `getSignatureApplicabilityError()` calls `getTypeAtPosition()`, which ... calls `getTypeForVariableLikeDeclaration()`, which contains:
```ts
                if (isInJSFile(declaration)) {
                    const type = getParameterTypeOfTypeTag(func, declaration);
                    if (type) return type;
                }
```
since https://github.com/microsoft/TypeScript/pull/26694 (or https://github.com/microsoft/TypeScript/pull/22692?).

Backing up, `resolveCallExpression()` calls `resolveCall()` on `callSignatures` returned by `getSignaturesOfType()` (with the wrong `minArgumentCount`).

`getSignaturesOfType()` calls ... `getSignatureFromDeclaration()`, which obeys `@param` tags, but not `@type` tags?

So maybe the solution is to (roughly) copy the `@type` tag logic from `getTypeForVariableLikeDeclaration()` -> `getSignatureFromDeclaration()`? That's what I've tried to do in this PR.

### :mag: Search terms

<!--
  What search terms did you use when trying to find an existing bug report?
  List them here so people in the future can find this one more easily.
-->
jsdoc type tag optional parameters signature arity

### :clock8: Version & regression information

<!-- When did you start seeing this bug occur?

"Bugs" that have existed in TS for a long time are very likely to be FAQs; refer to
  https://github.com/Microsoft/TypeScript/wiki/FAQ#common-bugs-that-arent-bugs

If possible, please try testing the nightly version of TS to see if it's already been fixed.
For npm: `typescript@next`
This is also the 'Nightly' version in the playground: http://www.typescriptlang.org/play/?ts=Nightly

Note: The TypeScript Playground can be used to try older versions of TypeScript.

Please keep and fill in the line that best applies:
-->
2.8.0-dev.20180320 - 4.7.0-dev.20220305

### :play_or_pause_button: Playground link

<!--
  A link to a TypeScript Playground "Share" link which shows this behavior

  The TypeScript Workbench can be used for more complex setups, try
  https://www.typescriptlang.org/dev/bug-workbench/

  As a last resort, you can link to a repo, but these will be slower for us to investigate.
-->
[Workbench repro](https://www.typescriptlang.org/dev/bug-workbench/?checkJs=true#code/PTAEAEGMAsFNINYCkDOAoEEBmBLANrAHYCGAtrAFyg6EAOArgC4B0AVupuLAE7cD23FFQBMAZgAsAVjQYAVLLShZERgE9asUAG8AFH1qMcfQigD8VAOT7Dx4ngsBKUAF4AfKABufHABMAvoqywGiwAB60AoygWPSEkDaEoLR49ADmNHoGRiZOWgFoyWkZAETW2XbFDgDcoJiAKOSA8H+gAHJ8oDz8ggA0oMQo7eHwjLA+BSnphDrFAEZ8qfQolTX1TQCC3PPkhFFqGu28Aj19AxrxI2NFk9W1YIAy5KAAqoRhp8M+vdw4avudQA)

### :technologist: Code

<!-- Please post the relevant code sample here as well -->
```ts repro
// @checkJs
// @filename: input.js
// @errors: 2345

/**
 * @type {(options?: 'optional') => void}
 */
export function plugin(options) {}

plugin("optional"); // ✔️ No errors, as expected
plugin("bogus"); // ✔️ Argument type error, as expected
plugin(); // ❌ Unexpected arity error
```

### :slightly_frowning_face: Actual behavior

<!-- What happened, and why it was wrong -->
```sh
$ tsc --noEmit --checkJs input.js 
input.js:11:8 - error TS2345: Argument of type '"bogus"' is not assignable to parameter of type '"optional"'.

11 plugin("bogus"); // ✔️ Argument type error, as expected
          ~~~~~~~

input.js:12:1 - error TS2554: Expected 1 arguments, but got 0.

12 plugin(); // ❌ Unexpected arity error
   ~~~~~~~~

  input.js:8:24
    8 export function plugin(options) {}
                             ~~~~~~~
    An argument for 'options' was not provided.


Found 2 errors in the same file, starting at: input.js:11
```

### :slightly_smiling_face: Expected behavior

<!-- What you expected to happen instead, and why -->
With this PR:
```sh
$ tsc --noEmit --checkJs input.js 
input.js:11:8 - error TS2345: Argument of type '"bogus"' is not assignable to parameter of type '"optional"'.

11 plugin("bogus"); // ✔️ Argument type error, as expected
          ~~~~~~~


Found 1 error in input.js:11
```