### PR TITLE
Add server tracepoints

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2591,7 +2591,10 @@ namespace ts {
      *    file to. e.g. outDir
      */
     export function parseJsonSourceFileConfigFileContent(sourceFile: TsConfigSourceFile, host: ParseConfigHost, basePath: string, existingOptions?: CompilerOptions, configFileName?: string, resolutionStack?: Path[], extraFileExtensions?: readonly FileExtensionInfo[], extendedConfigCache?: Map<ExtendedConfigCacheEntry>, existingWatchOptions?: WatchOptions): ParsedCommandLine {
-        return parseJsonConfigFileContentWorker(/*json*/ undefined, sourceFile, host, basePath, existingOptions, existingWatchOptions, configFileName, resolutionStack, extraFileExtensions, extendedConfigCache);
+        tracing?.push(tracing.Phase.Parse, "parseJsonSourceFileConfigFileContent", { path: sourceFile.fileName });
+        const result = parseJsonConfigFileContentWorker(/*json*/ undefined, sourceFile, host, basePath, existingOptions, existingWatchOptions, configFileName, resolutionStack, extraFileExtensions, extendedConfigCache);
+        tracing?.pop();
+        return result;
     }
 
     /*@internal*/

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2062,6 +2062,7 @@ namespace ts.server {
 
         /* @internal */
         createConfiguredProject(configFileName: NormalizedPath) {
+            tracing?.instant(tracing.Phase.Session, "createConfiguredProject", { path: configFileName });
             this.logger.info(`Creating configuration project ${configFileName}`);
             const canonicalConfigFilePath = asNormalizedPath(this.toCanonicalFileName(configFileName));
             let configFileExistenceInfo = this.configFileExistenceInfoCache.get(canonicalConfigFilePath);
@@ -2119,6 +2120,7 @@ namespace ts.server {
          */
         /* @internal */
         private loadConfiguredProject(project: ConfiguredProject, reason: string) {
+            tracing?.push(tracing.Phase.Session, "loadConfiguredProject", { args: project.canonicalConfigFilePath });
             this.sendProjectLoadingStartEvent(project, reason);
 
             // Read updated contents from disk
@@ -2160,6 +2162,7 @@ namespace ts.server {
             project.enablePluginsWithOptions(compilerOptions, this.currentPluginConfigOverrides);
             const filesToAdd = parsedCommandLine.fileNames.concat(project.getExternalFiles());
             this.updateRootAndOptionsOfNonInferredProject(project, filesToAdd, fileNamePropertyReader, compilerOptions, parsedCommandLine.typeAcquisition!, parsedCommandLine.compileOnSave, parsedCommandLine.watchOptions);
+            tracing?.pop();
         }
 
         /*@internal*/

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2062,7 +2062,7 @@ namespace ts.server {
 
         /* @internal */
         createConfiguredProject(configFileName: NormalizedPath) {
-            tracing?.instant(tracing.Phase.Session, "createConfiguredProject", { path: configFileName });
+            tracing?.instant(tracing.Phase.Session, "createConfiguredProject", { configFilePath: configFileName });
             this.logger.info(`Creating configuration project ${configFileName}`);
             const canonicalConfigFilePath = asNormalizedPath(this.toCanonicalFileName(configFileName));
             let configFileExistenceInfo = this.configFileExistenceInfoCache.get(canonicalConfigFilePath);
@@ -2120,7 +2120,7 @@ namespace ts.server {
          */
         /* @internal */
         private loadConfiguredProject(project: ConfiguredProject, reason: string) {
-            tracing?.push(tracing.Phase.Session, "loadConfiguredProject", { args: project.canonicalConfigFilePath });
+            tracing?.push(tracing.Phase.Session, "loadConfiguredProject", { configFilePath: project.canonicalConfigFilePath });
             this.sendProjectLoadingStartEvent(project, reason);
 
             // Read updated contents from disk

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2273,6 +2273,7 @@ namespace ts.server {
          * @returns: true if set of files in the project stays the same and false - otherwise.
          */
         updateGraph(): boolean {
+            tracing?.push(tracing.Phase.Session, "updateGraph", { path: this.canonicalConfigFilePath });
             const isInitialLoad = this.isInitialLoadPending();
             this.isInitialLoadPending = returnFalse;
             const reloadLevel = this.pendingReload;
@@ -2296,6 +2297,7 @@ namespace ts.server {
             this.compilerHost = undefined;
             this.projectService.sendProjectLoadingFinishEvent(this);
             this.projectService.sendProjectTelemetry(this);
+            tracing?.pop();
             return result;
         }
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2273,7 +2273,7 @@ namespace ts.server {
          * @returns: true if set of files in the project stays the same and false - otherwise.
          */
         updateGraph(): boolean {
-            tracing?.push(tracing.Phase.Session, "updateGraph", { path: this.canonicalConfigFilePath });
+            tracing?.push(tracing.Phase.Session, "updateGraph", { configFilePath: this.canonicalConfigFilePath });
             const isInitialLoad = this.isInitialLoadPending();
             this.isInitialLoadPending = returnFalse;
             const reloadLevel = this.pendingReload;

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1128,7 +1128,9 @@ namespace ts.server {
             this.resolutionCache.startCachingPerDirectoryResolution();
             this.program = this.languageService.getProgram(); // TODO: GH#18217
             this.dirty = false;
+            tracing?.push(tracing.Phase.Session, "finishCachingPerDirectoryResolution");
             this.resolutionCache.finishCachingPerDirectoryResolution();
+            tracing?.pop();
 
             Debug.assert(oldProgram === undefined || this.program !== undefined);
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1045,6 +1045,7 @@ namespace ts.server {
          * @returns: true if set of files in the project stays the same and false - otherwise.
          */
         updateGraph(): boolean {
+            tracing?.push(tracing.Phase.Session, "updateGraph", { name: this.projectName, kind: ProjectKind[this.projectKind] });
             perfLogger.logStartUpdateGraph();
             this.resolutionCache.startRecordingFilesWithChangedResolutions();
 
@@ -1092,6 +1093,7 @@ namespace ts.server {
                 this.getPackageJsonAutoImportProvider();
             }
             perfLogger.logStopUpdateGraph();
+            tracing?.pop();
             return !hasNewProgram;
         }
 
@@ -2275,7 +2277,6 @@ namespace ts.server {
          * @returns: true if set of files in the project stays the same and false - otherwise.
          */
         updateGraph(): boolean {
-            tracing?.push(tracing.Phase.Session, "updateGraph", { configFilePath: this.canonicalConfigFilePath });
             const isInitialLoad = this.isInitialLoadPending();
             this.isInitialLoadPending = returnFalse;
             const reloadLevel = this.pendingReload;
@@ -2299,7 +2300,6 @@ namespace ts.server {
             this.compilerHost = undefined;
             this.projectService.sendProjectLoadingFinishEvent(this);
             this.projectService.sendProjectTelemetry(this);
-            tracing?.pop();
             return result;
         }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -897,7 +897,6 @@ namespace ts.server {
         }
 
         public event<T extends object>(body: T, eventName: string): void {
-            tracing?.instant(tracing.Phase.Session, "event", { eventName });
             this.send(toEvent(eventName, body));
         }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -948,18 +948,24 @@ namespace ts.server {
         }
 
         private semanticCheck(file: NormalizedPath, project: Project) {
+            tracing?.push(tracing.Phase.Session, "semanticCheck", { file, configFilePath: (project as ConfiguredProject).canonicalConfigFilePath }); // undefined is fine if the cast fails
             const diags = isDeclarationFileInJSOnlyNonConfiguredProject(project, file)
                 ? emptyArray
                 : project.getLanguageService().getSemanticDiagnostics(file).filter(d => !!d.file);
             this.sendDiagnosticsEvent(file, project, diags, "semanticDiag");
+            tracing?.pop();
         }
 
         private syntacticCheck(file: NormalizedPath, project: Project) {
+            tracing?.push(tracing.Phase.Session, "syntacticCheck", { file, configFilePath: (project as ConfiguredProject).canonicalConfigFilePath }); // undefined is fine if the cast fails
             this.sendDiagnosticsEvent(file, project, project.getLanguageService().getSyntacticDiagnostics(file), "syntaxDiag");
+            tracing?.pop();
         }
 
         private suggestionCheck(file: NormalizedPath, project: Project) {
+            tracing?.push(tracing.Phase.Session, "suggestionCheck", { file, configFilePath: (project as ConfiguredProject).canonicalConfigFilePath }); // undefined is fine if the cast fails
             this.sendDiagnosticsEvent(file, project, project.getLanguageService().getSuggestionDiagnostics(file), "suggestionDiag");
+            tracing?.pop();
         }
 
         private sendDiagnosticsEvent(file: NormalizedPath, project: Project, diagnostics: readonly Diagnostic[], kind: protocol.DiagnosticEventKind): void {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1004,9 +1004,11 @@ namespace ts {
 
             // Initialize the list with the root file names
             const rootFileNames = host.getScriptFileNames();
+            tracing?.push(tracing.Phase.Session, "initializeHostCache", { count: rootFileNames.length });
             for (const fileName of rootFileNames) {
                 this.createEntry(fileName, toPath(fileName, this.currentDirectory, getCanonicalFileName));
             }
+            tracing?.pop();
         }
 
         private createEntry(fileName: string, path: Path) {


### PR DESCRIPTION
Fill in some of the gaps around project loading time and drop some unhelpful tracepoints.