### PR TITLE
Add explicit tests for unconstrained type param not being assignable to `{}` and `Record<string, any>`

### DIFF
--- a/tests/baselines/reference/genericUnboundedTypeParamAssignability.errors.txt
+++ b/tests/baselines/reference/genericUnboundedTypeParamAssignability.errors.txt
@@ -1,0 +1,36 @@
+tests/cases/compiler/genericUnboundedTypeParamAssignability.ts(2,5): error TS2339: Property 'toString' does not exist on type 'T'.
+tests/cases/compiler/genericUnboundedTypeParamAssignability.ts(15,6): error TS2345: Argument of type 'T' is not assignable to parameter of type '{}'.
+tests/cases/compiler/genericUnboundedTypeParamAssignability.ts(16,6): error TS2345: Argument of type 'T' is not assignable to parameter of type 'Record<string, any>'.
+tests/cases/compiler/genericUnboundedTypeParamAssignability.ts(17,5): error TS2339: Property 'toString' does not exist on type 'T'.
+
+
+==== tests/cases/compiler/genericUnboundedTypeParamAssignability.ts (4 errors) ====
+    function f1<T>(o: T) {
+      o.toString(); // error
+        ~~~~~~~~
+!!! error TS2339: Property 'toString' does not exist on type 'T'.
+    }
+    
+    function f2<T extends {}>(o: T) {
+      o.toString(); // no error
+    }
+    
+    function f3<T extends Record<string, any>>(o: T) {
+      o.toString(); // no error
+    }
+    
+    function user<T>(t: T) {
+      f1(t);
+      f2(t); // error in strict, unbounded T doesn't satisfy the constraint
+         ~
+!!! error TS2345: Argument of type 'T' is not assignable to parameter of type '{}'.
+!!! related TS2208 tests/cases/compiler/genericUnboundedTypeParamAssignability.ts:13:15: This type parameter probably needs an `extends object` constraint.
+      f3(t); // error in strict, unbounded T doesn't satisfy the constraint
+         ~
+!!! error TS2345: Argument of type 'T' is not assignable to parameter of type 'Record<string, any>'.
+!!! related TS2208 tests/cases/compiler/genericUnboundedTypeParamAssignability.ts:13:15: This type parameter probably needs an `extends object` constraint.
+      t.toString();  // error, for the same reason as f1()
+        ~~~~~~~~
+!!! error TS2339: Property 'toString' does not exist on type 'T'.
+    }
+    

--- a/tests/baselines/reference/genericUnboundedTypeParamAssignability.js
+++ b/tests/baselines/reference/genericUnboundedTypeParamAssignability.js
@@ -1,0 +1,38 @@
+//// [genericUnboundedTypeParamAssignability.ts]
+function f1<T>(o: T) {
+  o.toString(); // error
+}
+
+function f2<T extends {}>(o: T) {
+  o.toString(); // no error
+}
+
+function f3<T extends Record<string, any>>(o: T) {
+  o.toString(); // no error
+}
+
+function user<T>(t: T) {
+  f1(t);
+  f2(t); // error in strict, unbounded T doesn't satisfy the constraint
+  f3(t); // error in strict, unbounded T doesn't satisfy the constraint
+  t.toString();  // error, for the same reason as f1()
+}
+
+
+//// [genericUnboundedTypeParamAssignability.js]
+"use strict";
+function f1(o) {
+    o.toString(); // error
+}
+function f2(o) {
+    o.toString(); // no error
+}
+function f3(o) {
+    o.toString(); // no error
+}
+function user(t) {
+    f1(t);
+    f2(t); // error in strict, unbounded T doesn't satisfy the constraint
+    f3(t); // error in strict, unbounded T doesn't satisfy the constraint
+    t.toString(); // error, for the same reason as f1()
+}

--- a/tests/baselines/reference/genericUnboundedTypeParamAssignability.symbols
+++ b/tests/baselines/reference/genericUnboundedTypeParamAssignability.symbols
@@ -1,0 +1,58 @@
+=== tests/cases/compiler/genericUnboundedTypeParamAssignability.ts ===
+function f1<T>(o: T) {
+>f1 : Symbol(f1, Decl(genericUnboundedTypeParamAssignability.ts, 0, 0))
+>T : Symbol(T, Decl(genericUnboundedTypeParamAssignability.ts, 0, 12))
+>o : Symbol(o, Decl(genericUnboundedTypeParamAssignability.ts, 0, 15))
+>T : Symbol(T, Decl(genericUnboundedTypeParamAssignability.ts, 0, 12))
+
+  o.toString(); // error
+>o : Symbol(o, Decl(genericUnboundedTypeParamAssignability.ts, 0, 15))
+}
+
+function f2<T extends {}>(o: T) {
+>f2 : Symbol(f2, Decl(genericUnboundedTypeParamAssignability.ts, 2, 1))
+>T : Symbol(T, Decl(genericUnboundedTypeParamAssignability.ts, 4, 12))
+>o : Symbol(o, Decl(genericUnboundedTypeParamAssignability.ts, 4, 26))
+>T : Symbol(T, Decl(genericUnboundedTypeParamAssignability.ts, 4, 12))
+
+  o.toString(); // no error
+>o.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+>o : Symbol(o, Decl(genericUnboundedTypeParamAssignability.ts, 4, 26))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+}
+
+function f3<T extends Record<string, any>>(o: T) {
+>f3 : Symbol(f3, Decl(genericUnboundedTypeParamAssignability.ts, 6, 1))
+>T : Symbol(T, Decl(genericUnboundedTypeParamAssignability.ts, 8, 12))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>o : Symbol(o, Decl(genericUnboundedTypeParamAssignability.ts, 8, 43))
+>T : Symbol(T, Decl(genericUnboundedTypeParamAssignability.ts, 8, 12))
+
+  o.toString(); // no error
+>o.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+>o : Symbol(o, Decl(genericUnboundedTypeParamAssignability.ts, 8, 43))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+}
+
+function user<T>(t: T) {
+>user : Symbol(user, Decl(genericUnboundedTypeParamAssignability.ts, 10, 1))
+>T : Symbol(T, Decl(genericUnboundedTypeParamAssignability.ts, 12, 14))
+>t : Symbol(t, Decl(genericUnboundedTypeParamAssignability.ts, 12, 17))
+>T : Symbol(T, Decl(genericUnboundedTypeParamAssignability.ts, 12, 14))
+
+  f1(t);
+>f1 : Symbol(f1, Decl(genericUnboundedTypeParamAssignability.ts, 0, 0))
+>t : Symbol(t, Decl(genericUnboundedTypeParamAssignability.ts, 12, 17))
+
+  f2(t); // error in strict, unbounded T doesn't satisfy the constraint
+>f2 : Symbol(f2, Decl(genericUnboundedTypeParamAssignability.ts, 2, 1))
+>t : Symbol(t, Decl(genericUnboundedTypeParamAssignability.ts, 12, 17))
+
+  f3(t); // error in strict, unbounded T doesn't satisfy the constraint
+>f3 : Symbol(f3, Decl(genericUnboundedTypeParamAssignability.ts, 6, 1))
+>t : Symbol(t, Decl(genericUnboundedTypeParamAssignability.ts, 12, 17))
+
+  t.toString();  // error, for the same reason as f1()
+>t : Symbol(t, Decl(genericUnboundedTypeParamAssignability.ts, 12, 17))
+}
+

--- a/tests/baselines/reference/genericUnboundedTypeParamAssignability.types
+++ b/tests/baselines/reference/genericUnboundedTypeParamAssignability.types
@@ -1,0 +1,60 @@
+=== tests/cases/compiler/genericUnboundedTypeParamAssignability.ts ===
+function f1<T>(o: T) {
+>f1 : <T>(o: T) => void
+>o : T
+
+  o.toString(); // error
+>o.toString() : any
+>o.toString : any
+>o : T
+>toString : any
+}
+
+function f2<T extends {}>(o: T) {
+>f2 : <T extends {}>(o: T) => void
+>o : T
+
+  o.toString(); // no error
+>o.toString() : string
+>o.toString : () => string
+>o : T
+>toString : () => string
+}
+
+function f3<T extends Record<string, any>>(o: T) {
+>f3 : <T extends Record<string, any>>(o: T) => void
+>o : T
+
+  o.toString(); // no error
+>o.toString() : string
+>o.toString : () => string
+>o : T
+>toString : () => string
+}
+
+function user<T>(t: T) {
+>user : <T>(t: T) => void
+>t : T
+
+  f1(t);
+>f1(t) : void
+>f1 : <T>(o: T) => void
+>t : T
+
+  f2(t); // error in strict, unbounded T doesn't satisfy the constraint
+>f2(t) : void
+>f2 : <T extends {}>(o: T) => void
+>t : T
+
+  f3(t); // error in strict, unbounded T doesn't satisfy the constraint
+>f3(t) : void
+>f3 : <T extends Record<string, any>>(o: T) => void
+>t : T
+
+  t.toString();  // error, for the same reason as f1()
+>t.toString() : any
+>t.toString : any
+>t : T
+>toString : any
+}
+

--- a/tests/cases/compiler/genericUnboundedTypeParamAssignability.ts
+++ b/tests/cases/compiler/genericUnboundedTypeParamAssignability.ts
@@ -1,0 +1,20 @@
+// @strict: true
+
+function f1<T>(o: T) {
+  o.toString(); // error
+}
+
+function f2<T extends {}>(o: T) {
+  o.toString(); // no error
+}
+
+function f3<T extends Record<string, any>>(o: T) {
+  o.toString(); // no error
+}
+
+function user<T>(t: T) {
+  f1(t);
+  f2(t); // error in strict, unbounded T doesn't satisfy the constraint
+  f3(t); // error in strict, unbounded T doesn't satisfy the constraint
+  t.toString();  // error, for the same reason as f1()
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/microsoft/TypeScript/pull/48366 .

The PR only mentions adjusted assignability rules for `{}` and I was wondering if this has affected `Record<string, any>` as well. So I've tried it out locally and it turns out that yeah - it did. Those types might be very similar for the compiler so maybe that's a "given" but for a layman like me - this wasn't that obvious.

cc @weswigham