### PR TITLE
Add more options to `DateTimeFormatOptions.timeZoneName`

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4404,7 +4404,7 @@ declare namespace Intl {
         hour?: "numeric" | "2-digit" | undefined;
         minute?: "numeric" | "2-digit" | undefined;
         second?: "numeric" | "2-digit" | undefined;
-        timeZoneName?: "long" | "short" | undefined;
+        timeZoneName?: "short" | "long" | "shortOffset" | "longOffset" | "shortGeneric" | "longGeneric" | undefined;
         formatMatcher?: "best fit" | "basic" | undefined;
         hour12?: boolean | undefined;
         timeZone?: string | undefined;

--- a/tests/baselines/reference/es2022IntlAPIs.js
+++ b/tests/baselines/reference/es2022IntlAPIs.js
@@ -1,0 +1,20 @@
+//// [es2022IntlAPIs.ts]
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#using_timezonename
+const timezoneNames = ['short', 'long', 'shortOffset', 'longOffset', 'shortGeneric', 'longGeneric'] as const;
+for (const zoneName of timezoneNames) {
+  var formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    timeZoneName: zoneName,
+  });
+}
+
+
+//// [es2022IntlAPIs.js]
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#using_timezonename
+const timezoneNames = ['short', 'long', 'shortOffset', 'longOffset', 'shortGeneric', 'longGeneric'];
+for (const zoneName of timezoneNames) {
+    var formatter = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'America/Los_Angeles',
+        timeZoneName: zoneName,
+    });
+}

--- a/tests/baselines/reference/es2022IntlAPIs.symbols
+++ b/tests/baselines/reference/es2022IntlAPIs.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/es2022/es2022IntlAPIs.ts ===
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#using_timezonename
+const timezoneNames = ['short', 'long', 'shortOffset', 'longOffset', 'shortGeneric', 'longGeneric'] as const;
+>timezoneNames : Symbol(timezoneNames, Decl(es2022IntlAPIs.ts, 1, 5))
+>const : Symbol(const)
+
+for (const zoneName of timezoneNames) {
+>zoneName : Symbol(zoneName, Decl(es2022IntlAPIs.ts, 2, 10))
+>timezoneNames : Symbol(timezoneNames, Decl(es2022IntlAPIs.ts, 1, 5))
+
+  var formatter = new Intl.DateTimeFormat('en-US', {
+>formatter : Symbol(formatter, Decl(es2022IntlAPIs.ts, 3, 5))
+>Intl.DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2021.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --) ... and 1 more)
+>DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2021.intl.d.ts, --, --))
+
+    timeZone: 'America/Los_Angeles',
+>timeZone : Symbol(timeZone, Decl(es2022IntlAPIs.ts, 3, 52))
+
+    timeZoneName: zoneName,
+>timeZoneName : Symbol(timeZoneName, Decl(es2022IntlAPIs.ts, 4, 36))
+>zoneName : Symbol(zoneName, Decl(es2022IntlAPIs.ts, 2, 10))
+
+  });
+}
+

--- a/tests/baselines/reference/es2022IntlAPIs.types
+++ b/tests/baselines/reference/es2022IntlAPIs.types
@@ -1,0 +1,37 @@
+=== tests/cases/conformance/es2022/es2022IntlAPIs.ts ===
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#using_timezonename
+const timezoneNames = ['short', 'long', 'shortOffset', 'longOffset', 'shortGeneric', 'longGeneric'] as const;
+>timezoneNames : readonly ["short", "long", "shortOffset", "longOffset", "shortGeneric", "longGeneric"]
+>['short', 'long', 'shortOffset', 'longOffset', 'shortGeneric', 'longGeneric'] as const : readonly ["short", "long", "shortOffset", "longOffset", "shortGeneric", "longGeneric"]
+>['short', 'long', 'shortOffset', 'longOffset', 'shortGeneric', 'longGeneric'] : readonly ["short", "long", "shortOffset", "longOffset", "shortGeneric", "longGeneric"]
+>'short' : "short"
+>'long' : "long"
+>'shortOffset' : "shortOffset"
+>'longOffset' : "longOffset"
+>'shortGeneric' : "shortGeneric"
+>'longGeneric' : "longGeneric"
+
+for (const zoneName of timezoneNames) {
+>zoneName : "short" | "long" | "shortOffset" | "longOffset" | "shortGeneric" | "longGeneric"
+>timezoneNames : readonly ["short", "long", "shortOffset", "longOffset", "shortGeneric", "longGeneric"]
+
+  var formatter = new Intl.DateTimeFormat('en-US', {
+>formatter : Intl.DateTimeFormat
+>new Intl.DateTimeFormat('en-US', {    timeZone: 'America/Los_Angeles',    timeZoneName: zoneName,  }) : Intl.DateTimeFormat
+>Intl.DateTimeFormat : { (locales?: string | string[], options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat; new (locales?: string | string[], options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat; supportedLocalesOf(locales: string | string[], options?: Intl.DateTimeFormatOptions): string[]; readonly prototype: Intl.DateTimeFormat; }
+>Intl : typeof Intl
+>DateTimeFormat : { (locales?: string | string[], options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat; new (locales?: string | string[], options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat; supportedLocalesOf(locales: string | string[], options?: Intl.DateTimeFormatOptions): string[]; readonly prototype: Intl.DateTimeFormat; }
+>'en-US' : "en-US"
+>{    timeZone: 'America/Los_Angeles',    timeZoneName: zoneName,  } : { timeZone: string; timeZoneName: "short" | "long" | "shortOffset" | "longOffset" | "shortGeneric" | "longGeneric"; }
+
+    timeZone: 'America/Los_Angeles',
+>timeZone : string
+>'America/Los_Angeles' : "America/Los_Angeles"
+
+    timeZoneName: zoneName,
+>timeZoneName : "short" | "long" | "shortOffset" | "longOffset" | "shortGeneric" | "longGeneric"
+>zoneName : "short" | "long" | "shortOffset" | "longOffset" | "shortGeneric" | "longGeneric"
+
+  });
+}
+

--- a/tests/cases/conformance/es2022/es2022IntlAPIs.ts
+++ b/tests/cases/conformance/es2022/es2022IntlAPIs.ts
@@ -1,0 +1,10 @@
+// @target: es2022
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#using_timezonename
+const timezoneNames = ['short', 'long', 'shortOffset', 'longOffset', 'shortGeneric', 'longGeneric'] as const;
+for (const zoneName of timezoneNames) {
+  var formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    timeZoneName: zoneName,
+  });
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #48391

Placed the tests under `es2022` because these options were introduced in that spec version. Sources: [Extend TimeZoneName Option Proposal](https://github.com/tc39/proposal-intl-extend-timezonename) and [ECMAScript® 2022 Internationalization API Specification](https://tc39.es/ecma402/2022/#table-datetimeformat-components).