### PR TITLE
fix(48166): Checking module.exports should not yield a This condition will always return true since this function is always defined error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37599,6 +37599,7 @@ namespace ts {
                     (condExpr.operatorToken.kind === SyntaxKind.BarBarToken || condExpr.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken)
                     ? condExpr.right
                     : condExpr;
+                if (isModuleExportsAccessExpression(location)) return;
                 const type = checkTruthinessExpression(location);
                 const isPropertyExpressionCast = isPropertyAccessExpression(location) && isTypeAssertion(location.expression);
                 if (getFalsyFlags(type) || isPropertyExpressionCast) return;

--- a/tests/baselines/reference/truthinessCallExpressionCoercion4.symbols
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion4.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/a.js ===
+function fn() {}
+>fn : Symbol(fn, Decl(a.js, 0, 0))
+
+if (typeof module === 'object' && module.exports) {
+>module : Symbol(module, Decl(a.js, 2, 51))
+>module.exports : Symbol(module.exports, Decl(a.js, 0, 0))
+>module : Symbol(module, Decl(a.js, 2, 51))
+>exports : Symbol(module.exports, Decl(a.js, 0, 0))
+
+    module.exports = fn;
+>module.exports : Symbol(module.exports, Decl(a.js, 0, 0))
+>module : Symbol(export=, Decl(a.js, 2, 51))
+>exports : Symbol(export=, Decl(a.js, 2, 51))
+>fn : Symbol(fn, Decl(a.js, 0, 0))
+}
+

--- a/tests/baselines/reference/truthinessCallExpressionCoercion4.types
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion4.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/a.js ===
+function fn() {}
+>fn : () => void
+
+if (typeof module === 'object' && module.exports) {
+>typeof module === 'object' && module.exports : false | (() => void)
+>typeof module === 'object' : boolean
+>typeof module : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>module : { exports: () => void; }
+>'object' : "object"
+>module.exports : () => void
+>module : { exports: () => void; }
+>exports : () => void
+
+    module.exports = fn;
+>module.exports = fn : () => void
+>module.exports : () => void
+>module : { exports: () => void; }
+>exports : () => void
+>fn : () => void
+}
+

--- a/tests/cases/compiler/truthinessCallExpressionCoercion4.ts
+++ b/tests/cases/compiler/truthinessCallExpressionCoercion4.ts
@@ -1,0 +1,11 @@
+// @checkJs: true
+// @allowJs: true
+// @strict: true
+// @noEmit: true
+// @filename: a.js
+
+function fn() {}
+
+if (typeof module === 'object' && module.exports) {
+    module.exports = fn;
+}


### PR DESCRIPTION
Fixes #48166