### PR TITLE
Revert "Fix contextual discrimination for omitted members (#43937)"

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26813,13 +26813,6 @@ namespace ts {
             return false;
         }
 
-        function uniqueStrings(strings: readonly __String[]): __String[] {
-            const unique = new Set(strings);
-            const result: __String[] = [];
-            unique.forEach(str => result.push(str));
-            return result;
-        }
-
         function discriminateContextualTypeByObjectMembers(node: ObjectLiteralExpression, contextualType: UnionType) {
             return getMatchingUnionConstituentForObjectLiteral(contextualType, node) || discriminateTypeByDiscriminableItems(contextualType,
                 concatenate(
@@ -26828,13 +26821,8 @@ namespace ts {
                         prop => ([() => getContextFreeTypeOfExpression((prop as PropertyAssignment).initializer), prop.symbol.escapedName] as [() => Type, __String])
                     ),
                     map(
-                        uniqueStrings(flatMap(contextualType.types, memberType =>
-                            map(
-                                filter(getPropertiesOfType(memberType), s => !!(s.flags & SymbolFlags.Optional) && !!node?.symbol?.members && !node.symbol.members.has(s.escapedName) && isDiscriminantProperty(contextualType, s.escapedName)),
-                                s => s.escapedName
-                            )
-                        )),
-                        name => [() => undefinedType, name] as [() => Type, __String]
+                        filter(getPropertiesOfType(contextualType), s => !!(s.flags & SymbolFlags.Optional) && !!node?.symbol?.members && !node.symbol.members.has(s.escapedName) && isDiscriminantProperty(contextualType, s.escapedName)),
+                        s => [() => undefinedType, s.escapedName] as [() => Type, __String]
                     )
                 ),
                 isTypeAssignableTo,
@@ -26850,13 +26838,8 @@ namespace ts {
                         prop => ([!(prop as JsxAttribute).initializer ? (() => trueType) : (() => getContextFreeTypeOfExpression((prop as JsxAttribute).initializer!)), prop.symbol.escapedName] as [() => Type, __String])
                     ),
                     map(
-                        uniqueStrings(flatMap(contextualType.types, memberType =>
-                            map(
-                                filter(getPropertiesOfType(memberType), s => !!(s.flags & SymbolFlags.Optional) && !!node?.symbol?.members && !node.symbol.members.has(s.escapedName) && isDiscriminantProperty(contextualType, s.escapedName)),
-                                s => s.escapedName
-                            )
-                        )),
-                        name => [() => undefinedType, name] as [() => Type, __String]
+                        filter(getPropertiesOfType(contextualType), s => !!(s.flags & SymbolFlags.Optional) && !!node?.symbol?.members && !node.symbol.members.has(s.escapedName) && isDiscriminantProperty(contextualType, s.escapedName)),
+                        s => [() => undefinedType, s.escapedName] as [() => Type, __String]
                     )
                 ),
                 isTypeAssignableTo,

--- a/tests/baselines/reference/discriminantPropertyInference.js
+++ b/tests/baselines/reference/discriminantPropertyInference.js
@@ -11,9 +11,7 @@ type DiscriminatorFalse = {
     cb: (x: number) => void;
 }
 
-type Unrelated = {
-    val: number;
-}
+type Props = DiscriminatorTrue | DiscriminatorFalse;
 
 declare function f(options: DiscriminatorTrue | DiscriminatorFalse): any;
 
@@ -41,14 +39,6 @@ f({
 });
 
 
-declare function g(options: DiscriminatorTrue | DiscriminatorFalse | Unrelated): any;
-
-// requires checking properties of all types, rather than properties of just the union type (e.g. only intersection)
-g({
-    cb: n => n.toFixed()
-});
-
-
 //// [discriminantPropertyInference.js]
 // Repro from #41759
 // simple inference
@@ -68,9 +58,5 @@ f({
 });
 // requires checking type information since discriminator is missing from object
 f({
-    cb: function (n) { return n.toFixed(); }
-});
-// requires checking properties of all types, rather than properties of just the union type (e.g. only intersection)
-g({
     cb: function (n) { return n.toFixed(); }
 });

--- a/tests/baselines/reference/discriminantPropertyInference.symbols
+++ b/tests/baselines/reference/discriminantPropertyInference.symbols
@@ -23,97 +23,74 @@ type DiscriminatorFalse = {
 >x : Symbol(x, Decl(discriminantPropertyInference.ts, 9, 9))
 }
 
-type Unrelated = {
->Unrelated : Symbol(Unrelated, Decl(discriminantPropertyInference.ts, 10, 1))
-
-    val: number;
->val : Symbol(val, Decl(discriminantPropertyInference.ts, 12, 18))
-}
+type Props = DiscriminatorTrue | DiscriminatorFalse;
+>Props : Symbol(Props, Decl(discriminantPropertyInference.ts, 10, 1))
+>DiscriminatorTrue : Symbol(DiscriminatorTrue, Decl(discriminantPropertyInference.ts, 0, 0))
+>DiscriminatorFalse : Symbol(DiscriminatorFalse, Decl(discriminantPropertyInference.ts, 5, 1))
 
 declare function f(options: DiscriminatorTrue | DiscriminatorFalse): any;
->f : Symbol(f, Decl(discriminantPropertyInference.ts, 14, 1))
->options : Symbol(options, Decl(discriminantPropertyInference.ts, 16, 19))
+>f : Symbol(f, Decl(discriminantPropertyInference.ts, 12, 52))
+>options : Symbol(options, Decl(discriminantPropertyInference.ts, 14, 19))
 >DiscriminatorTrue : Symbol(DiscriminatorTrue, Decl(discriminantPropertyInference.ts, 0, 0))
 >DiscriminatorFalse : Symbol(DiscriminatorFalse, Decl(discriminantPropertyInference.ts, 5, 1))
 
 // simple inference
 f({
->f : Symbol(f, Decl(discriminantPropertyInference.ts, 14, 1))
+>f : Symbol(f, Decl(discriminantPropertyInference.ts, 12, 52))
 
     disc: true,
->disc : Symbol(disc, Decl(discriminantPropertyInference.ts, 19, 3))
+>disc : Symbol(disc, Decl(discriminantPropertyInference.ts, 17, 3))
 
     cb: s => parseInt(s)
->cb : Symbol(cb, Decl(discriminantPropertyInference.ts, 20, 15))
->s : Symbol(s, Decl(discriminantPropertyInference.ts, 21, 7))
+>cb : Symbol(cb, Decl(discriminantPropertyInference.ts, 18, 15))
+>s : Symbol(s, Decl(discriminantPropertyInference.ts, 19, 7))
 >parseInt : Symbol(parseInt, Decl(lib.es5.d.ts, --, --))
->s : Symbol(s, Decl(discriminantPropertyInference.ts, 21, 7))
+>s : Symbol(s, Decl(discriminantPropertyInference.ts, 19, 7))
 
 });
 
 // simple inference
 f({
->f : Symbol(f, Decl(discriminantPropertyInference.ts, 14, 1))
+>f : Symbol(f, Decl(discriminantPropertyInference.ts, 12, 52))
 
     disc: false,
->disc : Symbol(disc, Decl(discriminantPropertyInference.ts, 25, 3))
+>disc : Symbol(disc, Decl(discriminantPropertyInference.ts, 23, 3))
 
     cb: n => n.toFixed()
->cb : Symbol(cb, Decl(discriminantPropertyInference.ts, 26, 16))
->n : Symbol(n, Decl(discriminantPropertyInference.ts, 27, 7))
+>cb : Symbol(cb, Decl(discriminantPropertyInference.ts, 24, 16))
+>n : Symbol(n, Decl(discriminantPropertyInference.ts, 25, 7))
 >n.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
->n : Symbol(n, Decl(discriminantPropertyInference.ts, 27, 7))
+>n : Symbol(n, Decl(discriminantPropertyInference.ts, 25, 7))
 >toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
 
 });
 
 // simple inference when strict-null-checks are enabled
 f({
->f : Symbol(f, Decl(discriminantPropertyInference.ts, 14, 1))
+>f : Symbol(f, Decl(discriminantPropertyInference.ts, 12, 52))
 
     disc: undefined,
->disc : Symbol(disc, Decl(discriminantPropertyInference.ts, 31, 3))
+>disc : Symbol(disc, Decl(discriminantPropertyInference.ts, 29, 3))
 >undefined : Symbol(undefined)
 
     cb: n => n.toFixed()
->cb : Symbol(cb, Decl(discriminantPropertyInference.ts, 32, 20))
->n : Symbol(n, Decl(discriminantPropertyInference.ts, 33, 7))
+>cb : Symbol(cb, Decl(discriminantPropertyInference.ts, 30, 20))
+>n : Symbol(n, Decl(discriminantPropertyInference.ts, 31, 7))
 >n.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
->n : Symbol(n, Decl(discriminantPropertyInference.ts, 33, 7))
+>n : Symbol(n, Decl(discriminantPropertyInference.ts, 31, 7))
 >toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
 
 });
 
 // requires checking type information since discriminator is missing from object
 f({
->f : Symbol(f, Decl(discriminantPropertyInference.ts, 14, 1))
+>f : Symbol(f, Decl(discriminantPropertyInference.ts, 12, 52))
 
     cb: n => n.toFixed()
->cb : Symbol(cb, Decl(discriminantPropertyInference.ts, 37, 3))
->n : Symbol(n, Decl(discriminantPropertyInference.ts, 38, 7))
+>cb : Symbol(cb, Decl(discriminantPropertyInference.ts, 35, 3))
+>n : Symbol(n, Decl(discriminantPropertyInference.ts, 36, 7))
 >n.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
->n : Symbol(n, Decl(discriminantPropertyInference.ts, 38, 7))
->toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
-
-});
-
-
-declare function g(options: DiscriminatorTrue | DiscriminatorFalse | Unrelated): any;
->g : Symbol(g, Decl(discriminantPropertyInference.ts, 39, 3))
->options : Symbol(options, Decl(discriminantPropertyInference.ts, 42, 19))
->DiscriminatorTrue : Symbol(DiscriminatorTrue, Decl(discriminantPropertyInference.ts, 0, 0))
->DiscriminatorFalse : Symbol(DiscriminatorFalse, Decl(discriminantPropertyInference.ts, 5, 1))
->Unrelated : Symbol(Unrelated, Decl(discriminantPropertyInference.ts, 10, 1))
-
-// requires checking properties of all types, rather than properties of just the union type (e.g. only intersection)
-g({
->g : Symbol(g, Decl(discriminantPropertyInference.ts, 39, 3))
-
-    cb: n => n.toFixed()
->cb : Symbol(cb, Decl(discriminantPropertyInference.ts, 45, 3))
->n : Symbol(n, Decl(discriminantPropertyInference.ts, 46, 7))
->n.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
->n : Symbol(n, Decl(discriminantPropertyInference.ts, 46, 7))
+>n : Symbol(n, Decl(discriminantPropertyInference.ts, 36, 7))
 >toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
 
 });

--- a/tests/baselines/reference/discriminantPropertyInference.types
+++ b/tests/baselines/reference/discriminantPropertyInference.types
@@ -25,12 +25,8 @@ type DiscriminatorFalse = {
 >x : number
 }
 
-type Unrelated = {
->Unrelated : Unrelated
-
-    val: number;
->val : number
-}
+type Props = DiscriminatorTrue | DiscriminatorFalse;
+>Props : Props
 
 declare function f(options: DiscriminatorTrue | DiscriminatorFalse): any;
 >f : (options: DiscriminatorTrue | DiscriminatorFalse) => any
@@ -102,28 +98,6 @@ f({
 f({
 >f({    cb: n => n.toFixed()}) : any
 >f : (options: DiscriminatorTrue | DiscriminatorFalse) => any
->{    cb: n => n.toFixed()} : { cb: (n: number) => string; }
-
-    cb: n => n.toFixed()
->cb : (n: number) => string
->n => n.toFixed() : (n: number) => string
->n : number
->n.toFixed() : string
->n.toFixed : (fractionDigits?: number | undefined) => string
->n : number
->toFixed : (fractionDigits?: number | undefined) => string
-
-});
-
-
-declare function g(options: DiscriminatorTrue | DiscriminatorFalse | Unrelated): any;
->g : (options: DiscriminatorTrue | DiscriminatorFalse | Unrelated) => any
->options : DiscriminatorTrue | DiscriminatorFalse | Unrelated
-
-// requires checking properties of all types, rather than properties of just the union type (e.g. only intersection)
-g({
->g({    cb: n => n.toFixed()}) : any
->g : (options: DiscriminatorTrue | DiscriminatorFalse | Unrelated) => any
 >{    cb: n => n.toFixed()} : { cb: (n: number) => string; }
 
     cb: n => n.toFixed()

--- a/tests/baselines/reference/tsxDiscriminantPropertyInference.js
+++ b/tests/baselines/reference/tsxDiscriminantPropertyInference.js
@@ -14,15 +14,9 @@ type DiscriminatorFalse = {
     cb: (x: number) => void;
 }
 
-type Unrelated = {
-    val: number;
-}
-
 type Props = DiscriminatorTrue | DiscriminatorFalse;
 
-type UnrelatedProps = Props | Unrelated;
-
-declare function Comp(props: Props): JSX.Element;
+declare function Comp(props: DiscriminatorTrue | DiscriminatorFalse): JSX.Element;
 
 // simple inference
 void (<Comp disc cb={s => parseInt(s)} />);
@@ -36,11 +30,6 @@ void (<Comp disc={undefined} cb={n => n.toFixed()} />);
 // requires checking type information since discriminator is missing from object
 void (<Comp cb={n => n.toFixed()} />);
 
-declare function UnrelatedComp(props: UnrelatedProps): JSX.Element;
-
-// requires checking properties of all types, rather than properties of just the union type (e.g. only intersection)
-void (<Comp cb={n => n.toFixed()} />);
-
 
 //// [tsxDiscriminantPropertyInference.jsx]
 // simple inference
@@ -50,6 +39,4 @@ void (<Comp disc={false} cb={function (n) { return n.toFixed(); }}/>);
 // simple inference when strict-null-checks are enabled
 void (<Comp disc={undefined} cb={function (n) { return n.toFixed(); }}/>);
 // requires checking type information since discriminator is missing from object
-void (<Comp cb={function (n) { return n.toFixed(); }}/>);
-// requires checking properties of all types, rather than properties of just the union type (e.g. only intersection)
 void (<Comp cb={function (n) { return n.toFixed(); }}/>);

--- a/tests/baselines/reference/tsxDiscriminantPropertyInference.symbols
+++ b/tests/baselines/reference/tsxDiscriminantPropertyInference.symbols
@@ -29,82 +29,55 @@ type DiscriminatorFalse = {
 >x : Symbol(x, Decl(tsxDiscriminantPropertyInference.tsx, 12, 9))
 }
 
-type Unrelated = {
->Unrelated : Symbol(Unrelated, Decl(tsxDiscriminantPropertyInference.tsx, 13, 1))
-
-    val: number;
->val : Symbol(val, Decl(tsxDiscriminantPropertyInference.tsx, 15, 18))
-}
-
 type Props = DiscriminatorTrue | DiscriminatorFalse;
->Props : Symbol(Props, Decl(tsxDiscriminantPropertyInference.tsx, 17, 1))
+>Props : Symbol(Props, Decl(tsxDiscriminantPropertyInference.tsx, 13, 1))
 >DiscriminatorTrue : Symbol(DiscriminatorTrue, Decl(tsxDiscriminantPropertyInference.tsx, 3, 1))
 >DiscriminatorFalse : Symbol(DiscriminatorFalse, Decl(tsxDiscriminantPropertyInference.tsx, 8, 1))
 
-type UnrelatedProps = Props | Unrelated;
->UnrelatedProps : Symbol(UnrelatedProps, Decl(tsxDiscriminantPropertyInference.tsx, 19, 52))
->Props : Symbol(Props, Decl(tsxDiscriminantPropertyInference.tsx, 17, 1))
->Unrelated : Symbol(Unrelated, Decl(tsxDiscriminantPropertyInference.tsx, 13, 1))
-
-declare function Comp(props: Props): JSX.Element;
->Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 21, 40))
->props : Symbol(props, Decl(tsxDiscriminantPropertyInference.tsx, 23, 22))
->Props : Symbol(Props, Decl(tsxDiscriminantPropertyInference.tsx, 17, 1))
+declare function Comp(props: DiscriminatorTrue | DiscriminatorFalse): JSX.Element;
+>Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 15, 52))
+>props : Symbol(props, Decl(tsxDiscriminantPropertyInference.tsx, 17, 22))
+>DiscriminatorTrue : Symbol(DiscriminatorTrue, Decl(tsxDiscriminantPropertyInference.tsx, 3, 1))
+>DiscriminatorFalse : Symbol(DiscriminatorFalse, Decl(tsxDiscriminantPropertyInference.tsx, 8, 1))
 >JSX : Symbol(JSX, Decl(tsxDiscriminantPropertyInference.tsx, 0, 0))
 >Element : Symbol(JSX.Element, Decl(tsxDiscriminantPropertyInference.tsx, 1, 15))
 
 // simple inference
 void (<Comp disc cb={s => parseInt(s)} />);
->Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 21, 40))
->disc : Symbol(disc, Decl(tsxDiscriminantPropertyInference.tsx, 26, 11))
->cb : Symbol(cb, Decl(tsxDiscriminantPropertyInference.tsx, 26, 16))
->s : Symbol(s, Decl(tsxDiscriminantPropertyInference.tsx, 26, 21))
+>Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 15, 52))
+>disc : Symbol(disc, Decl(tsxDiscriminantPropertyInference.tsx, 20, 11))
+>cb : Symbol(cb, Decl(tsxDiscriminantPropertyInference.tsx, 20, 16))
+>s : Symbol(s, Decl(tsxDiscriminantPropertyInference.tsx, 20, 21))
 >parseInt : Symbol(parseInt, Decl(lib.es5.d.ts, --, --))
->s : Symbol(s, Decl(tsxDiscriminantPropertyInference.tsx, 26, 21))
+>s : Symbol(s, Decl(tsxDiscriminantPropertyInference.tsx, 20, 21))
 
 // simple inference
 void (<Comp disc={false} cb={n => n.toFixed()} />);
->Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 21, 40))
->disc : Symbol(disc, Decl(tsxDiscriminantPropertyInference.tsx, 29, 11))
->cb : Symbol(cb, Decl(tsxDiscriminantPropertyInference.tsx, 29, 24))
->n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 29, 29))
+>Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 15, 52))
+>disc : Symbol(disc, Decl(tsxDiscriminantPropertyInference.tsx, 23, 11))
+>cb : Symbol(cb, Decl(tsxDiscriminantPropertyInference.tsx, 23, 24))
+>n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 23, 29))
 >n.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
->n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 29, 29))
+>n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 23, 29))
 >toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
 
 // simple inference when strict-null-checks are enabled
 void (<Comp disc={undefined} cb={n => n.toFixed()} />);
->Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 21, 40))
->disc : Symbol(disc, Decl(tsxDiscriminantPropertyInference.tsx, 32, 11))
+>Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 15, 52))
+>disc : Symbol(disc, Decl(tsxDiscriminantPropertyInference.tsx, 26, 11))
 >undefined : Symbol(undefined)
->cb : Symbol(cb, Decl(tsxDiscriminantPropertyInference.tsx, 32, 28))
->n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 32, 33))
+>cb : Symbol(cb, Decl(tsxDiscriminantPropertyInference.tsx, 26, 28))
+>n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 26, 33))
 >n.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
->n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 32, 33))
+>n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 26, 33))
 >toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
 
 // requires checking type information since discriminator is missing from object
 void (<Comp cb={n => n.toFixed()} />);
->Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 21, 40))
->cb : Symbol(cb, Decl(tsxDiscriminantPropertyInference.tsx, 35, 11))
->n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 35, 16))
+>Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 15, 52))
+>cb : Symbol(cb, Decl(tsxDiscriminantPropertyInference.tsx, 29, 11))
+>n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 29, 16))
 >n.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
->n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 35, 16))
->toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
-
-declare function UnrelatedComp(props: UnrelatedProps): JSX.Element;
->UnrelatedComp : Symbol(UnrelatedComp, Decl(tsxDiscriminantPropertyInference.tsx, 35, 38))
->props : Symbol(props, Decl(tsxDiscriminantPropertyInference.tsx, 37, 31))
->UnrelatedProps : Symbol(UnrelatedProps, Decl(tsxDiscriminantPropertyInference.tsx, 19, 52))
->JSX : Symbol(JSX, Decl(tsxDiscriminantPropertyInference.tsx, 0, 0))
->Element : Symbol(JSX.Element, Decl(tsxDiscriminantPropertyInference.tsx, 1, 15))
-
-// requires checking properties of all types, rather than properties of just the union type (e.g. only intersection)
-void (<Comp cb={n => n.toFixed()} />);
->Comp : Symbol(Comp, Decl(tsxDiscriminantPropertyInference.tsx, 21, 40))
->cb : Symbol(cb, Decl(tsxDiscriminantPropertyInference.tsx, 40, 11))
->n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 40, 16))
->n.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
->n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 40, 16))
+>n : Symbol(n, Decl(tsxDiscriminantPropertyInference.tsx, 29, 16))
 >toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
 

--- a/tests/baselines/reference/tsxDiscriminantPropertyInference.types
+++ b/tests/baselines/reference/tsxDiscriminantPropertyInference.types
@@ -28,22 +28,12 @@ type DiscriminatorFalse = {
 >x : number
 }
 
-type Unrelated = {
->Unrelated : Unrelated
-
-    val: number;
->val : number
-}
-
 type Props = DiscriminatorTrue | DiscriminatorFalse;
 >Props : Props
 
-type UnrelatedProps = Props | Unrelated;
->UnrelatedProps : UnrelatedProps
-
-declare function Comp(props: Props): JSX.Element;
->Comp : (props: Props) => JSX.Element
->props : Props
+declare function Comp(props: DiscriminatorTrue | DiscriminatorFalse): JSX.Element;
+>Comp : (props: DiscriminatorTrue | DiscriminatorFalse) => JSX.Element
+>props : DiscriminatorTrue | DiscriminatorFalse
 >JSX : any
 
 // simple inference
@@ -51,7 +41,7 @@ void (<Comp disc cb={s => parseInt(s)} />);
 >void (<Comp disc cb={s => parseInt(s)} />) : undefined
 >(<Comp disc cb={s => parseInt(s)} />) : JSX.Element
 ><Comp disc cb={s => parseInt(s)} /> : JSX.Element
->Comp : (props: Props) => JSX.Element
+>Comp : (props: DiscriminatorTrue | DiscriminatorFalse) => JSX.Element
 >disc : true
 >cb : (s: string) => number
 >s => parseInt(s) : (s: string) => number
@@ -65,7 +55,7 @@ void (<Comp disc={false} cb={n => n.toFixed()} />);
 >void (<Comp disc={false} cb={n => n.toFixed()} />) : undefined
 >(<Comp disc={false} cb={n => n.toFixed()} />) : JSX.Element
 ><Comp disc={false} cb={n => n.toFixed()} /> : JSX.Element
->Comp : (props: Props) => JSX.Element
+>Comp : (props: DiscriminatorTrue | DiscriminatorFalse) => JSX.Element
 >disc : false
 >false : false
 >cb : (n: number) => string
@@ -81,7 +71,7 @@ void (<Comp disc={undefined} cb={n => n.toFixed()} />);
 >void (<Comp disc={undefined} cb={n => n.toFixed()} />) : undefined
 >(<Comp disc={undefined} cb={n => n.toFixed()} />) : JSX.Element
 ><Comp disc={undefined} cb={n => n.toFixed()} /> : JSX.Element
->Comp : (props: Props) => JSX.Element
+>Comp : (props: DiscriminatorTrue | DiscriminatorFalse) => JSX.Element
 >disc : undefined
 >undefined : undefined
 >cb : (n: number) => string
@@ -97,26 +87,7 @@ void (<Comp cb={n => n.toFixed()} />);
 >void (<Comp cb={n => n.toFixed()} />) : undefined
 >(<Comp cb={n => n.toFixed()} />) : JSX.Element
 ><Comp cb={n => n.toFixed()} /> : JSX.Element
->Comp : (props: Props) => JSX.Element
->cb : (n: number) => string
->n => n.toFixed() : (n: number) => string
->n : number
->n.toFixed() : string
->n.toFixed : (fractionDigits?: number | undefined) => string
->n : number
->toFixed : (fractionDigits?: number | undefined) => string
-
-declare function UnrelatedComp(props: UnrelatedProps): JSX.Element;
->UnrelatedComp : (props: UnrelatedProps) => JSX.Element
->props : UnrelatedProps
->JSX : any
-
-// requires checking properties of all types, rather than properties of just the union type (e.g. only intersection)
-void (<Comp cb={n => n.toFixed()} />);
->void (<Comp cb={n => n.toFixed()} />) : undefined
->(<Comp cb={n => n.toFixed()} />) : JSX.Element
-><Comp cb={n => n.toFixed()} /> : JSX.Element
->Comp : (props: Props) => JSX.Element
+>Comp : (props: DiscriminatorTrue | DiscriminatorFalse) => JSX.Element
 >cb : (n: number) => string
 >n => n.toFixed() : (n: number) => string
 >n : number

--- a/tests/cases/compiler/discriminantPropertyInference.ts
+++ b/tests/cases/compiler/discriminantPropertyInference.ts
@@ -13,9 +13,7 @@ type DiscriminatorFalse = {
     cb: (x: number) => void;
 }
 
-type Unrelated = {
-    val: number;
-}
+type Props = DiscriminatorTrue | DiscriminatorFalse;
 
 declare function f(options: DiscriminatorTrue | DiscriminatorFalse): any;
 
@@ -39,13 +37,5 @@ f({
 
 // requires checking type information since discriminator is missing from object
 f({
-    cb: n => n.toFixed()
-});
-
-
-declare function g(options: DiscriminatorTrue | DiscriminatorFalse | Unrelated): any;
-
-// requires checking properties of all types, rather than properties of just the union type (e.g. only intersection)
-g({
     cb: n => n.toFixed()
 });

--- a/tests/cases/compiler/tsxDiscriminantPropertyInference.tsx
+++ b/tests/cases/compiler/tsxDiscriminantPropertyInference.tsx
@@ -17,15 +17,9 @@ type DiscriminatorFalse = {
     cb: (x: number) => void;
 }
 
-type Unrelated = {
-    val: number;
-}
-
 type Props = DiscriminatorTrue | DiscriminatorFalse;
 
-type UnrelatedProps = Props | Unrelated;
-
-declare function Comp(props: Props): JSX.Element;
+declare function Comp(props: DiscriminatorTrue | DiscriminatorFalse): JSX.Element;
 
 // simple inference
 void (<Comp disc cb={s => parseInt(s)} />);
@@ -37,9 +31,4 @@ void (<Comp disc={false} cb={n => n.toFixed()} />);
 void (<Comp disc={undefined} cb={n => n.toFixed()} />);
 
 // requires checking type information since discriminator is missing from object
-void (<Comp cb={n => n.toFixed()} />);
-
-declare function UnrelatedComp(props: UnrelatedProps): JSX.Element;
-
-// requires checking properties of all types, rather than properties of just the union type (e.g. only intersection)
 void (<Comp cb={n => n.toFixed()} />);


### PR DESCRIPTION
This reverts commit 751c11412618e8b2a504380135bc2f0b2505e18f, which caused check time for our MUI benchmark to increase by ~25%.

See #48298