### PR TITLE
fix(48445): import { type X } not flagged in JavaScript

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2273,6 +2273,13 @@ namespace ts {
                                 return "skip";
                             }
                             break;
+                        case SyntaxKind.ImportSpecifier:
+                        case SyntaxKind.ExportSpecifier:
+                            if ((node as ImportOrExportSpecifier).isTypeOnly) {
+                                diagnostics.push(createDiagnosticForNode(node, Diagnostics._0_declarations_can_only_be_used_in_TypeScript_files, isImportSpecifier(node) ? "import...type" : "export...type"));
+                                return "skip";
+                            }
+                            break;
                         case SyntaxKind.ImportEqualsDeclaration:
                             diagnostics.push(createDiagnosticForNode(node, Diagnostics.import_can_only_be_used_in_TypeScript_files));
                             return "skip";

--- a/tests/baselines/reference/exportSpecifiers_js.errors.txt
+++ b/tests/baselines/reference/exportSpecifiers_js.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/externalModules/typeOnly/a.js(2,10): error TS8006: 'export...type' declarations can only be used in TypeScript files.
+
+
+==== tests/cases/conformance/externalModules/typeOnly/a.js (1 errors) ====
+    const foo = 0;
+    export { type foo };
+             ~~~~~~~~
+!!! error TS8006: 'export...type' declarations can only be used in TypeScript files.
+    

--- a/tests/baselines/reference/exportSpecifiers_js.symbols
+++ b/tests/baselines/reference/exportSpecifiers_js.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.js ===
+const foo = 0;
+>foo : Symbol(foo, Decl(a.js, 0, 5))
+
+export { type foo };
+>foo : Symbol(foo, Decl(a.js, 1, 8))
+

--- a/tests/baselines/reference/exportSpecifiers_js.types
+++ b/tests/baselines/reference/exportSpecifiers_js.types
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.js ===
+const foo = 0;
+>foo : 0
+>0 : 0
+
+export { type foo };
+>foo : 0
+

--- a/tests/baselines/reference/importSpecifiers_js.errors.txt
+++ b/tests/baselines/reference/importSpecifiers_js.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/conformance/externalModules/typeOnly/a.js(1,10): error TS8006: 'import...type' declarations can only be used in TypeScript files.
+
+
+==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
+    export interface A {}
+    
+==== tests/cases/conformance/externalModules/typeOnly/a.js (1 errors) ====
+    import { type A } from "./a";
+             ~~~~~~
+!!! error TS8006: 'import...type' declarations can only be used in TypeScript files.
+    

--- a/tests/baselines/reference/importSpecifiers_js.symbols
+++ b/tests/baselines/reference/importSpecifiers_js.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export interface A {}
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+=== tests/cases/conformance/externalModules/typeOnly/a.js ===
+import { type A } from "./a";
+>A : Symbol(A, Decl(a.js, 0, 8))
+

--- a/tests/baselines/reference/importSpecifiers_js.types
+++ b/tests/baselines/reference/importSpecifiers_js.types
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export interface A {}
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/externalModules/typeOnly/a.js ===
+import { type A } from "./a";
+>A : any
+

--- a/tests/cases/conformance/externalModules/typeOnly/exportSpecifiers_js.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/exportSpecifiers_js.ts
@@ -1,0 +1,7 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: ./a.js
+const foo = 0;
+export { type foo };

--- a/tests/cases/conformance/externalModules/typeOnly/importSpecifiers_js.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/importSpecifiers_js.ts
@@ -1,0 +1,9 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: ./a.ts
+export interface A {}
+
+// @Filename: ./a.js
+import { type A } from "./a";


### PR DESCRIPTION
Fixes #48445



