### PR TITLE
Fix document registry cache key calculation for `paths` compiler option

### DIFF
--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -357,7 +357,7 @@ namespace ts {
         };
     }
 
-    function compilerOptionValueToString(value: unknown, configPathIfPaths?: string): string {
+    function compilerOptionValueToString(value: unknown): string {
         if (value === null || typeof value !== "object") { // eslint-disable-line no-null/no-null
             return "" + value;
         }
@@ -365,9 +365,6 @@ namespace ts {
             return `[${map(value, e => compilerOptionValueToString(e))?.join(",")}]`;
         }
         let str = "{";
-        if (configPathIfPaths) { // config file path has to be in key for `paths` so `paths` from different configs produce differing keys
-            str += `|config:${configPathIfPaths}|`;
-        }
         for (const key in value) {
             if (ts.hasOwnProperty.call(value, key)) { // eslint-disable-line @typescript-eslint/no-unnecessary-qualifier
                 str += `${key}: ${compilerOptionValueToString((value as any)[key])}`;
@@ -377,6 +374,6 @@ namespace ts {
     }
 
     function getKeyForCompilationSettings(settings: CompilerOptions): DocumentRegistryBucketKey {
-        return sourceFileAffectingCompilerOptions.map(option => compilerOptionValueToString(getCompilerOptionValue(settings, option), option.name === "paths" ? settings.configFilePath || "" : undefined)).join("|") as DocumentRegistryBucketKey;
+        return sourceFileAffectingCompilerOptions.map(option => compilerOptionValueToString(getCompilerOptionValue(settings, option))).join("|") + (settings.pathsBasePath ? `|${settings.pathsBasePath}` : undefined) as DocumentRegistryBucketKey;
     }
 }

--- a/src/testRunner/unittests/tsserver/languageService.ts
+++ b/src/testRunner/unittests/tsserver/languageService.ts
@@ -1,5 +1,5 @@
 namespace ts.projectSystem {
-    describe("unittests:: tsserver:: Language service", () => {
+    describe("unittests:: tsserver:: languageService", () => {
         it("should work correctly on case-sensitive file systems", () => {
             const lib = {
                 path: "/a/Lib/lib.d.ts",
@@ -14,6 +14,55 @@ namespace ts.projectSystem {
             projectService.openClientFile(f.path);
             projectService.checkNumberOfProjects({ inferredProjects: 1 });
             projectService.inferredProjects[0].getLanguageService().getProgram();
+        });
+
+        it("should support multiple projects with the same file under differing `paths` settings", () => {
+            const files = [
+                {
+                    path: "/project/shared.ts",
+                    content: Utils.dedent`
+                    import {foo_a} from "foo";
+                    `
+                },
+                {
+                    path: `/project/a/tsconfig.json`,
+                    content: `{ "compilerOptions": { "paths": { "foo": ["./foo.d.ts"] } }, "files": ["./index.ts", "./foo.d.ts"] }`
+                },
+                {
+                    path: `/project/a/foo.d.ts`,
+                    content: Utils.dedent`
+                    export const foo_a = 1;
+                    `
+                },
+                {
+                    path: "/project/a/index.ts",
+                    content: `import "../shared";`
+                },
+                {
+                    path: `/project/b/tsconfig.json`,
+                    content: `{ "compilerOptions": { "paths": { "foo": ["./foo.d.ts"] } }, "files": ["./index.ts", "./foo.d.ts"] }`
+                },
+                {
+                    path: `/project/b/foo.d.ts`,
+                    content: Utils.dedent`
+                    export const foo_b = 1;
+                    `
+                },
+                {
+                    path: "/project/b/index.ts",
+                    content: `import "../shared";`
+                }
+            ];
+
+            const host = createServerHost(files, { executingFilePath: "/project/tsc.js", useCaseSensitiveFileNames: true });
+            const projectService = createProjectService(host);
+            projectService.openClientFile(files[3].path);
+            projectService.openClientFile(files[6].path);
+            projectService.checkNumberOfProjects({ configuredProjects: 2 });
+            const proj1Diags = projectService.configuredProjects.get(files[1].path)!.getLanguageService().getProgram()!.getSemanticDiagnostics();
+            Debug.assertEqual(proj1Diags.length, 0);
+            const proj2Diags = projectService.configuredProjects.get(files[4].path)!.getLanguageService().getProgram()!.getSemanticDiagnostics();
+            Debug.assertEqual(proj2Diags.length, 1);
         });
     });
 }


### PR DESCRIPTION
Fixes #48278
