### PR TITLE
fix: do not allow classifying non-declaration files as default library source files

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1958,6 +1958,10 @@ namespace ts {
         }
 
         function isSourceFileDefaultLibrary(file: SourceFile): boolean {
+            if (!file.isDeclarationFile) {
+                return false;
+            }
+
             if (file.hasNoDefaultLib) {
                 return true;
             }


### PR DESCRIPTION
I still need to come up with a test, but wanted to get some feedback first. Basically, in Deno we were had non-declaration files not being emitted by the ts compiler because they augmented the global scope and did "no-default-lib". This fixes the issue, but maybe it's not the right fix?

About no-default-lib references, the website says:

> This directive marks a file as a default library. You will see this comment at the top of lib.d.ts and its different variants.

>
> This directive instructs the compiler to not include the default library (i.e. lib.d.ts) in the compilation. The impact here is similar to passing [noLib](https://www.typescriptlang.org/tsconfig#noLib) on the command line.

https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-no-default-libtrue

But it seems reasonable to not have a non-declaration file be classified as "default lib"? If so, I'll try to come up with a test for this one.

Thanks for your time.

Ref: https://github.com/denoland/deno/issues/14093