### PR TITLE
fix(48418): Refactoring: "Add missing properties" fails for interfaces containing a function property whose definition includes a generic argument that is an empty tuple

### DIFF
--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -192,7 +192,12 @@ namespace ts.codefix {
         const program = context.program;
         const checker = program.getTypeChecker();
         const scriptTarget = getEmitScriptTarget(program.getCompilerOptions());
-        const flags = NodeBuilderFlags.NoTruncation | NodeBuilderFlags.NoUndefinedOptionalParameterType | NodeBuilderFlags.SuppressAnyReturnType | (quotePreference === QuotePreference.Single ? NodeBuilderFlags.UseSingleQuotesForStringLiteralType : 0);
+        const flags =
+            NodeBuilderFlags.NoTruncation
+            | NodeBuilderFlags.NoUndefinedOptionalParameterType
+            | NodeBuilderFlags.SuppressAnyReturnType
+            | NodeBuilderFlags.AllowEmptyTuple
+            | (quotePreference === QuotePreference.Single ? NodeBuilderFlags.UseSingleQuotesForStringLiteralType : NodeBuilderFlags.None);
         const signatureDeclaration = checker.signatureToSignatureDeclaration(signature, kind, enclosingDeclaration, flags, getNoopSymbolTrackerWithResolver(context)) as ArrowFunction | FunctionExpression | MethodDeclaration;
         if (!signatureDeclaration) {
             return undefined;

--- a/tests/cases/fourslash/codeFixAddMissingProperties19.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties19.ts
@@ -1,0 +1,28 @@
+/// <reference path='fourslash.ts' />
+
+////export interface Foo<T> {
+////    z(...args: T extends unknown[] ? T : [T]);
+////}
+////export interface Bar {
+////    a(foo: Foo<[number]>): void;
+////    b(foo: Foo<[]>): void;
+////    c(foo: Foo<number>): void;
+////}
+////[|const bar: Bar = {};|]
+
+verify.codeFix({
+    index: 0,
+    description: ts.Diagnostics.Add_missing_properties.message,
+    newRangeContent:
+`const bar: Bar = {
+    a: function(foo: Foo<[number]>): void {
+        throw new Error("Function not implemented.");
+    },
+    b: function(foo: Foo<[]>): void {
+        throw new Error("Function not implemented.");
+    },
+    c: function(foo: Foo<number>): void {
+        throw new Error("Function not implemented.");
+    }
+};`,
+});


### PR DESCRIPTION
Fixes #48418


