### PR TITLE
Signature variance checking

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5812,6 +5812,10 @@ namespace ts {
         isolatedSignatureType?: ObjectType; // A manufactured type that just contains the signature for purposes of signature comparison
         /* @internal */
         instantiations?: ESMap<string, Signature>;    // Generic signature instantiation cache
+        /* @internal */
+        variances?: VarianceFlags[]; // Calculated variances for all type parameters referenced in signature
+        /* @internal */
+        allTypeParameters?: readonly TypeParameter[]; // typeParameters of signature followed by outer type parameters of signature
     }
 
     export const enum IndexKind {

--- a/tests/baselines/reference/complexRecursiveCollections.types
+++ b/tests/baselines/reference/complexRecursiveCollections.types
@@ -1137,7 +1137,7 @@ declare module Immutable {
 >Seq : typeof Seq
 
     function isSeq(maybeSeq: any): maybeSeq is Seq.Indexed<any> | Seq.Keyed<any, any>;
->isSeq : (maybeSeq: any) => maybeSeq is Indexed<any> | Keyed<any, any>
+>isSeq : (maybeSeq: any) => maybeSeq is Keyed<any, any> | Indexed<any>
 >maybeSeq : any
 >Seq : any
 >Seq : any

--- a/tests/baselines/reference/extendAndImplementTheSameBaseType2.errors.txt
+++ b/tests/baselines/reference/extendAndImplementTheSameBaseType2.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/extendAndImplementTheSameBaseType2.ts(7,7): error TS2720: Class 'D' incorrectly implements class 'C<number>'. Did you mean to extend 'C<number>' and inherit its members as a subclass?
-  The types returned by 'bar()' are incompatible between these types.
-    Type 'string' is not assignable to type 'number'.
+  Types of property 'bar' are incompatible.
+    Type '() => string' is not assignable to type '() => number'.
+      Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/extendAndImplementTheSameBaseType2.ts(12,5): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/extendAndImplementTheSameBaseType2.ts(16,5): error TS2322: Type 'string' is not assignable to type 'number'.
 
@@ -15,8 +16,9 @@ tests/cases/compiler/extendAndImplementTheSameBaseType2.ts(16,5): error TS2322: 
     class D extends C<string> implements C<number> {
           ~
 !!! error TS2720: Class 'D' incorrectly implements class 'C<number>'. Did you mean to extend 'C<number>' and inherit its members as a subclass?
-!!! error TS2720:   The types returned by 'bar()' are incompatible between these types.
-!!! error TS2720:     Type 'string' is not assignable to type 'number'.
+!!! error TS2720:   Types of property 'bar' are incompatible.
+!!! error TS2720:     Type '() => string' is not assignable to type '() => number'.
+!!! error TS2720:       Type 'string' is not assignable to type 'number'.
         baz() { }
     }
     

--- a/tests/baselines/reference/for-of39.errors.txt
+++ b/tests/baselines/reference/for-of39.errors.txt
@@ -7,8 +7,6 @@ tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,11): error TS2769: No
             Type 'IteratorYieldResult<[string, number] | [string, true]>' is not assignable to type 'IteratorYieldResult<readonly [string, boolean]>'.
               Type '[string, number] | [string, true]' is not assignable to type 'readonly [string, boolean]'.
                 Type '[string, number]' is not assignable to type 'readonly [string, boolean]'.
-                  Type at position 1 in source is not compatible with type at position 1 in target.
-                    Type 'number' is not assignable to type 'boolean'.
   Overload 2 of 4, '(entries?: readonly (readonly [string, boolean])[]): Map<string, boolean>', gave the following error.
     Type 'number' is not assignable to type 'boolean'.
 
@@ -25,8 +23,6 @@ tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,11): error TS2769: No
 !!! error TS2769:             Type 'IteratorYieldResult<[string, number] | [string, true]>' is not assignable to type 'IteratorYieldResult<readonly [string, boolean]>'.
 !!! error TS2769:               Type '[string, number] | [string, true]' is not assignable to type 'readonly [string, boolean]'.
 !!! error TS2769:                 Type '[string, number]' is not assignable to type 'readonly [string, boolean]'.
-!!! error TS2769:                   Type at position 1 in source is not compatible with type at position 1 in target.
-!!! error TS2769:                     Type 'number' is not assignable to type 'boolean'.
 !!! error TS2769:   Overload 2 of 4, '(entries?: readonly (readonly [string, boolean])[]): Map<string, boolean>', gave the following error.
 !!! error TS2769:     Type 'number' is not assignable to type 'boolean'.
     for (var [k, v] of map) {

--- a/tests/baselines/reference/genericTypeAssertions2.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions2.errors.txt
@@ -1,8 +1,7 @@
 tests/cases/compiler/genericTypeAssertions2.ts(10,5): error TS2322: Type 'B<string>' is not assignable to type 'A<number>'.
   Types of property 'foo' are incompatible.
     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
-      Types of parameters 'x' and 'x' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+      Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/genericTypeAssertions2.ts(11,5): error TS2741: Property 'bar' is missing in type 'A<number>' but required in type 'B<number>'.
 tests/cases/compiler/genericTypeAssertions2.ts(13,21): error TS2352: Conversion of type 'undefined[]' to type 'A<number>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'foo' is missing in type 'undefined[]' but required in type 'A<number>'.
@@ -23,8 +22,7 @@ tests/cases/compiler/genericTypeAssertions2.ts(13,21): error TS2352: Conversion 
 !!! error TS2322: Type 'B<string>' is not assignable to type 'A<number>'.
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
-!!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:         Type 'number' is not assignable to type 'string'.
+!!! error TS2322:       Type 'string' is not assignable to type 'number'.
     var r3: B<number> = <A<number>>new B(); // error
         ~~
 !!! error TS2741: Property 'bar' is missing in type 'A<number>' but required in type 'B<number>'.

--- a/tests/baselines/reference/instantiatedReturnTypeContravariance.errors.txt
+++ b/tests/baselines/reference/instantiatedReturnTypeContravariance.errors.txt
@@ -1,0 +1,42 @@
+tests/cases/compiler/instantiatedReturnTypeContravariance.ts(21,1): error TS2416: Property 'foo' in type 'd' is not assignable to the same property in base type 'c'.
+  Type '() => B<number>' is not assignable to type '() => B<void>'.
+    Type 'B<number>' is not assignable to type 'B<void>'.
+      Type 'number' is not assignable to type 'void'.
+
+
+==== tests/cases/compiler/instantiatedReturnTypeContravariance.ts (1 errors) ====
+    interface B<T> {
+    
+    name: string;
+    
+    x(): T;
+    
+    }
+     
+    class c {
+    
+    foo(): B<void> {
+    
+    return null;
+    
+    }
+    
+    }
+     
+    class d extends c {
+    
+    foo(): B<number> {
+    ~~~
+!!! error TS2416: Property 'foo' in type 'd' is not assignable to the same property in base type 'c'.
+!!! error TS2416:   Type '() => B<number>' is not assignable to type '() => B<void>'.
+!!! error TS2416:     Type 'B<number>' is not assignable to type 'B<void>'.
+!!! error TS2416:       Type 'number' is not assignable to type 'void'.
+    
+    return null;
+    
+    }
+    
+    }
+    
+     
+    

--- a/tests/baselines/reference/invariantGenericErrorElaboration.errors.txt
+++ b/tests/baselines/reference/invariantGenericErrorElaboration.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/invariantGenericErrorElaboration.ts(3,7): error TS2322: Type 'Num' is not assignable to type 'Runtype<any>'.
-  The types of 'constraint.constraint' are incompatible between these types.
-    Type 'Constraint<Constraint<Num>>' is not assignable to type 'Constraint<Constraint<Runtype<any>>>'.
+  The types of 'constraint.check' are incompatible between these types.
+    Type '(x: number) => void' is not assignable to type '(x: any) => void'.
       Type 'Runtype<any>' is not assignable to type 'Num'.
 tests/cases/compiler/invariantGenericErrorElaboration.ts(4,19): error TS2322: Type 'Num' is not assignable to type 'Runtype<any>'.
 
@@ -11,8 +11,8 @@ tests/cases/compiler/invariantGenericErrorElaboration.ts(4,19): error TS2322: Ty
     const wat: Runtype<any> = Num;
           ~~~
 !!! error TS2322: Type 'Num' is not assignable to type 'Runtype<any>'.
-!!! error TS2322:   The types of 'constraint.constraint' are incompatible between these types.
-!!! error TS2322:     Type 'Constraint<Constraint<Num>>' is not assignable to type 'Constraint<Constraint<Runtype<any>>>'.
+!!! error TS2322:   The types of 'constraint.check' are incompatible between these types.
+!!! error TS2322:     Type '(x: number) => void' is not assignable to type '(x: any) => void'.
 !!! error TS2322:       Type 'Runtype<any>' is not assignable to type 'Num'.
     const Foo = Obj({ foo: Num })
                       ~~~

--- a/tests/baselines/reference/iterableArrayPattern28.errors.txt
+++ b/tests/baselines/reference/iterableArrayPattern28.errors.txt
@@ -7,8 +7,6 @@ tests/cases/conformance/es6/destructuring/iterableArrayPattern28.ts(2,24): error
             Type 'IteratorYieldResult<[string, number] | [string, boolean]>' is not assignable to type 'IteratorYieldResult<readonly [string, number]>'.
               Type '[string, number] | [string, boolean]' is not assignable to type 'readonly [string, number]'.
                 Type '[string, boolean]' is not assignable to type 'readonly [string, number]'.
-                  Type at position 1 in source is not compatible with type at position 1 in target.
-                    Type 'boolean' is not assignable to type 'number'.
   Overload 2 of 4, '(entries?: readonly (readonly [string, number])[]): Map<string, number>', gave the following error.
     Type 'boolean' is not assignable to type 'number'.
 
@@ -26,7 +24,5 @@ tests/cases/conformance/es6/destructuring/iterableArrayPattern28.ts(2,24): error
 !!! error TS2769:             Type 'IteratorYieldResult<[string, number] | [string, boolean]>' is not assignable to type 'IteratorYieldResult<readonly [string, number]>'.
 !!! error TS2769:               Type '[string, number] | [string, boolean]' is not assignable to type 'readonly [string, number]'.
 !!! error TS2769:                 Type '[string, boolean]' is not assignable to type 'readonly [string, number]'.
-!!! error TS2769:                   Type at position 1 in source is not compatible with type at position 1 in target.
-!!! error TS2769:                     Type 'boolean' is not assignable to type 'number'.
 !!! error TS2769:   Overload 2 of 4, '(entries?: readonly (readonly [string, number])[]): Map<string, number>', gave the following error.
 !!! error TS2769:     Type 'boolean' is not assignable to type 'number'.

--- a/tests/baselines/reference/nestedCallbackErrorNotFlattened.errors.txt
+++ b/tests/baselines/reference/nestedCallbackErrorNotFlattened.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/nestedCallbackErrorNotFlattened.ts(6,1): error TS2322: Type '() => () => () => () => number' is not assignable to type '() => () => () => () => string'.
-  Call signature return types '() => () => () => number' and '() => () => () => string' are incompatible.
-    Call signature return types '() => () => number' and '() => () => string' are incompatible.
-      Call signature return types '() => number' and '() => string' are incompatible.
+  Type '() => () => () => number' is not assignable to type '() => () => () => string'.
+    Type '() => () => number' is not assignable to type '() => () => string'.
+      Type '() => number' is not assignable to type '() => string'.
         Type 'number' is not assignable to type 'string'.
 
 
@@ -14,7 +14,7 @@ tests/cases/compiler/nestedCallbackErrorNotFlattened.ts(6,1): error TS2322: Type
     y = x;
     ~
 !!! error TS2322: Type '() => () => () => () => number' is not assignable to type '() => () => () => () => string'.
-!!! error TS2322:   Call signature return types '() => () => () => number' and '() => () => () => string' are incompatible.
-!!! error TS2322:     Call signature return types '() => () => number' and '() => () => string' are incompatible.
-!!! error TS2322:       Call signature return types '() => number' and '() => string' are incompatible.
+!!! error TS2322:   Type '() => () => () => number' is not assignable to type '() => () => () => string'.
+!!! error TS2322:     Type '() => () => number' is not assignable to type '() => () => string'.
+!!! error TS2322:       Type '() => number' is not assignable to type '() => string'.
 !!! error TS2322:         Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/nongenericPartialInstantiationsRelatedInBothDirections.errors.txt
+++ b/tests/baselines/reference/nongenericPartialInstantiationsRelatedInBothDirections.errors.txt
@@ -1,0 +1,27 @@
+tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts(11,1): error TS2322: Type 'ObjectContaining<{ a: number; foo: number; }>' is not assignable to type 'ObjectContaining<Foo>'.
+  Type '{ a: number; foo: number; }' is missing the following properties from type 'Foo': b, bar
+tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts(12,1): error TS2322: Type 'ObjectContaining<Foo>' is not assignable to type 'ObjectContaining<{ a: number; foo: number; }>'.
+  Property 'foo' is missing in type 'Foo' but required in type '{ a: number; foo: number; }'.
+
+
+==== tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts (2 errors) ====
+    interface Foo {
+        a: number;
+        b: number;
+        bar: string;
+    }
+    interface ObjectContaining<T> {
+      new (sample: Partial<T>): Partial<T>
+    }
+    declare let cafoo: ObjectContaining<{ a: number, foo: number }>;
+    declare let cfoo: ObjectContaining<Foo>;
+    cfoo = cafoo;
+    ~~~~
+!!! error TS2322: Type 'ObjectContaining<{ a: number; foo: number; }>' is not assignable to type 'ObjectContaining<Foo>'.
+!!! error TS2322:   Type '{ a: number; foo: number; }' is missing the following properties from type 'Foo': b, bar
+    cafoo = cfoo;
+    ~~~~~
+!!! error TS2322: Type 'ObjectContaining<Foo>' is not assignable to type 'ObjectContaining<{ a: number; foo: number; }>'.
+!!! error TS2322:   Property 'foo' is missing in type 'Foo' but required in type '{ a: number; foo: number; }'.
+!!! related TS2728 tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts:9:50: 'foo' is declared here.
+    

--- a/tests/baselines/reference/strictFunctionTypesErrors.errors.txt
+++ b/tests/baselines/reference/strictFunctionTypesErrors.errors.txt
@@ -64,8 +64,7 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(111,1): error TS2322: Type 'Co
 tests/cases/compiler/strictFunctionTypesErrors.ts(126,1): error TS2322: Type 'Crate<Dog>' is not assignable to type 'Crate<Animal>'.
   Types of property 'onSetItem' are incompatible.
     Type '(item: Dog) => void' is not assignable to type '(item: Animal) => void'.
-      Types of parameters 'item' and 'item' are incompatible.
-        Type 'Animal' is not assignable to type 'Dog'.
+      Type 'Animal' is not assignable to type 'Dog'.
 tests/cases/compiler/strictFunctionTypesErrors.ts(127,1): error TS2322: Type 'Crate<Animal>' is not assignable to type 'Crate<Dog>'.
   Types of property 'item' are incompatible.
     Type 'Animal' is not assignable to type 'Dog'.
@@ -309,8 +308,7 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(155,5): error TS2322: Type '(c
 !!! error TS2322: Type 'Crate<Dog>' is not assignable to type 'Crate<Animal>'.
 !!! error TS2322:   Types of property 'onSetItem' are incompatible.
 !!! error TS2322:     Type '(item: Dog) => void' is not assignable to type '(item: Animal) => void'.
-!!! error TS2322:       Types of parameters 'item' and 'item' are incompatible.
-!!! error TS2322:         Type 'Animal' is not assignable to type 'Dog'.
+!!! error TS2322:       Type 'Animal' is not assignable to type 'Dog'.
     dogCrate = animalCrate;  // Error
     ~~~~~~~~
 !!! error TS2322: Type 'Crate<Animal>' is not assignable to type 'Crate<Dog>'.

--- a/tests/baselines/reference/unwitnessedTypeParameterVariance.errors.txt
+++ b/tests/baselines/reference/unwitnessedTypeParameterVariance.errors.txt
@@ -1,0 +1,34 @@
+tests/cases/compiler/unwitnessedTypeParameterVariance.ts(11,11): error TS2322: Type 'CalcObj<unknown>' is not assignable to type 'CalcObj<O>'.
+  Types of property 'read' are incompatible.
+    Type '(origin: unknown) => CalcValue<unknown>' is not assignable to type '(origin: O) => CalcValue<O>'.
+
+
+==== tests/cases/compiler/unwitnessedTypeParameterVariance.ts (1 errors) ====
+    // Repros from #33872
+    
+    export interface CalcObj<O> {
+        read: (origin: O) => CalcValue<O>;
+    }
+    
+    export type CalcValue<O> = CalcObj<O>;
+    
+    function foo<O>() {
+        const unk: CalcObj<unknown> = { read: (origin: unknown) => unk }
+        const x: CalcObj<O> = unk;
+              ~
+!!! error TS2322: Type 'CalcObj<unknown>' is not assignable to type 'CalcObj<O>'.
+!!! error TS2322:   Types of property 'read' are incompatible.
+!!! error TS2322:     Type '(origin: unknown) => CalcValue<unknown>' is not assignable to type '(origin: O) => CalcValue<O>'.
+    }
+    
+    type A<T> = B<T>;
+    
+    interface B<T> {
+        prop: A<T>;
+    }
+    
+    declare let a: A<number>;
+    declare let b: A<3>;
+     
+    b = a;
+    

--- a/tests/baselines/reference/varianceMeasurement.errors.txt
+++ b/tests/baselines/reference/varianceMeasurement.errors.txt
@@ -6,8 +6,7 @@ tests/cases/compiler/varianceMeasurement.ts(21,7): error TS2322: Type 'Foo2<stri
 tests/cases/compiler/varianceMeasurement.ts(22,7): error TS2322: Type 'Foo2<string>' is not assignable to type 'Foo2<unknown>'.
   The types of 'y.x' are incompatible between these types.
     Type '(arg: string) => void' is not assignable to type '(arg: unknown) => void'.
-      Types of parameters 'arg' and 'arg' are incompatible.
-        Type 'unknown' is not assignable to type 'string'.
+      Type 'unknown' is not assignable to type 'string'.
 tests/cases/compiler/varianceMeasurement.ts(33,7): error TS2322: Type 'Foo3<string>' is not assignable to type 'Foo3<"a">'.
   Type 'string' is not assignable to type '"a"'.
 tests/cases/compiler/varianceMeasurement.ts(44,7): error TS2322: Type 'Foo4<string>' is not assignable to type 'Foo4<"a">'.
@@ -16,8 +15,7 @@ tests/cases/compiler/varianceMeasurement.ts(44,7): error TS2322: Type 'Foo4<stri
 tests/cases/compiler/varianceMeasurement.ts(45,7): error TS2322: Type 'Foo4<string>' is not assignable to type 'Foo4<unknown>'.
   The types of 'y.x' are incompatible between these types.
     Type '(arg: string) => void' is not assignable to type '(arg: unknown) => void'.
-      Types of parameters 'arg' and 'arg' are incompatible.
-        Type 'unknown' is not assignable to type 'string'.
+      Type 'unknown' is not assignable to type 'string'.
 tests/cases/compiler/varianceMeasurement.ts(57,7): error TS2322: Type 'Fn<string, number>' is not assignable to type 'Fn<unknown, number>'.
   Type 'unknown' is not assignable to type 'string'.
 tests/cases/compiler/varianceMeasurement.ts(62,7): error TS2322: Type 'Fn<string, number>' is not assignable to type 'Fn<string, 0>'.
@@ -60,8 +58,7 @@ tests/cases/compiler/varianceMeasurement.ts(75,7): error TS2322: Type 'C<unknown
 !!! error TS2322: Type 'Foo2<string>' is not assignable to type 'Foo2<unknown>'.
 !!! error TS2322:   The types of 'y.x' are incompatible between these types.
 !!! error TS2322:     Type '(arg: string) => void' is not assignable to type '(arg: unknown) => void'.
-!!! error TS2322:       Types of parameters 'arg' and 'arg' are incompatible.
-!!! error TS2322:         Type 'unknown' is not assignable to type 'string'.
+!!! error TS2322:       Type 'unknown' is not assignable to type 'string'.
     
     // The type below should be invariant in T but is measured as covariant because
     // we don't analyze recursive references.
@@ -96,8 +93,7 @@ tests/cases/compiler/varianceMeasurement.ts(75,7): error TS2322: Type 'C<unknown
 !!! error TS2322: Type 'Foo4<string>' is not assignable to type 'Foo4<unknown>'.
 !!! error TS2322:   The types of 'y.x' are incompatible between these types.
 !!! error TS2322:     Type '(arg: string) => void' is not assignable to type '(arg: unknown) => void'.
-!!! error TS2322:       Types of parameters 'arg' and 'arg' are incompatible.
-!!! error TS2322:         Type 'unknown' is not assignable to type 'string'.
+!!! error TS2322:       Type 'unknown' is not assignable to type 'string'.
     
     // Repro from #3580
     


### PR DESCRIPTION
This does variance checking on signatures when we try to relate two signatures which are instances of the same original signature. This isn't _quite_ done yet - there's some cleanup to be done with merging variance relating codepaths and some extra structural fallbacks that need to be added, as the baselines show, but it should be good enough to run the perf suite and get a handle on if this'll actually help out or not.
