### PR TITLE
Follow `paths` in triple-slash types references

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -354,7 +354,10 @@ namespace ts {
         }
         const conditions = features & NodeResolutionFeatures.Exports ? features & NodeResolutionFeatures.EsmMode ? ["node", "import", "types"] : ["node", "require", "types"] : [];
         const moduleResolutionState: ModuleResolutionState = { compilerOptions: options, host, traceEnabled, failedLookupLocations, packageJsonInfoCache: cache, features, conditions };
-        let resolved = primaryLookup();
+        const loader: ResolutionKindSpecificLoader = (extensions, candidate, onlyRecordFailures, state) => nodeLoadModuleByRelativeName(extensions, candidate, onlyRecordFailures, state, /*considerPackageJson*/ true);
+        const optional = tryLoadModuleUsingOptionalResolutionSettings(Extensions.DtsOnly, typeReferenceDirectiveName, containingDirectory || "", loader, moduleResolutionState);
+        // tryLoadModuleUsingOptionalResolutionSettings will happily return what a user wrote in `paths` varbatim - this means if a user writes `.js`, it'll return a `.js` file, even if we're looking for TS files
+        let resolved = optional && hasTSFileExtension(optional.path) && { fileName: optional.path, packageId: optional.packageId } || primaryLookup();
         let primary = true;
         if (!resolved) {
             resolved = secondaryLookup();

--- a/tests/baselines/reference/pathsAppliedToTypesReference.js
+++ b/tests/baselines/reference/pathsAppliedToTypesReference.js
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/pathsAppliedToTypesReference.ts] ////
+
+//// [index.d.ts]
+export { };
+declare global {
+    const foo: number;
+}
+
+//// [index.ts]
+/// <reference types="p1" />
+foo;
+
+
+//// [index.js]
+/// <reference types="p1" />
+foo;

--- a/tests/cases/compiler/pathsAppliedToTypesReference.ts
+++ b/tests/cases/compiler/pathsAppliedToTypesReference.ts
@@ -1,0 +1,21 @@
+// @noTypesAndSymbols: true
+// @noImplicitReferences: true
+
+// @Filename: /other/tsconfig.json
+{
+    "compilerOptions": {
+        "paths": {
+            "p1": ["./lib/p1"]
+        }
+    }
+}
+
+// @Filename: /other/lib/p1/index.d.ts
+export { };
+declare global {
+    const foo: number;
+}
+
+// @Filename: /project/index.ts
+/// <reference types="p1" />
+foo;


### PR DESCRIPTION
Everyone I've spoken to seems to agree that `///<reference types` comments not following the `paths` (and `baseUrl`) compiler options seems to be an oversight on our part.

Fixes an issue I brought up on our teams chat while doing work on #48278.