### PR TITLE
Add label details to completion entry

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8753,6 +8753,7 @@ namespace ts {
         readonly includeCompletionsWithInsertText?: boolean;
         readonly includeCompletionsWithClassMemberSnippets?: boolean;
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
+        readonly includeCompletionsWithLabelDetails?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8753,7 +8753,7 @@ namespace ts {
         readonly includeCompletionsWithInsertText?: boolean;
         readonly includeCompletionsWithClassMemberSnippets?: boolean;
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
-        readonly includeCompletionsWithLabelDetails?: boolean;
+        readonly useLabelDetailsInCompletionEntries?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -983,6 +983,8 @@ namespace FourSlash {
                 assert.equal<boolean | undefined>(actual.isPackageJsonImport, expected.isPackageJsonImport, `At entry ${actual.name}: Expected 'isPackageJsonImport' properties to match`);
             }
 
+            assert.equal(actual.labelDetails?.description, expected.labelDetails?.description, `At entry ${actual.name}: Expected 'labelDetails.description' properties to match`);
+            assert.equal(actual.labelDetails?.detail, expected.labelDetails?.detail, `At entry ${actual.name}: Expected 'labelDetails.detail' properties to match`);
             assert.equal(actual.hasAction, expected.hasAction, `At entry ${actual.name}: Expected 'hasAction' properties to match`);
             assert.equal(actual.isRecommended, expected.isRecommended, `At entry ${actual.name}: Expected 'isRecommended' properties to match'`);
             assert.equal(actual.isSnippet, expected.isSnippet, `At entry ${actual.name}: Expected 'isSnippet' properties to match`);

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1719,8 +1719,14 @@ namespace FourSlashInterface {
         readonly text?: string;
         readonly documentation?: string;
         readonly sourceDisplay?: string;
+        readonly labelDetails?: ExpectedCompletionEntryLabelDetails;
         readonly tags?: readonly ts.JSDocTagInfo[];
         readonly sortText?: ts.Completions.SortText;
+    }
+
+    export interface ExpectedCompletionEntryLabelDetails {
+        detail?: string;
+        description?: string;
     }
 
     export type ExpectedExactCompletionsPlus = readonly ExpectedCompletionEntry[] & {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2291,6 +2291,10 @@ namespace ts.server.protocol {
          */
         sourceDisplay?: SymbolDisplayPart[];
         /**
+         * Additional details for the label.
+         */
+        labelDetails?: CompletionEntryLabelDetails;
+        /**
          * If true, this completion should be highlighted as recommended. There will only be one of these.
          * This will be set when we know the user should write an expression with a certain type and that type is an enum or constructable class.
          * Then either that enum/class or a namespace containing it will be the recommended symbol.
@@ -2317,6 +2321,21 @@ namespace ts.server.protocol {
          * items with the same name.
          */
         data?: unknown;
+    }
+
+    export interface CompletionEntryLabelDetails {
+        /**
+         * An optional string which is rendered less prominently directly after
+         * {@link CompletionEntry.name name}, without any spacing. Should be
+         * used for function signatures or type annotations.
+         */
+        detail?: string;
+        /**
+         * An optional string which is rendered less prominently after
+         * {@link CompletionEntryLabelDetails.detail}. Should be used for fully qualified
+         * names or file path.
+         */
+        description?: string;
     }
 
     /**

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3434,8 +3434,9 @@ namespace ts.server.protocol {
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
         /**
          * Indicates whether {@link CompletionEntry.labelDetails completion entry label details} are supported.
+         * If not, contents of `labelDetails` may be included in the {@link CompletionEntry.name} property.
          */
-        readonly includeCompletionsWithLabelDetails?: boolean;
+        readonly useLabelDetailsInCompletionEntries?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3432,6 +3432,10 @@ namespace ts.server.protocol {
          * in addition to `const objectLiteral: T = { foo }`.
          */
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
+        /**
+         * Indicates whether {@link CompletionEntry.labelDetails completion entry label details} are supported.
+         */
+        readonly includeCompletionsWithLabelDetails?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1837,10 +1837,41 @@ namespace ts.server {
             const prefix = args.prefix || "";
             const entries = mapDefined<CompletionEntry, protocol.CompletionEntry>(completions.entries, entry => {
                 if (completions.isMemberCompletion || startsWith(entry.name.toLowerCase(), prefix.toLowerCase())) {
-                    const { name, kind, kindModifiers, sortText, insertText, replacementSpan, hasAction, source, sourceDisplay, isSnippet, isRecommended, isPackageJsonImport, isImportStatementCompletion, data } = entry;
+                    const {
+                        name,
+                        kind,
+                        kindModifiers,
+                        sortText,
+                        insertText,
+                        replacementSpan,
+                        hasAction,
+                        source,
+                        sourceDisplay,
+                        labelDetails,
+                        isSnippet,
+                        isRecommended,
+                        isPackageJsonImport,
+                        isImportStatementCompletion,
+                        data } = entry;
                     const convertedSpan = replacementSpan ? toProtocolTextSpan(replacementSpan, scriptInfo) : undefined;
                     // Use `hasAction || undefined` to avoid serializing `false`.
-                    return { name, kind, kindModifiers, sortText, insertText, replacementSpan: convertedSpan, isSnippet, hasAction: hasAction || undefined, source, sourceDisplay, isRecommended, isPackageJsonImport, isImportStatementCompletion, data };
+                    return {
+                        name,
+                        kind,
+                        kindModifiers,
+                        sortText,
+                        insertText,
+                        replacementSpan: convertedSpan,
+                        isSnippet,
+                        hasAction: hasAction || undefined,
+                        source,
+                        sourceDisplay,
+                        labelDetails,
+                        isRecommended,
+                        isPackageJsonImport,
+                        isImportStatementCompletion,
+                        data
+                    };
                 }
             });
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1072,7 +1072,7 @@ namespace ts.Completions {
         options: CompilerOptions,
         preferences: UserPreferences,
         formatContext: formatting.FormatContext | undefined,
-        ): { insertText: string, isSnippet?: true, importAdder: codefix.ImportAdder, labelDetails: CompletionEntryLabelDetails } | undefined {
+    ): { insertText: string, isSnippet?: true, importAdder: codefix.ImportAdder, labelDetails: CompletionEntryLabelDetails } | undefined {
         const isSnippet = preferences.includeCompletionsWithSnippetText || undefined;
         let insertText: string = name;
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -782,7 +782,7 @@ namespace ts.Completions {
         if (origin && originIsObjectLiteralMethod(origin)) {
             let importAdder;
             ({ insertText, isSnippet, importAdder, labelDetails } = origin);
-            if (!preferences.includeCompletionsWithLabelDetails) {
+            if (!preferences.useLabelDetailsInCompletionEntries) {
                 name = name + labelDetails.detail;
                 labelDetails = undefined;
             }
@@ -1104,8 +1104,10 @@ namespace ts.Completions {
             target: options.target,
             omitTrailingSemicolon: true,
         });
+        // The `labelDetails.detail` will be displayed right beside the method name,
+        // so we drop the name (and modifiers) from the signature.
         const methodSignature = factory.createMethodSignature(
-            method.modifiers,
+            /*modifiers*/ undefined,
             /*name*/ "",
             method.questionToken,
             method.typeParameters,

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -782,6 +782,10 @@ namespace ts.Completions {
         if (origin && originIsObjectLiteralMethod(origin)) {
             let importAdder;
             ({ insertText, isSnippet, importAdder, labelDetails } = origin);
+            if (!preferences.includeCompletionsWithLabelDetails) {
+                name = name + labelDetails.detail;
+                labelDetails = undefined;
+            }
             source = CompletionSource.ObjectLiteralMethodSnippet;
             sortText = SortText.SortBelow(sortText);
             if (importAdder.hasFixes()) {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -98,7 +98,7 @@ namespace ts.Completions {
     interface SymbolOriginInfoObjectLiteralMethod extends SymbolOriginInfo {
         importAdder: codefix.ImportAdder,
         insertText: string,
-        sourceDisplay: SymbolDisplayPart[],
+        labelDetails: CompletionEntryLabelDetails,
         isSnippet?: true,
     }
 
@@ -706,6 +706,7 @@ namespace ts.Completions {
         let source = getSourceFromOrigin(origin);
         let sourceDisplay;
         let hasAction;
+        let labelDetails;
 
         const typeChecker = program.getTypeChecker();
         const insertQuestionDot = origin && originIsNullableMember(origin);
@@ -780,7 +781,7 @@ namespace ts.Completions {
 
         if (origin && originIsObjectLiteralMethod(origin)) {
             let importAdder;
-            ({ insertText, isSnippet, importAdder, sourceDisplay } = origin);
+            ({ insertText, isSnippet, importAdder, labelDetails } = origin);
             source = CompletionSource.ObjectLiteralMethodSnippet;
             sortText = SortText.SortBelow(sortText);
             if (importAdder.hasFixes()) {
@@ -842,6 +843,7 @@ namespace ts.Completions {
             insertText,
             replacementSpan,
             sourceDisplay,
+            labelDetails,
             isSnippet,
             isPackageJsonImport: originIsPackageJsonImport(origin) || undefined,
             isImportStatementCompletion: !!importCompletionNode || undefined,
@@ -1066,7 +1068,7 @@ namespace ts.Completions {
         options: CompilerOptions,
         preferences: UserPreferences,
         formatContext: formatting.FormatContext | undefined,
-    ): { insertText: string, isSnippet?: true, importAdder: codefix.ImportAdder, sourceDisplay: SymbolDisplayPart[] } | undefined {
+        ): { insertText: string, isSnippet?: true, importAdder: codefix.ImportAdder, labelDetails: CompletionEntryLabelDetails } | undefined {
         const isSnippet = preferences.includeCompletionsWithSnippetText || undefined;
         let insertText: string = name;
 
@@ -1092,16 +1094,22 @@ namespace ts.Completions {
             insertText = printer.printSnippetList(ListFormat.CommaDelimited | ListFormat.AllowTrailingComma, factory.createNodeArray([method], /*hasTrailingComma*/ true), sourceFile);
         }
 
+        const signaturePrinter = createPrinter({
+            removeComments: true,
+            module: options.module,
+            target: options.target,
+            omitTrailingSemicolon: true,
+        });
         const methodSignature = factory.createMethodSignature(
             method.modifiers,
-            method.name,
+            /*name*/ "",
             method.questionToken,
             method.typeParameters,
             method.parameters,
             method.type);
-        const sourceDisplay = nodeToDisplayParts(methodSignature, enclosingDeclaration);
+        const labelDetails = { detail: signaturePrinter.printNode(EmitHint.Unspecified, methodSignature, sourceFile) };
 
-        return { isSnippet, insertText, importAdder, sourceDisplay };
+        return { isSnippet, insertText, importAdder, labelDetails };
 
     };
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1232,6 +1232,7 @@ namespace ts {
         hasAction?: true;
         source?: string;
         sourceDisplay?: SymbolDisplayPart[];
+        labelDetails?: CompletionEntryLabelDetails;
         isRecommended?: true;
         isFromUncheckedFile?: true;
         isPackageJsonImport?: true;
@@ -1245,6 +1246,11 @@ namespace ts {
          * is an auto-import.
          */
         data?: CompletionEntryData;
+    }
+
+    export interface CompletionEntryLabelDetails {
+        detail?: string;
+        description?: string;
     }
 
     export interface CompletionEntryDetails {

--- a/src/testRunner/unittests/tsserver/completions.ts
+++ b/src/testRunner/unittests/tsserver/completions.ts
@@ -42,7 +42,8 @@ namespace ts.projectSystem {
                 source: "/a",
                 sourceDisplay: undefined,
                 isSnippet: undefined,
-                data: { exportName: "foo", fileName: "/a.ts", ambientModuleName: undefined, isPackageJsonImport: undefined }
+                data: { exportName: "foo", fileName: "/a.ts", ambientModuleName: undefined, isPackageJsonImport: undefined },
+                labelDetails: undefined,
             };
 
             // `data.exportMapKey` contains a SymbolId so should not be mocked up with an expected value here.

--- a/src/testRunner/unittests/tsserver/partialSemanticServer.ts
+++ b/src/testRunner/unittests/tsserver/partialSemanticServer.ts
@@ -75,6 +75,7 @@ import { something } from "something";
                     data: undefined,
                     sourceDisplay: undefined,
                     isSnippet: undefined,
+                    labelDetails: undefined,
                 };
             }
         });

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4100,6 +4100,7 @@ declare namespace ts {
         readonly includeCompletionsWithInsertText?: boolean;
         readonly includeCompletionsWithClassMemberSnippets?: boolean;
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
+        readonly includeCompletionsWithLabelDetails?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
@@ -9659,6 +9660,10 @@ declare namespace ts.server.protocol {
          * in addition to `const objectLiteral: T = { foo }`.
          */
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
+        /**
+         * Indicates whether {@link CompletionEntry.labelDetails completion entry label details} are supported.
+         */
+        readonly includeCompletionsWithLabelDetails?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4100,7 +4100,7 @@ declare namespace ts {
         readonly includeCompletionsWithInsertText?: boolean;
         readonly includeCompletionsWithClassMemberSnippets?: boolean;
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
-        readonly includeCompletionsWithLabelDetails?: boolean;
+        readonly useLabelDetailsInCompletionEntries?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
@@ -9662,8 +9662,9 @@ declare namespace ts.server.protocol {
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
         /**
          * Indicates whether {@link CompletionEntry.labelDetails completion entry label details} are supported.
+         * If not, contents of `labelDetails` may be included in the {@link CompletionEntry.name} property.
          */
-        readonly includeCompletionsWithLabelDetails?: boolean;
+        readonly useLabelDetailsInCompletionEntries?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6485,6 +6485,7 @@ declare namespace ts {
         hasAction?: true;
         source?: string;
         sourceDisplay?: SymbolDisplayPart[];
+        labelDetails?: CompletionEntryLabelDetails;
         isRecommended?: true;
         isFromUncheckedFile?: true;
         isPackageJsonImport?: true;
@@ -6498,6 +6499,10 @@ declare namespace ts {
          * is an auto-import.
          */
         data?: CompletionEntryData;
+    }
+    interface CompletionEntryLabelDetails {
+        detail?: string;
+        description?: string;
     }
     interface CompletionEntryDetails {
         name: string;
@@ -8709,6 +8714,10 @@ declare namespace ts.server.protocol {
          */
         sourceDisplay?: SymbolDisplayPart[];
         /**
+         * Additional details for the label.
+         */
+        labelDetails?: CompletionEntryLabelDetails;
+        /**
          * If true, this completion should be highlighted as recommended. There will only be one of these.
          * This will be set when we know the user should write an expression with a certain type and that type is an enum or constructable class.
          * Then either that enum/class or a namespace containing it will be the recommended symbol.
@@ -8735,6 +8744,20 @@ declare namespace ts.server.protocol {
          * items with the same name.
          */
         data?: unknown;
+    }
+    interface CompletionEntryLabelDetails {
+        /**
+         * An optional string which is rendered less prominently directly after
+         * {@link CompletionEntry.name name}, without any spacing. Should be
+         * used for function signatures or type annotations.
+         */
+        detail?: string;
+        /**
+         * An optional string which is rendered less prominently after
+         * {@link CompletionEntryLabelDetails.detail}. Should be used for fully qualified
+         * names or file path.
+         */
+        description?: string;
     }
     /**
      * Additional completion entry details, available on demand

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4100,6 +4100,7 @@ declare namespace ts {
         readonly includeCompletionsWithInsertText?: boolean;
         readonly includeCompletionsWithClassMemberSnippets?: boolean;
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
+        readonly includeCompletionsWithLabelDetails?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6485,6 +6485,7 @@ declare namespace ts {
         hasAction?: true;
         source?: string;
         sourceDisplay?: SymbolDisplayPart[];
+        labelDetails?: CompletionEntryLabelDetails;
         isRecommended?: true;
         isFromUncheckedFile?: true;
         isPackageJsonImport?: true;
@@ -6498,6 +6499,10 @@ declare namespace ts {
          * is an auto-import.
          */
         data?: CompletionEntryData;
+    }
+    interface CompletionEntryLabelDetails {
+        detail?: string;
+        description?: string;
     }
     interface CompletionEntryDetails {
         name: string;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4100,7 +4100,7 @@ declare namespace ts {
         readonly includeCompletionsWithInsertText?: boolean;
         readonly includeCompletionsWithClassMemberSnippets?: boolean;
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
-        readonly includeCompletionsWithLabelDetails?: boolean;
+        readonly useLabelDetailsInCompletionEntries?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */

--- a/tests/cases/fourslash/completionsObjectLiteralMethod1.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralMethod1.ts
@@ -38,6 +38,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
+        includeCompletionsWithLabelDetails: true,
     },
     includes: [
         {
@@ -51,6 +52,9 @@ verify.completions({
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "bar")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             insertText: "bar(x: number): void {\n},",
+            labelDetails: {
+                detail: "(x: number): void",
+            },
         },
     ],
 });
@@ -60,6 +64,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
+        includeCompletionsWithLabelDetails: true,
     },
     includes: [
         {
@@ -73,6 +78,9 @@ verify.completions({
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "bar")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             insertText: "bar(x: number): void {\n},",
+            labelDetails: {
+                detail: "(x: number): void",
+            },
         },
         {
             name: "foo",
@@ -85,6 +93,9 @@ verify.completions({
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "foo")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             insertText: "foo(x: string): string {\n},",
+            labelDetails: {
+                detail: "(x: string): string",
+            },
         },
     ],
 });
@@ -110,6 +121,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
+        includeCompletionsWithLabelDetails: true,
     },
     includes: [
         {
@@ -123,6 +135,9 @@ verify.completions({
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "\"space bar\"")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             insertText: "\"space bar\"(): string {\n},",
+            labelDetails: {
+                detail: "(): string",
+            },
         },
     ],
 });
@@ -132,6 +147,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: true,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
+        includeCompletionsWithLabelDetails: true,
     },
     includes: [
         {
@@ -141,6 +157,33 @@ verify.completions({
         },
         {
             name: "bar",
+            sortText: completion.SortText.SortBelow(
+                completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "bar")),
+            source: completion.CompletionSource.ObjectLiteralMethodSnippet,
+            isSnippet: true,
+            insertText: "bar(x: number): void {\n    $0\n},",
+            labelDetails: {
+                detail: "(x: number): void",
+            },
+        },
+    ],
+});
+verify.completions({
+    marker: "a",
+    preferences: {
+        includeCompletionsWithInsertText: true,
+        includeCompletionsWithSnippetText: true,
+        includeCompletionsWithObjectLiteralMethodSnippets: true,
+        includeCompletionsWithLabelDetails: false,
+    },
+    includes: [
+        {
+            name: "bar",
+            sortText: completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "bar"),
+            insertText: undefined,
+        },
+        {
+            name: "bar(x: number): void",
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "bar")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,

--- a/tests/cases/fourslash/completionsObjectLiteralMethod1.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralMethod1.ts
@@ -38,7 +38,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
-        includeCompletionsWithLabelDetails: true,
+        useLabelDetailsInCompletionEntries: true,
     },
     includes: [
         {
@@ -64,7 +64,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
-        includeCompletionsWithLabelDetails: true,
+        useLabelDetailsInCompletionEntries: true,
     },
     includes: [
         {
@@ -121,7 +121,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
-        includeCompletionsWithLabelDetails: true,
+        useLabelDetailsInCompletionEntries: true,
     },
     includes: [
         {
@@ -147,7 +147,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: true,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
-        includeCompletionsWithLabelDetails: true,
+        useLabelDetailsInCompletionEntries: true,
     },
     includes: [
         {
@@ -174,7 +174,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: true,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
-        includeCompletionsWithLabelDetails: false,
+        useLabelDetailsInCompletionEntries: false,
     },
     includes: [
         {

--- a/tests/cases/fourslash/completionsObjectLiteralMethod2.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralMethod2.ts
@@ -24,7 +24,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
-        includeCompletionsWithLabelDetails: true,
+        useLabelDetailsInCompletionEntries: true,
     },
     includes: [
         {
@@ -51,7 +51,7 @@ verify.applyCodeActionFromCompletion("a", {
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
-        includeCompletionsWithLabelDetails: true,
+        useLabelDetailsInCompletionEntries: true,
     },
     name: "foo",
     source: completion.CompletionSource.ObjectLiteralMethodSnippet,

--- a/tests/cases/fourslash/completionsObjectLiteralMethod2.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralMethod2.ts
@@ -24,6 +24,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
+        includeCompletionsWithLabelDetails: true,
     },
     includes: [
         {
@@ -38,6 +39,9 @@ verify.completions({
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             insertText: "foo(f: IFoo): void {\n},",
             hasAction: true,
+            labelDetails: {
+                detail: "(f: IFoo): void",
+            },
         },
     ],
 });
@@ -47,6 +51,7 @@ verify.applyCodeActionFromCompletion("a", {
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
+        includeCompletionsWithLabelDetails: true,
     },
     name: "foo",
     source: completion.CompletionSource.ObjectLiteralMethodSnippet,

--- a/tests/cases/fourslash/completionsObjectLiteralMethod3.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralMethod3.ts
@@ -39,7 +39,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
-        includeCompletionsWithLabelDetails: true,
+        useLabelDetailsInCompletionEntries: true,
     },
     includes: [
         {
@@ -97,7 +97,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
-        includeCompletionsWithLabelDetails: true,
+        useLabelDetailsInCompletionEntries: true,
     },
     includes: [
         {

--- a/tests/cases/fourslash/completionsObjectLiteralMethod3.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralMethod3.ts
@@ -39,6 +39,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
+        includeCompletionsWithLabelDetails: true,
     },
     includes: [
         {
@@ -52,6 +53,9 @@ verify.completions({
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "M")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             insertText: "M(x: number): void {\n},",
+            labelDetails: {
+                detail: "(x: number): void",
+            },
         },
     ],
 });
@@ -93,6 +97,7 @@ verify.completions({
         includeCompletionsWithInsertText: true,
         includeCompletionsWithSnippetText: false,
         includeCompletionsWithObjectLiteralMethodSnippets: true,
+        includeCompletionsWithLabelDetails: true,
     },
     includes: [
         {
@@ -106,6 +111,9 @@ verify.completions({
                 completion.SortText.ObjectLiteralProperty(completion.SortText.OptionalMember, "M")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             insertText: "M(x: number): void {\n},",
+            labelDetails: {
+                detail: "(x: number): void",
+            },
         },
         {
             name: "N",
@@ -118,6 +126,9 @@ verify.completions({
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "N")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             insertText: "N(x: string): void {\n},",
+            labelDetails: {
+                detail: "(x: string): void",
+            },
         },
         {
             name: "O",
@@ -130,6 +141,9 @@ verify.completions({
                 completion.SortText.ObjectLiteralProperty(completion.SortText.OptionalMember, "O")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             insertText: "O(): void {\n},",
+            labelDetails: {
+                detail: "(): void",
+            },
         },
     ],
 });

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -700,6 +700,12 @@ declare namespace FourSlashInterface {
         readonly documentation?: string;
         readonly tags?: ReadonlyArray<JSDocTagInfo>;
         readonly sourceDisplay?: string;
+        readonly labelDetails?: ExpectedCompletionEntryLabelDetails;
+    }
+
+    export interface ExpectedCompletionEntryLabelDetails {
+        detail?: string;
+        description?: string;
     }
 
     interface VerifySignatureHelpOptions {

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -648,6 +648,7 @@ declare namespace FourSlashInterface {
         readonly includeCompletionsWithInsertText?: boolean;
         readonly includeCompletionsWithClassMemberSnippets?: boolean;
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
+        readonly includeCompletionsWithLabelDetails?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         /** @deprecated use `includeCompletionsWithInsertText` */
         readonly includeInsertTextCompletions?: boolean;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -648,7 +648,7 @@ declare namespace FourSlashInterface {
         readonly includeCompletionsWithInsertText?: boolean;
         readonly includeCompletionsWithClassMemberSnippets?: boolean;
         readonly includeCompletionsWithObjectLiteralMethodSnippets?: boolean;
-        readonly includeCompletionsWithLabelDetails?: boolean;
+        readonly useLabelDetailsInCompletionEntries?: boolean;
         readonly allowIncompleteCompletions?: boolean;
         /** @deprecated use `includeCompletionsWithInsertText` */
         readonly includeInsertTextCompletions?: boolean;


### PR DESCRIPTION
Follow-up to #48168, as per [this comment](https://github.com/microsoft/TypeScript/pull/48168#issuecomment-1076908515).
This PR adds [label details](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemLabelDetails) in our completion entry type.
Since not all editors support this (vscode does, I think VS doesn't, or at least the TS extension in VS doesn't yet), there is also a new flag in `UserPreferences` that should be used by editors to indicate if they support this new property.

I've also changed the way object literal method snippet completions work to use label details, if they are available.
If they're not available, then we emulate it by modifying the name of the completion entry to be the full signature instead of just the name of the method (e.g. name: `foo` becomes name: `foo(x: number): number`.

Examples for what it looks like in vscode:
With label details:
![image](https://user-images.githubusercontent.com/19519347/160196904-56f9e4c3-e4a7-42d5-8948-f98b53b170d9.png)
 
 Without label details:
![image](https://user-images.githubusercontent.com/19519347/160196961-dc3a3e09-18b3-4f96-9f30-dc538f2dfa79.png)




