### PR TITLE
Update Intl.DisplayNames types for better spec compliance

### DIFF
--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -63,7 +63,7 @@ declare namespace Intl {
      *
      * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument).
      */
-    type LocalesArgument = UnicodeBCP47LocaleIdentifier | UnicodeBCP47LocaleIdentifier[] | Locale | Locale[] | undefined;
+    type LocalesArgument = UnicodeBCP47LocaleIdentifier | Locale | (UnicodeBCP47LocaleIdentifier | Locale)[] | undefined;
 
     /**
      * An object with some or all of properties of `options` parameter
@@ -295,30 +295,32 @@ declare namespace Intl {
         | "code"
         | "none";
 
-    type ResolvedDisplayNamesType =
+    type DisplayNamesType =
         | "language"
         | "region"
         | "script"
+        | "calendar"
+        | "dateTimeField"
         | "currency";
 
-    type DisplayNamesType =
-        | ResolvedDisplayNamesType
-        | "calendar"
-        | "datetimeField";
+    type DisplayNamesLanguageDisplay =
+        | "dialect"
+        | "standard";
 
     interface DisplayNamesOptions {
-        localeMatcher: RelativeTimeFormatLocaleMatcher;
-        style: RelativeTimeFormatStyle;
+        localeMatcher?: RelativeTimeFormatLocaleMatcher;
+        style?: RelativeTimeFormatStyle;
         type: DisplayNamesType;
-        languageDisplay: "dialect" | "standard";
-        fallback: DisplayNamesFallback;
+        languageDisplay?: DisplayNamesLanguageDisplay;
+        fallback?: DisplayNamesFallback;
     }
 
     interface ResolvedDisplayNamesOptions {
         locale: UnicodeBCP47LocaleIdentifier;
         style: RelativeTimeFormatStyle;
-        type: ResolvedDisplayNamesType;
+        type: DisplayNamesType;
         fallback: DisplayNamesFallback;
+        languageDisplay?: DisplayNamesLanguageDisplay;
     }
 
     interface DisplayNames {
@@ -365,7 +367,7 @@ declare namespace Intl {
          *
          * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/DisplayNames).
          */
-        new(locales?: BCP47LanguageTag | BCP47LanguageTag[], options?: Partial<DisplayNamesOptions>): DisplayNames;
+        new(locales: LocalesArgument, options: DisplayNamesOptions): DisplayNames;
 
         /**
          * Returns an array containing those of the provided locales that are supported in display names without having to fall back to the runtime's default locale.
@@ -380,7 +382,7 @@ declare namespace Intl {
          *
          * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/supportedLocalesOf).
          */
-        supportedLocalesOf(locales: BCP47LanguageTag | BCP47LanguageTag[], options?: {localeMatcher: RelativeTimeFormatLocaleMatcher}): BCP47LanguageTag[];
+        supportedLocalesOf(locales?: LocalesArgument, options?: { localeMatcher?: RelativeTimeFormatLocaleMatcher }): BCP47LanguageTag[];
     };
 
 }

--- a/tests/baselines/reference/es2020IntlAPIs.errors.txt
+++ b/tests/baselines/reference/es2020IntlAPIs.errors.txt
@@ -69,6 +69,7 @@ tests/cases/conformance/es2020/es2020IntlAPIs.ts(50,29): error TS2345: Argument 
 !!! error TS2345: Argument of type '{}' is not assignable to parameter of type 'DisplayNamesOptions'.
 !!! error TS2345:   Property 'type' is missing in type '{}' but required in type 'DisplayNamesOptions'.
 !!! related TS2728 /.ts/lib.es2020.intl.d.ts:333:9: 'type' is declared here.
+    console.log((new Intl.DisplayNames(undefined, {type: 'language'})).of('en-GB')); // "British English"
     
     const localesArg = ["es-ES", new Intl.Locale("en-US")];
     console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale); // "es-ES"

--- a/tests/baselines/reference/es2020IntlAPIs.errors.txt
+++ b/tests/baselines/reference/es2020IntlAPIs.errors.txt
@@ -1,7 +1,11 @@
 tests/cases/conformance/es2020/es2020IntlAPIs.ts(45,1): error TS2554: Expected 1-2 arguments, but got 0.
+tests/cases/conformance/es2020/es2020IntlAPIs.ts(48,1): error TS2554: Expected 2 arguments, but got 0.
+tests/cases/conformance/es2020/es2020IntlAPIs.ts(49,1): error TS2554: Expected 2 arguments, but got 1.
+tests/cases/conformance/es2020/es2020IntlAPIs.ts(50,29): error TS2345: Argument of type '{}' is not assignable to parameter of type 'DisplayNamesOptions'.
+  Property 'type' is missing in type '{}' but required in type 'DisplayNamesOptions'.
 
 
-==== tests/cases/conformance/es2020/es2020IntlAPIs.ts (1 errors) ====
+==== tests/cases/conformance/es2020/es2020IntlAPIs.ts (4 errors) ====
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation
     const count = 26254.39;
     const date = new Date("2012-05-24");
@@ -51,3 +55,24 @@ tests/cases/conformance/es2020/es2020IntlAPIs.ts(45,1): error TS2554: Expected 1
 !!! error TS2554: Expected 1-2 arguments, but got 0.
 !!! related TS6210 /.ts/lib.es2020.intl.d.ts:311:14: An argument for 'tag' was not provided.
     new Intl.Locale(new Intl.Locale('en-US'));
+    
+    new Intl.DisplayNames(); // TypeError: invalid_argument
+    ~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2554: Expected 2 arguments, but got 0.
+!!! related TS6210 /.ts/lib.es2020.intl.d.ts:390:13: An argument for 'locales' was not provided.
+    new Intl.DisplayNames('en'); // TypeError: invalid_argument
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2554: Expected 2 arguments, but got 1.
+!!! related TS6210 /.ts/lib.es2020.intl.d.ts:390:39: An argument for 'options' was not provided.
+    new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
+                                ~~
+!!! error TS2345: Argument of type '{}' is not assignable to parameter of type 'DisplayNamesOptions'.
+!!! error TS2345:   Property 'type' is missing in type '{}' but required in type 'DisplayNamesOptions'.
+!!! related TS2728 /.ts/lib.es2020.intl.d.ts:333:9: 'type' is declared here.
+    
+    const localesArg = ["es-ES", new Intl.Locale("en-US")];
+    console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale); // "es-ES"
+    console.log(Intl.DisplayNames.supportedLocalesOf(localesArg)); // ["es-ES", "en-US"]
+    console.log(Intl.DisplayNames.supportedLocalesOf()); // []
+    console.log(Intl.DisplayNames.supportedLocalesOf(localesArg, {})); // ["es-ES", "en-US"]
+    

--- a/tests/baselines/reference/es2020IntlAPIs.js
+++ b/tests/baselines/reference/es2020IntlAPIs.js
@@ -49,6 +49,7 @@ new Intl.Locale(new Intl.Locale('en-US'));
 new Intl.DisplayNames(); // TypeError: invalid_argument
 new Intl.DisplayNames('en'); // TypeError: invalid_argument
 new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
+console.log((new Intl.DisplayNames(undefined, {type: 'language'})).of('en-GB')); // "British English"
 
 const localesArg = ["es-ES", new Intl.Locale("en-US")];
 console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale); // "es-ES"
@@ -92,6 +93,7 @@ new Intl.Locale(new Intl.Locale('en-US'));
 new Intl.DisplayNames(); // TypeError: invalid_argument
 new Intl.DisplayNames('en'); // TypeError: invalid_argument
 new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
+console.log((new Intl.DisplayNames(undefined, { type: 'language' })).of('en-GB')); // "British English"
 const localesArg = ["es-ES", new Intl.Locale("en-US")];
 console.log((new Intl.DisplayNames(localesArg, { type: 'language' })).resolvedOptions().locale); // "es-ES"
 console.log(Intl.DisplayNames.supportedLocalesOf(localesArg)); // ["es-ES", "en-US"]

--- a/tests/baselines/reference/es2020IntlAPIs.js
+++ b/tests/baselines/reference/es2020IntlAPIs.js
@@ -46,6 +46,17 @@ console.log(Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', '))
 new Intl.Locale(); // should error
 new Intl.Locale(new Intl.Locale('en-US'));
 
+new Intl.DisplayNames(); // TypeError: invalid_argument
+new Intl.DisplayNames('en'); // TypeError: invalid_argument
+new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
+
+const localesArg = ["es-ES", new Intl.Locale("en-US")];
+console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale); // "es-ES"
+console.log(Intl.DisplayNames.supportedLocalesOf(localesArg)); // ["es-ES", "en-US"]
+console.log(Intl.DisplayNames.supportedLocalesOf()); // []
+console.log(Intl.DisplayNames.supportedLocalesOf(localesArg, {})); // ["es-ES", "en-US"]
+
+
 //// [es2020IntlAPIs.js]
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation
 const count = 26254.39;
@@ -78,3 +89,11 @@ const options1 = { localeMatcher: 'lookup' };
 console.log(Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', '));
 new Intl.Locale(); // should error
 new Intl.Locale(new Intl.Locale('en-US'));
+new Intl.DisplayNames(); // TypeError: invalid_argument
+new Intl.DisplayNames('en'); // TypeError: invalid_argument
+new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
+const localesArg = ["es-ES", new Intl.Locale("en-US")];
+console.log((new Intl.DisplayNames(localesArg, { type: 'language' })).resolvedOptions().locale); // "es-ES"
+console.log(Intl.DisplayNames.supportedLocalesOf(localesArg)); // ["es-ES", "en-US"]
+console.log(Intl.DisplayNames.supportedLocalesOf()); // []
+console.log(Intl.DisplayNames.supportedLocalesOf(localesArg, {})); // ["es-ES", "en-US"]

--- a/tests/baselines/reference/es2020IntlAPIs.symbols
+++ b/tests/baselines/reference/es2020IntlAPIs.symbols
@@ -160,3 +160,70 @@ new Intl.Locale(new Intl.Locale('en-US'));
 >Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >Locale : Symbol(Intl.Locale, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 
+new Intl.DisplayNames(); // TypeError: invalid_argument
+>Intl.DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+
+new Intl.DisplayNames('en'); // TypeError: invalid_argument
+>Intl.DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+
+new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
+>Intl.DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+
+const localesArg = ["es-ES", new Intl.Locale("en-US")];
+>localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 51, 5))
+>Intl.Locale : Symbol(Intl.Locale, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Locale : Symbol(Intl.Locale, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+
+console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale); // "es-ES"
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>(new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale : Symbol(Intl.ResolvedDisplayNamesOptions.locale, Decl(lib.es2020.intl.d.ts, --, --))
+>(new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions : Symbol(Intl.DisplayNames.resolvedOptions, Decl(lib.es2020.intl.d.ts, --, --))
+>Intl.DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 51, 5))
+>type : Symbol(type, Decl(es2020IntlAPIs.ts, 52, 48))
+>resolvedOptions : Symbol(Intl.DisplayNames.resolvedOptions, Decl(lib.es2020.intl.d.ts, --, --))
+>locale : Symbol(Intl.ResolvedDisplayNamesOptions.locale, Decl(lib.es2020.intl.d.ts, --, --))
+
+console.log(Intl.DisplayNames.supportedLocalesOf(localesArg)); // ["es-ES", "en-US"]
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>Intl.DisplayNames.supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
+>Intl.DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
+>localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 51, 5))
+
+console.log(Intl.DisplayNames.supportedLocalesOf()); // []
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>Intl.DisplayNames.supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
+>Intl.DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
+
+console.log(Intl.DisplayNames.supportedLocalesOf(localesArg, {})); // ["es-ES", "en-US"]
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>Intl.DisplayNames.supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
+>Intl.DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
+>localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 51, 5))
+

--- a/tests/baselines/reference/es2020IntlAPIs.symbols
+++ b/tests/baselines/reference/es2020IntlAPIs.symbols
@@ -175,8 +175,20 @@ new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
 >Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 
+console.log((new Intl.DisplayNames(undefined, {type: 'language'})).of('en-GB')); // "British English"
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>(new Intl.DisplayNames(undefined, {type: 'language'})).of : Symbol(Intl.DisplayNames.of, Decl(lib.es2020.intl.d.ts, --, --))
+>Intl.DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>undefined : Symbol(undefined)
+>type : Symbol(type, Decl(es2020IntlAPIs.ts, 50, 47))
+>of : Symbol(Intl.DisplayNames.of, Decl(lib.es2020.intl.d.ts, --, --))
+
 const localesArg = ["es-ES", new Intl.Locale("en-US")];
->localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 51, 5))
+>localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 52, 5))
 >Intl.Locale : Symbol(Intl.Locale, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >Locale : Symbol(Intl.Locale, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
@@ -190,8 +202,8 @@ console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOpti
 >Intl.DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
->localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 51, 5))
->type : Symbol(type, Decl(es2020IntlAPIs.ts, 52, 48))
+>localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 52, 5))
+>type : Symbol(type, Decl(es2020IntlAPIs.ts, 53, 48))
 >resolvedOptions : Symbol(Intl.DisplayNames.resolvedOptions, Decl(lib.es2020.intl.d.ts, --, --))
 >locale : Symbol(Intl.ResolvedDisplayNamesOptions.locale, Decl(lib.es2020.intl.d.ts, --, --))
 
@@ -204,7 +216,7 @@ console.log(Intl.DisplayNames.supportedLocalesOf(localesArg)); // ["es-ES", "en-
 >Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
->localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 51, 5))
+>localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 52, 5))
 
 console.log(Intl.DisplayNames.supportedLocalesOf()); // []
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
@@ -225,5 +237,5 @@ console.log(Intl.DisplayNames.supportedLocalesOf(localesArg, {})); // ["es-ES", 
 >Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >DisplayNames : Symbol(Intl.DisplayNames, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
->localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 51, 5))
+>localesArg : Symbol(localesArg, Decl(es2020IntlAPIs.ts, 52, 5))
 

--- a/tests/baselines/reference/es2020IntlAPIs.types
+++ b/tests/baselines/reference/es2020IntlAPIs.types
@@ -128,9 +128,9 @@ console.log(rtf2.format(2, 'day'));
 const regionNamesInEnglish = new Intl.DisplayNames(['en'], { type: 'region' });
 >regionNamesInEnglish : Intl.DisplayNames
 >new Intl.DisplayNames(['en'], { type: 'region' }) : Intl.DisplayNames
->Intl.DisplayNames : { new (locales?: string | string[], options?: Partial<Intl.DisplayNamesOptions>): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales: string | string[], options?: { localeMatcher: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
 >Intl : typeof Intl
->DisplayNames : { new (locales?: string | string[], options?: Partial<Intl.DisplayNamesOptions>): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales: string | string[], options?: { localeMatcher: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
 >['en'] : string[]
 >'en' : "en"
 >{ type: 'region' } : { type: "region"; }
@@ -140,9 +140,9 @@ const regionNamesInEnglish = new Intl.DisplayNames(['en'], { type: 'region' });
 const regionNamesInTraditionalChinese = new Intl.DisplayNames(['zh-Hant'], { type: 'region' });
 >regionNamesInTraditionalChinese : Intl.DisplayNames
 >new Intl.DisplayNames(['zh-Hant'], { type: 'region' }) : Intl.DisplayNames
->Intl.DisplayNames : { new (locales?: string | string[], options?: Partial<Intl.DisplayNamesOptions>): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales: string | string[], options?: { localeMatcher: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
 >Intl : typeof Intl
->DisplayNames : { new (locales?: string | string[], options?: Partial<Intl.DisplayNamesOptions>): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales: string | string[], options?: { localeMatcher: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
 >['zh-Hant'] : string[]
 >'zh-Hant' : "zh-Hant"
 >{ type: 'region' } : { type: "region"; }
@@ -197,11 +197,11 @@ console.log(Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', '))
 >Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', ') : string
 >Intl.DisplayNames.supportedLocalesOf(locales1, options1).join : (separator?: string) => string
 >Intl.DisplayNames.supportedLocalesOf(locales1, options1) : string[]
->Intl.DisplayNames.supportedLocalesOf : (locales: string | string[], options?: { localeMatcher: Intl.RelativeTimeFormatLocaleMatcher; }) => string[]
->Intl.DisplayNames : { new (locales?: string | string[], options?: Partial<Intl.DisplayNamesOptions>): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales: string | string[], options?: { localeMatcher: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl.DisplayNames.supportedLocalesOf : (locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }) => string[]
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
 >Intl : typeof Intl
->DisplayNames : { new (locales?: string | string[], options?: Partial<Intl.DisplayNamesOptions>): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales: string | string[], options?: { localeMatcher: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
->supportedLocalesOf : (locales: string | string[], options?: { localeMatcher: Intl.RelativeTimeFormatLocaleMatcher; }) => string[]
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>supportedLocalesOf : (locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }) => string[]
 >locales1 : string[]
 >options1 : { readonly localeMatcher: "lookup"; }
 >join : (separator?: string) => string

--- a/tests/baselines/reference/es2020IntlAPIs.types
+++ b/tests/baselines/reference/es2020IntlAPIs.types
@@ -224,3 +224,93 @@ new Intl.Locale(new Intl.Locale('en-US'));
 >Locale : new (tag: string | Intl.Locale, options?: Intl.LocaleOptions) => Intl.Locale
 >'en-US' : "en-US"
 
+new Intl.DisplayNames(); // TypeError: invalid_argument
+>new Intl.DisplayNames() : Intl.DisplayNames
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl : typeof Intl
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+
+new Intl.DisplayNames('en'); // TypeError: invalid_argument
+>new Intl.DisplayNames('en') : Intl.DisplayNames
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl : typeof Intl
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>'en' : "en"
+
+new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
+>new Intl.DisplayNames('en', {}) : Intl.DisplayNames
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl : typeof Intl
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>'en' : "en"
+>{} : {}
+
+const localesArg = ["es-ES", new Intl.Locale("en-US")];
+>localesArg : (string | Intl.Locale)[]
+>["es-ES", new Intl.Locale("en-US")] : (string | Intl.Locale)[]
+>"es-ES" : "es-ES"
+>new Intl.Locale("en-US") : Intl.Locale
+>Intl.Locale : new (tag: string | Intl.Locale, options?: Intl.LocaleOptions) => Intl.Locale
+>Intl : typeof Intl
+>Locale : new (tag: string | Intl.Locale, options?: Intl.LocaleOptions) => Intl.Locale
+>"en-US" : "en-US"
+
+console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale); // "es-ES"
+>console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>(new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale : string
+>(new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions() : Intl.ResolvedDisplayNamesOptions
+>(new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions : () => Intl.ResolvedDisplayNamesOptions
+>(new Intl.DisplayNames(localesArg, {type: 'language'})) : Intl.DisplayNames
+>new Intl.DisplayNames(localesArg, {type: 'language'}) : Intl.DisplayNames
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl : typeof Intl
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>localesArg : (string | Intl.Locale)[]
+>{type: 'language'} : { type: "language"; }
+>type : "language"
+>'language' : "language"
+>resolvedOptions : () => Intl.ResolvedDisplayNamesOptions
+>locale : string
+
+console.log(Intl.DisplayNames.supportedLocalesOf(localesArg)); // ["es-ES", "en-US"]
+>console.log(Intl.DisplayNames.supportedLocalesOf(localesArg)) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>Intl.DisplayNames.supportedLocalesOf(localesArg) : string[]
+>Intl.DisplayNames.supportedLocalesOf : (locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }) => string[]
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl : typeof Intl
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>supportedLocalesOf : (locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }) => string[]
+>localesArg : (string | Intl.Locale)[]
+
+console.log(Intl.DisplayNames.supportedLocalesOf()); // []
+>console.log(Intl.DisplayNames.supportedLocalesOf()) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>Intl.DisplayNames.supportedLocalesOf() : string[]
+>Intl.DisplayNames.supportedLocalesOf : (locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }) => string[]
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl : typeof Intl
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>supportedLocalesOf : (locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }) => string[]
+
+console.log(Intl.DisplayNames.supportedLocalesOf(localesArg, {})); // ["es-ES", "en-US"]
+>console.log(Intl.DisplayNames.supportedLocalesOf(localesArg, {})) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>Intl.DisplayNames.supportedLocalesOf(localesArg, {}) : string[]
+>Intl.DisplayNames.supportedLocalesOf : (locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }) => string[]
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl : typeof Intl
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>supportedLocalesOf : (locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }) => string[]
+>localesArg : (string | Intl.Locale)[]
+>{} : {}
+

--- a/tests/baselines/reference/es2020IntlAPIs.types
+++ b/tests/baselines/reference/es2020IntlAPIs.types
@@ -245,6 +245,25 @@ new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
 >'en' : "en"
 >{} : {}
 
+console.log((new Intl.DisplayNames(undefined, {type: 'language'})).of('en-GB')); // "British English"
+>console.log((new Intl.DisplayNames(undefined, {type: 'language'})).of('en-GB')) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>(new Intl.DisplayNames(undefined, {type: 'language'})).of('en-GB') : string
+>(new Intl.DisplayNames(undefined, {type: 'language'})).of : (code: string) => string
+>(new Intl.DisplayNames(undefined, {type: 'language'})) : Intl.DisplayNames
+>new Intl.DisplayNames(undefined, {type: 'language'}) : Intl.DisplayNames
+>Intl.DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>Intl : typeof Intl
+>DisplayNames : { new (locales: Intl.LocalesArgument, options: Intl.DisplayNamesOptions): Intl.DisplayNames; prototype: Intl.DisplayNames; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: { localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher; }): string[]; }
+>undefined : undefined
+>{type: 'language'} : { type: "language"; }
+>type : "language"
+>'language' : "language"
+>of : (code: string) => string
+>'en-GB' : "en-GB"
+
 const localesArg = ["es-ES", new Intl.Locale("en-US")];
 >localesArg : (string | Intl.Locale)[]
 >["es-ES", new Intl.Locale("en-US")] : (string | Intl.Locale)[]

--- a/tests/cases/conformance/es2020/es2020IntlAPIs.ts
+++ b/tests/cases/conformance/es2020/es2020IntlAPIs.ts
@@ -46,3 +46,13 @@ console.log(Intl.DisplayNames.supportedLocalesOf(locales1, options1).join(', '))
 
 new Intl.Locale(); // should error
 new Intl.Locale(new Intl.Locale('en-US'));
+
+new Intl.DisplayNames(); // TypeError: invalid_argument
+new Intl.DisplayNames('en'); // TypeError: invalid_argument
+new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
+
+const localesArg = ["es-ES", new Intl.Locale("en-US")];
+console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale); // "es-ES"
+console.log(Intl.DisplayNames.supportedLocalesOf(localesArg)); // ["es-ES", "en-US"]
+console.log(Intl.DisplayNames.supportedLocalesOf()); // []
+console.log(Intl.DisplayNames.supportedLocalesOf(localesArg, {})); // ["es-ES", "en-US"]

--- a/tests/cases/conformance/es2020/es2020IntlAPIs.ts
+++ b/tests/cases/conformance/es2020/es2020IntlAPIs.ts
@@ -50,6 +50,7 @@ new Intl.Locale(new Intl.Locale('en-US'));
 new Intl.DisplayNames(); // TypeError: invalid_argument
 new Intl.DisplayNames('en'); // TypeError: invalid_argument
 new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
+console.log((new Intl.DisplayNames(undefined, {type: 'language'})).of('en-GB')); // "British English"
 
 const localesArg = ["es-ES", new Intl.Locale("en-US")];
 console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale); // "es-ES"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Following up on issue #48218 (to avoid creating too many issues about the same topic) and based on the work from pr #48262 , here are some additional updates to keep `Intl.DisplayNames` up-to-date with the spec: 
* `ResolvedDisplayNamesOptions.type` should be the same type as `DisplayNamesOptions.type`, because DisplayName's internal type property [simply gets mapped to `resolvedOptions().type`](https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.resolvedOptions). 
* Similar to `DisplayNamesOptions.languageDisplay`, `resolvedOptions()` can [also have the property `languageDisplay`](https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.resolvedOptions), but [only when `DisplayNamesOptions.type` is of type `language`](https://tc39.es/ecma402/#sec-properties-of-intl-displaynames-instances).
* `Intl.DisplayNames(locales, options)` constructor [requires both `locales` and `options.type`](https://tc39.es/ecma402/#sec-Intl.DisplayNames), although `locales` [can be undefined](https://tc39.es/ecma402/#sec-canonicalizelocalelist).
* `locales` param in `Intl.DisplayNames(locales, options)` and `Intl.DisplayNames.supportedLocalesOf(locales)` is the same `LocalesArgument` type used across other functions from `Intl`. Additionally, `LocalesArgument` doesn't strictly need to be an array of solely strings or an array of solely Locale(s), it can be an array containing both. [`locales` argument are defined to be processed with this same operation](https://tc39.es/ecma402/#sec-canonicalizelocalelist).
* `locales`, `options`, and `options.localeMatcher` [are optional in `Intl.DisplayNames.supportedLocalesOf(locales, options)`](https://tc39.es/ecma402/#sec-Intl.DisplayNames.supportedLocalesOf).

These behaviors have been verified with the js code below, which should execute without issue (lines meant to recreate a `TypeError` have been commented, and can be uncommented for testing):
```javascript
/**
 * Intl.DisplayNames.prototype.resolvedOptions().type is the same as the options.type passed to Intl.DisplayNames(locales, options) constructor
 * 
 * This can be one of "calendar", "currency", "dateTimeField", "language", "region", or "script".
 */
const dnCalendar = new Intl.DisplayNames('en', {type: 'calendar'});
console.log(dnCalendar.of('roc')); // "Minguo Calendar"
console.log(dnCalendar.resolvedOptions().type); // "calendar"
const dnCurrency = new Intl.DisplayNames(['en'], {type: 'currency'});
console.log(dnCurrency.of('USD')); // "US Dollar"
console.log(dnCurrency.resolvedOptions().type); // "currency"
const dnDateTimeField = new Intl.DisplayNames('pt', {type: 'dateTimeField'});
console.log(dnDateTimeField.of('era')); // "era"
console.log(dnDateTimeField.resolvedOptions().type); // "dateTimeField"
const dnLanguage = new Intl.DisplayNames([], {type: 'language'});
console.log(dnLanguage.of('US')); // "us"
console.log(dnLanguage.resolvedOptions().type); // "language"
const dnRegion = new Intl.DisplayNames(['en'], {type: 'region'});
console.log(dnRegion.of('BZ'));  // "Belize"
console.log(dnRegion.resolvedOptions().type); // "region"
const dnScript = new Intl.DisplayNames(['en'], {type: 'script'});
console.log(dnScript.of('Latn')); // "Latin"
console.log(dnScript.resolvedOptions().type); // "script"
/**
 * Also, when options.type === "language", resolvedOptions().languageDisplay will be either "dialect" or "standard".
 * Else, resolvedOptions.languageDisplay is undefined.
 */
const dnStd = new Intl.DisplayNames('en', {type: 'language', languageDisplay: 'standard'});
console.log(dnStd.of('en-GB')); // "English (United Kingdom)"
console.log(dnStd.resolvedOptions().languageDisplay); // "standard"
console.log(dnLanguage.resolvedOptions().languageDisplay); // "dialect"
console.log(dnCurrency.resolvedOptions().languageDisplay); // undefined

/**
 * The constructor new Intl.DisplayNames(locales, options) requires options.
 * 
 * options.type is required, while all other fields are optional.
 */
// new Intl.DisplayNames(); // TypeError: invalid_argument
// new Intl.DisplayNames('en'); // TypeError: invalid_argument
// new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
console.log((new Intl.DisplayNames(undefined, {type: 'language'})).of('en-GB')); // "British English"

/**
 * locales argument can be an array of both strings and Locale(s) at the same time.
 * 
 * This applies to Intl.DisplayNames(locales, options) constructor and Intl.DisplayNames.supportedLocalesOf(locales)
 */
const localesArg = ["es-ES", new Intl.Locale("en-US")];
console.log((new Intl.DisplayNames(localesArg, {type: 'language'})).resolvedOptions().locale); // "es-ES"
console.log(Intl.DisplayNames.supportedLocalesOf(localesArg)); // ["es-ES", "en-US"]
/**
 * locales, options, and options.localeMatcher are optional in Intl.DisplayNames.supportedLocalesOf(locales, options)
 */
console.log(Intl.DisplayNames.supportedLocalesOf()); // []
console.log(Intl.DisplayNames.supportedLocalesOf(localesArg, {})); // ["es-ES", "en-US"]
```

The code above should behave as expected on modern browsers, tested on Chrome(99.0.4844.84) and Firefox(98.0.2). The only caveat is that `"calendar"`, `"dateTimeField"`, and `languageDisplay` are features introduced in `es2022` from [this proposal](https://github.com/tc39/proposal-intl-displaynames-v2), so those are currently not working in the latest NodeJs LTS v16.14.2, but should work in later versions (currently working on v17.8.0).