### PR TITLE
fix(48405): Crash on 'extract type' for deep recursive mapped type

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2370,6 +2370,7 @@ namespace ts {
                 writeLine();
                 decreaseIndent();
             }
+            emitList(node, node.members, ListFormat.PreserveLines);
             writePunctuation("}");
         }
 

--- a/tests/cases/fourslash/refactorExtractType76.ts
+++ b/tests/cases/fourslash/refactorExtractType76.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: a.ts
+////type Deep<T> = /*a*/{ [K in keyof T]: Deep<T[K]> }/*b*/
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract type",
+    actionName: "Extract to type alias",
+    actionDescription: "Extract to type alias",
+    newContent:
+`type /*RENAME*/NewType<T> = {
+    [K in keyof T]: Deep<T[K]>;
+};
+
+type Deep<T> = NewType<T>`,
+});

--- a/tests/cases/fourslash/refactorExtractType77.ts
+++ b/tests/cases/fourslash/refactorExtractType77.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: a.ts
+////type Expand<T> = T extends any
+////    ? /*a*/{ [K in keyof T]: Expand<T[K]> }/*b*/
+////    : never;
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract type",
+    actionName: "Extract to type alias",
+    actionDescription: "Extract to type alias",
+    newContent:
+`type /*RENAME*/NewType<T> = {
+    [K in keyof T]: Expand<T[K]>;
+};
+
+type Expand<T> = T extends any
+    ? NewType<T>
+    : never;`,
+});


### PR DESCRIPTION
Fixes #48405