### PR TITLE
Prevent looking up symbol for as const from triggering an error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1790,6 +1790,11 @@ namespace ts {
             }
         }
 
+        function isConstAssertion(location: Node) {
+            return (isAssertionExpression(location) && isConstTypeReference(location.type))
+                || (isJSDocTypeTag(location) && isConstTypeReference(location.typeExpression));
+        }
+
         /**
          * Resolve a given name for a given meaning at a given location. An error is reported if the name was not found and
          * the nameNotFoundMessage argument is not undefined. Returns the resolved symbol, or undefined if no symbol with
@@ -1831,6 +1836,11 @@ namespace ts {
             let isInExternalModule = false;
 
             loop: while (location) {
+                if (name === "const" && isConstAssertion(location)) {
+                    // `const` in an `as const` has no symbol, but issues no error because there is no *actual* lookup of the type
+                    // (it refers to the constant type of the expression instead)
+                    return undefined;
+                }
                 // Locals of a source file are not in scope (because they get merged into the global symbol table)
                 if (location.locals && !isGlobalSourceFile(location)) {
                     if (result = lookup(location.locals, name, meaning)) {

--- a/tests/cases/fourslash/asConstRefsNoErrors1.ts
+++ b/tests/cases/fourslash/asConstRefsNoErrors1.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+////class Tex {
+////    type = 'Text' as /**/const;
+////}
+
+verify.goToDefinition("", []);
+verify.noErrors();

--- a/tests/cases/fourslash/asConstRefsNoErrors2.ts
+++ b/tests/cases/fourslash/asConstRefsNoErrors2.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+////class Tex {
+////    type = </**/const>'Text';
+////}
+
+verify.goToDefinition("", []);
+verify.noErrors();

--- a/tests/cases/fourslash/asConstRefsNoErrors3.ts
+++ b/tests/cases/fourslash/asConstRefsNoErrors3.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+// @checkJs: true
+// @Filename: file.js
+////class Tex {
+////    type = (/** @type {/**/const} */'Text');
+////}
+
+verify.goToDefinition("", []);
+verify.noErrors();


### PR DESCRIPTION
Fixes #48462

This is pretty much a followup to #36741 that further hardens us to never report a symbol-not-found error when looking up the symbol for a `const` in `as const`, rather than relying on either not hitting `resolveName` (in the case of producing diagnostics) or not reporting the diagnostic (in the case of services), since there's never a symbol at that location (intentionally - it refers to the constant type of the expression, instead).