### PR TITLE
Ensure that we copy empty NodeArrays during transform

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5239,7 +5239,18 @@ namespace ts {
                         if (!nodeIsSynthesized(node) && getParseTreeNode(node) === node) {
                             return node;
                         }
-                        return setTextRange(factory.cloneNode(visitEachChild(node, deepCloneOrReuseNode, nullTransformationContext)), node);
+                        return setTextRange(factory.cloneNode(visitEachChild(node, deepCloneOrReuseNode, nullTransformationContext, deepCloneOrReuseNodes)), node);
+                    }
+
+                    function deepCloneOrReuseNodes<T extends Node>(nodes: NodeArray<T>, visitor: Visitor | undefined, test?: (node: Node) => boolean, start?: number, count?: number): NodeArray<T>;
+                    function deepCloneOrReuseNodes<T extends Node>(nodes: NodeArray<T> | undefined, visitor: Visitor | undefined, test?: (node: Node) => boolean, start?: number, count?: number): NodeArray<T> | undefined;
+                    function deepCloneOrReuseNodes<T extends Node>(nodes: NodeArray<T> | undefined, visitor: Visitor | undefined, test?: (node: Node) => boolean, start?: number, count?: number): NodeArray<T> | undefined {
+                        if (nodes && nodes.length === 0) {
+                            // Ensure we explicitly make a copy of an empty array; visitNodes will not do this unless the array has elements,
+                            // which can lead to us reusing the same empty NodeArray more than once within the same AST during type noding.
+                            return setTextRange(factory.createNodeArray<T>(/*nodes*/ undefined, nodes.hasTrailingComma), nodes);
+                        }
+                        return visitNodes(nodes, visitor, test, start, count);
                     }
                 }
 

--- a/tests/cases/fourslash/completionsOverridingMethodCrash1.ts
+++ b/tests/cases/fourslash/completionsOverridingMethodCrash1.ts
@@ -1,0 +1,28 @@
+/// <reference path="fourslash.ts" />
+
+// @newline: LF
+// @Filename: a.ts
+////declare class Component<T> {
+////    setState(stateHandler: ((oldState: T, newState: T) => void)): void;
+////}
+////
+////class SubComponent extends Component<{}> {
+////    /*$*/
+////}
+
+verify.completions({
+    marker: "$",
+    isNewIdentifierLocation: true,
+    preferences: {
+        includeCompletionsWithInsertText: true,
+        includeCompletionsWithSnippetText: false,
+        includeCompletionsWithClassMemberSnippets: true,
+    },
+    includes: [
+        {
+            name: "setState",
+            sortText: completion.SortText.ClassMemberSnippets,
+            insertText: "setState(stateHandler: (oldState: {}, newState: {}) => void): void {\n}",
+        }
+    ]
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #48379
Fixes #45744 (most likely)

In order to offer snippet completion for method overrides, we emit code. During emit, each node gets `__pos` and `__end` properties as a side effect, so that later those positions relative to the just-emitted text can be used.

To produce the code for the override, we convert signatures, which involves converting types to nodes. Unfortunately, the empty `NodeArray` inside of the type `{}` was getting cached then reused instead of cached then cloned. This led to every instance of `{}` in the transformed tree being the same object, which then caused emit to set position info more than once on the same node, which then caused debug assertions because earlier `{}`s would have the position info from the _last_ `{}`, which isn't legal.

So, during transform, when we are explicitly doing that "deep copy or reuse", actually ensure that a copy happens for empty `NodeArray`s.

I feel like it would be better for `visitNodes` to do this, or `createNodeArray` to do it, or similar, but doing so breaks some cases where it appears as though callers of `visitNodes` assume that the array is returned unmodified if empty, breaking some 25 cases.
