### PR TITLE
Change sortText for class member completions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -769,6 +769,7 @@ namespace ts.Completions {
             isClassLikeMemberCompletion(symbol, location)) {
             let importAdder;
             ({ insertText, isSnippet, importAdder, replacementSpan } = getEntryForMemberCompletion(host, program, options, preferences, name, symbol, location, contextToken, formatContext));
+            sortText = SortText.AutoImportSuggestions; // sortText has to be lower priority than the sortText for keywords. See #47852.
             if (importAdder?.hasFixes()) {
                 hasAction = true;
                 source = CompletionSource.ClassMemberSnippet;

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -17,15 +17,15 @@ namespace ts.Completions {
         SuggestedClassMembers = "14",
         GlobalsOrKeywords = "15",
         AutoImportSuggestions = "16",
-        ClassMemberSnippets = "16",
-        JavascriptIdentifiers = "17",
-        DeprecatedLocalDeclarationPriority = "18",
-        DeprecatedLocationPriority = "19",
-        DeprecatedOptionalMember = "20",
-        DeprecatedMemberDeclaredBySpreadAssignment = "21",
-        DeprecatedSuggestedClassMembers = "22",
-        DeprecatedGlobalsOrKeywords = "23",
-        DeprecatedAutoImportSuggestions = "24"
+        ClassMemberSnippets = "17",
+        JavascriptIdentifiers = "18",
+        DeprecatedLocalDeclarationPriority = "19",
+        DeprecatedLocationPriority = "20",
+        DeprecatedOptionalMember = "21",
+        DeprecatedMemberDeclaredBySpreadAssignment = "22",
+        DeprecatedSuggestedClassMembers = "23",
+        DeprecatedGlobalsOrKeywords = "24",
+        DeprecatedAutoImportSuggestions = "25"
     }
 
     const enum SortTextId {
@@ -38,8 +38,8 @@ namespace ts.Completions {
         AutoImportSuggestions = 16,
 
         // Don't use these directly.
-        _JavaScriptIdentifiers = 17,
-        _DeprecatedStart = 18,
+        _JavaScriptIdentifiers = 18,
+        _DeprecatedStart = 19,
         _First = LocalDeclarationPriority,
 
         DeprecatedOffset = _DeprecatedStart - _First,

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -17,6 +17,7 @@ namespace ts.Completions {
         SuggestedClassMembers = "14",
         GlobalsOrKeywords = "15",
         AutoImportSuggestions = "16",
+        ClassMemberSnippets = "16",
         JavascriptIdentifiers = "17",
         DeprecatedLocalDeclarationPriority = "18",
         DeprecatedLocationPriority = "19",
@@ -769,7 +770,7 @@ namespace ts.Completions {
             isClassLikeMemberCompletion(symbol, location)) {
             let importAdder;
             ({ insertText, isSnippet, importAdder, replacementSpan } = getEntryForMemberCompletion(host, program, options, preferences, name, symbol, location, contextToken, formatContext));
-            sortText = SortText.AutoImportSuggestions; // sortText has to be lower priority than the sortText for keywords. See #47852.
+            sortText = SortText.ClassMemberSnippets; // sortText has to be lower priority than the sortText for keywords. See #47852.
             if (importAdder?.hasFixes()) {
                 hasAction = true;
                 source = CompletionSource.ClassMemberSnippet;

--- a/tests/baselines/reference/completionsCommentsClass.baseline
+++ b/tests/baselines/reference/completionsCommentsClass.baseline
@@ -3760,7 +3760,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -3850,7 +3850,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",

--- a/tests/baselines/reference/completionsCommentsClassMembers.baseline
+++ b/tests/baselines/reference/completionsCommentsClassMembers.baseline
@@ -4632,7 +4632,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -4722,7 +4722,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -11688,7 +11688,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -11778,7 +11778,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -16500,7 +16500,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -16590,7 +16590,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -23556,7 +23556,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -23646,7 +23646,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -27620,7 +27620,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -27710,7 +27710,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -32839,7 +32839,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -32929,7 +32929,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -36857,7 +36857,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -36947,7 +36947,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -42030,7 +42030,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -42120,7 +42120,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -47249,7 +47249,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -47339,7 +47339,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -52468,7 +52468,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -52558,7 +52558,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -57687,7 +57687,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -57777,7 +57777,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -61746,7 +61746,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -61836,7 +61836,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -65805,7 +65805,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -65895,7 +65895,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -69864,7 +69864,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -69954,7 +69954,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -73923,7 +73923,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -74013,7 +74013,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -77982,7 +77982,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -78072,7 +78072,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -82041,7 +82041,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -82131,7 +82131,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -86596,7 +86596,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -86686,7 +86686,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -91952,7 +91952,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -92042,7 +92042,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -96407,7 +96407,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -96497,7 +96497,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",

--- a/tests/baselines/reference/completionsCommentsCommentParsing.baseline
+++ b/tests/baselines/reference/completionsCommentsCommentParsing.baseline
@@ -5467,7 +5467,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -5557,7 +5557,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -11910,7 +11910,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -12000,7 +12000,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -17533,7 +17533,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -17623,7 +17623,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -23233,7 +23233,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -23323,7 +23323,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -28975,7 +28975,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -29065,7 +29065,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -35418,7 +35418,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -35508,7 +35508,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -41118,7 +41118,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -41208,7 +41208,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",

--- a/tests/baselines/reference/completionsCommentsFunctionDeclaration.baseline
+++ b/tests/baselines/reference/completionsCommentsFunctionDeclaration.baseline
@@ -4130,7 +4130,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -4220,7 +4220,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -7606,7 +7606,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -7696,7 +7696,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -11916,7 +11916,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -12006,7 +12006,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",

--- a/tests/baselines/reference/completionsCommentsFunctionExpression.baseline
+++ b/tests/baselines/reference/completionsCommentsFunctionExpression.baseline
@@ -3667,7 +3667,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -3757,7 +3757,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -8389,7 +8389,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -8479,7 +8479,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -12055,7 +12055,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -12145,7 +12145,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -16549,7 +16549,7 @@
           "name": "escape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",
@@ -16639,7 +16639,7 @@
           "name": "unescape",
           "kind": "function",
           "kindModifiers": "deprecated,declare",
-          "sortText": "23",
+          "sortText": "24",
           "displayParts": [
             {
               "text": "function",

--- a/tests/baselines/reference/completionsSalsaMethodsOnAssignedFunctionExpressions.baseline
+++ b/tests/baselines/reference/completionsSalsaMethodsOnAssignedFunctionExpressions.baseline
@@ -127,35 +127,35 @@
           "name": "a",
           "kind": "warning",
           "kindModifiers": "",
-          "sortText": "17",
+          "sortText": "18",
           "isFromUncheckedFile": true
         },
         {
           "name": "C",
           "kind": "warning",
           "kindModifiers": "",
-          "sortText": "17",
+          "sortText": "18",
           "isFromUncheckedFile": true
         },
         {
           "name": "f",
           "kind": "warning",
           "kindModifiers": "",
-          "sortText": "17",
+          "sortText": "18",
           "isFromUncheckedFile": true
         },
         {
           "name": "prototype",
           "kind": "warning",
           "kindModifiers": "",
-          "sortText": "17",
+          "sortText": "18",
           "isFromUncheckedFile": true
         },
         {
           "name": "x",
           "kind": "warning",
           "kindModifiers": "",
-          "sortText": "17",
+          "sortText": "18",
           "isFromUncheckedFile": true
         }
       ]

--- a/tests/baselines/reference/completionsStringMethods.baseline
+++ b/tests/baselines/reference/completionsStringMethods.baseline
@@ -2164,7 +2164,7 @@
           "name": "substr",
           "kind": "method",
           "kindModifiers": "deprecated,declare",
-          "sortText": "19",
+          "sortText": "20",
           "displayParts": [
             {
               "text": "(",

--- a/tests/cases/fourslash/completionsOverridingMethod.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod.ts
@@ -123,7 +123,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "foo(param1: string, param2: boolean): Promise<void> {\n}",
         }
     ],
@@ -140,7 +140,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "foo(a: string, b: string): string {\n}",
         }
     ],
@@ -157,7 +157,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -174,7 +174,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -191,7 +191,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -208,7 +208,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -225,7 +225,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText:
 `foo(a: string): string;
 foo(a: undefined, b: number): string;
@@ -256,7 +256,7 @@ verify.completions({
     includes: [
         {
             name: "met",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             replacementSpan: test.ranges()[0],
             insertText: "static met(n: number): number {\n}",
         }
@@ -274,12 +274,12 @@ verify.completions({
     includes: [
         {
             name: "met",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "met<T>(t: T): T {\n}",
         },
         {
             name: "metcons",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "metcons<T extends string | number>(t: T): T {\n}",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod.ts
@@ -123,7 +123,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "foo(param1: string, param2: boolean): Promise<void> {\n}",
         }
     ],
@@ -140,7 +140,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "foo(a: string, b: string): string {\n}",
         }
     ],
@@ -157,7 +157,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -174,7 +174,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -191,7 +191,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -208,7 +208,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "foo(a: string): string {\n}",
         }
     ],
@@ -225,7 +225,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText:
 `foo(a: string): string;
 foo(a: undefined, b: number): string;
@@ -256,7 +256,7 @@ verify.completions({
     includes: [
         {
             name: "met",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[0],
             insertText: "static met(n: number): number {\n}",
         }
@@ -274,12 +274,12 @@ verify.completions({
     includes: [
         {
             name: "met",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "met<T>(t: T): T {\n}",
         },
         {
             name: "metcons",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "metcons<T extends string | number>(t: T): T {\n}",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod1.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod1.ts
@@ -24,7 +24,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "override foo(a: string): void {\n}",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod1.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod1.ts
@@ -24,7 +24,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "override foo(a: string): void {\n}",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod10.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod10.ts
@@ -25,19 +25,19 @@ verify.completions({
     includes: [
         {
             name: "a",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "a: string;",
         },
         {
             name: "b",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText:
 `b(a: string): void {
 }`,
         },
         {
             name: "c",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText:
 `c(a: string): string;
 c(a: number): number;

--- a/tests/cases/fourslash/completionsOverridingMethod10.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod10.ts
@@ -25,19 +25,19 @@ verify.completions({
     includes: [
         {
             name: "a",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "a: string;",
         },
         {
             name: "b",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText:
 `b(a: string): void {
 }`,
         },
         {
             name: "c",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText:
 `c(a: string): string;
 c(a: number): number;

--- a/tests/cases/fourslash/completionsOverridingMethod11.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod11.ts
@@ -31,19 +31,19 @@ verify.completions({
     includes: [
         {
             name: "a",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "a: string",
         },
         {
             name: "b",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText:
 `b(a: string): void {
 }`,
         },
         {
             name: "c",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText:
 `c(a: string): string
 c(a: number): number

--- a/tests/cases/fourslash/completionsOverridingMethod11.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod11.ts
@@ -31,19 +31,19 @@ verify.completions({
     includes: [
         {
             name: "a",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "a: string",
         },
         {
             name: "b",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText:
 `b(a: string): void {
 }`,
         },
         {
             name: "c",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText:
 `c(a: string): string
 c(a: number): number

--- a/tests/cases/fourslash/completionsOverridingMethod12.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod12.ts
@@ -28,7 +28,7 @@ verify.completions({
     includes: [
         {
             name: "P",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             replacementSpan: test.ranges()[0],
             insertText: "public abstract get P(): string;",
         },
@@ -46,7 +46,7 @@ verify.completions({
     includes: [
         {
             name: "P",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             replacementSpan: test.ranges()[1],
             insertText: "public abstract override get P(): string;",
         },

--- a/tests/cases/fourslash/completionsOverridingMethod12.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod12.ts
@@ -28,7 +28,7 @@ verify.completions({
     includes: [
         {
             name: "P",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[0],
             insertText: "public abstract get P(): string;",
         },
@@ -46,7 +46,7 @@ verify.completions({
     includes: [
         {
             name: "P",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[1],
             insertText: "public abstract override get P(): string;",
         },

--- a/tests/cases/fourslash/completionsOverridingMethod13.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod13.ts
@@ -2,32 +2,30 @@
 
 // @Filename: a.ts
 // @newline: LF
-// Case: abstract overloads
-////abstract class Base {
-////    abstract M<T>(t: T): void;
-////    abstract M<T>(t: T, x: number): void;
+
+////class A {
+////    protected foo(): void {
+////        return;
+////    }
 ////}
-////
-////abstract class Derived extends Base {
-////    [|abstract|] /*a*/
+////class B extends A {
+////    /**/
 ////}
 
 verify.completions({
-    marker: "a",
+    marker: "",
     isNewIdentifierLocation: true,
     preferences: {
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithClassMemberSnippets: true,
     },
-    includes: [
+    exact: [
+        ...completion.classElementKeywords,
         {
-            name: "M",
+            name: "foo",
             sortText: completion.SortText.AutoImportSuggestions,
-            replacementSpan: test.ranges()[0],
-            insertText:
-`abstract M<T>(t: T): void;
-abstract M<T>(t: T, x: number): void;`,
+            insertText: "protected foo(): void {\n}",
         },
     ],
 });

--- a/tests/cases/fourslash/completionsOverridingMethod13.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod13.ts
@@ -24,7 +24,7 @@ verify.completions({
         ...completion.classElementKeywords,
         {
             name: "foo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "protected foo(): void {\n}",
         },
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod2.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod2.ts
@@ -22,7 +22,7 @@ verify.completions({
     includes: [
         {
             name: "$usd",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             isSnippet: true,
             insertText: "\"\\$usd\"(a: number): number {\n    $0\n}",
         }

--- a/tests/cases/fourslash/completionsOverridingMethod2.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod2.ts
@@ -22,7 +22,7 @@ verify.completions({
     includes: [
         {
             name: "$usd",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             isSnippet: true,
             insertText: "\"\\$usd\"(a: number): number {\n    $0\n}",
         }

--- a/tests/cases/fourslash/completionsOverridingMethod3.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod3.ts
@@ -23,7 +23,7 @@ verify.completions({
     includes: [
         {
             name: "boo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "boo(): string;",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod3.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod3.ts
@@ -23,7 +23,7 @@ verify.completions({
     includes: [
         {
             name: "boo",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "boo(): string;",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod4.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod4.ts
@@ -42,12 +42,12 @@ verify.completions({
     includes: [
         {
             name: "hint",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "protected hint(): string {\n}",
         },
         {
             name: "refuse",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "public refuse(): string {\n}",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod4.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod4.ts
@@ -42,12 +42,12 @@ verify.completions({
     includes: [
         {
             name: "hint",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "protected hint(): string {\n}",
         },
         {
             name: "refuse",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "public refuse(): string {\n}",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod5.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod5.ts
@@ -28,12 +28,12 @@ verify.completions({
     includes: [
         {
             name: "met",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "met(n: string): void {\n}",
         },
         {
             name: "met2",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "met2(n: number): void {\n}",
         }
     ],
@@ -50,13 +50,13 @@ verify.completions({
     includes: [
         {
             name: "met",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[0],
             insertText: "abstract met(n: string): void;",
         },
         {
             name: "met2",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[0],
             insertText: "abstract met2(n: number): void;",
         }
@@ -74,13 +74,13 @@ verify.completions({
     includes: [
         {
             name: "met",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[1],
             insertText: "abstract met(n: string): void;",
         },
         {
             name: "met2",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[1],
             insertText: "abstract met2(n: number): void;",
         }

--- a/tests/cases/fourslash/completionsOverridingMethod5.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod5.ts
@@ -28,12 +28,12 @@ verify.completions({
     includes: [
         {
             name: "met",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "met(n: string): void {\n}",
         },
         {
             name: "met2",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "met2(n: number): void {\n}",
         }
     ],
@@ -50,13 +50,13 @@ verify.completions({
     includes: [
         {
             name: "met",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             replacementSpan: test.ranges()[0],
             insertText: "abstract met(n: string): void;",
         },
         {
             name: "met2",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             replacementSpan: test.ranges()[0],
             insertText: "abstract met2(n: number): void;",
         }
@@ -74,13 +74,13 @@ verify.completions({
     includes: [
         {
             name: "met",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             replacementSpan: test.ranges()[1],
             insertText: "abstract met(n: string): void;",
         },
         {
             name: "met2",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             replacementSpan: test.ranges()[1],
             insertText: "abstract met2(n: number): void;",
         }

--- a/tests/cases/fourslash/completionsOverridingMethod6.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod6.ts
@@ -37,7 +37,7 @@ verify.completions({
     includes: [
         {
             name: "method",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[1],
             insertText: "public override method(): number {\n}",
         },
@@ -55,7 +55,7 @@ verify.completions({
     includes: [
         {
             name: "method",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[0],
             insertText: "public abstract method(): number;",
         },
@@ -73,7 +73,7 @@ verify.completions({
     includes: [
         {
             name: "fun",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[2],
             insertText:
 `public fun(a: number): number;

--- a/tests/cases/fourslash/completionsOverridingMethod6.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod6.ts
@@ -37,7 +37,7 @@ verify.completions({
     includes: [
         {
             name: "method",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             replacementSpan: test.ranges()[1],
             insertText: "public override method(): number {\n}",
         },
@@ -55,7 +55,7 @@ verify.completions({
     includes: [
         {
             name: "method",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             replacementSpan: test.ranges()[0],
             insertText: "public abstract method(): number;",
         },
@@ -73,7 +73,7 @@ verify.completions({
     includes: [
         {
             name: "fun",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             replacementSpan: test.ranges()[2],
             insertText:
 `public fun(a: number): number;

--- a/tests/cases/fourslash/completionsOverridingMethod7.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod7.ts
@@ -23,7 +23,7 @@ verify.completions({
     includes: [
         {
             name: "M",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             replacementSpan: test.ranges()[0],
             insertText:
 `abstract M<T>(t: T): void;

--- a/tests/cases/fourslash/completionsOverridingMethod8.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod8.ts
@@ -26,7 +26,7 @@ verify.completions({
   },
   includes: [{
     name: "method",
-    sortText: completion.SortText.LocationPriority,
+    sortText: completion.SortText.AutoImportSuggestions,
     insertText: "method(p: I): void {\n}",
     hasAction: true,
     source: completion.CompletionSource.ClassMemberSnippet,

--- a/tests/cases/fourslash/completionsOverridingMethod8.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod8.ts
@@ -26,7 +26,7 @@ verify.completions({
   },
   includes: [{
     name: "method",
-    sortText: completion.SortText.AutoImportSuggestions,
+    sortText: completion.SortText.ClassMemberSnippets,
     insertText: "method(p: I): void {\n}",
     hasAction: true,
     source: completion.CompletionSource.ClassMemberSnippet,

--- a/tests/cases/fourslash/completionsOverridingMethod9.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod9.ts
@@ -22,12 +22,12 @@ verify.completions({
     includes: [
         {
             name: "a",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "a?: number;"
         },
         {
             name: "b",
-            sortText: completion.SortText.LocationPriority,
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "b(x: number): void {\n}"
         },
     ],

--- a/tests/cases/fourslash/completionsOverridingMethod9.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod9.ts
@@ -22,12 +22,12 @@ verify.completions({
     includes: [
         {
             name: "a",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "a?: number;"
         },
         {
             name: "b",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "b(x: number): void {\n}"
         },
     ],

--- a/tests/cases/fourslash/completionsOverridingProperties.ts
+++ b/tests/cases/fourslash/completionsOverridingProperties.ts
@@ -25,7 +25,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.AutoImportSuggestions,
+            sortText: completion.SortText.ClassMemberSnippets,
             insertText: "protected foo: string;",
         }
     ],

--- a/tests/cases/fourslash/completionsOverridingProperties.ts
+++ b/tests/cases/fourslash/completionsOverridingProperties.ts
@@ -25,12 +25,7 @@ verify.completions({
     includes: [
         {
             name: "foo",
-            sortText: completion.SortText.LocationPriority,
-            replacementSpan: {
-                fileName: "",
-                pos: 0,
-                end: 0,
-            },
+            sortText: completion.SortText.AutoImportSuggestions,
             insertText: "protected foo: string;",
         }
     ],

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -846,6 +846,7 @@ declare namespace completion {
         SuggestedClassMembers = "14",
         GlobalsOrKeywords = "15",
         AutoImportSuggestions = "16",
+        ClassMemberSnippets = "16",
         JavascriptIdentifiers = "17",
         DeprecatedLocalDeclarationPriority = "18",
         DeprecatedLocationPriority = "19",

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -846,15 +846,15 @@ declare namespace completion {
         SuggestedClassMembers = "14",
         GlobalsOrKeywords = "15",
         AutoImportSuggestions = "16",
-        ClassMemberSnippets = "16",
-        JavascriptIdentifiers = "17",
-        DeprecatedLocalDeclarationPriority = "18",
-        DeprecatedLocationPriority = "19",
-        DeprecatedOptionalMember = "20",
-        DeprecatedMemberDeclaredBySpreadAssignment = "21",
-        DeprecatedSuggestedClassMembers = "22",
-        DeprecatedGlobalsOrKeywords = "23",
-        DeprecatedAutoImportSuggestions = "24"
+        ClassMemberSnippets = "17",
+        JavascriptIdentifiers = "18",
+        DeprecatedLocalDeclarationPriority = "19",
+        DeprecatedLocationPriority = "20",
+        DeprecatedOptionalMember = "21",
+        DeprecatedMemberDeclaredBySpreadAssignment = "22",
+        DeprecatedSuggestedClassMembers = "23",
+        DeprecatedGlobalsOrKeywords = "24",
+        DeprecatedAutoImportSuggestions = "25"
     }
     export const enum CompletionSource {
         ThisProperty = "ThisProperty/",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #47852.

I've changed the `sortText` order of class member snippet completions to be lower priority than the `sortText` of keywords. This means that when a user is typing inside a class, if there is both a keyword and a class member completion that have the same score, the keyword appears first.

This score is something computed by vscode, based on how well the prefix (what the user has typed so far) matches the completion entry's text.
For instance, in the scenario below:
```ts
class A {
    protected foo(): void {
        return;
    }
}

class B extends A {
    pro|
}
```
The prefix is `pro`, and so this would match both an entry for the `protected` keyword, as well as a class member snippet entry for `protected foo(): void ...`. The score is the same because `pro` matches right at the beginning of both entries' text, but before this PR, `protected foo(): void ...` would appear first because its `sortText` was higher priority than the one for `protected`. After this PR, the opposite will happen: `protected` will appear before `protected foo(): void ...`.

The perhaps annoying counterpart to this change is that, if inside a class the user hasn't typed anything yet, the completion list will start with all the class keywords and only then show the methods.
But if we wanted a fix that had both the methods show up before the keywords when nothing is typed, *and* had the methods show up after the keywords if there's a partial prefix match, we'd probably need to tweak things on the vscode side.
