### PR TITLE
Widen boolean literals when contextual type is full boolean type

### DIFF
--- a/tests/baselines/reference/argumentExpressionContextualTyping.errors.txt
+++ b/tests/baselines/reference/argumentExpressionContextualTyping.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/expressions/contextualTyping/argumentExpressionContextualTyping.ts(16,5): error TS2345: Argument of type '(string | number | boolean)[]' is not assignable to parameter of type '[string, number, boolean]'.
   Target requires 3 element(s) but source may have fewer.
-tests/cases/conformance/expressions/contextualTyping/argumentExpressionContextualTyping.ts(17,5): error TS2345: Argument of type '[string, number, true, ...(string | number | boolean)[]]' is not assignable to parameter of type '[string, number, boolean]'.
+tests/cases/conformance/expressions/contextualTyping/argumentExpressionContextualTyping.ts(17,5): error TS2345: Argument of type '[string, number, boolean, ...(string | number | boolean)[]]' is not assignable to parameter of type '[string, number, boolean]'.
   Target allows only 3 element(s) but source may have more.
 tests/cases/conformance/expressions/contextualTyping/argumentExpressionContextualTyping.ts(18,5): error TS2345: Argument of type '{ x: (string | number)[]; y: { c: boolean; d: string; e: number; }; }' is not assignable to parameter of type '{ x: [any, any]; y: { c: any; d: any; e: any; }; }'.
   Types of property 'x' are incompatible.
@@ -30,7 +30,7 @@ tests/cases/conformance/expressions/contextualTyping/argumentExpressionContextua
 !!! error TS2345:   Target requires 3 element(s) but source may have fewer.
     baz(["string", 1, true, ...array]);  // Error
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '[string, number, true, ...(string | number | boolean)[]]' is not assignable to parameter of type '[string, number, boolean]'.
+!!! error TS2345: Argument of type '[string, number, boolean, ...(string | number | boolean)[]]' is not assignable to parameter of type '[string, number, boolean]'.
 !!! error TS2345:   Target allows only 3 element(s) but source may have more.
     foo(o);                              // Error because x has an array type namely (string|number)[]
         ~

--- a/tests/baselines/reference/argumentExpressionContextualTyping.types
+++ b/tests/baselines/reference/argumentExpressionContextualTyping.types
@@ -51,14 +51,14 @@ var o1: { x: [string, number], y: { c: boolean, d: string, e: number } } = { x: 
 >c : boolean
 >d : string
 >e : number
->{ x: ["string", 1], y: { c: true, d: "world", e: 3 } } : { x: [string, number]; y: { c: true; d: string; e: number; }; }
+>{ x: ["string", 1], y: { c: true, d: "world", e: 3 } } : { x: [string, number]; y: { c: boolean; d: string; e: number; }; }
 >x : [string, number]
 >["string", 1] : [string, number]
 >"string" : "string"
 >1 : 1
->y : { c: true; d: string; e: number; }
->{ c: true, d: "world", e: 3 } : { c: true; d: string; e: number; }
->c : true
+>y : { c: boolean; d: string; e: number; }
+>{ c: true, d: "world", e: 3 } : { c: boolean; d: string; e: number; }
+>c : boolean
 >true : true
 >d : string
 >"world" : "world"
@@ -96,7 +96,7 @@ var array = ["string", 1, true];
 
 var tuple: [string, number, boolean] = ["string", 1, true];
 >tuple : [string, number, boolean]
->["string", 1, true] : [string, number, true]
+>["string", 1, true] : [string, number, boolean]
 >"string" : "string"
 >1 : 1
 >true : true
@@ -109,7 +109,7 @@ baz(tuple);
 baz(["string", 1, true]);
 >baz(["string", 1, true]) : void
 >baz : (x: [string, number, boolean]) => void
->["string", 1, true] : [string, number, true]
+>["string", 1, true] : [string, number, boolean]
 >"string" : "string"
 >1 : 1
 >true : true
@@ -122,7 +122,7 @@ baz(array);                          // Error
 baz(["string", 1, true, ...array]);  // Error
 >baz(["string", 1, true, ...array]) : void
 >baz : (x: [string, number, boolean]) => void
->["string", 1, true, ...array] : [string, number, true, ...(string | number | boolean)[]]
+>["string", 1, true, ...array] : [string, number, boolean, ...(string | number | boolean)[]]
 >"string" : "string"
 >1 : 1
 >true : true

--- a/tests/baselines/reference/arrayBestCommonTypes.types
+++ b/tests/baselines/reference/arrayBestCommonTypes.types
@@ -249,15 +249,15 @@ module EmptyTypes {
 >t2 : { x: boolean; y: base; }[]
 >x : boolean
 >y : base
->[{ x: true, y: new derived() }, { x: false, y: new base() }] : ({ x: true; y: derived; } | { x: false; y: base; })[]
->{ x: true, y: new derived() } : { x: true; y: derived; }
->x : true
+>[{ x: true, y: new derived() }, { x: false, y: new base() }] : { x: boolean; y: derived; }[]
+>{ x: true, y: new derived() } : { x: boolean; y: derived; }
+>x : boolean
 >true : true
 >y : derived
 >new derived() : derived
 >derived : typeof derived
->{ x: false, y: new base() } : { x: false; y: base; }
->x : false
+>{ x: false, y: new base() } : { x: boolean; y: base; }
+>x : boolean
 >false : false
 >y : base
 >new base() : base
@@ -645,15 +645,15 @@ module NonEmptyTypes {
 >t2 : { x: boolean; y: base; }[]
 >x : boolean
 >y : base
->[{ x: true, y: new derived() }, { x: false, y: new base() }] : ({ x: true; y: derived; } | { x: false; y: base; })[]
->{ x: true, y: new derived() } : { x: true; y: derived; }
->x : true
+>[{ x: true, y: new derived() }, { x: false, y: new base() }] : { x: boolean; y: base; }[]
+>{ x: true, y: new derived() } : { x: boolean; y: derived; }
+>x : boolean
 >true : true
 >y : derived
 >new derived() : derived
 >derived : typeof derived
->{ x: false, y: new base() } : { x: false; y: base; }
->x : false
+>{ x: false, y: new base() } : { x: boolean; y: base; }
+>x : boolean
 >false : false
 >y : base
 >new base() : base

--- a/tests/baselines/reference/arrayLiteralInference.types
+++ b/tests/baselines/reference/arrayLiteralInference.types
@@ -119,21 +119,21 @@ declare function foo<T>(...args: T[]): T[];
 let b1: { x: boolean }[] = foo({ x: true }, { x: false });
 >b1 : { x: boolean; }[]
 >x : boolean
->foo({ x: true }, { x: false }) : ({ x: true; } | { x: false; })[]
+>foo({ x: true }, { x: false }) : { x: boolean; }[]
 >foo : <T>(...args: T[]) => T[]
->{ x: true } : { x: true; }
->x : true
+>{ x: true } : { x: boolean; }
+>x : boolean
 >true : true
->{ x: false } : { x: false; }
->x : false
+>{ x: false } : { x: boolean; }
+>x : boolean
 >false : false
 
 let b2: boolean[][] = foo([true], [false]);
 >b2 : boolean[][]
->foo([true], [false]) : (true[] | false[])[]
+>foo([true], [false]) : boolean[][]
 >foo : <T>(...args: T[]) => T[]
->[true] : true[]
+>[true] : boolean[]
 >true : true
->[false] : false[]
+>[false] : boolean[]
 >false : false
 

--- a/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
+++ b/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/arrayLiteralTypeInference.ts(14,14): error TS2322: Type '{ id: number; trueness: false; }' is not assignable to type 'Action'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(14,14): error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
   Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
 tests/cases/compiler/arrayLiteralTypeInference.ts(15,14): error TS2322: Type '{ id: number; name: string; }' is not assignable to type 'Action'.
   Object literal may only specify known properties, and 'name' does not exist in type 'Action'.
-tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '{ id: number; trueness: false; }' is not assignable to type '{ id: number; }'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
   Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
 tests/cases/compiler/arrayLiteralTypeInference.ts(32,18): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
@@ -24,7 +24,7 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(32,18): error TS2322: Type '{ 
     var x1: Action[] = [
         { id: 2, trueness: false },
                  ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; trueness: false; }' is not assignable to type 'Action'.
+!!! error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
 !!! error TS2322:   Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
         { id: 3, name: "three" }
                  ~~~~~~~~~~~~~
@@ -47,7 +47,7 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(32,18): error TS2322: Type '{ 
         [
             { id: 2, trueness: false },
                      ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; trueness: false; }' is not assignable to type '{ id: number; }'.
+!!! error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
             { id: 3, name: "three" }
                      ~~~~~~~~~~~~~

--- a/tests/baselines/reference/assignToFn.types
+++ b/tests/baselines/reference/assignToFn.types
@@ -10,9 +10,9 @@ module M {
 
     var x:I={ f:function(n) { return true; } };
 >x : I
->{ f:function(n) { return true; } } : { f: (n: number) => true; }
->f : (n: number) => true
->function(n) { return true; } : (n: number) => true
+>{ f:function(n) { return true; } } : { f: (n: number) => boolean; }
+>f : (n: number) => boolean
+>function(n) { return true; } : (n: number) => boolean
 >n : number
 >true : true
 

--- a/tests/baselines/reference/assignmentTypeNarrowing.types
+++ b/tests/baselines/reference/assignmentTypeNarrowing.types
@@ -11,14 +11,14 @@ x; // string
 >x : string
 
 [x] = [true];
->[x] = [true] : [true]
+>[x] = [true] : [boolean]
 >[x] : [string | number | boolean | RegExp]
 >x : string | number | boolean | RegExp
->[true] : [true]
+>[true] : [boolean]
 >true : true
 
 x; // boolean
->x : true
+>x : boolean
 
 [x = ""] = [1];
 >[x = ""] = [1] : [number]
@@ -33,16 +33,16 @@ x; // string | number
 >x : string | number
 
 ({x} = {x: true});
->({x} = {x: true}) : { x: true; }
->{x} = {x: true} : { x: true; }
+>({x} = {x: true}) : { x: boolean; }
+>{x} = {x: true} : { x: boolean; }
 >{x} : { x: string | number | boolean | RegExp; }
 >x : string | number | boolean | RegExp
->{x: true} : { x: true; }
->x : true
+>{x: true} : { x: boolean; }
+>x : boolean
 >true : true
 
 x; // boolean
->x : true
+>x : boolean
 
 ({y: x} = {y: 1});
 >({y: x} = {y: 1}) : { y: number; }
@@ -58,17 +58,17 @@ x; // number
 >x : number
 
 ({x = ""} = {x: true});
->({x = ""} = {x: true}) : { x?: true; }
->{x = ""} = {x: true} : { x?: true; }
+>({x = ""} = {x: true}) : { x?: boolean; }
+>{x = ""} = {x: true} : { x?: boolean; }
 >{x = ""} : { x?: string | number | boolean | RegExp; }
 >x : string | number | boolean | RegExp
 >"" : ""
->{x: true} : { x?: true; }
->x : true
+>{x: true} : { x?: boolean; }
+>x : boolean
 >true : true
 
 x; // string | boolean
->x : string | true
+>x : string | boolean
 
 ({y: x = /a/} = {y: 1});
 >({y: x = /a/} = {y: 1}) : { y?: number; }

--- a/tests/baselines/reference/asyncFunctionReturnType.types
+++ b/tests/baselines/reference/asyncFunctionReturnType.types
@@ -14,7 +14,7 @@ async function fAsyncExplicit(): Promise<[number, boolean]> {
 
     // This is contextually typed as a tuple.
     return [1, true];
->[1, true] : [number, true]
+>[1, true] : [number, boolean]
 >1 : 1
 >true : true
 }

--- a/tests/baselines/reference/awaitedType.types
+++ b/tests/baselines/reference/awaitedType.types
@@ -116,7 +116,7 @@ async function main() {
 >Promise.all : { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>; <T extends [] | readonly unknown[]>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }>; }
 >Promise : PromiseConstructor
 >all : { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>; <T extends [] | readonly unknown[]>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }>; }
->[        MaybePromise(1),        MaybePromise('2'),        MaybePromise(true),    ] : [number | Promise<1> | PromiseLike<1>, string | Promise<"2"> | PromiseLike<"2">, MaybePromise<true>]
+>[        MaybePromise(1),        MaybePromise('2'),        MaybePromise(true),    ] : [number | Promise<1> | PromiseLike<1>, string | Promise<"2"> | PromiseLike<"2">, boolean | Promise<true> | PromiseLike<true>]
 
         MaybePromise(1),
 >MaybePromise(1) : 1 | Promise<1> | PromiseLike<1>

--- a/tests/baselines/reference/awaitedTypeStrictNull.types
+++ b/tests/baselines/reference/awaitedTypeStrictNull.types
@@ -116,7 +116,7 @@ async function main() {
 >Promise.all : { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>; <T extends [] | readonly unknown[]>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }>; }
 >Promise : PromiseConstructor
 >all : { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>; <T extends [] | readonly unknown[]>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }>; }
->[        MaybePromise(1),        MaybePromise('2'),        MaybePromise(true),    ] : [number | Promise<1> | PromiseLike<1>, string | Promise<"2"> | PromiseLike<"2">, MaybePromise<true>]
+>[        MaybePromise(1),        MaybePromise('2'),        MaybePromise(true),    ] : [number | Promise<1> | PromiseLike<1>, string | Promise<"2"> | PromiseLike<"2">, boolean | Promise<true> | PromiseLike<true>]
 
         MaybePromise(1),
 >MaybePromise(1) : 1 | Promise<1> | PromiseLike<1>

--- a/tests/baselines/reference/callsOnComplexSignatures.types
+++ b/tests/baselines/reference/callsOnComplexSignatures.types
@@ -409,7 +409,7 @@ function test5() {
 >a : JSX.Element
 ><C p={true} /> : JSX.Element
 >C : React.ComponentType<P1> | React.ComponentType<P2>
->p : true
+>p : boolean
 >true : true
     }
 }

--- a/tests/baselines/reference/checkExportsObjectAssignProperty.types
+++ b/tests/baselines/reference/checkExportsObjectAssignProperty.types
@@ -181,10 +181,10 @@ Object.defineProperty(exports, "thing", { value: 42, writable: true });
 >defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
 >exports : typeof import("tests/cases/conformance/jsdoc/mod1")
 >"thing" : "thing"
->{ value: 42, writable: true } : { value: number; writable: true; }
+>{ value: 42, writable: true } : { value: number; writable: boolean; }
 >value : number
 >42 : 42
->writable : true
+>writable : boolean
 >true : true
 
 Object.defineProperty(exports, "readonlyProp", { value: "Smith", writable: false });
@@ -194,10 +194,10 @@ Object.defineProperty(exports, "readonlyProp", { value: "Smith", writable: false
 >defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
 >exports : typeof import("tests/cases/conformance/jsdoc/mod1")
 >"readonlyProp" : "readonlyProp"
->{ value: "Smith", writable: false } : { value: string; writable: false; }
+>{ value: "Smith", writable: false } : { value: string; writable: boolean; }
 >value : string
 >"Smith" : "Smith"
->writable : false
+>writable : boolean
 >false : false
 
 Object.defineProperty(exports, "rwAccessors", { get() { return 98122 }, set(_) { /*ignore*/ } });
@@ -259,10 +259,10 @@ Object.defineProperty(module.exports, "thing", { value: "yes", writable: true })
 >module : { exports: typeof module.exports; }
 >exports : typeof module.exports
 >"thing" : "thing"
->{ value: "yes", writable: true } : { value: string; writable: true; }
+>{ value: "yes", writable: true } : { value: string; writable: boolean; }
 >value : string
 >"yes" : "yes"
->writable : true
+>writable : boolean
 >true : true
 
 Object.defineProperty(module.exports, "readonlyProp", { value: "Smith", writable: false });
@@ -274,10 +274,10 @@ Object.defineProperty(module.exports, "readonlyProp", { value: "Smith", writable
 >module : { exports: typeof module.exports; }
 >exports : typeof module.exports
 >"readonlyProp" : "readonlyProp"
->{ value: "Smith", writable: false } : { value: string; writable: false; }
+>{ value: "Smith", writable: false } : { value: string; writable: boolean; }
 >value : string
 >"Smith" : "Smith"
->writable : false
+>writable : boolean
 >false : false
 
 Object.defineProperty(module.exports, "rwAccessors", { get() { return 98122 }, set(_) { /*ignore*/ } });

--- a/tests/baselines/reference/checkExportsObjectAssignPrototypeProperty.types
+++ b/tests/baselines/reference/checkExportsObjectAssignPrototypeProperty.types
@@ -136,10 +136,10 @@ Object.defineProperty(Person.prototype, "thing", { value: 42, writable: true });
 >Person : typeof Person
 >prototype : any
 >"thing" : "thing"
->{ value: 42, writable: true } : { value: number; writable: true; }
+>{ value: 42, writable: true } : { value: number; writable: boolean; }
 >value : number
 >42 : 42
->writable : true
+>writable : boolean
 >true : true
 
 Object.defineProperty(Person.prototype, "readonlyProp", { value: "Smith", writable: false });
@@ -151,10 +151,10 @@ Object.defineProperty(Person.prototype, "readonlyProp", { value: "Smith", writab
 >Person : typeof Person
 >prototype : any
 >"readonlyProp" : "readonlyProp"
->{ value: "Smith", writable: false } : { value: string; writable: false; }
+>{ value: "Smith", writable: false } : { value: string; writable: boolean; }
 >value : string
 >"Smith" : "Smith"
->writable : false
+>writable : boolean
 >false : false
 
 Object.defineProperty(Person.prototype, "rwAccessors", { get() { return 98122 }, set(_) { /*ignore*/ } });

--- a/tests/baselines/reference/checkObjectDefineProperty.types
+++ b/tests/baselines/reference/checkObjectDefineProperty.types
@@ -94,10 +94,10 @@ Object.defineProperty(x, "name", { value: "Charles", writable: true });
 >defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
 >x : typeof x
 >"name" : "name"
->{ value: "Charles", writable: true } : { value: string; writable: true; }
+>{ value: "Charles", writable: true } : { value: string; writable: boolean; }
 >value : string
 >"Charles" : "Charles"
->writable : true
+>writable : boolean
 >true : true
 
 Object.defineProperty(x, "middleInit", { value: "H" });
@@ -118,10 +118,10 @@ Object.defineProperty(x, "lastName", { value: "Smith", writable: false });
 >defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
 >x : typeof x
 >"lastName" : "lastName"
->{ value: "Smith", writable: false } : { value: string; writable: false; }
+>{ value: "Smith", writable: false } : { value: string; writable: boolean; }
 >value : string
 >"Smith" : "Smith"
->writable : false
+>writable : boolean
 >false : false
 
 Object.defineProperty(x, "zip", { get() { return 98122 }, set(_) { /*ignore*/ } });

--- a/tests/baselines/reference/checkOtherObjectAssignProperty.types
+++ b/tests/baselines/reference/checkOtherObjectAssignProperty.types
@@ -111,10 +111,10 @@ Object.defineProperty(exports, str, { value: 42, writable: true });
 >defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
 >exports : typeof import("tests/cases/conformance/jsdoc/mod1")
 >str : string
->{ value: 42, writable: true } : { value: number; writable: true; }
+>{ value: 42, writable: true } : { value: number; writable: boolean; }
 >value : number
 >42 : 42
->writable : true
+>writable : boolean
 >true : true
 
 const propName = "prop"
@@ -128,10 +128,10 @@ Object.defineProperty(exports, propName, { value: 42, writable: true });
 >defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
 >exports : typeof import("tests/cases/conformance/jsdoc/mod1")
 >propName : "prop"
->{ value: 42, writable: true } : { value: number; writable: true; }
+>{ value: 42, writable: true } : { value: number; writable: boolean; }
 >value : number
 >42 : 42
->writable : true
+>writable : boolean
 >true : true
 
 
@@ -164,7 +164,7 @@ Object.defineProperty(exports, "bad3", { writable: true });
 >defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
 >exports : typeof import("tests/cases/conformance/jsdoc/mod1")
 >"bad3" : "bad3"
->{ writable: true } : { writable: true; }
->writable : true
+>{ writable: true } : { writable: boolean; }
+>writable : boolean
 >true : true
 

--- a/tests/baselines/reference/coAndContraVariantInferences.types
+++ b/tests/baselines/reference/coAndContraVariantInferences.types
@@ -57,8 +57,8 @@ const actionA = { payload: 'any-string' } as Action<'ACTION_A', string>;
 const actionB = { payload: true } as Action<'ACTION_B', boolean>;
 >actionB : Action<"ACTION_B", boolean>
 >{ payload: true } as Action<'ACTION_B', boolean> : Action<"ACTION_B", boolean>
->{ payload: true } : { payload: true; }
->payload : true
+>{ payload: true } : { payload: boolean; }
+>payload : boolean
 >true : true
 
 function call<TName extends string,TPayload>(

--- a/tests/baselines/reference/computedPropertyNamesContextualType6_ES5.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType6_ES5.types
@@ -11,7 +11,7 @@ declare function foo<T>(obj: I<T>): T
 foo({
 >foo({    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : string | number | boolean | (() => void) | number[]
 >foo : <T>(obj: I<T>) => T
->{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | number | true | (() => void) | number[]; [x: number]: number | (() => void) | number[]; p: string; 0: () => void; }
+>{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | number | boolean | (() => void) | number[]; [x: number]: number | (() => void) | number[]; p: string; 0: () => void; }
 
     p: "",
 >p : string
@@ -22,7 +22,7 @@ foo({
 >() => { } : () => void
 
     ["hi" + "bye"]: true,
->["hi" + "bye"] : true
+>["hi" + "bye"] : boolean
 >"hi" + "bye" : string
 >"hi" : "hi"
 >"bye" : "bye"

--- a/tests/baselines/reference/computedPropertyNamesContextualType6_ES6.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType6_ES6.types
@@ -11,7 +11,7 @@ declare function foo<T>(obj: I<T>): T
 foo({
 >foo({    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : string | number | boolean | (() => void) | number[]
 >foo : <T>(obj: I<T>) => T
->{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | number | true | (() => void) | number[]; [x: number]: number | (() => void) | number[]; p: string; 0: () => void; }
+>{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | number | boolean | (() => void) | number[]; [x: number]: number | (() => void) | number[]; p: string; 0: () => void; }
 
     p: "",
 >p : string
@@ -22,7 +22,7 @@ foo({
 >() => { } : () => void
 
     ["hi" + "bye"]: true,
->["hi" + "bye"] : true
+>["hi" + "bye"] : boolean
 >"hi" + "bye" : string
 >"hi" : "hi"
 >"bye" : "bye"

--- a/tests/baselines/reference/conditionalTypeContextualTypeSimplificationsSuceeds.types
+++ b/tests/baselines/reference/conditionalTypeContextualTypeSimplificationsSuceeds.types
@@ -27,27 +27,27 @@ function good2<P extends Props>(
 bad({ when: value => false });
 >bad({ when: value => false }) : void
 >bad : <P extends Props>(attrs: string extends keyof P ? { [K in keyof P]: P[K]; } : { [K in keyof P]: P[K]; }) => void
->{ when: value => false } : { when: (value: string) => false; }
->when : (value: string) => false
->value => false : (value: string) => false
+>{ when: value => false } : { when: (value: string) => boolean; }
+>when : (value: string) => boolean
+>value => false : (value: string) => boolean
 >value : string
 >false : false
 
 good1({ when: value => false });
 >good1({ when: value => false }) : void
 >good1 : <P extends Props>(attrs: string extends keyof P ? P : { [K in keyof P]: P[K]; }) => void
->{ when: value => false } : { when: (value: string) => false; }
->when : (value: string) => false
->value => false : (value: string) => false
+>{ when: value => false } : { when: (value: string) => boolean; }
+>when : (value: string) => boolean
+>value => false : (value: string) => boolean
 >value : string
 >false : false
 
 good2({ when: value => false });
 >good2({ when: value => false }) : void
 >good2 : <P extends Props>(attrs: { [K in keyof P]: P[K]; }) => void
->{ when: value => false } : { when: (value: string) => false; }
->when : (value: string) => false
->value => false : (value: string) => false
+>{ when: value => false } : { when: (value: string) => boolean; }
+>when : (value: string) => boolean
+>value => false : (value: string) => boolean
 >value : string
 >false : false
 

--- a/tests/baselines/reference/constEnumPropertyAccess1.types
+++ b/tests/baselines/reference/constEnumPropertyAccess1.types
@@ -34,10 +34,10 @@ var o: {
 >idx : number
 
 } = {
->{        1: true    } : { 1: true; }
+>{        1: true    } : { 1: boolean; }
 
         1: true
->1 : true
+>1 : boolean
 >true : true
 
     };

--- a/tests/baselines/reference/contextualOverloadListFromUnionWithPrimitiveNoImplicitAny.types
+++ b/tests/baselines/reference/contextualOverloadListFromUnionWithPrimitiveNoImplicitAny.types
@@ -22,15 +22,15 @@ type Rule = string | FullRule;
 const obj: {field: Rule} = {
 >obj : { field: Rule; }
 >field : Rule
->{    field: {        validate: (_t, _p, _s) => false,        normalize: match => match.x,    }} : { field: { validate: (_t: string, _p: number, _s: Rule) => false; normalize: (match: any) => any; }; }
+>{    field: {        validate: (_t, _p, _s) => false,        normalize: match => match.x,    }} : { field: { validate: (_t: string, _p: number, _s: Rule) => boolean; normalize: (match: any) => any; }; }
 
     field: {
->field : { validate: (_t: string, _p: number, _s: Rule) => false; normalize: (match: any) => any; }
->{        validate: (_t, _p, _s) => false,        normalize: match => match.x,    } : { validate: (_t: string, _p: number, _s: Rule) => false; normalize: (match: any) => any; }
+>field : { validate: (_t: string, _p: number, _s: Rule) => boolean; normalize: (match: any) => any; }
+>{        validate: (_t, _p, _s) => false,        normalize: match => match.x,    } : { validate: (_t: string, _p: number, _s: Rule) => boolean; normalize: (match: any) => any; }
 
         validate: (_t, _p, _s) => false,
->validate : (_t: string, _p: number, _s: Rule) => false
->(_t, _p, _s) => false : (_t: string, _p: number, _s: Rule) => false
+>validate : (_t: string, _p: number, _s: Rule) => boolean
+>(_t, _p, _s) => false : (_t: string, _p: number, _s: Rule) => boolean
 >_t : string
 >_p : number
 >_s : Rule

--- a/tests/baselines/reference/contextualTypeWithTuple.types
+++ b/tests/baselines/reference/contextualTypeWithTuple.types
@@ -15,7 +15,7 @@ var numStrTuple2: [number, string] = [5, "foo", true];
 
 var numStrBoolTuple: [number, string, boolean] = [5, "foo", true];
 >numStrBoolTuple : [number, string, boolean]
->[5, "foo", true] : [number, string, true]
+>[5, "foo", true] : [number, string, boolean]
 >5 : 5
 >"foo" : "foo"
 >true : true

--- a/tests/baselines/reference/contextuallyTypedBooleanLiterals.js
+++ b/tests/baselines/reference/contextuallyTypedBooleanLiterals.js
@@ -1,0 +1,55 @@
+//// [contextuallyTypedBooleanLiterals.ts]
+// Repro from #48363
+
+type Box<T> = {
+    get: () => T,
+    set: (value: T) => void
+}
+
+declare function box<T>(value: T): Box<T>;
+
+const bn1 = box(0);  // Box<number>
+const bn2: Box<number> = box(0);  // Ok
+
+const bb1 = box(false);  // Box<boolean>
+const bb2: Box<boolean> = box(false);  // Error, box<false> not assignable to Box<boolean>
+
+// Repro from #48150
+
+interface Observable<T>
+{
+  (): T;
+  (value: T): any;
+}
+
+declare function observable<T>(value: T): Observable<T>;
+
+const x: Observable<boolean> = observable(false);
+
+
+//// [contextuallyTypedBooleanLiterals.js]
+"use strict";
+// Repro from #48363
+var bn1 = box(0); // Box<number>
+var bn2 = box(0); // Ok
+var bb1 = box(false); // Box<boolean>
+var bb2 = box(false); // Error, box<false> not assignable to Box<boolean>
+var x = observable(false);
+
+
+//// [contextuallyTypedBooleanLiterals.d.ts]
+declare type Box<T> = {
+    get: () => T;
+    set: (value: T) => void;
+};
+declare function box<T>(value: T): Box<T>;
+declare const bn1: Box<number>;
+declare const bn2: Box<number>;
+declare const bb1: Box<boolean>;
+declare const bb2: Box<boolean>;
+interface Observable<T> {
+    (): T;
+    (value: T): any;
+}
+declare function observable<T>(value: T): Observable<T>;
+declare const x: Observable<boolean>;

--- a/tests/baselines/reference/contextuallyTypedBooleanLiterals.symbols
+++ b/tests/baselines/reference/contextuallyTypedBooleanLiterals.symbols
@@ -1,0 +1,70 @@
+=== tests/cases/compiler/contextuallyTypedBooleanLiterals.ts ===
+// Repro from #48363
+
+type Box<T> = {
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 2, 9))
+
+    get: () => T,
+>get : Symbol(get, Decl(contextuallyTypedBooleanLiterals.ts, 2, 15))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 2, 9))
+
+    set: (value: T) => void
+>set : Symbol(set, Decl(contextuallyTypedBooleanLiterals.ts, 3, 17))
+>value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 4, 10))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 2, 9))
+}
+
+declare function box<T>(value: T): Box<T>;
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 1))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 7, 21))
+>value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 7, 24))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 7, 21))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 7, 21))
+
+const bn1 = box(0);  // Box<number>
+>bn1 : Symbol(bn1, Decl(contextuallyTypedBooleanLiterals.ts, 9, 5))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 1))
+
+const bn2: Box<number> = box(0);  // Ok
+>bn2 : Symbol(bn2, Decl(contextuallyTypedBooleanLiterals.ts, 10, 5))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 1))
+
+const bb1 = box(false);  // Box<boolean>
+>bb1 : Symbol(bb1, Decl(contextuallyTypedBooleanLiterals.ts, 12, 5))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 1))
+
+const bb2: Box<boolean> = box(false);  // Error, box<false> not assignable to Box<boolean>
+>bb2 : Symbol(bb2, Decl(contextuallyTypedBooleanLiterals.ts, 13, 5))
+>Box : Symbol(Box, Decl(contextuallyTypedBooleanLiterals.ts, 0, 0))
+>box : Symbol(box, Decl(contextuallyTypedBooleanLiterals.ts, 5, 1))
+
+// Repro from #48150
+
+interface Observable<T>
+>Observable : Symbol(Observable, Decl(contextuallyTypedBooleanLiterals.ts, 13, 37))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 17, 21))
+{
+  (): T;
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 17, 21))
+
+  (value: T): any;
+>value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 20, 3))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 17, 21))
+}
+
+declare function observable<T>(value: T): Observable<T>;
+>observable : Symbol(observable, Decl(contextuallyTypedBooleanLiterals.ts, 21, 1))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 23, 28))
+>value : Symbol(value, Decl(contextuallyTypedBooleanLiterals.ts, 23, 31))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 23, 28))
+>Observable : Symbol(Observable, Decl(contextuallyTypedBooleanLiterals.ts, 13, 37))
+>T : Symbol(T, Decl(contextuallyTypedBooleanLiterals.ts, 23, 28))
+
+const x: Observable<boolean> = observable(false);
+>x : Symbol(x, Decl(contextuallyTypedBooleanLiterals.ts, 25, 5))
+>Observable : Symbol(Observable, Decl(contextuallyTypedBooleanLiterals.ts, 13, 37))
+>observable : Symbol(observable, Decl(contextuallyTypedBooleanLiterals.ts, 21, 1))
+

--- a/tests/baselines/reference/contextuallyTypedBooleanLiterals.types
+++ b/tests/baselines/reference/contextuallyTypedBooleanLiterals.types
@@ -1,0 +1,61 @@
+=== tests/cases/compiler/contextuallyTypedBooleanLiterals.ts ===
+// Repro from #48363
+
+type Box<T> = {
+>Box : Box<T>
+
+    get: () => T,
+>get : () => T
+
+    set: (value: T) => void
+>set : (value: T) => void
+>value : T
+}
+
+declare function box<T>(value: T): Box<T>;
+>box : <T>(value: T) => Box<T>
+>value : T
+
+const bn1 = box(0);  // Box<number>
+>bn1 : Box<number>
+>box(0) : Box<number>
+>box : <T>(value: T) => Box<T>
+>0 : 0
+
+const bn2: Box<number> = box(0);  // Ok
+>bn2 : Box<number>
+>box(0) : Box<number>
+>box : <T>(value: T) => Box<T>
+>0 : 0
+
+const bb1 = box(false);  // Box<boolean>
+>bb1 : Box<boolean>
+>box(false) : Box<boolean>
+>box : <T>(value: T) => Box<T>
+>false : false
+
+const bb2: Box<boolean> = box(false);  // Error, box<false> not assignable to Box<boolean>
+>bb2 : Box<boolean>
+>box(false) : Box<boolean>
+>box : <T>(value: T) => Box<T>
+>false : false
+
+// Repro from #48150
+
+interface Observable<T>
+{
+  (): T;
+  (value: T): any;
+>value : T
+}
+
+declare function observable<T>(value: T): Observable<T>;
+>observable : <T>(value: T) => Observable<T>
+>value : T
+
+const x: Observable<boolean> = observable(false);
+>x : Observable<boolean>
+>observable(false) : Observable<boolean>
+>observable : <T>(value: T) => Observable<T>
+>false : false
+

--- a/tests/baselines/reference/controlFlowElementAccess.types
+++ b/tests/baselines/reference/controlFlowElementAccess.types
@@ -2,8 +2,8 @@
 let x: { o: boolean } = { o: false }
 >x : { o: boolean; }
 >o : boolean
->{ o: false } : { o: false; }
->o : false
+>{ o: false } : { o: boolean; }
+>o : boolean
 >false : false
 
 if (x['o'] === false) {

--- a/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.symbols
+++ b/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.symbols
@@ -17,7 +17,7 @@ var [a2, [b2, { x12, y12: c2 }]=["abc", { x12: 10, y12: false }]] = [1, ["hello"
 >a2 : Symbol(a2, Decl(declarationEmitDestructuringArrayPattern2.ts, 5, 5))
 >b2 : Symbol(b2, Decl(declarationEmitDestructuringArrayPattern2.ts, 5, 10))
 >x12 : Symbol(x12, Decl(declarationEmitDestructuringArrayPattern2.ts, 5, 15))
->y12 : Symbol(y12, Decl(declarationEmitDestructuringArrayPattern2.ts, 5, 50))
+>y12 : Symbol(y12, Decl(declarationEmitDestructuringArrayPattern2.ts, 5, 91))
 >c2 : Symbol(c2, Decl(declarationEmitDestructuringArrayPattern2.ts, 5, 20))
 >x12 : Symbol(x12, Decl(declarationEmitDestructuringArrayPattern2.ts, 5, 41))
 >y12 : Symbol(y12, Decl(declarationEmitDestructuringArrayPattern2.ts, 5, 50))

--- a/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.types
+++ b/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.types
@@ -38,14 +38,14 @@ var [a2, [b2, { x12, y12: c2 }]=["abc", { x12: 10, y12: false }]] = [1, ["hello"
 >10 : 10
 >y12 : boolean
 >false : false
->[1, ["hello", { x12: 5, y12: true }]] : [number, [string, { x12: number; y12: true; }]]
+>[1, ["hello", { x12: 5, y12: true }]] : [number, [string, { x12: number; y12: boolean; }]]
 >1 : 1
->["hello", { x12: 5, y12: true }] : [string, { x12: number; y12: true; }]
+>["hello", { x12: 5, y12: true }] : [string, { x12: number; y12: boolean; }]
 >"hello" : "hello"
->{ x12: 5, y12: true } : { x12: number; y12: true; }
+>{ x12: 5, y12: true } : { x12: number; y12: boolean; }
 >x12 : number
 >5 : 5
->y12 : true
+>y12 : boolean
 >true : true
 
 var [x13, y13] = [1, "hello"];

--- a/tests/baselines/reference/declarationsAndAssignments.errors.txt
+++ b/tests/baselines/reference/declarationsAndAssignments.errors.txt
@@ -17,7 +17,7 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(73,11): 
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(73,14): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(74,11): error TS2339: Property 'a' does not exist on type 'undefined[]'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(74,14): error TS2339: Property 'b' does not exist on type 'undefined[]'.
-tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(106,17): error TS2741: Property 'x' is missing in type '{ y: false; }' but required in type '{ x: any; y?: boolean; }'.
+tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(106,17): error TS2741: Property 'x' is missing in type '{ y: boolean; }' but required in type '{ x: any; y?: boolean; }'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,6): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): error TS2322: Type 'number' is not assignable to type 'string'.
 
@@ -169,7 +169,7 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): 
     f14([2, ["abc", { x: 0 }]]);
     f14([2, ["abc", { y: false }]]);  // Error, no x
                     ~~~~~~~~~~~~
-!!! error TS2741: Property 'x' is missing in type '{ y: false; }' but required in type '{ x: any; y?: boolean; }'.
+!!! error TS2741: Property 'x' is missing in type '{ y: boolean; }' but required in type '{ x: any; y?: boolean; }'.
     
     module M {
         export var [a, b] = [1, 2];

--- a/tests/baselines/reference/declarationsAndAssignments.symbols
+++ b/tests/baselines/reference/declarationsAndAssignments.symbols
@@ -271,7 +271,7 @@ function f12() {
 >a : Symbol(a, Decl(declarationsAndAssignments.ts, 86, 9), Decl(declarationsAndAssignments.ts, 87, 7))
 >b : Symbol(b, Decl(declarationsAndAssignments.ts, 86, 13), Decl(declarationsAndAssignments.ts, 88, 7))
 >x : Symbol(x, Decl(declarationsAndAssignments.ts, 86, 17), Decl(declarationsAndAssignments.ts, 89, 7))
->y : Symbol(y, Decl(declarationsAndAssignments.ts, 86, 47))
+>y : Symbol(y, Decl(declarationsAndAssignments.ts, 86, 84))
 >c : Symbol(c, Decl(declarationsAndAssignments.ts, 86, 20), Decl(declarationsAndAssignments.ts, 90, 7))
 >x : Symbol(x, Decl(declarationsAndAssignments.ts, 86, 40))
 >y : Symbol(y, Decl(declarationsAndAssignments.ts, 86, 47))

--- a/tests/baselines/reference/declarationsAndAssignments.types
+++ b/tests/baselines/reference/declarationsAndAssignments.types
@@ -369,14 +369,14 @@ function f12() {
 >10 : 10
 >y : boolean
 >false : false
->[1, ["hello", { x: 5, y: true }]] : [number, [string, { x: number; y: true; }]]
+>[1, ["hello", { x: 5, y: true }]] : [number, [string, { x: number; y: boolean; }]]
 >1 : 1
->["hello", { x: 5, y: true }] : [string, { x: number; y: true; }]
+>["hello", { x: 5, y: true }] : [string, { x: number; y: boolean; }]
 >"hello" : "hello"
->{ x: 5, y: true } : { x: number; y: true; }
+>{ x: 5, y: true } : { x: number; y: boolean; }
 >x : number
 >5 : 5
->y : true
+>y : boolean
 >true : true
 
     var a: number;
@@ -439,14 +439,14 @@ function f14([a = 1, [b = "hello", { x, y: c = false }]]) {
 f14([2, ["abc", { x: 0, y: true }]]);
 >f14([2, ["abc", { x: 0, y: true }]]) : void
 >f14 : ([a, [b, { x, y: c }]]: [number, [string, { x: any; y?: boolean; }]]) => void
->[2, ["abc", { x: 0, y: true }]] : [number, [string, { x: number; y: true; }]]
+>[2, ["abc", { x: 0, y: true }]] : [number, [string, { x: number; y: boolean; }]]
 >2 : 2
->["abc", { x: 0, y: true }] : [string, { x: number; y: true; }]
+>["abc", { x: 0, y: true }] : [string, { x: number; y: boolean; }]
 >"abc" : "abc"
->{ x: 0, y: true } : { x: number; y: true; }
+>{ x: 0, y: true } : { x: number; y: boolean; }
 >x : number
 >0 : 0
->y : true
+>y : boolean
 >true : true
 
 f14([2, ["abc", { x: 0 }]]);
@@ -463,12 +463,12 @@ f14([2, ["abc", { x: 0 }]]);
 f14([2, ["abc", { y: false }]]);  // Error, no x
 >f14([2, ["abc", { y: false }]]) : void
 >f14 : ([a, [b, { x, y: c }]]: [number, [string, { x: any; y?: boolean; }]]) => void
->[2, ["abc", { y: false }]] : [number, [string, { y: false; }]]
+>[2, ["abc", { y: false }]] : [number, [string, { y: boolean; }]]
 >2 : 2
->["abc", { y: false }] : [string, { y: false; }]
+>["abc", { y: false }] : [string, { y: boolean; }]
 >"abc" : "abc"
->{ y: false } : { y: false; }
->y : false
+>{ y: false } : { y: boolean; }
+>y : boolean
 >false : false
 
 module M {
@@ -540,8 +540,8 @@ f17({ a: "hello" });
 f17({ c: true });
 >f17({ c: true }) : void
 >f17 : ({ a, b, c }: { a?: string; b?: number; c?: boolean; }) => void
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 
 f17(f15());

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.types
@@ -109,7 +109,7 @@ var [[[c3]], [[[[c4]]]]] = [[[]], [[[[]]]]]
 var [[c5], c6]: [[string|number], boolean] = [[1], true];
 >c5 : string | number
 >c6 : boolean
->[[1], true] : [[number], true]
+>[[1], true] : [[number], boolean]
 >[1] : [number]
 >1 : 1
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.types
@@ -109,7 +109,7 @@ var [[[c3]], [[[[c4]]]]] = [[[]], [[[[]]]]]
 var [[c5], c6]: [[string|number], boolean] = [[1], true];
 >c5 : string | number
 >c6 : boolean
->[[1], true] : [[number], true]
+>[[1], true] : [[number], boolean]
 >[1] : [number]
 >1 : 1
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES6.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES6.types
@@ -109,7 +109,7 @@ var [[[c3]], [[[[c4]]]]] = [[[]], [[[[]]]]]
 var [[c5], c6]: [[string|number], boolean] = [[1], true];
 >c5 : string | number
 >c6 : boolean
->[[1], true] : [[number], true]
+>[[1], true] : [[number], boolean]
 >[1] : [number]
 >1 : 1
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.types
@@ -79,10 +79,10 @@ function foo(idx: number): F {
 >idx : number
 
     return {
->{        2: true    } : { 2: true; }
+>{        2: true    } : { 2: boolean; }
 
         2: true
->2 : true
+>2 : boolean
 >true : true
     }
 }

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES5.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES5.types
@@ -67,10 +67,10 @@ function foo(): F {
 >foo : () => F
 
     return {
->{        1: true    } : { 1: true; }
+>{        1: true    } : { 1: boolean; }
 
         1: true
->1 : true
+>1 : boolean
 >true : true
 
     };
@@ -80,10 +80,10 @@ function bar(): F {
 >bar : () => F
 
     return {
->{        2: true    } : { 2: true; }
+>{        2: true    } : { 2: boolean; }
 
         2: true
->2 : true
+>2 : boolean
 >true : true
 
     };

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES6.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES6.types
@@ -67,10 +67,10 @@ function foo(): F {
 >foo : () => F
 
     return {
->{        1: true    } : { 1: true; }
+>{        1: true    } : { 1: boolean; }
 
         1: true
->1 : true
+>1 : boolean
 >true : true
 
     };
@@ -80,10 +80,10 @@ function bar(): F {
 >bar : () => F
 
     return {
->{        2: true    } : { 2: true; }
+>{        2: true    } : { 2: boolean; }
 
         2: true
->2 : true
+>2 : boolean
 >true : true
 
     };

--- a/tests/baselines/reference/destructuringParameterProperties1.types
+++ b/tests/baselines/reference/destructuringParameterProperties1.types
@@ -102,12 +102,12 @@ var c3 = new C3({x: 0, y: "", z: false});
 >c3 : C3
 >new C3({x: 0, y: "", z: false}) : C3
 >C3 : typeof C3
->{x: 0, y: "", z: false} : { x: number; y: string; z: false; }
+>{x: 0, y: "", z: false} : { x: number; y: string; z: boolean; }
 >x : number
 >0 : 0
 >y : string
 >"" : ""
->z : false
+>z : boolean
 >false : false
 
 c3 = new C3({x: 0, "y": "y", z: true});
@@ -115,12 +115,12 @@ c3 = new C3({x: 0, "y": "y", z: true});
 >c3 : C3
 >new C3({x: 0, "y": "y", z: true}) : C3
 >C3 : typeof C3
->{x: 0, "y": "y", z: true} : { x: number; y: string; z: true; }
+>{x: 0, "y": "y", z: true} : { x: number; y: string; z: boolean; }
 >x : number
 >0 : 0
 >"y" : string
 >"y" : "y"
->z : true
+>z : boolean
 >true : true
 
 var [c3_x, c3_y, c3_z] = [c3.x, c3.y, c3.z];

--- a/tests/baselines/reference/destructuringParameterProperties2.types
+++ b/tests/baselines/reference/destructuringParameterProperties2.types
@@ -103,7 +103,7 @@ var y = new C1(10, [0, "", true]);
 >new C1(10, [0, "", true]) : C1
 >C1 : typeof C1
 >10 : 10
->[0, "", true] : [number, string, true]
+>[0, "", true] : [number, string, boolean]
 >0 : 0
 >"" : ""
 >true : true

--- a/tests/baselines/reference/destructuringParameterProperties3.types
+++ b/tests/baselines/reference/destructuringParameterProperties3.types
@@ -75,7 +75,7 @@ var x = new C1(undefined, [0, true, ""]);
 >new C1(undefined, [0, true, ""]) : C1<number, boolean, string>
 >C1 : typeof C1
 >undefined : undefined
->[0, true, ""] : [number, true, string]
+>[0, true, ""] : [number, boolean, string]
 >0 : 0
 >true : true
 >"" : ""
@@ -103,7 +103,7 @@ var y = new C1(10, [0, true, true]);
 >new C1(10, [0, true, true]) : C1<number, boolean, boolean>
 >C1 : typeof C1
 >10 : 10
->[0, true, true] : [number, true, true]
+>[0, true, true] : [number, boolean, boolean]
 >0 : 0
 >true : true
 >true : true

--- a/tests/baselines/reference/destructuringParameterProperties5.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties5.errors.txt
@@ -7,7 +7,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,51): error TS2339: Property 'x3' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,62): error TS2339: Property 'y' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,72): error TS2339: Property 'z' does not exist on type 'C1'.
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,19): error TS2322: Type '{ x1: number; x2: string; x3: true; }' is not assignable to type 'ObjType1'.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,19): error TS2322: Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type 'ObjType1'.
   Object literal may only specify known properties, and 'x1' does not exist in type 'ObjType1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,47): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,51): error TS2322: Type 'boolean' is not assignable to type 'string'.
@@ -49,7 +49,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(1
     
     var a = new C1([{ x1: 10, x2: "", x3: true }, "", false]);
                       ~~~~~~
-!!! error TS2322: Type '{ x1: number; x2: string; x3: true; }' is not assignable to type 'ObjType1'.
+!!! error TS2322: Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type 'ObjType1'.
 !!! error TS2322:   Object literal may only specify known properties, and 'x1' does not exist in type 'ObjType1'.
                                                   ~~
 !!! error TS2322: Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [["hello"]], true];
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [["hello"]], true] : [number, [[string]], true]
+>[1, [["hello"]], true] : [number, [[string]], boolean]
 >1 : 1
 >[["hello"]] : [[string]]
 >["hello"] : [string]
@@ -52,11 +52,11 @@ var [b2 = 3, b3 = true, b4 = temp] = [3, false, { t1: false, t2: "hello" }];
 >true : true
 >b4 : { t1: boolean; t2: string; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: "hello" }] : [number, false, { t1: false; t2: string; }]
+>[3, false, { t1: false, t2: "hello" }] : [number, boolean, { t1: boolean; t2: string; }]
 >3 : 3
 >false : false
->{ t1: false, t2: "hello" } : { t1: false; t2: string; }
->t1 : false
+>{ t1: false, t2: "hello" } : { t1: boolean; t2: string; }
+>t1 : boolean
 >false : false
 >t2 : string
 >"hello" : "hello"

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [["hello"]], true];
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [["hello"]], true] : [number, [[string]], true]
+>[1, [["hello"]], true] : [number, [[string]], boolean]
 >1 : 1
 >[["hello"]] : [[string]]
 >["hello"] : [string]
@@ -52,11 +52,11 @@ var [b2 = 3, b3 = true, b4 = temp] = [3, false, { t1: false, t2: "hello" }];
 >true : true
 >b4 : { t1: boolean; t2: string; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: "hello" }] : [number, false, { t1: false; t2: string; }]
+>[3, false, { t1: false, t2: "hello" }] : [number, boolean, { t1: boolean; t2: string; }]
 >3 : 3
 >false : false
->{ t1: false, t2: "hello" } : { t1: false; t2: string; }
->t1 : false
+>{ t1: false, t2: "hello" } : { t1: boolean; t2: string; }
+>t1 : boolean
 >false : false
 >t2 : string
 >"hello" : "hello"

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES6.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES6.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [["hello"]], true];
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [["hello"]], true] : [number, [[string]], true]
+>[1, [["hello"]], true] : [number, [[string]], boolean]
 >1 : 1
 >[["hello"]] : [[string]]
 >["hello"] : [string]
@@ -52,11 +52,11 @@ var [b2 = 3, b3 = true, b4 = temp] = [3, false, { t1: false, t2: "hello" }];
 >true : true
 >b4 : { t1: boolean; t2: string; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: "hello" }] : [number, false, { t1: false; t2: string; }]
+>[3, false, { t1: false, t2: "hello" }] : [number, boolean, { t1: boolean; t2: string; }]
 >3 : 3
 >false : false
->{ t1: false, t2: "hello" } : { t1: false; t2: string; }
->t1 : false
+>{ t1: false, t2: "hello" } : { t1: boolean; t2: string; }
+>t1 : boolean
 >false : false
 >t2 : string
 >"hello" : "hello"

--- a/tests/baselines/reference/destructuringVariableDeclaration2.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration2.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [[false]], true];  // 
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [[false]], true] : [number, [[boolean]], true]
+>[1, [[false]], true] : [number, [[boolean]], boolean]
 >1 : 1
 >[[false]] : [[boolean]]
 >[false] : [boolean]
@@ -38,13 +38,13 @@ var [b0 = 3, b1 = true, b2 = temp] = [3, false, { t1: false, t2: 5}];  // Error
 >3 : 3
 >b1 : boolean
 >true : true
->b2 : { t1: boolean; t2: string; } | { t1: false; t2: number; }
+>b2 : { t1: boolean; t2: string; } | { t1: boolean; t2: number; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: 5}] : [number, false, { t1: false; t2: number; }]
+>[3, false, { t1: false, t2: 5}] : [number, boolean, { t1: boolean; t2: number; }]
 >3 : 3
 >false : false
->{ t1: false, t2: 5} : { t1: false; t2: number; }
->t1 : false
+>{ t1: false, t2: 5} : { t1: boolean; t2: number; }
+>t1 : boolean
 >false : false
 >t2 : number
 >5 : 5

--- a/tests/baselines/reference/disallowLineTerminatorBeforeArrow.types
+++ b/tests/baselines/reference/disallowLineTerminatorBeforeArrow.types
@@ -150,7 +150,7 @@ function foo(func: () => boolean) { }
 foo(()
 >foo(()    => true) : void
 >foo : (func: () => boolean) => void
->()    => true : () => true
+>()    => true : () => boolean
 
     => true);
 >true : true
@@ -158,7 +158,7 @@ foo(()
 foo(()
 >foo(()    => { return false; }) : void
 >foo : (func: () => boolean) => void
->()    => { return false; } : () => false
+>()    => { return false; } : () => boolean
 
     => { return false; });
 >false : false

--- a/tests/baselines/reference/duplicateLocalVariable1.types
+++ b/tests/baselines/reference/duplicateLocalVariable1.types
@@ -221,7 +221,7 @@ export var tests: TestRunner = (function () {
 >new TestCase("Basic test", function () { return true; }) : TestCase
 >TestCase : typeof TestCase
 >"Basic test" : "Basic test"
->function () { return true; } : () => true
+>function () { return true; } : () => boolean
 >true : true
 
     testRunner.addTest(new TestCase("Test for any error", function () { throw new Error(); return false; }, ""));
@@ -232,7 +232,7 @@ export var tests: TestRunner = (function () {
 >new TestCase("Test for any error", function () { throw new Error(); return false; }, "") : TestCase
 >TestCase : typeof TestCase
 >"Test for any error" : "Test for any error"
->function () { throw new Error(); return false; } : () => false
+>function () { throw new Error(); return false; } : () => boolean
 >new Error() : Error
 >Error : ErrorConstructor
 >false : false
@@ -246,7 +246,7 @@ export var tests: TestRunner = (function () {
 >new TestCase("Test RegEx error message match", function () { throw new Error("Should also pass"); return false; }, "Should [also]+ pass") : TestCase
 >TestCase : typeof TestCase
 >"Test RegEx error message match" : "Test RegEx error message match"
->function () { throw new Error("Should also pass"); return false; } : () => false
+>function () { throw new Error("Should also pass"); return false; } : () => boolean
 >new Error("Should also pass") : Error
 >Error : ErrorConstructor
 >"Should also pass" : "Should also pass"
@@ -1095,7 +1095,7 @@ export var tests: TestRunner = (function () {
 >"Check saving a file" : "Check saving a file"
 
         function () {
->function () {            var filename = TestFileDir + "\\tmpUTF16LE.txt";            var fb = new FileManager.FileBuffer(14);            fb.writeUtf16leBom();            var chars = [0x0054, 0x00E8, 0x1D23, 0x2020, 0x000D, 0x000A];            chars.forEach(function (val) { fb.writeUtf16CodePoint(val, false); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf16le') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xFF, 0xFE, 0x54, 0x00, 0xE8, 0x00, 0x23, 0x1D, 0x20, 0x20, 0x0D, 0x00, 0x0A, 0x00]            savedFile.index = 0;            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\tmpUTF16LE.txt";            var fb = new FileManager.FileBuffer(14);            fb.writeUtf16leBom();            var chars = [0x0054, 0x00E8, 0x1D23, 0x2020, 0x000D, 0x000A];            chars.forEach(function (val) { fb.writeUtf16CodePoint(val, false); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf16le') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xFF, 0xFE, 0x54, 0x00, 0xE8, 0x00, 0x23, 0x1D, 0x20, 0x20, 0x0D, 0x00, 0x0A, 0x00]            savedFile.index = 0;            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\tmpUTF16LE.txt";
 >filename : string
@@ -1234,7 +1234,7 @@ export var tests: TestRunner = (function () {
 >"Check reading past buffer asserts" : "Check reading past buffer asserts"
 
     function () {
->function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        var result = fb.readByte(200);        return true;    } : () => true
+>function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        var result = fb.readByte(200);        return true;    } : () => boolean
 
         var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");
 >fb : any
@@ -1270,7 +1270,7 @@ export var tests: TestRunner = (function () {
 >"Check writing past buffer asserts" : "Check writing past buffer asserts"
 
     function () {
->function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        fb.writeByte(5, 200);        return true;    } : () => true
+>function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        fb.writeByte(5, 200);        return true;    } : () => boolean
 
         var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");
 >fb : any
@@ -1464,7 +1464,7 @@ export var tests: TestRunner = (function () {
 >"Write non-BMP utf8 chars" : "Write non-BMP utf8 chars"
 
         function () {
->function () {            var filename = TestFileDir + "\\tmpUTF8nonBmp.txt";            var fb = new FileManager.FileBuffer(15);            var chars = [0x10480, 0x10481, 0x10482, 0x54, 0x68, 0x69];            chars.forEach(function (val) { fb.writeUtf8CodePoint(val); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf8') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xF0, 0x90, 0x92, 0x80, 0xF0, 0x90, 0x92, 0x81, 0xF0, 0x90, 0x92, 0x82, 0x54, 0x68, 0x69];            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\tmpUTF8nonBmp.txt";            var fb = new FileManager.FileBuffer(15);            var chars = [0x10480, 0x10481, 0x10482, 0x54, 0x68, 0x69];            chars.forEach(function (val) { fb.writeUtf8CodePoint(val); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf8') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xF0, 0x90, 0x92, 0x80, 0xF0, 0x90, 0x92, 0x81, 0xF0, 0x90, 0x92, 0x82, 0x54, 0x68, 0x69];            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\tmpUTF8nonBmp.txt";
 >filename : string
@@ -1590,7 +1590,7 @@ export var tests: TestRunner = (function () {
 >"Test invalid lead UTF8 byte" : "Test invalid lead UTF8 byte"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf8BadLeadByte.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\utf8BadLeadByte.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\utf8BadLeadByte.txt";
 >filename : string
@@ -1622,7 +1622,7 @@ export var tests: TestRunner = (function () {
 >"Test invalid tail UTF8 byte" : "Test invalid tail UTF8 byte"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf8InvalidTail.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\utf8InvalidTail.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\utf8InvalidTail.txt";
 >filename : string
@@ -1654,7 +1654,7 @@ export var tests: TestRunner = (function () {
 >"Test ANSI fails validation" : "Test ANSI fails validation"
 
         function () {
->function () {            var filename = TestFileDir + "\\ansi.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\ansi.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\ansi.txt";
 >filename : string
@@ -1686,7 +1686,7 @@ export var tests: TestRunner = (function () {
 >"Test UTF-16LE with invalid surrogate trail fails" : "Test UTF-16LE with invalid surrogate trail fails"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf16leInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\utf16leInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\utf16leInvalidSurrogate.txt";
 >filename : string
@@ -1718,7 +1718,7 @@ export var tests: TestRunner = (function () {
 >"Test UTF-16BE with invalid surrogate head fails" : "Test UTF-16BE with invalid surrogate head fails"
 
         function () {
->function () {            var filename = TestFileDir + "\\UTF16BEInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\UTF16BEInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\UTF16BEInvalidSurrogate.txt";
 >filename : string
@@ -1750,7 +1750,7 @@ export var tests: TestRunner = (function () {
 >"Test UTF-16LE with missing trail surrogate fails" : "Test UTF-16LE with missing trail surrogate fails"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf16leMissingTrailSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\utf16leMissingTrailSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\utf16leMissingTrailSurrogate.txt";
 >filename : string
@@ -1842,7 +1842,7 @@ export var tests: TestRunner = (function () {
 >"Test file with control character" : "Test file with control character"
 
         function () {
->function () {            var filename = TestFileDir + "\\controlChar.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\controlChar.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\controlChar.txt";
 >filename : string

--- a/tests/baselines/reference/emitArrowFunction.types
+++ b/tests/baselines/reference/emitArrowFunction.types
@@ -31,12 +31,12 @@ function foo(func: () => boolean) { }
 foo(() => true);
 >foo(() => true) : void
 >foo : (func: () => boolean) => void
->() => true : () => true
+>() => true : () => boolean
 >true : true
 
 foo(() => { return false; });
 >foo(() => { return false; }) : void
 >foo : (func: () => boolean) => void
->() => { return false; } : () => false
+>() => { return false; } : () => boolean
 >false : false
 

--- a/tests/baselines/reference/emitArrowFunctionES6.types
+++ b/tests/baselines/reference/emitArrowFunctionES6.types
@@ -31,13 +31,13 @@ function foo(func: () => boolean) { }
 foo(() => true);
 >foo(() => true) : void
 >foo : (func: () => boolean) => void
->() => true : () => true
+>() => true : () => boolean
 >true : true
 
 foo(() => { return false; });
 >foo(() => { return false; }) : void
 >foo : (func: () => boolean) => void
->() => { return false; } : () => false
+>() => { return false; } : () => boolean
 >false : false
 
 // Binding patterns in arrow functions

--- a/tests/baselines/reference/emitArrowFunctionThisCapturing.types
+++ b/tests/baselines/reference/emitArrowFunctionThisCapturing.types
@@ -32,7 +32,7 @@ function foo(func: () => boolean) { }
 foo(() => {
 >foo(() => {    this.age = 100;    return true;}) : void
 >foo : (func: () => boolean) => void
->() => {    this.age = 100;    return true;} : () => true
+>() => {    this.age = 100;    return true;} : () => boolean
 
     this.age = 100;
 >this.age = 100 : 100

--- a/tests/baselines/reference/emitArrowFunctionThisCapturingES6.types
+++ b/tests/baselines/reference/emitArrowFunctionThisCapturingES6.types
@@ -32,7 +32,7 @@ function foo(func: () => boolean){ }
 foo(() => {
 >foo(() => {    this.age = 100;    return true;}) : void
 >foo : (func: () => boolean) => void
->() => {    this.age = 100;    return true;} : () => true
+>() => {    this.age = 100;    return true;} : () => boolean
 
     this.age = 100;
 >this.age = 100 : 100

--- a/tests/baselines/reference/emitOneLineVariableDeclarationRemoveCommentsFalse.types
+++ b/tests/baselines/reference/emitOneLineVariableDeclarationRemoveCommentsFalse.types
@@ -10,8 +10,8 @@ let b: any = /*[[${something}]]*/ {};
 let c: { hoge: boolean } = /*[[${something}]]*/ { hoge: true };
 >c : { hoge: boolean; }
 >hoge : boolean
->{ hoge: true } : { hoge: true; }
->hoge : true
+>{ hoge: true } : { hoge: boolean; }
+>hoge : boolean
 >true : true
 
 let d: any  /*[[${something}]]*/ = {};

--- a/tests/baselines/reference/ensureNoCrashExportAssignmentDefineProperrtyPotentialMerge.types
+++ b/tests/baselines/reference/ensureNoCrashExportAssignmentDefineProperrtyPotentialMerge.types
@@ -64,10 +64,10 @@ Object.defineProperty(B, "NS", { value: "why though", writable: true });
 >defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
 >B : typeof B
 >"NS" : "NS"
->{ value: "why though", writable: true } : { value: string; writable: true; }
+>{ value: "why though", writable: true } : { value: string; writable: boolean; }
 >value : string
 >"why though" : "why though"
->writable : true
+>writable : boolean
 >true : true
 
 module.exports = B;

--- a/tests/baselines/reference/es2018ObjectAssign.types
+++ b/tests/baselines/reference/es2018ObjectAssign.types
@@ -6,8 +6,8 @@ const test = Object.assign({}, { test: true });
 >Object : ObjectConstructor
 >assign : { <T extends {}, U>(target: T, source: U): T & U; <T extends {}, U, V>(target: T, source1: U, source2: V): T & U & V; <T extends {}, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W; (target: object, ...sources: any[]): any; }
 >{} : {}
->{ test: true } : { test: true; }
->test : true
+>{ test: true } : { test: boolean; }
+>test : boolean
 >true : true
 
 declare const p: Promise<number>;

--- a/tests/baselines/reference/esNextWeakRefs_IterableWeakMap.types
+++ b/tests/baselines/reference/esNextWeakRefs_IterableWeakMap.types
@@ -313,25 +313,25 @@ Object.defineProperties(IterableWeakMap.prototype, {
 >IterableWeakMap.prototype : IterableWeakMap<any, any>
 >IterableWeakMap : typeof IterableWeakMap
 >prototype : IterableWeakMap<any, any>
->{    [Symbol.iterator]: {        configurable: true,        enumerable: false,        writable: true,        value: Object.getOwnPropertyDescriptor(            IterableWeakMap.prototype,            "entries",        )!.value,    },    [Symbol.toStringTag]: {        configurable: true,        enumerable: false,        writable: false,        value: "IterableWeakMap",    },} : { [Symbol.iterator]: { configurable: true; enumerable: false; writable: true; value: any; }; [Symbol.toStringTag]: { configurable: true; enumerable: false; writable: false; value: string; }; }
+>{    [Symbol.iterator]: {        configurable: true,        enumerable: false,        writable: true,        value: Object.getOwnPropertyDescriptor(            IterableWeakMap.prototype,            "entries",        )!.value,    },    [Symbol.toStringTag]: {        configurable: true,        enumerable: false,        writable: false,        value: "IterableWeakMap",    },} : { [Symbol.iterator]: { configurable: boolean; enumerable: boolean; writable: boolean; value: any; }; [Symbol.toStringTag]: { configurable: boolean; enumerable: boolean; writable: boolean; value: string; }; }
 
     [Symbol.iterator]: {
->[Symbol.iterator] : { configurable: true; enumerable: false; writable: true; value: any; }
+>[Symbol.iterator] : { configurable: boolean; enumerable: boolean; writable: boolean; value: any; }
 >Symbol.iterator : unique symbol
 >Symbol : SymbolConstructor
 >iterator : unique symbol
->{        configurable: true,        enumerable: false,        writable: true,        value: Object.getOwnPropertyDescriptor(            IterableWeakMap.prototype,            "entries",        )!.value,    } : { configurable: true; enumerable: false; writable: true; value: any; }
+>{        configurable: true,        enumerable: false,        writable: true,        value: Object.getOwnPropertyDescriptor(            IterableWeakMap.prototype,            "entries",        )!.value,    } : { configurable: boolean; enumerable: boolean; writable: boolean; value: any; }
 
         configurable: true,
->configurable : true
+>configurable : boolean
 >true : true
 
         enumerable: false,
->enumerable : false
+>enumerable : boolean
 >false : false
 
         writable: true,
->writable : true
+>writable : boolean
 >true : true
 
         value: Object.getOwnPropertyDescriptor(
@@ -356,22 +356,22 @@ Object.defineProperties(IterableWeakMap.prototype, {
 
     },
     [Symbol.toStringTag]: {
->[Symbol.toStringTag] : { configurable: true; enumerable: false; writable: false; value: string; }
+>[Symbol.toStringTag] : { configurable: boolean; enumerable: boolean; writable: boolean; value: string; }
 >Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
 >toStringTag : unique symbol
->{        configurable: true,        enumerable: false,        writable: false,        value: "IterableWeakMap",    } : { configurable: true; enumerable: false; writable: false; value: string; }
+>{        configurable: true,        enumerable: false,        writable: false,        value: "IterableWeakMap",    } : { configurable: boolean; enumerable: boolean; writable: boolean; value: string; }
 
         configurable: true,
->configurable : true
+>configurable : boolean
 >true : true
 
         enumerable: false,
->enumerable : false
+>enumerable : boolean
 >false : false
 
         writable: false,
->writable : false
+>writable : boolean
 >false : false
 
         value: "IterableWeakMap",

--- a/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.errors.txt
+++ b/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.errors.txt
@@ -1,12 +1,14 @@
 tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(30,5): error TS2322: Type '{ type: "number"; value: number; multipleOf: number; format: string; }' is not assignable to type 'Primitive'.
   Object literal may only specify known properties, and 'multipleOf' does not exist in type 'Float'.
-tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(41,5): error TS2322: Type '{ p1: "left"; p2: false; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
+tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(41,5): error TS2322: Type '{ p1: "left"; p2: boolean; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
+  Object literal may only specify known properties, and 'p3' does not exist in type '{ p1: "left"; p2: boolean; }'.
+tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(49,5): error TS2322: Type '{ p1: "left"; p2: boolean; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
   Object literal may only specify known properties, and 'p3' does not exist in type '{ p1: "left"; p2: boolean; }'.
 tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(57,5): error TS2322: Type '{ p1: "right"; p2: false; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
   Object literal may only specify known properties, and 'p3' does not exist in type '{ p1: "right"; p2: false; p4: string; }'.
 
 
-==== tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts (3 errors) ====
+==== tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts (4 errors) ====
     // Repro from #32657
     
     interface Base<T> {
@@ -52,7 +54,7 @@ tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(57,5): erro
         p2: false,
         p3: 42,
         ~~~~~~
-!!! error TS2322: Type '{ p1: "left"; p2: false; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
+!!! error TS2322: Type '{ p1: "left"; p2: boolean; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
 !!! error TS2322:   Object literal may only specify known properties, and 'p3' does not exist in type '{ p1: "left"; p2: boolean; }'.
         p4: "hello"
     };
@@ -62,6 +64,9 @@ tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(57,5): erro
         p1: 'left',
         p2: true,
         p3: 42,
+        ~~~~~~
+!!! error TS2322: Type '{ p1: "left"; p2: boolean; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
+!!! error TS2322:   Object literal may only specify known properties, and 'p3' does not exist in type '{ p1: "left"; p2: boolean; }'.
         p4: "hello"
     };
     

--- a/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.errors.txt
+++ b/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.errors.txt
@@ -4,7 +4,7 @@ tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(41,5): erro
   Object literal may only specify known properties, and 'p3' does not exist in type '{ p1: "left"; p2: boolean; }'.
 tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(49,5): error TS2322: Type '{ p1: "left"; p2: boolean; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
   Object literal may only specify known properties, and 'p3' does not exist in type '{ p1: "left"; p2: boolean; }'.
-tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(57,5): error TS2322: Type '{ p1: "right"; p2: false; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
+tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(65,5): error TS2322: Type '{ p1: "right"; p2: false; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
   Object literal may only specify known properties, and 'p3' does not exist in type '{ p1: "right"; p2: false; p4: string; }'.
 
 
@@ -59,14 +59,22 @@ tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts(57,5): erro
         p4: "hello"
     };
     
-    // This has no excess error because variant one and three are both applicable.
-    const b: DisjointDiscriminants = {
+    // This has excess error because variant three is the only applicable case.
+    const b1: DisjointDiscriminants = {
         p1: 'left',
         p2: true,
         p3: 42,
         ~~~~~~
 !!! error TS2322: Type '{ p1: "left"; p2: boolean; p3: number; p4: string; }' is not assignable to type 'DisjointDiscriminants'.
 !!! error TS2322:   Object literal may only specify known properties, and 'p3' does not exist in type '{ p1: "left"; p2: boolean; }'.
+        p4: "hello"
+    };
+    
+    // This has no excess error because variant one and three are both applicable.
+    const b2: DisjointDiscriminants = {
+        p1: 'left',
+        p2: true as const,
+        p3: 42,
         p4: "hello"
     };
     

--- a/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.js
+++ b/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.js
@@ -43,10 +43,18 @@ const a: DisjointDiscriminants = {
     p4: "hello"
 };
 
-// This has no excess error because variant one and three are both applicable.
-const b: DisjointDiscriminants = {
+// This has excess error because variant three is the only applicable case.
+const b1: DisjointDiscriminants = {
     p1: 'left',
     p2: true,
+    p3: 42,
+    p4: "hello"
+};
+
+// This has no excess error because variant one and three are both applicable.
+const b2: DisjointDiscriminants = {
+    p1: 'left',
+    p2: true as const,
     p3: 42,
     p4: "hello"
 };
@@ -75,8 +83,15 @@ var a = {
     p3: 42,
     p4: "hello"
 };
+// This has excess error because variant three is the only applicable case.
+var b1 = {
+    p1: 'left',
+    p2: true,
+    p3: 42,
+    p4: "hello"
+};
 // This has no excess error because variant one and three are both applicable.
-var b = {
+var b2 = {
     p1: 'left',
     p2: true,
     p3: 42,

--- a/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.symbols
+++ b/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.symbols
@@ -103,13 +103,13 @@ const a: DisjointDiscriminants = {
 
 };
 
-// This has no excess error because variant one and three are both applicable.
-const b: DisjointDiscriminants = {
->b : Symbol(b, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 45, 5))
+// This has excess error because variant three is the only applicable case.
+const b1: DisjointDiscriminants = {
+>b1 : Symbol(b1, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 45, 5))
 >DisjointDiscriminants : Symbol(DisjointDiscriminants, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 31, 1))
 
     p1: 'left',
->p1 : Symbol(p1, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 45, 34))
+>p1 : Symbol(p1, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 45, 35))
 
     p2: true,
 >p2 : Symbol(p2, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 46, 15))
@@ -122,22 +122,42 @@ const b: DisjointDiscriminants = {
 
 };
 
-// This has excess error because variant two is the only applicable case
-const c: DisjointDiscriminants = {
->c : Symbol(c, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 53, 5))
+// This has no excess error because variant one and three are both applicable.
+const b2: DisjointDiscriminants = {
+>b2 : Symbol(b2, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 53, 5))
 >DisjointDiscriminants : Symbol(DisjointDiscriminants, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 31, 1))
 
-    p1: 'right',
->p1 : Symbol(p1, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 53, 34))
+    p1: 'left',
+>p1 : Symbol(p1, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 53, 35))
 
-    p2: false,
->p2 : Symbol(p2, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 54, 16))
+    p2: true as const,
+>p2 : Symbol(p2, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 54, 15))
+>const : Symbol(const)
 
     p3: 42,
->p3 : Symbol(p3, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 55, 14))
+>p3 : Symbol(p3, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 55, 22))
 
     p4: "hello"
 >p4 : Symbol(p4, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 56, 11))
+
+};
+
+// This has excess error because variant two is the only applicable case
+const c: DisjointDiscriminants = {
+>c : Symbol(c, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 61, 5))
+>DisjointDiscriminants : Symbol(DisjointDiscriminants, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 31, 1))
+
+    p1: 'right',
+>p1 : Symbol(p1, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 61, 34))
+
+    p2: false,
+>p2 : Symbol(p2, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 62, 16))
+
+    p3: 42,
+>p3 : Symbol(p3, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 63, 14))
+
+    p4: "hello"
+>p4 : Symbol(p4, Decl(excessPropertyCheckWithMultipleDiscriminants.ts, 64, 11))
 
 };
 

--- a/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.types
+++ b/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.types
@@ -73,14 +73,14 @@ type DisjointDiscriminants = { p1: 'left'; p2: true; p3: number } | { p1: 'right
 // This has excess error because variant three is the only applicable case.
 const a: DisjointDiscriminants = {
 >a : DisjointDiscriminants
->{    p1: 'left',    p2: false,    p3: 42,    p4: "hello"} : { p1: "left"; p2: false; p3: number; p4: string; }
+>{    p1: 'left',    p2: false,    p3: 42,    p4: "hello"} : { p1: "left"; p2: boolean; p3: number; p4: string; }
 
     p1: 'left',
 >p1 : "left"
 >'left' : "left"
 
     p2: false,
->p2 : false
+>p2 : boolean
 >false : false
 
     p3: 42,
@@ -96,14 +96,14 @@ const a: DisjointDiscriminants = {
 // This has no excess error because variant one and three are both applicable.
 const b: DisjointDiscriminants = {
 >b : DisjointDiscriminants
->{    p1: 'left',    p2: true,    p3: 42,    p4: "hello"} : { p1: "left"; p2: true; p3: number; p4: string; }
+>{    p1: 'left',    p2: true,    p3: 42,    p4: "hello"} : { p1: "left"; p2: boolean; p3: number; p4: string; }
 
     p1: 'left',
 >p1 : "left"
 >'left' : "left"
 
     p2: true,
->p2 : true
+>p2 : boolean
 >true : true
 
     p3: 42,

--- a/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.types
+++ b/tests/baselines/reference/excessPropertyCheckWithMultipleDiscriminants.types
@@ -93,9 +93,9 @@ const a: DisjointDiscriminants = {
 
 };
 
-// This has no excess error because variant one and three are both applicable.
-const b: DisjointDiscriminants = {
->b : DisjointDiscriminants
+// This has excess error because variant three is the only applicable case.
+const b1: DisjointDiscriminants = {
+>b1 : DisjointDiscriminants
 >{    p1: 'left',    p2: true,    p3: 42,    p4: "hello"} : { p1: "left"; p2: boolean; p3: number; p4: string; }
 
     p1: 'left',
@@ -104,6 +104,30 @@ const b: DisjointDiscriminants = {
 
     p2: true,
 >p2 : boolean
+>true : true
+
+    p3: 42,
+>p3 : number
+>42 : 42
+
+    p4: "hello"
+>p4 : string
+>"hello" : "hello"
+
+};
+
+// This has no excess error because variant one and three are both applicable.
+const b2: DisjointDiscriminants = {
+>b2 : DisjointDiscriminants
+>{    p1: 'left',    p2: true as const,    p3: 42,    p4: "hello"} : { p1: "left"; p2: true; p3: number; p4: string; }
+
+    p1: 'left',
+>p1 : "left"
+>'left' : "left"
+
+    p2: true as const,
+>p2 : true
+>true as const : true
 >true : true
 
     p3: 42,

--- a/tests/baselines/reference/excessPropertyCheckWithUnions.errors.txt
+++ b/tests/baselines/reference/excessPropertyCheckWithUnions.errors.txt
@@ -12,8 +12,8 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(39,1): error TS2322: Type 
   Type '{ tag: "A"; }' is not assignable to type '{ tag: "C"; }'.
     Types of property 'tag' are incompatible.
       Type '"A"' is not assignable to type '"C"'.
-tests/cases/compiler/excessPropertyCheckWithUnions.ts(40,1): error TS2322: Type '{ tag: "A"; z: true; }' is not assignable to type 'Ambiguous'.
-  Type '{ tag: "A"; z: true; }' is not assignable to type '{ tag: "B"; z: boolean; }'.
+tests/cases/compiler/excessPropertyCheckWithUnions.ts(40,1): error TS2322: Type '{ tag: "A"; z: boolean; }' is not assignable to type 'Ambiguous'.
+  Type '{ tag: "A"; z: boolean; }' is not assignable to type '{ tag: "B"; z: boolean; }'.
     Types of property 'tag' are incompatible.
       Type '"A"' is not assignable to type '"B"'.
 tests/cases/compiler/excessPropertyCheckWithUnions.ts(49,35): error TS2322: Type '{ a: 1; b: 1; first: string; second: string; }' is not assignable to type 'Overlapping'.
@@ -94,8 +94,8 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(114,63): error TS2322: Typ
 !!! error TS2322:       Type '"A"' is not assignable to type '"C"'.
     amb = { tag: "A", z: true }
     ~~~
-!!! error TS2322: Type '{ tag: "A"; z: true; }' is not assignable to type 'Ambiguous'.
-!!! error TS2322:   Type '{ tag: "A"; z: true; }' is not assignable to type '{ tag: "B"; z: boolean; }'.
+!!! error TS2322: Type '{ tag: "A"; z: boolean; }' is not assignable to type 'Ambiguous'.
+!!! error TS2322:   Type '{ tag: "A"; z: boolean; }' is not assignable to type '{ tag: "B"; z: boolean; }'.
 !!! error TS2322:     Types of property 'tag' are incompatible.
 !!! error TS2322:       Type '"A"' is not assignable to type '"B"'.
     

--- a/tests/baselines/reference/excessPropertyCheckWithUnions.types
+++ b/tests/baselines/reference/excessPropertyCheckWithUnions.types
@@ -137,12 +137,12 @@ amb = { tag: "A" }
 >"A" : "A"
 
 amb = { tag: "A", z: true }
->amb = { tag: "A", z: true } : { tag: "A"; z: true; }
+>amb = { tag: "A", z: true } : { tag: "A"; z: boolean; }
 >amb : Ambiguous
->{ tag: "A", z: true } : { tag: "A"; z: true; }
+>{ tag: "A", z: true } : { tag: "A"; z: boolean; }
 >tag : "A"
 >"A" : "A"
->z : true
+>z : boolean
 >true : true
 
 type Overlapping =

--- a/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.errors.txt
+++ b/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.errors.txt
@@ -8,9 +8,9 @@ tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(34,5): error
   Object literal may only specify known properties, and 'xyz' does not exist in type '{ id: number; } & { url: string; }'.
 tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(43,9): error TS2322: Type '{ id: number; url: string; xyz: number; }' is not assignable to type '{ id: number; } & { url: string; }'.
   Object literal may only specify known properties, and 'xyz' does not exist in type '{ id: number; } & { url: string; }'.
-tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(68,32): error TS2322: Type '{ foo: true; bar: true; boo: boolean; }' is not assignable to type 'View<TypeA>'.
+tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(68,32): error TS2322: Type '{ foo: boolean; bar: boolean; boo: boolean; }' is not assignable to type 'View<TypeA>'.
   Object literal may only specify known properties, and 'boo' does not exist in type 'View<TypeA>'.
-tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(70,50): error TS2322: Type '{ foo: true; bar: true; boo: true; }' is not assignable to type 'boolean | View<TypeB>'.
+tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(70,50): error TS2322: Type '{ foo: boolean; bar: boolean; boo: boolean; }' is not assignable to type 'boolean | View<TypeB>'.
   Object literal may only specify known properties, and 'boo' does not exist in type 'View<TypeB>'.
 
 
@@ -105,12 +105,12 @@ tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(70,50): erro
     
     test = { foo: true, bar: true, boo: true }
                                    ~~~~~~~~~
-!!! error TS2322: Type '{ foo: true; bar: true; boo: boolean; }' is not assignable to type 'View<TypeA>'.
+!!! error TS2322: Type '{ foo: boolean; bar: boolean; boo: boolean; }' is not assignable to type 'View<TypeA>'.
 !!! error TS2322:   Object literal may only specify known properties, and 'boo' does not exist in type 'View<TypeA>'.
     
     test = { foo: true, bar: { foo: true, bar: true, boo: true } }
                                                      ~~~~~~~~~
-!!! error TS2322: Type '{ foo: true; bar: true; boo: true; }' is not assignable to type 'boolean | View<TypeB>'.
+!!! error TS2322: Type '{ foo: boolean; bar: boolean; boo: boolean; }' is not assignable to type 'boolean | View<TypeB>'.
 !!! error TS2322:   Object literal may only specify known properties, and 'boo' does not exist in type 'View<TypeB>'.
 !!! related TS6500 tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts:63:5: The expected type comes from property 'bar' which is declared here on type 'View<TypeA>'
     

--- a/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.types
+++ b/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.types
@@ -174,27 +174,27 @@ let test: View<TypeA>;
 >test : View<TypeA>
 
 test = { foo: true, bar: true, boo: true }
->test = { foo: true, bar: true, boo: true } : { foo: true; bar: true; boo: boolean; }
+>test = { foo: true, bar: true, boo: true } : { foo: boolean; bar: boolean; boo: boolean; }
 >test : View<TypeA>
->{ foo: true, bar: true, boo: true } : { foo: true; bar: true; boo: boolean; }
->foo : true
+>{ foo: true, bar: true, boo: true } : { foo: boolean; bar: boolean; boo: boolean; }
+>foo : boolean
 >true : true
->bar : true
+>bar : boolean
 >true : true
 >boo : boolean
 >true : true
 
 test = { foo: true, bar: { foo: true, bar: true, boo: true } }
->test = { foo: true, bar: { foo: true, bar: true, boo: true } } : { foo: true; bar: { foo: true; bar: true; boo: boolean; }; }
+>test = { foo: true, bar: { foo: true, bar: true, boo: true } } : { foo: boolean; bar: { foo: boolean; bar: boolean; boo: boolean; }; }
 >test : View<TypeA>
->{ foo: true, bar: { foo: true, bar: true, boo: true } } : { foo: true; bar: { foo: true; bar: true; boo: boolean; }; }
->foo : true
+>{ foo: true, bar: { foo: true, bar: true, boo: true } } : { foo: boolean; bar: { foo: boolean; bar: boolean; boo: boolean; }; }
+>foo : boolean
 >true : true
->bar : { foo: true; bar: true; boo: boolean; }
->{ foo: true, bar: true, boo: true } : { foo: true; bar: true; boo: boolean; }
->foo : true
+>bar : { foo: boolean; bar: boolean; boo: boolean; }
+>{ foo: true, bar: true, boo: true } : { foo: boolean; bar: boolean; boo: boolean; }
+>foo : boolean
 >true : true
->bar : true
+>bar : boolean
 >true : true
 >boo : boolean
 >true : true

--- a/tests/baselines/reference/for-of36.types
+++ b/tests/baselines/reference/for-of36.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of36.ts ===
 var tuple: [string, boolean] = ["", true];
 >tuple : [string, boolean]
->["", true] : [string, true]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of37.types
+++ b/tests/baselines/reference/for-of37.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of38.types
+++ b/tests/baselines/reference/for-of38.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of39.errors.txt
+++ b/tests/baselines/reference/for-of39.errors.txt
@@ -1,11 +1,11 @@
 tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,11): error TS2769: No overload matches this call.
   Overload 1 of 4, '(iterable?: Iterable<readonly [string, boolean]>): Map<string, boolean>', gave the following error.
-    Argument of type '([string, number] | [string, true])[]' is not assignable to parameter of type 'Iterable<readonly [string, boolean]>'.
+    Argument of type '([string, boolean] | [string, number])[]' is not assignable to parameter of type 'Iterable<readonly [string, boolean]>'.
       The types returned by '[Symbol.iterator]().next(...)' are incompatible between these types.
-        Type 'IteratorResult<[string, number] | [string, true], any>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
-          Type 'IteratorYieldResult<[string, number] | [string, true]>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
-            Type 'IteratorYieldResult<[string, number] | [string, true]>' is not assignable to type 'IteratorYieldResult<readonly [string, boolean]>'.
-              Type '[string, number] | [string, true]' is not assignable to type 'readonly [string, boolean]'.
+        Type 'IteratorResult<[string, boolean] | [string, number], any>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
+          Type 'IteratorYieldResult<[string, boolean] | [string, number]>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
+            Type 'IteratorYieldResult<[string, boolean] | [string, number]>' is not assignable to type 'IteratorYieldResult<readonly [string, boolean]>'.
+              Type '[string, boolean] | [string, number]' is not assignable to type 'readonly [string, boolean]'.
                 Type '[string, number]' is not assignable to type 'readonly [string, boolean]'.
                   Type at position 1 in source is not compatible with type at position 1 in target.
                     Type 'number' is not assignable to type 'boolean'.
@@ -18,12 +18,12 @@ tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,11): error TS2769: No
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 4, '(iterable?: Iterable<readonly [string, boolean]>): Map<string, boolean>', gave the following error.
-!!! error TS2769:     Argument of type '([string, number] | [string, true])[]' is not assignable to parameter of type 'Iterable<readonly [string, boolean]>'.
+!!! error TS2769:     Argument of type '([string, boolean] | [string, number])[]' is not assignable to parameter of type 'Iterable<readonly [string, boolean]>'.
 !!! error TS2769:       The types returned by '[Symbol.iterator]().next(...)' are incompatible between these types.
-!!! error TS2769:         Type 'IteratorResult<[string, number] | [string, true], any>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
-!!! error TS2769:           Type 'IteratorYieldResult<[string, number] | [string, true]>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
-!!! error TS2769:             Type 'IteratorYieldResult<[string, number] | [string, true]>' is not assignable to type 'IteratorYieldResult<readonly [string, boolean]>'.
-!!! error TS2769:               Type '[string, number] | [string, true]' is not assignable to type 'readonly [string, boolean]'.
+!!! error TS2769:         Type 'IteratorResult<[string, boolean] | [string, number], any>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
+!!! error TS2769:           Type 'IteratorYieldResult<[string, boolean] | [string, number]>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
+!!! error TS2769:             Type 'IteratorYieldResult<[string, boolean] | [string, number]>' is not assignable to type 'IteratorYieldResult<readonly [string, boolean]>'.
+!!! error TS2769:               Type '[string, boolean] | [string, number]' is not assignable to type 'readonly [string, boolean]'.
 !!! error TS2769:                 Type '[string, number]' is not assignable to type 'readonly [string, boolean]'.
 !!! error TS2769:                   Type at position 1 in source is not compatible with type at position 1 in target.
 !!! error TS2769:                     Type 'number' is not assignable to type 'boolean'.

--- a/tests/baselines/reference/for-of39.types
+++ b/tests/baselines/reference/for-of39.types
@@ -3,8 +3,8 @@ var map = new Map([["", true], ["", 0]]);
 >map : Map<string, boolean>
 >new Map([["", true], ["", 0]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true], ["", 0]] : ([string, number] | [string, true])[]
->["", true] : [string, true]
+>[["", true], ["", 0]] : ([string, boolean] | [string, number])[]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 >["", 0] : [string, number]

--- a/tests/baselines/reference/for-of40.types
+++ b/tests/baselines/reference/for-of40.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of44.types
+++ b/tests/baselines/reference/for-of44.types
@@ -1,11 +1,11 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of44.ts ===
 var array: [number, string | boolean | symbol][] = [[0, ""], [0, true], [1, Symbol()]]
 >array : [number, string | boolean | symbol][]
->[[0, ""], [0, true], [1, Symbol()]] : ([number, string] | [number, true] | [number, symbol])[]
+>[[0, ""], [0, true], [1, Symbol()]] : ([number, string] | [number, boolean] | [number, symbol])[]
 >[0, ""] : [number, string]
 >0 : 0
 >"" : ""
->[0, true] : [number, true]
+>[0, true] : [number, boolean]
 >0 : 0
 >true : true
 >[1, Symbol()] : [number, symbol]

--- a/tests/baselines/reference/for-of45.types
+++ b/tests/baselines/reference/for-of45.types
@@ -7,8 +7,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of46.types
+++ b/tests/baselines/reference/for-of46.types
@@ -7,8 +7,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of49.types
+++ b/tests/baselines/reference/for-of49.types
@@ -7,8 +7,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of50.types
+++ b/tests/baselines/reference/for-of50.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/functionOverloads39.types
+++ b/tests/baselines/reference/functionOverloads39.types
@@ -19,8 +19,8 @@ var x = foo([{a:true}]);
 >x : number
 >foo([{a:true}]) : number
 >foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
->[{a:true}] : { a: true; }[]
->{a:true} : { a: true; }
->a : true
+>[{a:true}] : { a: boolean; }[]
+>{a:true} : { a: boolean; }
+>a : boolean
 >true : true
 

--- a/tests/baselines/reference/genericArgumentCallSigAssignmentCompat.types
+++ b/tests/baselines/reference/genericArgumentCallSigAssignmentCompat.types
@@ -31,7 +31,7 @@ _.all([true, 1, null, 'yes'], _.identity);
 >_.all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => boolean
 >_ : Underscore.Static
 >all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => boolean
->[true, 1, null, 'yes'] : (string | number | true)[]
+>[true, 1, null, 'yes'] : (string | number | boolean)[]
 >true : true
 >1 : 1
 >null : null
@@ -46,7 +46,7 @@ _.all([true], _.identity);
 >_.all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => boolean
 >_ : Underscore.Static
 >all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => boolean
->[true] : true[]
+>[true] : boolean[]
 >true : true
 >_.identity : <T>(value: T) => T
 >_ : Underscore.Static

--- a/tests/baselines/reference/genericTypeArgumentInference1.types
+++ b/tests/baselines/reference/genericTypeArgumentInference1.types
@@ -28,7 +28,7 @@ var r = _.all([true, 1, null, 'yes'], _.identity);
 >_.all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => T
 >_ : Underscore.Static
 >all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => T
->[true, 1, null, 'yes'] : (string | number | true)[]
+>[true, 1, null, 'yes'] : (string | number | boolean)[]
 >true : true
 >1 : 1
 >null : null
@@ -43,7 +43,7 @@ var r2 = _.all([true], _.identity);
 >_.all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => T
 >_ : Underscore.Static
 >all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => T
->[true] : true[]
+>[true] : boolean[]
 >true : true
 >_.identity : <T>(value: T) => T
 >_ : Underscore.Static

--- a/tests/baselines/reference/getAndSetAsMemberNames.types
+++ b/tests/baselines/reference/getAndSetAsMemberNames.types
@@ -40,7 +40,7 @@ class C5 {
 
     public set: () => boolean = function () { return true; };
 >set : () => boolean
->function () { return true; } : () => true
+>function () { return true; } : () => boolean
 >true : true
 
     get (): boolean { return true; }

--- a/tests/baselines/reference/getterSetterNonAccessor.types
+++ b/tests/baselines/reference/getterSetterNonAccessor.types
@@ -15,8 +15,8 @@ Object.defineProperty({}, "0", <PropertyDescriptor>({
 >{} : {}
 >"0" : "0"
 ><PropertyDescriptor>({          get: getFunc,          set: setFunc,          configurable: true      }) : PropertyDescriptor
->({          get: getFunc,          set: setFunc,          configurable: true      }) : { get: () => any; set: (v: any) => void; configurable: true; }
->{          get: getFunc,          set: setFunc,          configurable: true      } : { get: () => any; set: (v: any) => void; configurable: true; }
+>({          get: getFunc,          set: setFunc,          configurable: true      }) : { get: () => any; set: (v: any) => void; configurable: boolean; }
+>{          get: getFunc,          set: setFunc,          configurable: true      } : { get: () => any; set: (v: any) => void; configurable: boolean; }
 
           get: getFunc,
 >get : () => any
@@ -27,7 +27,7 @@ Object.defineProperty({}, "0", <PropertyDescriptor>({
 >setFunc : (v: any) => void
 
           configurable: true
->configurable : true
+>configurable : boolean
 >true : true
 
       }));

--- a/tests/baselines/reference/indexerWithTuple.types
+++ b/tests/baselines/reference/indexerWithTuple.types
@@ -21,7 +21,7 @@ var unionTuple1: [number, string| number] = [10, "foo"];
 
 var unionTuple2: [boolean, string| number] = [true, "foo"]; 
 >unionTuple2 : [boolean, string | number]
->[true, "foo"] : [true, string]
+>[true, "foo"] : [boolean, string]
 >true : true
 >"foo" : "foo"
 

--- a/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.errors.txt
+++ b/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.errors.txt
@@ -1,5 +1,4 @@
 tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts(28,30): error TS2345: Argument of type 'string' is not assignable to parameter of type '"bar"'.
-tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts(175,47): error TS2322: Type 'boolean' is not assignable to type 'true'.
 tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts(180,26): error TS2322: Type '{ state: State.A; }[] | { state: State.B; }[]' is not assignable to type '{ state: State.A; }[]'.
   Type '{ state: State.B; }[]' is not assignable to type '{ state: State.A; }[]'.
     Type '{ state: State.B; }' is not assignable to type '{ state: State.A; }'.
@@ -7,7 +6,7 @@ tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts(180,26): error TS23
         Type 'State.B' is not assignable to type 'State.A'.
 
 
-==== tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts (3 errors) ====
+==== tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts (2 errors) ====
     // Repros from #5487
     
     function truePromise(): Promise<true> {
@@ -185,9 +184,6 @@ tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts(180,26): error TS23
     
     declare function foldLeft<U>(z: U, f: (acc: U, t: boolean) => U): U;
     let res: boolean = foldLeft(true, (acc, t) => acc && t);  // Error
-                                                  ~~~~~~~~
-!!! error TS2322: Type 'boolean' is not assignable to type 'true'.
-!!! related TS6502 tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts:174:39: The expected type comes from the return type of this signature.
     
     enum State { A, B }
     type Foo = { state: State }

--- a/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.types
+++ b/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.types
@@ -461,14 +461,14 @@ declare function foldLeft<U>(z: U, f: (acc: U, t: boolean) => U): U;
 
 let res: boolean = foldLeft(true, (acc, t) => acc && t);  // Error
 >res : boolean
->foldLeft(true, (acc, t) => acc && t) : true
+>foldLeft(true, (acc, t) => acc && t) : boolean
 >foldLeft : <U>(z: U, f: (acc: U, t: boolean) => U) => U
 >true : true
->(acc, t) => acc && t : (acc: true, t: boolean) => boolean
->acc : true
+>(acc, t) => acc && t : (acc: boolean, t: boolean) => boolean
+>acc : boolean
 >t : boolean
 >acc && t : boolean
->acc : true
+>acc : boolean
 >t : boolean
 
 enum State { A, B }

--- a/tests/baselines/reference/interfaceContextualType.types
+++ b/tests/baselines/reference/interfaceContextualType.types
@@ -28,30 +28,30 @@ class Bug {
 >{} : {}
 
         this.values['comments'] = { italic: true };
->this.values['comments'] = { italic: true } : { italic: true; }
+>this.values['comments'] = { italic: true } : { italic: boolean; }
 >this.values['comments'] : IOptions
 >this.values : IMap
 >this : this
 >values : IMap
 >'comments' : "comments"
->{ italic: true } : { italic: true; }
->italic : true
+>{ italic: true } : { italic: boolean; }
+>italic : boolean
 >true : true
     }
     shouldBeOK() {
 >shouldBeOK : () => void
 
         this.values = {
->this.values = {            comments: { italic: true }        } : { comments: { italic: true; }; }
+>this.values = {            comments: { italic: true }        } : { comments: { italic: boolean; }; }
 >this.values : IMap
 >this : this
 >values : IMap
->{            comments: { italic: true }        } : { comments: { italic: true; }; }
+>{            comments: { italic: true }        } : { comments: { italic: boolean; }; }
 
             comments: { italic: true }
->comments : { italic: true; }
->{ italic: true } : { italic: true; }
->italic : true
+>comments : { italic: boolean; }
+>{ italic: true } : { italic: boolean; }
+>italic : boolean
 >true : true
 
         };

--- a/tests/baselines/reference/interfaceWithPropertyOfEveryType.types
+++ b/tests/baselines/reference/interfaceWithPropertyOfEveryType.types
@@ -70,7 +70,7 @@ interface Foo {
 
 var a: Foo = {
 >a : Foo
->{    a: 1,    b: '',    c: true,    d: {},    e: null ,    f: [1],    g: {},    h: (x: number) => 1,    i: <T>(x: T) => x,    j: <Foo>null,    k: new C(),    l: f1,    m: M,    n: {},    o: E.A} : { a: number; b: string; c: true; d: {}; e: null; f: number[]; g: {}; h: (x: number) => number; i: <T>(x: T) => T; j: Foo; k: C; l: () => void; m: typeof M; n: {}; o: E.A; }
+>{    a: 1,    b: '',    c: true,    d: {},    e: null ,    f: [1],    g: {},    h: (x: number) => 1,    i: <T>(x: T) => x,    j: <Foo>null,    k: new C(),    l: f1,    m: M,    n: {},    o: E.A} : { a: number; b: string; c: boolean; d: {}; e: null; f: number[]; g: {}; h: (x: number) => number; i: <T>(x: T) => T; j: Foo; k: C; l: () => void; m: typeof M; n: {}; o: E.A; }
 
     a: 1,
 >a : number
@@ -81,7 +81,7 @@ var a: Foo = {
 >'' : ""
 
     c: true,
->c : true
+>c : boolean
 >true : true
 
     d: {},

--- a/tests/baselines/reference/isomorphicMappedTypeInference.types
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.types
@@ -214,8 +214,8 @@ function f3() {
 >assignBoxified(b, { c: false }) : void
 >assignBoxified : <T>(obj: Boxified<T>, values: T) => void
 >b : { a: Box<number>; b: Box<string>; c: Box<boolean>; }
->{ c: false } : { c: false; }
->c : false
+>{ c: false } : { c: boolean; }
+>c : boolean
 >false : false
 }
 

--- a/tests/baselines/reference/iterableArrayPattern23.errors.txt
+++ b/tests/baselines/reference/iterableArrayPattern23.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/es6/destructuring/iterableArrayPattern23.ts(2,1): error TS2488: Type '{ 0: string; 1: true; }' must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/destructuring/iterableArrayPattern23.ts(2,1): error TS2488: Type '{ 0: string; 1: boolean; }' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/destructuring/iterableArrayPattern23.ts (1 errors) ====
     var a: string, b: boolean;
     [a, b] = { 0: "", 1: true };
     ~~~~~~
-!!! error TS2488: Type '{ 0: string; 1: true; }' must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type '{ 0: string; 1: boolean; }' must have a '[Symbol.iterator]()' method that returns an iterator.

--- a/tests/baselines/reference/iterableArrayPattern23.types
+++ b/tests/baselines/reference/iterableArrayPattern23.types
@@ -4,13 +4,13 @@ var a: string, b: boolean;
 >b : boolean
 
 [a, b] = { 0: "", 1: true };
->[a, b] = { 0: "", 1: true } : { 0: string; 1: true; }
+>[a, b] = { 0: "", 1: true } : { 0: string; 1: boolean; }
 >[a, b] : [string, boolean]
 >a : string
 >b : boolean
->{ 0: "", 1: true } : { 0: string; 1: true; }
+>{ 0: "", 1: true } : { 0: string; 1: boolean; }
 >0 : string
 >"" : ""
->1 : true
+>1 : boolean
 >true : true
 

--- a/tests/baselines/reference/iterableArrayPattern24.errors.txt
+++ b/tests/baselines/reference/iterableArrayPattern24.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/es6/destructuring/iterableArrayPattern24.ts(2,1): error TS2488: Type '{ 0: string; 1: true; }' must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/destructuring/iterableArrayPattern24.ts(2,1): error TS2488: Type '{ 0: string; 1: boolean; }' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/destructuring/iterableArrayPattern24.ts (1 errors) ====
     var a: string, b: boolean[];
     [a, ...b] = { 0: "", 1: true };
     ~~~~~~~~~
-!!! error TS2488: Type '{ 0: string; 1: true; }' must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type '{ 0: string; 1: boolean; }' must have a '[Symbol.iterator]()' method that returns an iterator.

--- a/tests/baselines/reference/iterableArrayPattern24.types
+++ b/tests/baselines/reference/iterableArrayPattern24.types
@@ -4,14 +4,14 @@ var a: string, b: boolean[];
 >b : boolean[]
 
 [a, ...b] = { 0: "", 1: true };
->[a, ...b] = { 0: "", 1: true } : { 0: string; 1: true; }
+>[a, ...b] = { 0: "", 1: true } : { 0: string; 1: boolean; }
 >[a, ...b] : [string, ...boolean[]]
 >a : string
 >...b : boolean
 >b : boolean[]
->{ 0: "", 1: true } : { 0: string; 1: true; }
+>{ 0: "", 1: true } : { 0: string; 1: boolean; }
 >0 : string
 >"" : ""
->1 : true
+>1 : boolean
 >true : true
 

--- a/tests/baselines/reference/iterableArrayPattern29.types
+++ b/tests/baselines/reference/iterableArrayPattern29.types
@@ -12,11 +12,11 @@ takeFirstTwoEntries(...new Map([["", true], ["hello", true]]));
 >...new Map([["", true], ["hello", true]]) : [string, boolean]
 >new Map([["", true], ["hello", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true], ["hello", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true], ["hello", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
->["hello", true] : [string, true]
+>["hello", true] : [string, boolean]
 >"hello" : "hello"
 >true : true
 

--- a/tests/baselines/reference/iterableArrayPattern30.types
+++ b/tests/baselines/reference/iterableArrayPattern30.types
@@ -6,11 +6,11 @@ const [[k1, v1], [k2, v2]] = new Map([["", true], ["hello", true]])
 >v2 : boolean
 >new Map([["", true], ["hello", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true], ["hello", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true], ["hello", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
->["hello", true] : [string, true]
+>["hello", true] : [string, boolean]
 >"hello" : "hello"
 >true : true
 

--- a/tests/baselines/reference/jsExpandoObjectDefineProperty.types
+++ b/tests/baselines/reference/jsExpandoObjectDefineProperty.types
@@ -10,10 +10,10 @@ Object.defineProperty(chrome, 'devtools', { value: {}, enumerable: true })
 >defineProperty : <T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>) => T
 >chrome : typeof chrome
 >'devtools' : "devtools"
->{ value: {}, enumerable: true } : { value: {}; enumerable: true; }
+>{ value: {}, enumerable: true } : { value: {}; enumerable: boolean; }
 >value : {}
 >{} : {}
->enumerable : true
+>enumerable : boolean
 >true : true
 
 chrome.devtools.inspectedWindow = {}

--- a/tests/baselines/reference/jsdocParamTagTypeLiteral.types
+++ b/tests/baselines/reference/jsdocParamTagTypeLiteral.types
@@ -149,20 +149,20 @@ function foo5(opts5) {
 foo5([{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }]);
 >foo5([{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }]) : void
 >foo5 : (opts5: { help: string; what: { a: string; bad: { idea: string; oh: boolean; }[]; }; unnest: number; }[]) => void
->[{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }] : { help: string; what: { a: string; bad: { idea: string; oh: false; }[]; }; unnest: number; }[]
->{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 } : { help: string; what: { a: string; bad: { idea: string; oh: false; }[]; }; unnest: number; }
+>[{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }] : { help: string; what: { a: string; bad: { idea: string; oh: boolean; }[]; }; unnest: number; }[]
+>{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 } : { help: string; what: { a: string; bad: { idea: string; oh: boolean; }[]; }; unnest: number; }
 >help : string
 >"help" : "help"
->what : { a: string; bad: { idea: string; oh: false; }[]; }
->{ a: 'a', bad: [{ idea: 'idea', oh: false }] } : { a: string; bad: { idea: string; oh: false; }[]; }
+>what : { a: string; bad: { idea: string; oh: boolean; }[]; }
+>{ a: 'a', bad: [{ idea: 'idea', oh: false }] } : { a: string; bad: { idea: string; oh: boolean; }[]; }
 >a : string
 >'a' : "a"
->bad : { idea: string; oh: false; }[]
->[{ idea: 'idea', oh: false }] : { idea: string; oh: false; }[]
->{ idea: 'idea', oh: false } : { idea: string; oh: false; }
+>bad : { idea: string; oh: boolean; }[]
+>[{ idea: 'idea', oh: false }] : { idea: string; oh: boolean; }[]
+>{ idea: 'idea', oh: false } : { idea: string; oh: boolean; }
 >idea : string
 >'idea' : "idea"
->oh : false
+>oh : boolean
 >false : false
 >unnest : number
 >1 : 1

--- a/tests/baselines/reference/jsdocTemplateTag3.types
+++ b/tests/baselines/reference/jsdocTemplateTag3.types
@@ -62,8 +62,8 @@ f({ a: 12, b: 'hi', c: null }, undefined, { c: false, d: 12, b: undefined }, 101
 >c : null
 >null : null
 >undefined : undefined
->{ c: false, d: 12, b: undefined } : { c: false; d: number; b: undefined; }
->c : false
+>{ c: false, d: 12, b: undefined } : { c: boolean; d: number; b: undefined; }
+>c : boolean
 >false : false
 >d : number
 >12 : 12

--- a/tests/baselines/reference/jsxComplexSignatureHasApplicabilityError.types
+++ b/tests/baselines/reference/jsxComplexSignatureHasApplicabilityError.types
@@ -53,11 +53,11 @@ export function createReactSingleSelect<
 >props : Omit<Omit<WrappedProps, "multi">, keyof Omit<WrappedProps, "multi"> & keyof Props<ExtractValueType<WrappedProps>>> & Props<ExtractValueType<WrappedProps>> & { children?: React.ReactNode; }
 
                 multi={false}
->multi : false
+>multi : boolean
 >false : false
 
                 autosize={false}
->autosize : false
+>autosize : boolean
 >false : false
 
                 value={props.value}

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -490,14 +490,14 @@ function f31<K extends keyof Shape>(key: K) {
 
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
 >shape : Shape
->{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: true; }
+>{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: boolean; }
 >name : string
 >"foo" : "foo"
 >width : number
 >5 : 5
 >height : number
 >10 : 10
->visible : true
+>visible : boolean
 >true : true
 
     return shape[key];  // Shape[K]
@@ -512,14 +512,14 @@ function f32<K extends "width" | "height">(key: K) {
 
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
 >shape : Shape
->{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: true; }
+>{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: boolean; }
 >name : string
 >"foo" : "foo"
 >width : number
 >5 : 5
 >height : number
 >10 : 10
->visible : true
+>visible : boolean
 >true : true
 
     return shape[key];  // Shape[K]
@@ -815,8 +815,8 @@ function f71(func: <T, U>(x: T, y: U) => Partial<T & U>) {
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 
     x.a;  // number | undefined
@@ -851,8 +851,8 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'a' : "a"
 
@@ -865,8 +865,8 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'b' : "b"
 
@@ -879,8 +879,8 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'c' : "c"
 }
@@ -901,8 +901,8 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'a' : "a"
 
@@ -915,8 +915,8 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'b' : "b"
 
@@ -929,8 +929,8 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'c' : "c"
 }
@@ -951,10 +951,10 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ a: 2, b: true } : { a: number; b: true; }
+>{ a: 2, b: true } : { a: number; b: boolean; }
 >a : number
 >2 : 2
->b : true
+>b : boolean
 >true : true
 >'a' : "a"
 
@@ -967,10 +967,10 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ a: 2, b: true } : { a: number; b: true; }
+>{ a: 2, b: true } : { a: number; b: boolean; }
 >a : number
 >2 : 2
->b : true
+>b : boolean
 >true : true
 >'b' : "b"
 }

--- a/tests/baselines/reference/literalTypes2.types
+++ b/tests/baselines/reference/literalTypes2.types
@@ -498,8 +498,8 @@ function f6() {
 >0 : 0
 >x3 : string
 >"foo" : "foo"
->{ x1: false, x2: 1, x3: "bar" } : { x1?: false; x2?: number; x3?: string; }
->x1 : false
+>{ x1: false, x2: 1, x3: "bar" } : { x1?: boolean; x2?: number; x3?: string; }
+>x1 : boolean
 >false : false
 >x2 : number
 >1 : 1

--- a/tests/baselines/reference/mappedTypeErrors.types
+++ b/tests/baselines/reference/mappedTypeErrors.types
@@ -475,10 +475,10 @@ type O = {x: number, y: boolean};
 
 let o: O = {x: 5, y: false};
 >o : O
->{x: 5, y: false} : { x: number; y: false; }
+>{x: 5, y: false} : { x: number; y: boolean; }
 >x : number
 >5 : 5
->y : false
+>y : boolean
 >false : false
 
 let f: Foo2<O, 'x'> = {

--- a/tests/baselines/reference/neverReturningFunctions1.types
+++ b/tests/baselines/reference/neverReturningFunctions1.types
@@ -589,7 +589,7 @@ const Component = registerComponent('test-component', {
 >parse : () => boolean[]
 
 				return [true];
->[true] : true[]
+>[true] : boolean[]
 >true : true
 			}
 		},

--- a/tests/baselines/reference/objectLiteralExcessProperties.errors.txt
+++ b/tests/baselines/reference/objectLiteralExcessProperties.errors.txt
@@ -24,7 +24,7 @@ tests/cases/compiler/objectLiteralExcessProperties.ts(39,11): error TS2322: Type
 tests/cases/compiler/objectLiteralExcessProperties.ts(41,11): error TS2322: Type '{ name: string; prop: boolean; }' is not assignable to type 'T & { prop: boolean; }'.
   Type '{ name: string; prop: boolean; }' is not assignable to type 'T'.
     '{ name: string; prop: boolean; }' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'IFoo'.
-tests/cases/compiler/objectLiteralExcessProperties.ts(43,43): error TS2322: Type '{ name: string; prop: true; }' is not assignable to type 'T | { prop: boolean; }'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(43,43): error TS2322: Type '{ name: string; prop: boolean; }' is not assignable to type 'T | { prop: boolean; }'.
   Object literal may only specify known properties, and 'name' does not exist in type '{ prop: boolean; }'.
 tests/cases/compiler/objectLiteralExcessProperties.ts(45,76): error TS2322: Type '{ name: string; prop: boolean; }' is not assignable to type '(T & { prop: boolean; }) | { name: string; }'.
   Object literal may only specify known properties, and 'prop' does not exist in type '{ name: string; }'.
@@ -117,7 +117,7 @@ tests/cases/compiler/objectLiteralExcessProperties.ts(49,44): error TS2322: Type
         // Excess property checks only on non-generic parts of unions
         const obj3: T | { prop: boolean } = { name: "test", prop: true };
                                               ~~~~~~~~~~~~
-!!! error TS2322: Type '{ name: string; prop: true; }' is not assignable to type 'T | { prop: boolean; }'.
+!!! error TS2322: Type '{ name: string; prop: boolean; }' is not assignable to type 'T | { prop: boolean; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ prop: boolean; }'.
         // Excess property checks only on non-generic parts of unions
         const obj4: T & { prop: boolean } | { name: string } = { name: "test", prop: true };

--- a/tests/baselines/reference/objectLiteralExcessProperties.types
+++ b/tests/baselines/reference/objectLiteralExcessProperties.types
@@ -124,10 +124,10 @@ function test<T extends IFoo>() {
     const obj3: T | { prop: boolean } = { name: "test", prop: true };
 >obj3 : T | { prop: boolean; }
 >prop : boolean
->{ name: "test", prop: true } : { name: string; prop: true; }
+>{ name: "test", prop: true } : { name: string; prop: boolean; }
 >name : string
 >"test" : "test"
->prop : true
+>prop : boolean
 >true : true
 
     // Excess property checks only on non-generic parts of unions

--- a/tests/baselines/reference/objectLiteralNormalization.errors.txt
+++ b/tests/baselines/reference/objectLiteralNormalization.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(7,14): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(8,1): error TS2322: Type '{ b: string; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
   Type '{ b: string; }' is missing the following properties from type '{ a: number; b: string; c: boolean; }': a, c
-tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(9,1): error TS2322: Type '{ c: true; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
-  Type '{ c: true; }' is missing the following properties from type '{ a: number; b: string; c: boolean; }': a, b
+tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(9,1): error TS2322: Type '{ c: boolean; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
+  Type '{ c: boolean; }' is missing the following properties from type '{ a: number; b: string; c: boolean; }': a, b
 tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(17,1): error TS2322: Type '{ a: string; b: number; }' is not assignable to type '{ a: number; b: number; } | { a: string; b?: undefined; } | { a?: undefined; b?: undefined; }'.
   Type '{ a: string; b: number; }' is not assignable to type '{ a?: undefined; b?: undefined; }'.
     Types of property 'a' are incompatible.
@@ -30,8 +30,8 @@ tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
 !!! error TS2322:   Type '{ b: string; }' is missing the following properties from type '{ a: number; b: string; c: boolean; }': a, c
     a1 = { c: true };  // Error
     ~~
-!!! error TS2322: Type '{ c: true; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
-!!! error TS2322:   Type '{ c: true; }' is missing the following properties from type '{ a: number; b: string; c: boolean; }': a, b
+!!! error TS2322: Type '{ c: boolean; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
+!!! error TS2322:   Type '{ c: boolean; }' is missing the following properties from type '{ a: number; b: string; c: boolean; }': a, b
     
     let a2 = [{ a: 1, b: 2 }, { a: "abc" }, {}][0];
     a2.a;  // string | number | undefined

--- a/tests/baselines/reference/objectLiteralNormalization.types
+++ b/tests/baselines/reference/objectLiteralNormalization.types
@@ -60,10 +60,10 @@ a1 = { b: "y" };  // Error
 >"y" : "y"
 
 a1 = { c: true };  // Error
->a1 = { c: true } : { c: true; }
+>a1 = { c: true } : { c: boolean; }
 >a1 : { a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 
 let a2 = [{ a: 1, b: 2 }, { a: "abc" }, {}][0];

--- a/tests/baselines/reference/objectLiteralParameterResolution.types
+++ b/tests/baselines/reference/objectLiteralParameterResolution.types
@@ -20,7 +20,7 @@ var s = $.extend({
 >$.extend : { <T>(target: T, ...objs: any[]): T; <T>(deep: boolean, target: T, ...objs: any[]): T; }
 >$ : Foo
 >extend : { <T>(target: T, ...objs: any[]): T; <T>(deep: boolean, target: T, ...objs: any[]): T; }
->{    type: "GET" ,    data: "data" ,    success: wrapSuccessCallback(requestContext, callback) ,    error: wrapErrorCallback(requestContext, errorCallback) ,    dataType: "json" ,    converters: { "text json": "" },    traditional: true ,    timeout: 12,    } : { type: string; data: string; success: any; error: any; dataType: string; converters: { "text json": string; }; traditional: true; timeout: number; }
+>{    type: "GET" ,    data: "data" ,    success: wrapSuccessCallback(requestContext, callback) ,    error: wrapErrorCallback(requestContext, errorCallback) ,    dataType: "json" ,    converters: { "text json": "" },    traditional: true ,    timeout: 12,    } : { type: string; data: string; success: any; error: any; dataType: string; converters: { "text json": string; }; traditional: boolean; timeout: number; }
 
     type: "GET" ,
 >type : string
@@ -55,7 +55,7 @@ var s = $.extend({
 >"" : ""
 
     traditional: true ,
->traditional : true
+>traditional : boolean
 >true : true
 
     timeout: 12,

--- a/tests/baselines/reference/objectSpread.types
+++ b/tests/baselines/reference/objectSpread.types
@@ -31,9 +31,9 @@ let addAfter: { a: number, b: string, c: boolean } =
 >c : boolean
 
     { ...o, c: false }
->{ ...o, c: false } : { c: false; a: number; b: string; }
+>{ ...o, c: false } : { c: boolean; a: number; b: string; }
 >o : { a: number; b: string; }
->c : false
+>c : boolean
 >false : false
 
 let addBefore: { a: number, b: string, c: boolean } =
@@ -43,8 +43,8 @@ let addBefore: { a: number, b: string, c: boolean } =
 >c : boolean
 
     { c: false, ...o }
->{ c: false, ...o } : { a: number; b: string; c: false; }
->c : false
+>{ c: false, ...o } : { a: number; b: string; c: boolean; }
+>c : boolean
 >false : false
 >o : { a: number; b: string; }
 
@@ -66,12 +66,12 @@ let nested: { a: number, b: boolean, c: string } =
 >c : string
 
     { ...{ a: 3, ...{ b: false, c: 'overriden' } }, c: 'whatever' }
->{ ...{ a: 3, ...{ b: false, c: 'overriden' } }, c: 'whatever' } : { c: string; b: false; a: number; }
->{ a: 3, ...{ b: false, c: 'overriden' } } : { b: false; c: string; a: number; }
+>{ ...{ a: 3, ...{ b: false, c: 'overriden' } }, c: 'whatever' } : { c: string; b: boolean; a: number; }
+>{ a: 3, ...{ b: false, c: 'overriden' } } : { b: boolean; c: string; a: number; }
 >a : number
 >3 : 3
->{ b: false, c: 'overriden' } : { b: false; c: string; }
->b : false
+>{ b: false, c: 'overriden' } : { b: boolean; c: string; }
+>b : boolean
 >false : false
 >c : string
 >'overriden' : "overriden"
@@ -109,12 +109,12 @@ let combinedNestedChangeType: { a: number, b: boolean, c: number } =
 >c : number
 
     { ...{ a: 1, ...{ b: false, c: 'overriden' } }, c: -1 }
->{ ...{ a: 1, ...{ b: false, c: 'overriden' } }, c: -1 } : { c: number; b: false; a: number; }
->{ a: 1, ...{ b: false, c: 'overriden' } } : { b: false; c: string; a: number; }
+>{ ...{ a: 1, ...{ b: false, c: 'overriden' } }, c: -1 } : { c: number; b: boolean; a: number; }
+>{ a: 1, ...{ b: false, c: 'overriden' } } : { b: boolean; c: string; a: number; }
 >a : number
 >1 : 1
->{ b: false, c: 'overriden' } : { b: false; c: string; }
->b : false
+>{ b: false, c: 'overriden' } : { b: boolean; c: string; }
+>b : boolean
 >false : false
 >c : string
 >'overriden' : "overriden"
@@ -518,10 +518,10 @@ let exclusive: { id: string, a: number, b: string, c: string, d: boolean } =
 >1 : 1
 >b : string
 >'yes' : "yes"
->{ c: 'no', d: false } : { c: string; d: false; }
+>{ c: 'no', d: false } : { c: string; d: boolean; }
 >c : string
 >'no' : "no"
->d : false
+>d : boolean
 >false : false
 
 let overlap: { id: string, a: number, b: string } =
@@ -567,10 +567,10 @@ let overwriteId: { id: string, a: number, c: number, d: string } =
     f({ a: 1, id: true }, { c: 1, d: 'no' })
 >f({ a: 1, id: true }, { c: 1, d: 'no' }) : never
 >f : <T, U>(t: T, u: U) => T & U & { id: string; }
->{ a: 1, id: true } : { a: number; id: true; }
+>{ a: 1, id: true } : { a: number; id: boolean; }
 >a : number
 >1 : 1
->id : true
+>id : boolean
 >true : true
 >{ c: 1, d: 'no' } : { c: number; d: string; }
 >c : number

--- a/tests/baselines/reference/objectSpreadNegative.types
+++ b/tests/baselines/reference/objectSpreadNegative.types
@@ -171,12 +171,12 @@ let combinedNested: { a: number, b: boolean, c: string, d: string } =
 >d : string
 
     { ...{ a: 4, ...{ b: false, c: 'overriden' } }, d: 'actually new', ...{ a: 5, d: 'maybe new' } }
->{ ...{ a: 4, ...{ b: false, c: 'overriden' } }, d: 'actually new', ...{ a: 5, d: 'maybe new' } } : { a: number; d: string; b: false; c: string; }
->{ a: 4, ...{ b: false, c: 'overriden' } } : { b: false; c: string; a: number; }
+>{ ...{ a: 4, ...{ b: false, c: 'overriden' } }, d: 'actually new', ...{ a: 5, d: 'maybe new' } } : { a: number; d: string; b: boolean; c: string; }
+>{ a: 4, ...{ b: false, c: 'overriden' } } : { b: boolean; c: string; a: number; }
 >a : number
 >4 : 4
->{ b: false, c: 'overriden' } : { b: false; c: string; }
->b : false
+>{ b: false, c: 'overriden' } : { b: boolean; c: string; }
+>b : boolean
 >false : false
 >c : string
 >'overriden' : "overriden"

--- a/tests/baselines/reference/optionalBindingParameters1.types
+++ b/tests/baselines/reference/optionalBindingParameters1.types
@@ -10,7 +10,7 @@ function foo([x,y,z]?: [string, number, boolean]) {
 foo(["", 0, false]);
 >foo(["", 0, false]) : void
 >foo : ([x, y, z]?: [string, number, boolean]) => void
->["", 0, false] : [string, number, false]
+>["", 0, false] : [string, number, boolean]
 >"" : ""
 >0 : 0
 >false : false

--- a/tests/baselines/reference/optionalBindingParameters2.types
+++ b/tests/baselines/reference/optionalBindingParameters2.types
@@ -13,12 +13,12 @@ function foo({ x, y, z }?: { x: string; y: number; z: boolean }) {
 foo({ x: "", y: 0, z: false });
 >foo({ x: "", y: 0, z: false }) : void
 >foo : ({ x, y, z }?: { x: string; y: number; z: boolean; }) => void
->{ x: "", y: 0, z: false } : { x: string; y: number; z: false; }
+>{ x: "", y: 0, z: false } : { x: string; y: number; z: boolean; }
 >x : string
 >"" : ""
 >y : number
 >0 : 0
->z : false
+>z : boolean
 >false : false
 
 foo({ x: false, y: 0, z: "" });

--- a/tests/baselines/reference/optionalBindingParametersInOverloads1.types
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads1.types
@@ -14,7 +14,7 @@ function foo(...rest: any[]) {
 foo(["", 0, false]);
 >foo(["", 0, false]) : any
 >foo : ([x, y, z]?: [string, number, boolean]) => any
->["", 0, false] : [string, number, false]
+>["", 0, false] : [string, number, boolean]
 >"" : ""
 >0 : 0
 >false : false

--- a/tests/baselines/reference/optionalBindingParametersInOverloads2.types
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads2.types
@@ -17,12 +17,12 @@ function foo(...rest: any[]) {
 foo({ x: "", y: 0, z: false });
 >foo({ x: "", y: 0, z: false }) : any
 >foo : ({ x, y, z }?: { x: string; y: number; z: boolean; }) => any
->{ x: "", y: 0, z: false } : { x: string; y: number; z: false; }
+>{ x: "", y: 0, z: false } : { x: string; y: number; z: boolean; }
 >x : string
 >"" : ""
 >y : number
 >0 : 0
->z : false
+>z : boolean
 >false : false
 
 foo({ x: false, y: 0, z: "" });

--- a/tests/baselines/reference/optionalTupleElements1.types
+++ b/tests/baselines/reference/optionalTupleElements1.types
@@ -138,9 +138,9 @@ t3 = [42, "hello"];
 >"hello" : "hello"
 
 t3 = [42,,true]
->t3 = [42,,true] : [number, undefined, true]
+>t3 = [42,,true] : [number, undefined, boolean]
 >t3 : T3
->[42,,true] : [number, undefined, true]
+>[42,,true] : [number, undefined, boolean]
 >42 : 42
 > : undefined
 >true : true
@@ -159,25 +159,25 @@ t4 = [42, "hello"];
 >"hello" : "hello"
 
 t4 = [42,,true];
->t4 = [42,,true] : [number, undefined, true]
+>t4 = [42,,true] : [number, undefined, boolean]
 >t4 : T4
->[42,,true] : [number, undefined, true]
+>[42,,true] : [number, undefined, boolean]
 >42 : 42
 > : undefined
 >true : true
 
 t4 = [,"hello", true];
->t4 = [,"hello", true] : [undefined, string, true]
+>t4 = [,"hello", true] : [undefined, string, boolean]
 >t4 : T4
->[,"hello", true] : [undefined, string, true]
+>[,"hello", true] : [undefined, string, boolean]
 > : undefined
 >"hello" : "hello"
 >true : true
 
 t4 = [,,true];
->t4 = [,,true] : [undefined, undefined, true]
+>t4 = [,,true] : [undefined, undefined, boolean]
 >t4 : T4
->[,,true] : [undefined, undefined, true]
+>[,,true] : [undefined, undefined, boolean]
 > : undefined
 > : undefined
 >true : true

--- a/tests/baselines/reference/overloadResolutionTest1.types
+++ b/tests/baselines/reference/overloadResolutionTest1.types
@@ -19,9 +19,9 @@ var x1 = foo([{a:true}]); // works
 >x1 : number
 >foo([{a:true}]) : number
 >foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
->[{a:true}] : { a: true; }[]
->{a:true} : { a: true; }
->a : true
+>[{a:true}] : { a: boolean; }[]
+>{a:true} : { a: boolean; }
+>a : boolean
 >true : true
 
 var x11 = foo([{a:0}]); // works
@@ -81,8 +81,8 @@ var x3 = foo2({a:true}); // works
 >x3 : number
 >foo2({a:true}) : number
 >foo2 : { (bar: { a: number; }): string; (bar: { a: boolean; }): number; }
->{a:true} : { a: true; }
->a : true
+>{a:true} : { a: boolean; }
+>a : boolean
 >true : true
 
 var x4 = foo2({a:"s"}); // error

--- a/tests/baselines/reference/parserUsingConstructorAsIdentifier.types
+++ b/tests/baselines/reference/parserUsingConstructorAsIdentifier.types
@@ -97,14 +97,14 @@
 >constructor : any
 >prototype : any
 >"constructor" : "constructor"
->{ value: constructor, writable: true, configurable: true, enumerable: true } : { value: any; writable: true; configurable: true; enumerable: true; }
+>{ value: constructor, writable: true, configurable: true, enumerable: true } : { value: any; writable: boolean; configurable: boolean; enumerable: boolean; }
 >value : any
 >constructor : any
->writable : true
+>writable : boolean
 >true : true
->configurable : true
+>configurable : boolean
 >true : true
->enumerable : true
+>enumerable : boolean
 >true : true
 
                 if (instanceMembers) {

--- a/tests/baselines/reference/parserharness.types
+++ b/tests/baselines/reference/parserharness.types
@@ -1528,14 +1528,14 @@ module Harness {
 
                     var metadata: IScenarioMetadata = { id: undefined, desc: this.description, pass: false, bugs: assert.bugIds };
 >metadata : IScenarioMetadata
->{ id: undefined, desc: this.description, pass: false, bugs: assert.bugIds } : { id: undefined; desc: any; pass: false; bugs: any; }
+>{ id: undefined, desc: this.description, pass: false, bugs: assert.bugIds } : { id: undefined; desc: any; pass: boolean; bugs: any; }
 >id : undefined
 >undefined : undefined
 >desc : any
 >this.description : any
 >this : any
 >description : any
->pass : false
+>pass : boolean
 >false : false
 >bugs : any
 >assert.bugIds : any

--- a/tests/baselines/reference/privacyCheckAnonymousFunctionParameter.types
+++ b/tests/baselines/reference/privacyCheckAnonymousFunctionParameter.types
@@ -24,7 +24,7 @@ module Query {
         return fromDoWhile(test => {
 >fromDoWhile(test => {            return true;        }) : Iterator<unknown>
 >fromDoWhile : <T>(doWhile: (test: Iterator<T>) => boolean) => Iterator<T>
->test => {            return true;        } : (test: Iterator<unknown>) => true
+>test => {            return true;        } : (test: Iterator<unknown>) => boolean
 >test : Iterator<unknown>
 
             return true;

--- a/tests/baselines/reference/propertyAssignmentUseParentType1.types
+++ b/tests/baselines/reference/propertyAssignmentUseParentType1.types
@@ -6,7 +6,7 @@ interface N {
 }
 export const interfaced: N = () => true;
 >interfaced : N
->() => true : { (): true; num: 123; }
+>() => true : { (): boolean; num: 123; }
 >true : true
 
 interfaced.num = 123;
@@ -19,7 +19,7 @@ interfaced.num = 123;
 export const inlined: { (): boolean; nun: 456 } = () => true;
 >inlined : { (): boolean; nun: 456; }
 >nun : 456
->() => true : { (): true; nun: 456; }
+>() => true : { (): boolean; nun: 456; }
 >true : true
 
 inlined.nun = 456;

--- a/tests/baselines/reference/reactDefaultPropsInferenceSuccess.types
+++ b/tests/baselines/reference/reactDefaultPropsInferenceSuccess.types
@@ -79,11 +79,11 @@ class FieldFeedbackBeta<P extends Props = BaseProps> extends React.Component<P> 
 
   static defaultProps: BaseProps = {
 >defaultProps : BaseProps
->{    when: () => true  } : { when: () => true; }
+>{    when: () => true  } : { when: () => boolean; }
 
     when: () => true
->when : () => true
->() => true : () => true
+>when : () => boolean
+>() => true : () => boolean
 >true : true
 
   };

--- a/tests/baselines/reference/recursiveTypeReferences1.types
+++ b/tests/baselines/reference/recursiveTypeReferences1.types
@@ -60,7 +60,7 @@ type Json = string | number | boolean | null | Json[] | { [key: string]: Json };
 
 let data: Json = {
 >data : Json
->{    caption: "Test",    location: { x: 10, y: 20 },    values: [true, [10, 20], null]} : { caption: string; location: { x: number; y: number; }; values: (true | number[] | null)[]; }
+>{    caption: "Test",    location: { x: 10, y: 20 },    values: [true, [10, 20], null]} : { caption: string; location: { x: number; y: number; }; values: (boolean | number[] | null)[]; }
 
     caption: "Test",
 >caption : string
@@ -75,8 +75,8 @@ let data: Json = {
 >20 : 20
 
     values: [true, [10, 20], null]
->values : (true | number[] | null)[]
->[true, [10, 20], null] : (true | number[] | null)[]
+>values : (boolean | number[] | null)[]
+>[true, [10, 20], null] : (boolean | number[] | null)[]
 >true : true
 >[10, 20] : number[]
 >10 : 10

--- a/tests/baselines/reference/restTupleElements1.types
+++ b/tests/baselines/reference/restTupleElements1.types
@@ -189,7 +189,7 @@ f0([1, 2, 3]);
 f0([1, "hello", true]);
 >f0([1, "hello", true]) : [number, string | boolean]
 >f0 : <T, U>(x: [T, ...U[]]) => [T, U]
->[1, "hello", true] : [number, string, true]
+>[1, "hello", true] : [number, string, boolean]
 >1 : 1
 >"hello" : "hello"
 >true : true

--- a/tests/baselines/reference/reverseMappedContravariantInference.types
+++ b/tests/baselines/reference/reverseMappedContravariantInference.types
@@ -11,9 +11,9 @@ conforms({ foo: (v: string) => false })({ foo: "hello" });
 >conforms({ foo: (v: string) => false })({ foo: "hello" }) : boolean
 >conforms({ foo: (v: string) => false }) : (value: { foo: string; }) => boolean
 >conforms : <T>(source: { [K in keyof T]: (val: T[K]) => boolean; }) => (value: T) => boolean
->{ foo: (v: string) => false } : { foo: (v: string) => false; }
->foo : (v: string) => false
->(v: string) => false : (v: string) => false
+>{ foo: (v: string) => false } : { foo: (v: string) => boolean; }
+>foo : (v: string) => boolean
+>(v: string) => false : (v: string) => boolean
 >v : string
 >false : false
 >{ foo: "hello" } : { foo: string; }

--- a/tests/baselines/reference/strictOptionalProperties1.errors.txt
+++ b/tests/baselines/reference/strictOptionalProperties1.errors.txt
@@ -9,9 +9,9 @@ tests/cases/compiler/strictOptionalProperties1.ts(64,5): error TS2322: Type '[nu
   Target allows only 2 element(s) but source may have more.
 tests/cases/compiler/strictOptionalProperties1.ts(73,5): error TS2322: Type '[number, never?, never?, never?]' is not assignable to type '[number, string?, boolean?]'.
   Target allows only 3 element(s) but source may have more.
-tests/cases/compiler/strictOptionalProperties1.ts(74,5): error TS2322: Type '[never?, never?, true?]' is not assignable to type '[number, string?, boolean?]'.
+tests/cases/compiler/strictOptionalProperties1.ts(74,5): error TS2322: Type '[never?, never?, boolean?]' is not assignable to type '[number, string?, boolean?]'.
   Source provides no match for required element at position 0 in target.
-tests/cases/compiler/strictOptionalProperties1.ts(75,5): error TS2322: Type '[number, undefined, true]' is not assignable to type '[number, string?, boolean?]'.
+tests/cases/compiler/strictOptionalProperties1.ts(75,5): error TS2322: Type '[number, undefined, boolean]' is not assignable to type '[number, string?, boolean?]'.
   Type at position 1 in source is not compatible with type at position 1 in target.
     Type 'undefined' is not assignable to type 'string'.
 tests/cases/compiler/strictOptionalProperties1.ts(99,7): error TS2375: Type '{ foo: undefined; bar: string; }' is not assignable to type 'InputProps' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
@@ -142,11 +142,11 @@ tests/cases/compiler/strictOptionalProperties1.ts(211,1): error TS2322: Type 'st
 !!! error TS2322:   Target allows only 3 element(s) but source may have more.
         t = [, , true];  // Error
         ~
-!!! error TS2322: Type '[never?, never?, true?]' is not assignable to type '[number, string?, boolean?]'.
+!!! error TS2322: Type '[never?, never?, boolean?]' is not assignable to type '[number, string?, boolean?]'.
 !!! error TS2322:   Source provides no match for required element at position 0 in target.
         t = [42, undefined, true];  // Error
         ~
-!!! error TS2322: Type '[number, undefined, true]' is not assignable to type '[number, string?, boolean?]'.
+!!! error TS2322: Type '[number, undefined, boolean]' is not assignable to type '[number, string?, boolean?]'.
 !!! error TS2322:   Type at position 1 in source is not compatible with type at position 1 in target.
 !!! error TS2322:     Type 'undefined' is not assignable to type 'string'.
     }

--- a/tests/baselines/reference/strictOptionalProperties1.types
+++ b/tests/baselines/reference/strictOptionalProperties1.types
@@ -318,9 +318,9 @@ function f5(t: [number, string?, boolean?]) {
 >'abc' : "abc"
 
     t = [42, 'abc', true];
->t = [42, 'abc', true] : [number, string, true]
+>t = [42, 'abc', true] : [number, string, boolean]
 >t : [number, string?, boolean?]
->[42, 'abc', true] : [number, string, true]
+>[42, 'abc', true] : [number, string, boolean]
 >42 : 42
 >'abc' : "abc"
 >true : true
@@ -350,17 +350,17 @@ function f5(t: [number, string?, boolean?]) {
 > : undefined
 
     t = [, , true];  // Error
->t = [, , true] : [never?, never?, true?]
+>t = [, , true] : [never?, never?, boolean?]
 >t : [number, string?, boolean?]
->[, , true] : [never?, never?, true?]
+>[, , true] : [never?, never?, boolean?]
 > : undefined
 > : undefined
 >true : true
 
     t = [42, undefined, true];  // Error
->t = [42, undefined, true] : [number, undefined, true]
+>t = [42, undefined, true] : [number, undefined, boolean]
 >t : [number, string?, boolean?]
->[42, undefined, true] : [number, undefined, true]
+>[42, undefined, true] : [number, undefined, boolean]
 >42 : 42
 >undefined : undefined
 >true : true

--- a/tests/baselines/reference/substitutionTypesInIndexedAccessTypes.types
+++ b/tests/baselines/reference/substitutionTypesInIndexedAccessTypes.types
@@ -33,13 +33,13 @@ const boundaryResult = withBoundary({
 });
 
 const withoutBoundaryResult = withoutBoundary({
->withoutBoundaryResult : { select: true; }
->withoutBoundary({  select: true,}) : { select: true; }
+>withoutBoundaryResult : { select: boolean; }
+>withoutBoundary({  select: true,}) : { select: boolean; }
 >withoutBoundary : <T extends UserArgs>(args?: T | undefined) => T
->{  select: true,} : { select: true; }
+>{  select: true,} : { select: boolean; }
 
   select: true,
->select : true
+>select : boolean
 >true : true
 
 });

--- a/tests/baselines/reference/symbolProperty21.errors.txt
+++ b/tests/baselines/reference/symbolProperty21.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }' is not assignable to parameter of type 'I<boolean, string>'.
+tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
 
 
@@ -14,7 +14,7 @@ tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Arg
         [Symbol.isConcatSpreadable]: "",
         [Symbol.toPrimitive]: 0,
         ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }' is not assignable to parameter of type 'I<boolean, string>'.
+!!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
 !!! error TS2345:   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
         [Symbol.unscopables]: true
     });

--- a/tests/baselines/reference/symbolProperty21.types
+++ b/tests/baselines/reference/symbolProperty21.types
@@ -22,7 +22,7 @@ declare function foo<T, U>(p: I<T, U>): { t: T; u: U };
 foo({
 >foo({    [Symbol.isConcatSpreadable]: "",    [Symbol.toPrimitive]: 0,    [Symbol.unscopables]: true}) : { t: boolean; u: string; }
 >foo : <T, U>(p: I<T, U>) => { t: T; u: U; }
->{    [Symbol.isConcatSpreadable]: "",    [Symbol.toPrimitive]: 0,    [Symbol.unscopables]: true} : { [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }
+>{    [Symbol.isConcatSpreadable]: "",    [Symbol.toPrimitive]: 0,    [Symbol.unscopables]: true} : { [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }
 
     [Symbol.isConcatSpreadable]: "",
 >[Symbol.isConcatSpreadable] : string
@@ -39,7 +39,7 @@ foo({
 >0 : 0
 
     [Symbol.unscopables]: true
->[Symbol.unscopables] : true
+>[Symbol.unscopables] : boolean
 >Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
 >unscopables : unique symbol

--- a/tests/baselines/reference/targetTypeArgs.types
+++ b/tests/baselines/reference/targetTypeArgs.types
@@ -35,7 +35,7 @@ foo(function(x) { x });
 >["hello"] : string[]
 >"hello" : "hello"
 >every : { <S extends string>(predicate: (value: string, index: number, array: string[]) => value is S, thisArg?: any): this is S[]; (predicate: (value: string, index: number, array: string[]) => unknown, thisArg?: any): boolean; }
->function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => true
+>function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => boolean
 >v : string
 >i : number
 >a : string[]
@@ -47,7 +47,7 @@ foo(function(x) { x });
 >[1] : number[]
 >1 : 1
 >every : { <S extends number>(predicate: (value: number, index: number, array: number[]) => value is S, thisArg?: any): this is S[]; (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any): boolean; }
->function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => true
+>function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => boolean
 >v : number
 >i : number
 >a : number[]
@@ -59,7 +59,7 @@ foo(function(x) { x });
 >[1] : number[]
 >1 : 1
 >every : { <S extends number>(predicate: (value: number, index: number, array: number[]) => value is S, thisArg?: any): this is S[]; (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any): boolean; }
->function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => true
+>function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => boolean
 >v : number
 >i : number
 >a : number[]
@@ -71,7 +71,7 @@ foo(function(x) { x });
 >["s"] : string[]
 >"s" : "s"
 >every : { <S extends string>(predicate: (value: string, index: number, array: string[]) => value is S, thisArg?: any): this is S[]; (predicate: (value: string, index: number, array: string[]) => unknown, thisArg?: any): boolean; }
->function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => true
+>function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => boolean
 >v : string
 >i : number
 >a : string[]

--- a/tests/baselines/reference/tsxAttributeResolution10.types
+++ b/tests/baselines/reference/tsxAttributeResolution10.types
@@ -35,7 +35,7 @@ export class MyComponent {
 <MyComponent bar={true} />;
 ><MyComponent bar={true} /> : JSX.Element
 >MyComponent : typeof MyComponent
->bar : true
+>bar : boolean
 >true : true
 
 // Should be ok

--- a/tests/baselines/reference/tsxAttributeResolution6.types
+++ b/tests/baselines/reference/tsxAttributeResolution6.types
@@ -37,7 +37,7 @@ declare module JSX {
 <test1 n={false} />;
 ><test1 n={false} /> : JSX.Element
 >test1 : any
->n : false
+>n : boolean
 >false : false
 
 <test2 n />;

--- a/tests/baselines/reference/twiceNestedKeyofIndexInference.types
+++ b/tests/baselines/reference/twiceNestedKeyofIndexInference.types
@@ -43,7 +43,7 @@ interface State {
 
 const state: State = {
 >state : State
->{    a: {        b: "",        c: 0,    },    d: false,} : { a: { b: string; c: number; }; d: false; }
+>{    a: {        b: "",        c: 0,    },    d: false,} : { a: { b: string; c: number; }; d: boolean; }
 
     a: {
 >a : { b: string; c: number; }
@@ -59,7 +59,7 @@ const state: State = {
 
     },
     d: false,
->d : false
+>d : boolean
 >false : false
 
 };

--- a/tests/baselines/reference/typeAliases.types
+++ b/tests/baselines/reference/typeAliases.types
@@ -199,7 +199,7 @@ f16(x);
 
 var y: StringAndBoolean = ["1", false];
 >y : StringAndBoolean
->["1", false] : [string, false]
+>["1", false] : [string, boolean]
 >"1" : "1"
 >false : false
 

--- a/tests/baselines/reference/typeGuardsOnClassProperty.types
+++ b/tests/baselines/reference/typeGuardsOnClassProperty.types
@@ -67,14 +67,14 @@ var o: {
 >prop2 : string | boolean
 
 } = {
->{        prop1: "string" ,        prop2: true    } : { prop1: string; prop2: true; }
+>{        prop1: "string" ,        prop2: true    } : { prop1: string; prop2: boolean; }
 
         prop1: "string" ,
 >prop1 : string
 >"string" : "string"
 
         prop2: true
->prop2 : true
+>prop2 : boolean
 >true : true
     }
 

--- a/tests/baselines/reference/typeInferenceLiteralUnion.types
+++ b/tests/baselines/reference/typeInferenceLiteralUnion.types
@@ -63,7 +63,7 @@ extentMixed = extent([new NumCoercible(10), 13, '12', true]);
 >extentMixed : [undefined, undefined] | [Primitive | NumCoercible, Primitive | NumCoercible]
 >extent([new NumCoercible(10), 13, '12', true]) : [undefined, undefined] | [Primitive | NumCoercible, Primitive | NumCoercible]
 >extent : <T extends Numeric>(array: (Primitive | T)[]) => [Primitive | T, Primitive | T] | [undefined, undefined]
->[new NumCoercible(10), 13, '12', true] : (string | number | true | NumCoercible)[]
+>[new NumCoercible(10), 13, '12', true] : (string | number | boolean | NumCoercible)[]
 >new NumCoercible(10) : NumCoercible
 >NumCoercible : typeof NumCoercible
 >10 : 10

--- a/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively.types
+++ b/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively.types
@@ -47,12 +47,12 @@ foo({ x: 1 }, { x: 1, y: '' }, { x: 2, y: '', z: true });
 >1 : 1
 >y : string
 >'' : ""
->{ x: 2, y: '', z: true } : { x: number; y: string; z: true; }
+>{ x: 2, y: '', z: true } : { x: number; y: string; z: boolean; }
 >x : number
 >2 : 2
 >y : string
 >'' : ""
->z : true
+>z : boolean
 >true : true
 
 foo(a, b, c);
@@ -67,12 +67,12 @@ foo(a, b, { foo: 1, bar: '', hm: true });
 >foo : <T, U, V>(x: T, y: U, z: V) => V
 >a : A
 >b : B
->{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: true; }
+>{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: boolean; }
 >foo : number
 >1 : 1
 >bar : string
 >'' : ""
->hm : true
+>hm : boolean
 >true : true
 
 foo((x: number, y) => { }, (x) => { }, () => { });

--- a/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively2.types
+++ b/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively2.types
@@ -47,12 +47,12 @@ foo({ x: 1 }, { x: 1, y: '' }, { x: 2, y: 2, z: true });
 >1 : 1
 >y : string
 >'' : ""
->{ x: 2, y: 2, z: true } : { x: number; y: number; z: true; }
+>{ x: 2, y: 2, z: true } : { x: number; y: number; z: boolean; }
 >x : number
 >2 : 2
 >y : number
 >2 : 2
->z : true
+>z : boolean
 >true : true
 
 foo(a, b, a);
@@ -66,12 +66,12 @@ foo(a, { foo: 1, bar: '', hm: true }, b);
 >foo(a, { foo: 1, bar: '', hm: true }, b) : B
 >foo : <T, U, V>(x: T, y: U, z: V) => V
 >a : A
->{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: true; }
+>{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: boolean; }
 >foo : number
 >1 : 1
 >bar : string
 >'' : ""
->hm : true
+>hm : boolean
 >true : true
 >b : B
 

--- a/tests/baselines/reference/underscoreTest1.types
+++ b/tests/baselines/reference/underscoreTest1.types
@@ -235,7 +235,7 @@ _.all([true, 1, null, 'yes'], _.identity);
 >_.all : { <T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean; <T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean; }
 >_ : Underscore.Static
 >all : { <T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean; <T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean; }
->[true, 1, null, 'yes'] : (string | number | true)[]
+>[true, 1, null, 'yes'] : (string | number | boolean)[]
 >true : true
 >1 : 1
 >null : null
@@ -249,7 +249,7 @@ _.any([null, 0, 'yes', false]);
 >_.any : { <T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean; <T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean; }
 >_ : Underscore.Static
 >any : { <T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean; <T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean; }
->[null, 0, 'yes', false] : (string | number | false)[]
+>[null, 0, 'yes', false] : (string | number | boolean)[]
 >null : null
 >0 : 0
 >'yes' : "yes"
@@ -512,7 +512,7 @@ _.compact([0, 1, false, 2, '', 3]);
 >_.compact : <T>(list: T[]) => T[]
 >_ : Underscore.Static
 >compact : <T>(list: T[]) => T[]
->[0, 1, false, 2, '', 3] : (string | number | false)[]
+>[0, 1, false, 2, '', 3] : (string | number | boolean)[]
 >0 : 0
 >1 : 1
 >false : false

--- a/tests/baselines/reference/unionTypeInference.types
+++ b/tests/baselines/reference/unionTypeInference.types
@@ -70,7 +70,7 @@ var b1 = f2(["string", true]);  // boolean
 >b1 : boolean
 >f2(["string", true]) : boolean
 >f2 : <T>(value: [string, T]) => T
->["string", true] : [string, true]
+>["string", true] : [string, boolean]
 >"string" : "string"
 >true : true
 

--- a/tests/baselines/reference/useObjectValuesAndEntries1.types
+++ b/tests/baselines/reference/useObjectValuesAndEntries1.types
@@ -58,8 +58,8 @@ var entries2 = Object.entries({ a: true, b: 2 });   // [string, number|boolean][
 >Object.entries : { <T>(o: { [s: string]: T; } | ArrayLike<T>): [string, T][]; (o: {}): [string, any][]; }
 >Object : ObjectConstructor
 >entries : { <T>(o: { [s: string]: T; } | ArrayLike<T>): [string, T][]; (o: {}): [string, any][]; }
->{ a: true, b: 2 } : { a: true; b: number; }
->a : true
+>{ a: true, b: 2 } : { a: boolean; b: number; }
+>a : boolean
 >true : true
 >b : number
 >2 : 2
@@ -70,8 +70,8 @@ var values2 = Object.values({ a: true, b: 2 });     // (number|boolean)[]
 >Object.values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
 >Object : ObjectConstructor
 >values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
->{ a: true, b: 2 } : { a: true; b: number; }
->a : true
+>{ a: true, b: 2 } : { a: boolean; b: number; }
+>a : boolean
 >true : true
 >b : number
 >2 : 2

--- a/tests/baselines/reference/variadicTuples1.errors.txt
+++ b/tests/baselines/reference/variadicTuples1.errors.txt
@@ -36,7 +36,7 @@ tests/cases/conformance/types/tuple/variadicTuples1.ts(191,5): error TS2322: Typ
 tests/cases/conformance/types/tuple/variadicTuples1.ts(203,5): error TS2322: Type 'string' is not assignable to type 'keyof [1, 2, ...T]'.
   Type '"2"' is not assignable to type '"0" | "1" | keyof T[]'.
 tests/cases/conformance/types/tuple/variadicTuples1.ts(357,26): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/tuple/variadicTuples1.ts(397,7): error TS2322: Type '[false, false]' is not assignable to type '[...number[], boolean]'.
+tests/cases/conformance/types/tuple/variadicTuples1.ts(397,7): error TS2322: Type '[boolean, boolean]' is not assignable to type '[...number[], boolean]'.
   Type at position 0 in source is not compatible with type at position 0 in target.
     Type 'boolean' is not assignable to type 'number'.
 
@@ -498,7 +498,7 @@ tests/cases/conformance/types/tuple/variadicTuples1.ts(397,7): error TS2322: Typ
     type Unbounded = [...Numbers, boolean];
     const data: Unbounded = [false, false];  // Error
           ~~~~
-!!! error TS2322: Type '[false, false]' is not assignable to type '[...number[], boolean]'.
+!!! error TS2322: Type '[boolean, boolean]' is not assignable to type '[...number[], boolean]'.
 !!! error TS2322:   Type at position 0 in source is not compatible with type at position 0 in target.
 !!! error TS2322:     Type 'boolean' is not assignable to type 'number'.
     

--- a/tests/baselines/reference/variadicTuples1.types
+++ b/tests/baselines/reference/variadicTuples1.types
@@ -61,7 +61,7 @@ const t2 = tup2(['hello'], [10, true]);
 >tup2 : <T extends unknown[], U extends unknown[]>(t: [...T], u: [...U]) => readonly [1, ...T, 2, ...U, 3]
 >['hello'] : [string]
 >'hello' : "hello"
->[10, true] : [number, true]
+>[10, true] : [number, boolean]
 >10 : 10
 >true : true
 
@@ -427,12 +427,12 @@ let tm1 = fm1([['abc'], [42], [true], ['def']]);  // [boolean, string]
 >tm1 : [boolean, string]
 >fm1([['abc'], [42], [true], ['def']]) : [boolean, string]
 >fm1 : <T extends unknown[]>(t: [string[], number[], ...Arrayify<T>]) => T
->[['abc'], [42], [true], ['def']] : [string[], number[], true[], string[]]
+>[['abc'], [42], [true], ['def']] : [string[], number[], boolean[], string[]]
 >['abc'] : string[]
 >'abc' : "abc"
 >[42] : number[]
 >42 : 42
->[true] : true[]
+>[true] : boolean[]
 >true : true
 >['def'] : string[]
 >'def' : "def"
@@ -1163,7 +1163,7 @@ curry2(fn10, ['hello', 42], [true]);
 >['hello', 42] : [string, number]
 >'hello' : "hello"
 >42 : 42
->[true] : [true]
+>[true] : [boolean]
 >true : true
 
 curry2(fn10, ['hello'], [42, true]);
@@ -1172,7 +1172,7 @@ curry2(fn10, ['hello'], [42, true]);
 >fn10 : (a: string, b: number, c: boolean) => string[]
 >['hello'] : [string]
 >'hello' : "hello"
->[42, true] : [number, true]
+>[42, true] : [number, boolean]
 >42 : 42
 >true : true
 
@@ -1397,7 +1397,7 @@ type Unbounded = [...Numbers, boolean];
 
 const data: Unbounded = [false, false];  // Error
 >data : [...number[], boolean]
->[false, false] : [false, false]
+>[false, false] : [boolean, boolean]
 >false : false
 >false : false
 

--- a/tests/baselines/reference/vueLikeDataAndPropsInference.types
+++ b/tests/baselines/reference/vueLikeDataAndPropsInference.types
@@ -69,10 +69,10 @@ test({
 >bar : boolean
 
         return {
->{            bar: true        } : { bar: true; }
+>{            bar: true        } : { bar: boolean; }
 
             bar: true
->bar : true
+>bar : boolean
 >true : true
         }
     },

--- a/tests/baselines/reference/vueLikeDataAndPropsInference2.types
+++ b/tests/baselines/reference/vueLikeDataAndPropsInference2.types
@@ -70,10 +70,10 @@ test({
 >bar : boolean
 
         return {
->{            bar: true        } : { bar: true; }
+>{            bar: true        } : { bar: boolean; }
 
             bar: true
->bar : true
+>bar : boolean
 >true : true
         }
     },

--- a/tests/cases/compiler/contextuallyTypedBooleanLiterals.ts
+++ b/tests/cases/compiler/contextuallyTypedBooleanLiterals.ts
@@ -1,0 +1,29 @@
+// @strict: true
+// @declaration: true
+
+// Repro from #48363
+
+type Box<T> = {
+    get: () => T,
+    set: (value: T) => void
+}
+
+declare function box<T>(value: T): Box<T>;
+
+const bn1 = box(0);  // Box<number>
+const bn2: Box<number> = box(0);  // Ok
+
+const bb1 = box(false);  // Box<boolean>
+const bb2: Box<boolean> = box(false);  // Error, box<false> not assignable to Box<boolean>
+
+// Repro from #48150
+
+interface Observable<T>
+{
+  (): T;
+  (value: T): any;
+}
+
+declare function observable<T>(value: T): Observable<T>;
+
+const x: Observable<boolean> = observable(false);

--- a/tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts
+++ b/tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts
@@ -42,10 +42,18 @@ const a: DisjointDiscriminants = {
     p4: "hello"
 };
 
-// This has no excess error because variant one and three are both applicable.
-const b: DisjointDiscriminants = {
+// This has excess error because variant three is the only applicable case.
+const b1: DisjointDiscriminants = {
     p1: 'left',
     p2: true,
+    p3: 42,
+    p4: "hello"
+};
+
+// This has no excess error because variant one and three are both applicable.
+const b2: DisjointDiscriminants = {
+    p1: 'left',
+    p2: true as const,
     p3: 42,
     p4: "hello"
 };


### PR DESCRIPTION
Fixes #48363.

Also fixes issue mentioned [here](https://github.com/microsoft/TypeScript/pull/29478#issuecomment-457875877) because boolean literals contextually typed by `boolean` are now widened.