### PR TITLE
Introduce set with custom equals and getHashCode

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1488,6 +1488,13 @@ namespace ts {
         return createMultiMap() as UnderscoreEscapedMultiMap<T>;
     }
 
+    /**
+     * Creates a Set with custom equality and hash code functionality.  This is useful when you
+     * want to use something looser than object identity - e.g. "has the same span".
+     *
+     * If `equals(a, b)`, it must be the case that `getHashCode(a) === getHashCode(b)`.
+     * The converse is not required.
+     */
     export function createSet<TElement, THash = number>(getHashCode: (element: TElement) => THash, equals: EqualityComparer<TElement>): Set<TElement> {
         const multiMap = new Map<THash, TElement[]>();
         let size = 0;

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1518,7 +1518,7 @@ namespace ts {
         }
 
         const set: Set<TElement> = {
-            has: function (element: TElement): boolean {
+            has(element: TElement): boolean {
                 const hash = getHashCode(element);
                 const candidates = multiMap.get(hash);
                 if (candidates) {
@@ -1531,7 +1531,7 @@ namespace ts {
 
                 return false;
             },
-            add: function (element: TElement): Set<TElement> {
+            add(element: TElement): Set<TElement> {
                 const hash = getHashCode(element);
                 const values = multiMap.get(hash);
                 if (values) {
@@ -1542,11 +1542,12 @@ namespace ts {
                 }
                 else {
                     multiMap.set(hash, [ element ]);
+                    size++;
                 }
 
                 return this;
             },
-            delete: function (element: TElement): boolean {
+            delete(element: TElement): boolean {
                 const hash = getHashCode(element);
                 const candidates = multiMap.get(hash);
                 if (candidates) {
@@ -1566,32 +1567,32 @@ namespace ts {
 
                 return false;
             },
-            clear: function (): void {
+            clear(): void {
                 multiMap.clear();
                 size = 0;
             },
             get size() {
                 return size;
             },
-            forEach: function (action: (value: TElement, key: TElement) => void): void {
+            forEach(action: (value: TElement, key: TElement) => void): void {
                 for (const elements of arrayFrom(multiMap.values())) {
                     for (const element of elements) {
                         action(element, element);
                     }
                 }
             },
-            keys: function (): Iterator<TElement> {
+            keys(): Iterator<TElement> {
                 return getElementIterator();
             },
-            values: function (): Iterator<TElement> {
+            values(): Iterator<TElement> {
                 return getElementIterator();
             },
-            entries: function (): Iterator<[TElement, TElement]> {
+            entries(): Iterator<[TElement, TElement]> {
                 const it = getElementIterator();
                 return {
                     next: () => {
                         const n = it.next();
-                        return n.done ? n : { value: [ n.value, n.value ] }
+                        return n.done ? n : { value: [ n.value, n.value ] };
                     }
                 };
             },

--- a/src/testRunner/unittests/compilerCore.ts
+++ b/src/testRunner/unittests/compilerCore.ts
@@ -70,6 +70,24 @@ namespace ts {
                 assert.isTrue(set.delete(11));
                 assert.equal(set.size, 0);
             });
+            it("resizing", () => {
+                const set = createSet<number, number>(x => x % 2, (x, y) => x === y);
+                const elementCount = 100;
+
+                for (let i = 0; i < elementCount; i++) {
+                    assert.isFalse(set.has(i));
+                    set.add(i);
+                    assert.isTrue(set.has(i));
+                    assert.equal(set.size, i + 1);
+                }
+
+                for (let i = 0; i < elementCount; i++) {
+                    assert.isTrue(set.has(i));
+                    set.delete(i);
+                    assert.isFalse(set.has(i));
+                    assert.equal(set.size, elementCount - (i + 1));
+                }
+            });
             it("clear", () => {
                 const set = createSet<number, number>(x => x % 2, (x, y) => (x % 4) === (y % 4));
                 for (let j = 0; j < 2; j++) {

--- a/src/testRunner/unittests/compilerCore.ts
+++ b/src/testRunner/unittests/compilerCore.ts
@@ -29,5 +29,149 @@ namespace ts {
                 assert.isTrue(equalOwnProperties({ a: 1 }, { a: 2 }, () => true), "valid equality");
             });
         });
+        describe("customSet", () => {
+            it("mutation", () => {
+                const set = createSet<number, number>(x => x % 2, (x, y) => (x % 4) === (y % 4));
+                assert.equal(set.size, 0);
+
+                const newSet = set.add(0);
+                assert.strictEqual(newSet, set);
+                assert.equal(set.size, 1);
+
+                set.add(1);
+                assert.equal(set.size, 2);
+
+                set.add(2); // Collision with 0
+                assert.equal(set.size, 3);
+
+                set.add(3); // Collision with 1
+                assert.equal(set.size, 4);
+
+                set.add(4); // Already present as 0
+                assert.equal(set.size, 4);
+
+                set.add(5); // Already present as 1
+                assert.equal(set.size, 4);
+
+                assert.isTrue(set.has(6));
+                assert.isTrue(set.has(7));
+
+                assert.isTrue(set.delete(8));
+                assert.equal(set.size, 3);
+                assert.isFalse(set.has(8));
+                assert.isFalse(set.delete(8));
+
+                assert.isTrue(set.delete(9));
+                assert.equal(set.size, 2);
+
+                assert.isTrue(set.delete(10));
+                assert.equal(set.size, 1);
+
+                assert.isTrue(set.delete(11));
+                assert.equal(set.size, 0);
+            });
+            it("clear", () => {
+                const set = createSet<number, number>(x => x % 2, (x, y) => (x % 4) === (y % 4));
+                for (let j = 0; j < 2; j++) {
+                    for (let i = 0; i < 100; i++) {
+                        set.add(i);
+                    }
+                    assert.equal(set.size, 4);
+
+                    set.clear();
+                    assert.equal(set.size, 0);
+                    assert.isFalse(set.has(0));
+                }
+            });
+            it("forEach", () => {
+                const set = createSet<number, number>(x => x % 2, (x, y) => (x % 4) === (y % 4));
+                for (let i = 0; i < 100; i++) {
+                    set.add(i);
+                }
+
+                const values: number[] = [];
+                const keys: number[] = [];
+                set.forEach((value, key) => {
+                    values.push(value);
+                    keys.push(key);
+                });
+
+                assert.equal(values.length, 4);
+
+                values.sort();
+                keys.sort();
+
+                // NB: first equal value wins (i.e. not [96, 97, 98, 99])
+                const expected = [0, 1, 2, 3];
+                assert.deepEqual(values, expected);
+                assert.deepEqual(keys, expected);
+            });
+            it("iteration", () => {
+                const set = createSet<number, number>(x => x % 2, (x, y) => (x % 4) === (y % 4));
+                for (let i = 0; i < 4; i++) {
+                    set.add(i);
+                }
+
+                const expected = [0, 1, 2, 3];
+                let actual: number[];
+
+                actual = arrayFrom(set.keys());
+                actual.sort();
+                assert.deepEqual(actual, expected);
+
+                actual = arrayFrom(set.values());
+                actual.sort();
+                assert.deepEqual(actual, expected);
+
+                const actualTuple = arrayFrom(set.entries());
+                assert.isFalse(actualTuple.some(([v, k]) => v !== k));
+                actual = actualTuple.map(([v, _]) => v);
+                actual.sort();
+                assert.deepEqual(actual, expected);
+            });
+            it("string hash code", () => {
+                interface Thing {
+                    x: number;
+                    y: string;
+                }
+
+                const set = createSet<Thing, string>(t => t.y, (t, u) => t.x === u.x && t.y === u.y);
+
+                const thing1: Thing = {
+                    x: 1,
+                    y: "a",
+                };
+
+                const thing2: Thing = {
+                    x: 2,
+                    y: "b",
+                };
+
+                const thing3: Thing = {
+                    x: 3,
+                    y: "a", // Collides with thing1
+                };
+
+                set.add(thing1);
+                set.add(thing2);
+                set.add(thing3);
+
+                assert.equal(set.size, 3);
+
+                assert.isTrue(set.has(thing1));
+                assert.isTrue(set.has(thing2));
+                assert.isTrue(set.has(thing3));
+
+                assert.isFalse(set.has({
+                    x: 4,
+                    y: "a", // Collides with thing1
+                }));
+
+                assert.isFalse(set.has({
+                    x: 5,
+                    y: "c", // No collision
+                }));
+            });
+        });
     });
 }


### PR DESCRIPTION
I got tired of not having custom hash sets in JS so I made a naive one.

Not using linear search to de-dup rename locations cuts search for locations of `Type` from 1750 ms to 1450 ms.

I plan to use this in a bunch of other places in my FAR cleanup.

TODO: this is the simplest possible implementation
TODO: these were the consumers that I'd encountered recently