### PR TITLE
Reuse type reference resolutions between programs when possible

### DIFF
--- a/src/testRunner/unittests/reuseProgramStructure.ts
+++ b/src/testRunner/unittests/reuseProgramStructure.ts
@@ -211,7 +211,7 @@ namespace ts {
         checkCache("resolved type directives", program, fileName, expectedContent, f => f.resolvedTypeReferenceDirectiveNames, checkResolvedTypeDirective);
     }
 
-    describe("unittests:: Reuse program structure:: General", () => {
+    describe("unittests:: reuseProgramStructure:: General", () => {
         const target = ScriptTarget.Latest;
         const files: NamedSourceText[] = [
             {
@@ -692,11 +692,7 @@ namespace ts {
                     "Explicitly specified module resolution kind: 'Classic'.",
                     "File 'b1.ts' exist - use it as a name resolution result.",
                     "======== Module name './b1' was successfully resolved to 'b1.ts'. ========",
-                    "======== Resolving type reference directive 'typerefs2', containing file 'f2.ts', root directory 'node_modules/@types'. ========",
-                    "Resolving with primary search path 'node_modules/@types'.",
-                    "File 'node_modules/@types/typerefs2/package.json' does not exist.",
-                    "File 'node_modules/@types/typerefs2/index.d.ts' exist - use it as a name resolution result.",
-                    "======== Type reference directive 'typerefs2' was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts', primary: true. ========",
+                    "Reusing resolution of module 'typerefs2' from 'f2.ts' of old program, it was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts'.",
                     "Reusing resolution of module './b2' from 'f2.ts' of old program, it was successfully resolved to 'b2.ts'.",
                     "Reusing resolution of module './f1' from 'f2.ts' of old program, it was successfully resolved to 'f1.ts'."
                 ], "program2: reuse module resolutions in f2 since it is unchanged");
@@ -716,11 +712,7 @@ namespace ts {
                     "Explicitly specified module resolution kind: 'Classic'.",
                     "File 'b1.ts' exist - use it as a name resolution result.",
                     "======== Module name './b1' was successfully resolved to 'b1.ts'. ========",
-                    "======== Resolving type reference directive 'typerefs2', containing file 'f2.ts', root directory 'node_modules/@types'. ========",
-                    "Resolving with primary search path 'node_modules/@types'.",
-                    "File 'node_modules/@types/typerefs2/package.json' does not exist.",
-                    "File 'node_modules/@types/typerefs2/index.d.ts' exist - use it as a name resolution result.",
-                    "======== Type reference directive 'typerefs2' was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts', primary: true. ========",
+                    "Reusing resolution of module 'typerefs2' from 'f2.ts' of old program, it was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts'.",
                     "Reusing resolution of module './b2' from 'f2.ts' of old program, it was successfully resolved to 'b2.ts'.",
                     "Reusing resolution of module './f1' from 'f2.ts' of old program, it was successfully resolved to 'f1.ts'."
                 ], "program3: reuse module resolutions in f2 since it is unchanged");
@@ -741,11 +733,7 @@ namespace ts {
                     "Explicitly specified module resolution kind: 'Classic'.",
                     "File 'b1.ts' exist - use it as a name resolution result.",
                     "======== Module name './b1' was successfully resolved to 'b1.ts'. ========",
-                    "======== Resolving type reference directive 'typerefs2', containing file 'f2.ts', root directory 'node_modules/@types'. ========",
-                    "Resolving with primary search path 'node_modules/@types'.",
-                    "File 'node_modules/@types/typerefs2/package.json' does not exist.",
-                    "File 'node_modules/@types/typerefs2/index.d.ts' exist - use it as a name resolution result.",
-                    "======== Type reference directive 'typerefs2' was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts', primary: true. ========",
+                    "Reusing resolution of module 'typerefs2' from 'f2.ts' of old program, it was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts'.",
                     "Reusing resolution of module './b2' from 'f2.ts' of old program, it was successfully resolved to 'b2.ts'.",
                     "Reusing resolution of module './f1' from 'f2.ts' of old program, it was successfully resolved to 'f1.ts'.",
                 ], "program_4: reuse module resolutions in f2 since it is unchanged");
@@ -782,11 +770,7 @@ namespace ts {
                     "Explicitly specified module resolution kind: 'Classic'.",
                     "File 'b1.ts' exist - use it as a name resolution result.",
                     "======== Module name './b1' was successfully resolved to 'b1.ts'. ========",
-                    "======== Resolving type reference directive 'typerefs2', containing file 'f2.ts', root directory 'node_modules/@types'. ========",
-                    "Resolving with primary search path 'node_modules/@types'.",
-                    "File 'node_modules/@types/typerefs2/package.json' does not exist.",
-                    "File 'node_modules/@types/typerefs2/index.d.ts' exist - use it as a name resolution result.",
-                    "======== Type reference directive 'typerefs2' was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts', primary: true. ========",
+                    "Reusing resolution of module 'typerefs2' from 'f2.ts' of old program, it was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts'.",
                     "Reusing resolution of module './b2' from 'f2.ts' of old program, it was successfully resolved to 'b2.ts'.",
                     "Reusing resolution of module './f1' from 'f2.ts' of old program, it was successfully resolved to 'f1.ts'.",
                 ], "program_6: reuse module resolutions in f2 since it is unchanged");
@@ -802,11 +786,7 @@ namespace ts {
                 assert.lengthOf(program7Diagnostics, expectedErrors, `removing import is noop with respect to program, so no change in diagnostics.`);
 
                 assert.deepEqual(program7.host.getTrace(), [
-                    "======== Resolving type reference directive 'typerefs2', containing file 'f2.ts', root directory 'node_modules/@types'. ========",
-                    "Resolving with primary search path 'node_modules/@types'.",
-                    "File 'node_modules/@types/typerefs2/package.json' does not exist.",
-                    "File 'node_modules/@types/typerefs2/index.d.ts' exist - use it as a name resolution result.",
-                    "======== Type reference directive 'typerefs2' was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts', primary: true. ========",
+                    "Reusing resolution of module 'typerefs2' from 'f2.ts' of old program, it was successfully resolved to 'node_modules/@types/typerefs2/index.d.ts'.",
                     "Reusing resolution of module './b2' from 'f2.ts' of old program, it was successfully resolved to 'b2.ts'.",
                     "Reusing resolution of module './f1' from 'f2.ts' of old program, it was successfully resolved to 'f1.ts'.",
                 ], "program_7 should reuse module resolutions in f2 since it is unchanged");


### PR DESCRIPTION
Fixes a perf issue I noticed while looking at #48278 - we were always unconditionally redoing type reference resolution, even when we had old ones we could reuse.