### PR TITLE
Fix test build post-LKG

### DIFF
--- a/src/testRunner/unittests/tsserver/projectReferencesSourcemap.ts
+++ b/src/testRunner/unittests/tsserver/projectReferencesSourcemap.ts
@@ -271,7 +271,7 @@ fn5();
             });
         }
 
-        interface Action<Req = protocol.Request, Response = {}> {
+        interface Action<Req = protocol.Request, Response = unknown> {
             reqName: string;
             request: Partial<Req>;
             expectedResponse: Response;


### PR DESCRIPTION
Just another `{}` -> `unknown` needed because of the assignability rule change under `strict` that wasn't already fixed in the original PR.