### PR TITLE
resolve from outDir

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -839,6 +839,14 @@ namespace ts {
             description: Diagnostics.Specify_multiple_folders_that_act_like_Slashnode_modules_Slash_types
         },
         {
+            name: "resolveFromOutDir",
+            type: "boolean",
+            affectsModuleResolution: true,
+            category: Diagnostics.Modules,
+            description: Diagnostics.Allow_resolving_files_relative_to_the_output_directory,
+            defaultValueDescription: false
+        },
+        {
             name: "types",
             type: "list",
             element: {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4433,6 +4433,10 @@
         "category": "Message",
         "code": 6107
     },
+    "'resolveFromOutDir' option is set, using it to resolve relative module name '{0}'.": {
+        "category": "Message",
+        "code": 16107
+    },
     "Longest matching prefix for '{0}' is '{1}'.": {
         "category": "Message",
         "code": 6108
@@ -4441,6 +4445,10 @@
         "category": "Message",
         "code": 6109
     },
+    "Loading '{0}' from the out dir '{1}', candidate location '{2}'.": {
+        "category": "Message",
+        "code": 16109
+    },
     "Trying other entries in 'rootDirs'.": {
         "category": "Message",
         "code": 6110
@@ -4448,6 +4456,10 @@
     "Module resolution using 'rootDirs' has failed.": {
         "category": "Message",
         "code": 6111
+    },
+    "Module resolution using 'outDir' has failed.": {
+        "category": "Message",
+        "code": 16111
     },
     "Do not emit 'use strict' directives in module output.": {
         "category": "Message",
@@ -5721,6 +5733,11 @@
         "category": "Message",
         "code": 6718
     },
+    "Allow resolving files relative to the output directory.": {
+        "category": "Message",
+        "code": 6719
+    },
+
     "Default catch clause variables as 'unknown' instead of 'any'.": {
         "category": "Message",
         "code": 6803

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6156,6 +6156,7 @@ namespace ts {
         project?: string;
         /* @internal */ pretty?: boolean;
         reactNamespace?: string;
+        resolveFromOutDir?: boolean;
         jsxFactory?: string;
         jsxFragmentFactory?: string;
         jsxImportSource?: string;


### PR DESCRIPTION
Under the new proposed `compilerOptions.resolveFromOutDir` boolean,
module resolution is attempted relative to the output folder.

This is analogous to loading from the rootDirs, however it allows
compilation where the output directory is configured on the command line
rather than in the tsconfig.json.

See the attached issue for context.

TODO:
- figure out what tests to add
- reason about whether this interacts correctly with other related
module resolution conditional logic
- verify this works in some Bazel projects where the problem is observed

Fixes #22208
Fixes #37378
