### PR TITLE
fix(48191): Duplicates comments on "Add definite assignment assertion to property"

### DIFF
--- a/src/services/codefixes/fixStrictClassInitialization.ts
+++ b/src/services/codefixes/fixStrictClassInitialization.ts
@@ -67,6 +67,7 @@ namespace ts.codefix {
     }
 
     function addDefiniteAssignmentAssertion(changeTracker: textChanges.ChangeTracker, propertyDeclarationSourceFile: SourceFile, propertyDeclaration: PropertyDeclaration): void {
+        suppressLeadingAndTrailingTrivia(propertyDeclaration);
         const property = factory.updatePropertyDeclaration(
             propertyDeclaration,
             propertyDeclaration.decorators,

--- a/src/services/codefixes/fixStrictClassInitialization.ts
+++ b/src/services/codefixes/fixStrictClassInitialization.ts
@@ -109,6 +109,7 @@ namespace ts.codefix {
     }
 
     function addInitializer(changeTracker: textChanges.ChangeTracker, propertyDeclarationSourceFile: SourceFile, propertyDeclaration: PropertyDeclaration, initializer: Expression): void {
+        suppressLeadingAndTrailingTrivia(propertyDeclaration);
         const property = factory.updatePropertyDeclaration(
             propertyDeclaration,
             propertyDeclaration.decorators,

--- a/tests/cases/fourslash/codeFixClassPropertyInitialization17.ts
+++ b/tests/cases/fourslash/codeFixClassPropertyInitialization17.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+// @strict: true
+
+//// class T {
+////     // comment
+////     a: string;
+//// }
+
+verify.codeFix({
+    description: `Add definite assignment assertion to property 'a: string;'`,
+    newFileContent: `class T {
+    // comment
+    a!: string;
+}`,
+    index: 1
+})

--- a/tests/cases/fourslash/codeFixClassPropertyInitialization18.ts
+++ b/tests/cases/fourslash/codeFixClassPropertyInitialization18.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+// @strict: true
+
+//// class T {
+////     a: string; // comment
+//// }
+
+verify.codeFix({
+    description: `Add definite assignment assertion to property 'a: string;'`,
+    newFileContent: `class T {
+    a!: string; // comment
+}`,
+    index: 1
+})

--- a/tests/cases/fourslash/codeFixClassPropertyInitialization19.ts
+++ b/tests/cases/fourslash/codeFixClassPropertyInitialization19.ts
@@ -4,14 +4,14 @@
 
 //// class T {
 ////     // comment
-////     a: string;
+////     a: 2;
 //// }
 
 verify.codeFix({
-    description: `Add 'undefined' type to property 'a'`,
+    description: `Add initializer to property 'a'`,
     newFileContent: `class T {
     // comment
-    a: string | undefined;
+    a: 2 = 2;
 }`,
-    index: 0
+    index: 2
 })

--- a/tests/cases/fourslash/codeFixClassPropertyInitialization19.ts
+++ b/tests/cases/fourslash/codeFixClassPropertyInitialization19.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+// @strict: true
+
+//// class T {
+////     // comment
+////     a: string;
+//// }
+
+verify.codeFix({
+    description: `Add 'undefined' type to property 'a'`,
+    newFileContent: `class T {
+    // comment
+    a: string | undefined;
+}`,
+    index: 0
+})

--- a/tests/cases/fourslash/codeFixClassPropertyInitialization20.ts
+++ b/tests/cases/fourslash/codeFixClassPropertyInitialization20.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+// @strict: true
+
+//// class T {
+////     a: string; // comment
+//// }
+
+verify.codeFix({
+    description: `Add 'undefined' type to property 'a'`,
+    newFileContent: `class T {
+    a: string | undefined; // comment
+}`,
+    index: 0
+})

--- a/tests/cases/fourslash/codeFixClassPropertyInitialization20.ts
+++ b/tests/cases/fourslash/codeFixClassPropertyInitialization20.ts
@@ -3,13 +3,13 @@
 // @strict: true
 
 //// class T {
-////     a: string; // comment
+////     a: 2; // comment
 //// }
 
 verify.codeFix({
-    description: `Add 'undefined' type to property 'a'`,
+    description: `Add initializer to property 'a'`,
     newFileContent: `class T {
-    a: string | undefined; // comment
+    a: 2 = 2; // comment
 }`,
-    index: 0
+    index: 2
 })


### PR DESCRIPTION
Fixes #48191

When fixing #48191, I found the similar issue happen for `Add initializer to property` which is fixed in this.

Reproduce link: https://www.typescriptlang.org/play?#code/MYGwhgzhAECC0G8BQ1oHo3QBYFMQgHsVoAPALmgCYkBfJIA