### PR TITLE
Allow arrow function parameter parsing to bail out during speculation, redo

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3344,9 +3344,9 @@ namespace ts {
             return false;
         }
 
-        function parseParametersWorker(flags: SignatureFlags): NodeArray<ParameterDeclaration>;
+        function parseParametersWorker(flags: SignatureFlags, allowAmbiguity: true): NodeArray<ParameterDeclaration>;
         function parseParametersWorker(flags: SignatureFlags, allowAmbiguity: false): NodeArray<ParameterDeclaration> | undefined;
-        function parseParametersWorker(flags: SignatureFlags, allowAmbiguity = true): NodeArray<ParameterDeclaration> | undefined {
+        function parseParametersWorker(flags: SignatureFlags, allowAmbiguity: boolean): NodeArray<ParameterDeclaration> | undefined {
             // FormalParameters [Yield,Await]: (modified)
             //      [empty]
             //      FormalParameterList[?Yield,Await]
@@ -3394,7 +3394,7 @@ namespace ts {
                 return createMissingList<ParameterDeclaration>();
             }
 
-            const parameters = parseParametersWorker(flags);
+            const parameters = parseParametersWorker(flags, /*allowAmbiguity*/ true);
             parseExpected(SyntaxKind.CloseParenToken);
             return parameters;
         }
@@ -4673,7 +4673,7 @@ namespace ts {
                     parameters = maybeParameters;
                 }
                 else {
-                    parameters = parseParametersWorker(isAsync);
+                    parameters = parseParametersWorker(isAsync, allowAmbiguity);
                 }
                 if (!parseExpected(SyntaxKind.CloseParenToken) && !allowAmbiguity) {
                     return undefined;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3246,8 +3246,8 @@ namespace ts {
         }
 
         function isParameterNameStart() {
-            // Be permissive about await and yield; disallowing them during a speculative parse
-            // leads to many more follow-on errors than allowing the function to parse then later
+            // Be permissive about await and yield by calling isBindingIdentifier instead of isIdentifier; disallowing
+            // them during a speculative parse leads to many more follow-on errors than allowing the function to parse then later
             // complaining about the use of the keywords.
             return isBindingIdentifier() || token() === SyntaxKind.OpenBracketToken || token() === SyntaxKind.OpenBraceToken;
         }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3246,7 +3246,10 @@ namespace ts {
         }
 
         function isParameterNameStart() {
-            return isIdentifier() || token() === SyntaxKind.OpenBracketToken || token() === SyntaxKind.OpenBraceToken;
+            // Be permissive about await and yield; disallowing them during a speculative parse
+            // leads to many more follow-on errors than allowing the function to parse then later
+            // complaining about the use of the keywords.
+            return isBindingIdentifier() || token() === SyntaxKind.OpenBracketToken || token() === SyntaxKind.OpenBraceToken;
         }
 
         function parseParameter(inOuterAwaitContext: boolean): ParameterDeclaration {
@@ -3293,7 +3296,7 @@ namespace ts {
             const modifiers = parseModifiers();
             const dotDotDotToken = parseOptionalToken(SyntaxKind.DotDotDotToken);
 
-            if (!allowAmbiguity && inOuterAwaitContext && !isParameterNameStart()) {
+            if (!allowAmbiguity && !isParameterNameStart()) {
                 return undefined;
             }
 

--- a/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.js
+++ b/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.js
@@ -16,12 +16,14 @@ const test = () => ({
 
 
 //// [arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.js]
-var test = function () { return function (_a, , value, // remove ! to see that errors will be gone
-run) {
-    var 
+var test = function () { return ({
     // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
-     = _a.prop;
-    return 'special';
-}; };
-return 'default';
-;
+    prop: !value,
+    run: function () {
+        // comment next line or remove "()" to see that errors will be gone
+        if (!a.b()) {
+            return 'special';
+        }
+        return 'default';
+    }
+}); };

--- a/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.js
+++ b/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.js
@@ -1,0 +1,27 @@
+//// [arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts]
+// regression test for https://github.com/microsoft/TypeScript/issues/32914
+declare var value: boolean;
+declare var a: any;
+
+const test = () => ({
+    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
+    prop: !value, // remove ! to see that errors will be gone
+    run: () => { //replace arrow function with regular function to see that errors will be gone
+        // comment next line or remove "()" to see that errors will be gone
+        if(!a.b()) { return 'special'; }
+
+        return 'default';
+    }
+}); 
+
+
+//// [arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.js]
+var test = function () { return function (_a, , value, // remove ! to see that errors will be gone
+run) {
+    var 
+    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
+     = _a.prop;
+    return 'special';
+}; };
+return 'default';
+;

--- a/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.symbols
+++ b/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts ===
+// regression test for https://github.com/microsoft/TypeScript/issues/32914
+declare var value: boolean;
+>value : Symbol(value, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 1, 11))
+
+declare var a: any;
+>a : Symbol(a, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 2, 11))
+
+const test = () => ({
+>test : Symbol(test, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 4, 5))
+
+    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
+    prop: !value, // remove ! to see that errors will be gone
+>prop : Symbol(prop)
+> : Symbol((Missing), Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 4, 21))
+> : Symbol((Missing), Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 6, 9))
+>value : Symbol(value, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 6, 11))
+
+    run: () => { //replace arrow function with regular function to see that errors will be gone
+>run : Symbol(run, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 6, 17))
+
+        // comment next line or remove "()" to see that errors will be gone
+        if(!a.b()) { return 'special'; }
+>if : Symbol(if, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 7, 16))
+> : Symbol((Missing), Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 9, 11))
+>a : Symbol(a, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 9, 12))
+>b : Symbol(b, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 9, 14))
+
+        return 'default';
+    }
+}); 
+

--- a/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.symbols
+++ b/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.symbols
@@ -11,20 +11,15 @@ const test = () => ({
 
     // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
     prop: !value, // remove ! to see that errors will be gone
->prop : Symbol(prop)
-> : Symbol((Missing), Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 4, 21))
-> : Symbol((Missing), Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 6, 9))
->value : Symbol(value, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 6, 11))
+>prop : Symbol(prop, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 4, 21))
+>value : Symbol(value, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 1, 11))
 
     run: () => { //replace arrow function with regular function to see that errors will be gone
 >run : Symbol(run, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 6, 17))
 
         // comment next line or remove "()" to see that errors will be gone
         if(!a.b()) { return 'special'; }
->if : Symbol(if, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 7, 16))
-> : Symbol((Missing), Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 9, 11))
->a : Symbol(a, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 9, 12))
->b : Symbol(b, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 9, 14))
+>a : Symbol(a, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 2, 11))
 
         return 'default';
     }

--- a/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.types
+++ b/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.types
@@ -7,24 +7,26 @@ declare var a: any;
 >a : any
 
 const test = () => ({
->test : () => ({ prop:  }: { prop: any; }, : any, value: any, run: () => { (): any; if(: any, a: any, b: any): any; }) => string
->() => ({    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.    prop: !value, // remove ! to see that errors will be gone    run: () => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; } : () => ({ prop:  }: { prop: any; }, : any, value: any, run: () => { (): any; if(: any, a: any, b: any): any; }) => string
->({    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.    prop: !value, // remove ! to see that errors will be gone    run: () => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; } : ({ prop:  }: { prop: any; }, : any, value: any, run: () => { (): any; if(: any, a: any, b: any): any; }) => string
+>test : () => { prop: boolean; run: () => "special" | "default"; }
+>() => ({    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.    prop: !value, // remove ! to see that errors will be gone    run: () => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; }        return 'default';    }}) : () => { prop: boolean; run: () => "special" | "default"; }
+>({    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.    prop: !value, // remove ! to see that errors will be gone    run: () => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; }        return 'default';    }}) : { prop: boolean; run: () => "special" | "default"; }
+>{    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.    prop: !value, // remove ! to see that errors will be gone    run: () => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; }        return 'default';    }} : { prop: boolean; run: () => "special" | "default"; }
 
     // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
     prop: !value, // remove ! to see that errors will be gone
->prop : any
-> : any
-> : any
->value : any
+>prop : boolean
+>!value : boolean
+>value : boolean
 
     run: () => { //replace arrow function with regular function to see that errors will be gone
->run : () => { (): any; if(: any, a: any, b: any): any; }
+>run : () => "special" | "default"
+>() => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; }        return 'default';    } : () => "special" | "default"
 
         // comment next line or remove "()" to see that errors will be gone
         if(!a.b()) { return 'special'; }
->if : (: any, a: any, b: any) => any
-> : any
+>!a.b() : boolean
+>a.b() : any
+>a.b : any
 >a : any
 >b : any
 >'special' : "special"

--- a/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.types
+++ b/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.types
@@ -1,0 +1,36 @@
+=== tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts ===
+// regression test for https://github.com/microsoft/TypeScript/issues/32914
+declare var value: boolean;
+>value : boolean
+
+declare var a: any;
+>a : any
+
+const test = () => ({
+>test : () => ({ prop:  }: { prop: any; }, : any, value: any, run: () => { (): any; if(: any, a: any, b: any): any; }) => string
+>() => ({    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.    prop: !value, // remove ! to see that errors will be gone    run: () => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; } : () => ({ prop:  }: { prop: any; }, : any, value: any, run: () => { (): any; if(: any, a: any, b: any): any; }) => string
+>({    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.    prop: !value, // remove ! to see that errors will be gone    run: () => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; } : ({ prop:  }: { prop: any; }, : any, value: any, run: () => { (): any; if(: any, a: any, b: any): any; }) => string
+
+    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
+    prop: !value, // remove ! to see that errors will be gone
+>prop : any
+> : any
+> : any
+>value : any
+
+    run: () => { //replace arrow function with regular function to see that errors will be gone
+>run : () => { (): any; if(: any, a: any, b: any): any; }
+
+        // comment next line or remove "()" to see that errors will be gone
+        if(!a.b()) { return 'special'; }
+>if : (: any, a: any, b: any) => any
+> : any
+>a : any
+>b : any
+>'special' : "special"
+
+        return 'default';
+>'default' : "default"
+    }
+}); 
+

--- a/tests/baselines/reference/arrowFunctionParsingGenericInObject.js
+++ b/tests/baselines/reference/arrowFunctionParsingGenericInObject.js
@@ -1,0 +1,47 @@
+//// [arrowFunctionParsingGenericInObject.ts]
+// Apparent parser error when first property of returned object is generic function with default type
+const fails1 = () => ({
+    test: <T = undefined>(value: T): T => value,
+    extraValue: () => {},
+})
+
+// Without a default type, it works fine
+const works1 = () => ({
+    test: <T>(value: T): T => value,
+    extraValue: () => {},
+})
+
+// As second property, it works fine
+const works2 = () => ({
+    extraValue: () => {},
+    test: <T = undefined>(value: T): T => value,
+})
+
+// The first property _must_ be a function, though
+const fails2 = () => ({
+    extraValue: '',
+    test: <T = undefined>(value: T): T => value,
+})
+
+
+//// [arrowFunctionParsingGenericInObject.js]
+// Apparent parser error when first property of returned object is generic function with default type
+var fails1 = function () { return ({
+    test: function (value) { return value; },
+    extraValue: function () { }
+}); };
+// Without a default type, it works fine
+var works1 = function () { return ({
+    test: function (value) { return value; },
+    extraValue: function () { }
+}); };
+// As second property, it works fine
+var works2 = function () { return ({
+    extraValue: function () { },
+    test: function (value) { return value; }
+}); };
+// The first property _must_ be a function, though
+var fails2 = function () { return ({
+    extraValue: '',
+    test: function (value) { return value; }
+}); };

--- a/tests/baselines/reference/arrowFunctionParsingGenericInObject.js
+++ b/tests/baselines/reference/arrowFunctionParsingGenericInObject.js
@@ -1,23 +1,19 @@
 //// [arrowFunctionParsingGenericInObject.ts]
-// Apparent parser error when first property of returned object is generic function with default type
 const fails1 = () => ({
     test: <T = undefined>(value: T): T => value,
     extraValue: () => {},
 })
 
-// Without a default type, it works fine
 const works1 = () => ({
     test: <T>(value: T): T => value,
     extraValue: () => {},
 })
 
-// As second property, it works fine
 const works2 = () => ({
     extraValue: () => {},
     test: <T = undefined>(value: T): T => value,
 })
 
-// The first property _must_ be a function, though
 const fails2 = () => ({
     extraValue: '',
     test: <T = undefined>(value: T): T => value,
@@ -25,22 +21,18 @@ const fails2 = () => ({
 
 
 //// [arrowFunctionParsingGenericInObject.js]
-// Apparent parser error when first property of returned object is generic function with default type
 var fails1 = function () { return ({
     test: function (value) { return value; },
     extraValue: function () { }
 }); };
-// Without a default type, it works fine
 var works1 = function () { return ({
     test: function (value) { return value; },
     extraValue: function () { }
 }); };
-// As second property, it works fine
 var works2 = function () { return ({
     extraValue: function () { },
     test: function (value) { return value; }
 }); };
-// The first property _must_ be a function, though
 var fails2 = function () { return ({
     extraValue: '',
     test: function (value) { return value; }

--- a/tests/baselines/reference/arrowFunctionParsingGenericInObject.js
+++ b/tests/baselines/reference/arrowFunctionParsingGenericInObject.js
@@ -1,39 +1,75 @@
 //// [arrowFunctionParsingGenericInObject.ts]
-const fails1 = () => ({
+const fn1 = () => ({
     test: <T = undefined>(value: T): T => value,
     extraValue: () => {},
 })
 
-const works1 = () => ({
+const fn1async = () => ({
+    test: async <T = undefined>(value: T): Promise<T> => value,
+    extraValue: () => {},
+})
+
+const fn2 = () => ({
     test: <T>(value: T): T => value,
     extraValue: () => {},
 })
 
-const works2 = () => ({
+const fn2async = () => ({
+    test: async <T>(value: T): Promise<T> => value,
+    extraValue: () => {},
+})
+
+const fn3 = () => ({
     extraValue: () => {},
     test: <T = undefined>(value: T): T => value,
 })
 
-const fails2 = () => ({
+const fn3async = () => ({
+    extraValue: () => {},
+    test: async <T = undefined>(value: T): Promise<T> => value,
+})
+
+const fn4 = () => ({
     extraValue: '',
     test: <T = undefined>(value: T): T => value,
 })
 
+const fn4async = () => ({
+    extraValue: '',
+    test: async <T = undefined>(value: T): Promise<T> => value,
+})
+
 
 //// [arrowFunctionParsingGenericInObject.js]
-var fails1 = function () { return ({
-    test: function (value) { return value; },
-    extraValue: function () { }
-}); };
-var works1 = function () { return ({
-    test: function (value) { return value; },
-    extraValue: function () { }
-}); };
-var works2 = function () { return ({
-    extraValue: function () { },
-    test: function (value) { return value; }
-}); };
-var fails2 = function () { return ({
+const fn1 = () => ({
+    test: (value) => value,
+    extraValue: () => { },
+});
+const fn1async = () => ({
+    test: async (value) => value,
+    extraValue: () => { },
+});
+const fn2 = () => ({
+    test: (value) => value,
+    extraValue: () => { },
+});
+const fn2async = () => ({
+    test: async (value) => value,
+    extraValue: () => { },
+});
+const fn3 = () => ({
+    extraValue: () => { },
+    test: (value) => value,
+});
+const fn3async = () => ({
+    extraValue: () => { },
+    test: async (value) => value,
+});
+const fn4 = () => ({
     extraValue: '',
-    test: function (value) { return value; }
-}); };
+    test: (value) => value,
+});
+const fn4async = () => ({
+    extraValue: '',
+    test: async (value) => value,
+});

--- a/tests/baselines/reference/arrowFunctionParsingGenericInObject.symbols
+++ b/tests/baselines/reference/arrowFunctionParsingGenericInObject.symbols
@@ -1,69 +1,65 @@
 === tests/cases/compiler/arrowFunctionParsingGenericInObject.ts ===
-// Apparent parser error when first property of returned object is generic function with default type
 const fails1 = () => ({
->fails1 : Symbol(fails1, Decl(arrowFunctionParsingGenericInObject.ts, 1, 5))
+>fails1 : Symbol(fails1, Decl(arrowFunctionParsingGenericInObject.ts, 0, 5))
 
     test: <T = undefined>(value: T): T => value,
->test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 1, 23))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 2, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 2, 26))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 2, 11))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 2, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 2, 26))
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 0, 23))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 1, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 1, 26))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 1, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 1, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 1, 26))
 
     extraValue: () => {},
->extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 2, 48))
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 1, 48))
 
 })
 
-// Without a default type, it works fine
 const works1 = () => ({
->works1 : Symbol(works1, Decl(arrowFunctionParsingGenericInObject.ts, 7, 5))
+>works1 : Symbol(works1, Decl(arrowFunctionParsingGenericInObject.ts, 5, 5))
 
     test: <T>(value: T): T => value,
->test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 7, 23))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 8, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 8, 14))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 8, 11))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 8, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 8, 14))
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 5, 23))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 6, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 6, 14))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 6, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 6, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 6, 14))
 
     extraValue: () => {},
->extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 8, 36))
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 6, 36))
 
 })
 
-// As second property, it works fine
 const works2 = () => ({
->works2 : Symbol(works2, Decl(arrowFunctionParsingGenericInObject.ts, 13, 5))
+>works2 : Symbol(works2, Decl(arrowFunctionParsingGenericInObject.ts, 10, 5))
 
     extraValue: () => {},
->extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 13, 23))
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 10, 23))
 
     test: <T = undefined>(value: T): T => value,
->test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 14, 25))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 15, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 15, 26))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 15, 11))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 15, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 15, 26))
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 11, 25))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 12, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 12, 26))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 12, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 12, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 12, 26))
 
 })
 
-// The first property _must_ be a function, though
 const fails2 = () => ({
->fails2 : Symbol(fails2, Decl(arrowFunctionParsingGenericInObject.ts, 19, 5))
+>fails2 : Symbol(fails2, Decl(arrowFunctionParsingGenericInObject.ts, 15, 5))
 
     extraValue: '',
->extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 19, 23))
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 15, 23))
 
     test: <T = undefined>(value: T): T => value,
->test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 20, 19))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 21, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 21, 26))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 21, 11))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 21, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 21, 26))
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 16, 19))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 17, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 17, 26))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 17, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 17, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 17, 26))
 
 })
 

--- a/tests/baselines/reference/arrowFunctionParsingGenericInObject.symbols
+++ b/tests/baselines/reference/arrowFunctionParsingGenericInObject.symbols
@@ -1,9 +1,9 @@
 === tests/cases/compiler/arrowFunctionParsingGenericInObject.ts ===
-const fails1 = () => ({
->fails1 : Symbol(fails1, Decl(arrowFunctionParsingGenericInObject.ts, 0, 5))
+const fn1 = () => ({
+>fn1 : Symbol(fn1, Decl(arrowFunctionParsingGenericInObject.ts, 0, 5))
 
     test: <T = undefined>(value: T): T => value,
->test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 0, 23))
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 0, 20))
 >T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 1, 11))
 >value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 1, 26))
 >T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 1, 11))
@@ -15,51 +15,119 @@ const fails1 = () => ({
 
 })
 
-const works1 = () => ({
->works1 : Symbol(works1, Decl(arrowFunctionParsingGenericInObject.ts, 5, 5))
+const fn1async = () => ({
+>fn1async : Symbol(fn1async, Decl(arrowFunctionParsingGenericInObject.ts, 5, 5))
+
+    test: async <T = undefined>(value: T): Promise<T> => value,
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 5, 25))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 6, 17))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 6, 32))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 6, 17))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 6, 17))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 6, 32))
+
+    extraValue: () => {},
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 6, 63))
+
+})
+
+const fn2 = () => ({
+>fn2 : Symbol(fn2, Decl(arrowFunctionParsingGenericInObject.ts, 10, 5))
 
     test: <T>(value: T): T => value,
->test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 5, 23))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 6, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 6, 14))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 6, 11))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 6, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 6, 14))
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 10, 20))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 11, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 11, 14))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 11, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 11, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 11, 14))
 
     extraValue: () => {},
->extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 6, 36))
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 11, 36))
 
 })
 
-const works2 = () => ({
->works2 : Symbol(works2, Decl(arrowFunctionParsingGenericInObject.ts, 10, 5))
+const fn2async = () => ({
+>fn2async : Symbol(fn2async, Decl(arrowFunctionParsingGenericInObject.ts, 15, 5))
+
+    test: async <T>(value: T): Promise<T> => value,
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 15, 25))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 16, 17))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 16, 20))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 16, 17))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 16, 17))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 16, 20))
 
     extraValue: () => {},
->extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 10, 23))
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 16, 51))
+
+})
+
+const fn3 = () => ({
+>fn3 : Symbol(fn3, Decl(arrowFunctionParsingGenericInObject.ts, 20, 5))
+
+    extraValue: () => {},
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 20, 20))
 
     test: <T = undefined>(value: T): T => value,
->test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 11, 25))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 12, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 12, 26))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 12, 11))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 12, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 12, 26))
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 21, 25))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 22, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 22, 26))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 22, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 22, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 22, 26))
 
 })
 
-const fails2 = () => ({
->fails2 : Symbol(fails2, Decl(arrowFunctionParsingGenericInObject.ts, 15, 5))
+const fn3async = () => ({
+>fn3async : Symbol(fn3async, Decl(arrowFunctionParsingGenericInObject.ts, 25, 5))
+
+    extraValue: () => {},
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 25, 25))
+
+    test: async <T = undefined>(value: T): Promise<T> => value,
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 26, 25))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 27, 17))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 27, 32))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 27, 17))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 27, 17))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 27, 32))
+
+})
+
+const fn4 = () => ({
+>fn4 : Symbol(fn4, Decl(arrowFunctionParsingGenericInObject.ts, 30, 5))
 
     extraValue: '',
->extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 15, 23))
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 30, 20))
 
     test: <T = undefined>(value: T): T => value,
->test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 16, 19))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 17, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 17, 26))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 17, 11))
->T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 17, 11))
->value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 17, 26))
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 31, 19))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 32, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 32, 26))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 32, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 32, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 32, 26))
+
+})
+
+const fn4async = () => ({
+>fn4async : Symbol(fn4async, Decl(arrowFunctionParsingGenericInObject.ts, 35, 5))
+
+    extraValue: '',
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 35, 25))
+
+    test: async <T = undefined>(value: T): Promise<T> => value,
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 36, 19))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 37, 17))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 37, 32))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 37, 17))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 37, 17))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 37, 32))
 
 })
 

--- a/tests/baselines/reference/arrowFunctionParsingGenericInObject.symbols
+++ b/tests/baselines/reference/arrowFunctionParsingGenericInObject.symbols
@@ -1,0 +1,69 @@
+=== tests/cases/compiler/arrowFunctionParsingGenericInObject.ts ===
+// Apparent parser error when first property of returned object is generic function with default type
+const fails1 = () => ({
+>fails1 : Symbol(fails1, Decl(arrowFunctionParsingGenericInObject.ts, 1, 5))
+
+    test: <T = undefined>(value: T): T => value,
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 1, 23))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 2, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 2, 26))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 2, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 2, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 2, 26))
+
+    extraValue: () => {},
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 2, 48))
+
+})
+
+// Without a default type, it works fine
+const works1 = () => ({
+>works1 : Symbol(works1, Decl(arrowFunctionParsingGenericInObject.ts, 7, 5))
+
+    test: <T>(value: T): T => value,
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 7, 23))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 8, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 8, 14))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 8, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 8, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 8, 14))
+
+    extraValue: () => {},
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 8, 36))
+
+})
+
+// As second property, it works fine
+const works2 = () => ({
+>works2 : Symbol(works2, Decl(arrowFunctionParsingGenericInObject.ts, 13, 5))
+
+    extraValue: () => {},
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 13, 23))
+
+    test: <T = undefined>(value: T): T => value,
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 14, 25))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 15, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 15, 26))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 15, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 15, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 15, 26))
+
+})
+
+// The first property _must_ be a function, though
+const fails2 = () => ({
+>fails2 : Symbol(fails2, Decl(arrowFunctionParsingGenericInObject.ts, 19, 5))
+
+    extraValue: '',
+>extraValue : Symbol(extraValue, Decl(arrowFunctionParsingGenericInObject.ts, 19, 23))
+
+    test: <T = undefined>(value: T): T => value,
+>test : Symbol(test, Decl(arrowFunctionParsingGenericInObject.ts, 20, 19))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 21, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 21, 26))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 21, 11))
+>T : Symbol(T, Decl(arrowFunctionParsingGenericInObject.ts, 21, 11))
+>value : Symbol(value, Decl(arrowFunctionParsingGenericInObject.ts, 21, 26))
+
+})
+

--- a/tests/baselines/reference/arrowFunctionParsingGenericInObject.types
+++ b/tests/baselines/reference/arrowFunctionParsingGenericInObject.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/arrowFunctionParsingGenericInObject.ts ===
-const fails1 = () => ({
->fails1 : () => { test: <T = undefined>(value: T) => T; extraValue: () => void; }
+const fn1 = () => ({
+>fn1 : () => { test: <T = undefined>(value: T) => T; extraValue: () => void; }
 >() => ({    test: <T = undefined>(value: T): T => value,    extraValue: () => {},}) : () => { test: <T = undefined>(value: T) => T; extraValue: () => void; }
 >({    test: <T = undefined>(value: T): T => value,    extraValue: () => {},}) : { test: <T = undefined>(value: T) => T; extraValue: () => void; }
 >{    test: <T = undefined>(value: T): T => value,    extraValue: () => {},} : { test: <T = undefined>(value: T) => T; extraValue: () => void; }
@@ -17,8 +17,26 @@ const fails1 = () => ({
 
 })
 
-const works1 = () => ({
->works1 : () => { test: <T>(value: T) => T; extraValue: () => void; }
+const fn1async = () => ({
+>fn1async : () => { test: <T = undefined>(value: T) => Promise<T>; extraValue: () => void; }
+>() => ({    test: async <T = undefined>(value: T): Promise<T> => value,    extraValue: () => {},}) : () => { test: <T = undefined>(value: T) => Promise<T>; extraValue: () => void; }
+>({    test: async <T = undefined>(value: T): Promise<T> => value,    extraValue: () => {},}) : { test: <T = undefined>(value: T) => Promise<T>; extraValue: () => void; }
+>{    test: async <T = undefined>(value: T): Promise<T> => value,    extraValue: () => {},} : { test: <T = undefined>(value: T) => Promise<T>; extraValue: () => void; }
+
+    test: async <T = undefined>(value: T): Promise<T> => value,
+>test : <T = undefined>(value: T) => Promise<T>
+>async <T = undefined>(value: T): Promise<T> => value : <T = undefined>(value: T) => Promise<T>
+>value : T
+>value : T
+
+    extraValue: () => {},
+>extraValue : () => void
+>() => {} : () => void
+
+})
+
+const fn2 = () => ({
+>fn2 : () => { test: <T>(value: T) => T; extraValue: () => void; }
 >() => ({    test: <T>(value: T): T => value,    extraValue: () => {},}) : () => { test: <T>(value: T) => T; extraValue: () => void; }
 >({    test: <T>(value: T): T => value,    extraValue: () => {},}) : { test: <T>(value: T) => T; extraValue: () => void; }
 >{    test: <T>(value: T): T => value,    extraValue: () => {},} : { test: <T>(value: T) => T; extraValue: () => void; }
@@ -35,8 +53,26 @@ const works1 = () => ({
 
 })
 
-const works2 = () => ({
->works2 : () => { extraValue: () => void; test: <T = undefined>(value: T) => T; }
+const fn2async = () => ({
+>fn2async : () => { test: <T>(value: T) => Promise<T>; extraValue: () => void; }
+>() => ({    test: async <T>(value: T): Promise<T> => value,    extraValue: () => {},}) : () => { test: <T>(value: T) => Promise<T>; extraValue: () => void; }
+>({    test: async <T>(value: T): Promise<T> => value,    extraValue: () => {},}) : { test: <T>(value: T) => Promise<T>; extraValue: () => void; }
+>{    test: async <T>(value: T): Promise<T> => value,    extraValue: () => {},} : { test: <T>(value: T) => Promise<T>; extraValue: () => void; }
+
+    test: async <T>(value: T): Promise<T> => value,
+>test : <T>(value: T) => Promise<T>
+>async <T>(value: T): Promise<T> => value : <T>(value: T) => Promise<T>
+>value : T
+>value : T
+
+    extraValue: () => {},
+>extraValue : () => void
+>() => {} : () => void
+
+})
+
+const fn3 = () => ({
+>fn3 : () => { extraValue: () => void; test: <T = undefined>(value: T) => T; }
 >() => ({    extraValue: () => {},    test: <T = undefined>(value: T): T => value,}) : () => { extraValue: () => void; test: <T = undefined>(value: T) => T; }
 >({    extraValue: () => {},    test: <T = undefined>(value: T): T => value,}) : { extraValue: () => void; test: <T = undefined>(value: T) => T; }
 >{    extraValue: () => {},    test: <T = undefined>(value: T): T => value,} : { extraValue: () => void; test: <T = undefined>(value: T) => T; }
@@ -53,8 +89,26 @@ const works2 = () => ({
 
 })
 
-const fails2 = () => ({
->fails2 : () => { extraValue: string; test: <T = undefined>(value: T) => T; }
+const fn3async = () => ({
+>fn3async : () => { extraValue: () => void; test: <T = undefined>(value: T) => Promise<T>; }
+>() => ({    extraValue: () => {},    test: async <T = undefined>(value: T): Promise<T> => value,}) : () => { extraValue: () => void; test: <T = undefined>(value: T) => Promise<T>; }
+>({    extraValue: () => {},    test: async <T = undefined>(value: T): Promise<T> => value,}) : { extraValue: () => void; test: <T = undefined>(value: T) => Promise<T>; }
+>{    extraValue: () => {},    test: async <T = undefined>(value: T): Promise<T> => value,} : { extraValue: () => void; test: <T = undefined>(value: T) => Promise<T>; }
+
+    extraValue: () => {},
+>extraValue : () => void
+>() => {} : () => void
+
+    test: async <T = undefined>(value: T): Promise<T> => value,
+>test : <T = undefined>(value: T) => Promise<T>
+>async <T = undefined>(value: T): Promise<T> => value : <T = undefined>(value: T) => Promise<T>
+>value : T
+>value : T
+
+})
+
+const fn4 = () => ({
+>fn4 : () => { extraValue: string; test: <T = undefined>(value: T) => T; }
 >() => ({    extraValue: '',    test: <T = undefined>(value: T): T => value,}) : () => { extraValue: string; test: <T = undefined>(value: T) => T; }
 >({    extraValue: '',    test: <T = undefined>(value: T): T => value,}) : { extraValue: string; test: <T = undefined>(value: T) => T; }
 >{    extraValue: '',    test: <T = undefined>(value: T): T => value,} : { extraValue: string; test: <T = undefined>(value: T) => T; }
@@ -66,6 +120,24 @@ const fails2 = () => ({
     test: <T = undefined>(value: T): T => value,
 >test : <T = undefined>(value: T) => T
 ><T = undefined>(value: T): T => value : <T = undefined>(value: T) => T
+>value : T
+>value : T
+
+})
+
+const fn4async = () => ({
+>fn4async : () => { extraValue: string; test: <T = undefined>(value: T) => Promise<T>; }
+>() => ({    extraValue: '',    test: async <T = undefined>(value: T): Promise<T> => value,}) : () => { extraValue: string; test: <T = undefined>(value: T) => Promise<T>; }
+>({    extraValue: '',    test: async <T = undefined>(value: T): Promise<T> => value,}) : { extraValue: string; test: <T = undefined>(value: T) => Promise<T>; }
+>{    extraValue: '',    test: async <T = undefined>(value: T): Promise<T> => value,} : { extraValue: string; test: <T = undefined>(value: T) => Promise<T>; }
+
+    extraValue: '',
+>extraValue : string
+>'' : ""
+
+    test: async <T = undefined>(value: T): Promise<T> => value,
+>test : <T = undefined>(value: T) => Promise<T>
+>async <T = undefined>(value: T): Promise<T> => value : <T = undefined>(value: T) => Promise<T>
 >value : T
 >value : T
 

--- a/tests/baselines/reference/arrowFunctionParsingGenericInObject.types
+++ b/tests/baselines/reference/arrowFunctionParsingGenericInObject.types
@@ -1,0 +1,77 @@
+=== tests/cases/compiler/arrowFunctionParsingGenericInObject.ts ===
+// Apparent parser error when first property of returned object is generic function with default type
+const fails1 = () => ({
+>fails1 : () => { test: <T = undefined>(value: T) => T; extraValue: () => void; }
+>() => ({    test: <T = undefined>(value: T): T => value,    extraValue: () => {},}) : () => { test: <T = undefined>(value: T) => T; extraValue: () => void; }
+>({    test: <T = undefined>(value: T): T => value,    extraValue: () => {},}) : { test: <T = undefined>(value: T) => T; extraValue: () => void; }
+>{    test: <T = undefined>(value: T): T => value,    extraValue: () => {},} : { test: <T = undefined>(value: T) => T; extraValue: () => void; }
+
+    test: <T = undefined>(value: T): T => value,
+>test : <T = undefined>(value: T) => T
+><T = undefined>(value: T): T => value : <T = undefined>(value: T) => T
+>value : T
+>value : T
+
+    extraValue: () => {},
+>extraValue : () => void
+>() => {} : () => void
+
+})
+
+// Without a default type, it works fine
+const works1 = () => ({
+>works1 : () => { test: <T>(value: T) => T; extraValue: () => void; }
+>() => ({    test: <T>(value: T): T => value,    extraValue: () => {},}) : () => { test: <T>(value: T) => T; extraValue: () => void; }
+>({    test: <T>(value: T): T => value,    extraValue: () => {},}) : { test: <T>(value: T) => T; extraValue: () => void; }
+>{    test: <T>(value: T): T => value,    extraValue: () => {},} : { test: <T>(value: T) => T; extraValue: () => void; }
+
+    test: <T>(value: T): T => value,
+>test : <T>(value: T) => T
+><T>(value: T): T => value : <T>(value: T) => T
+>value : T
+>value : T
+
+    extraValue: () => {},
+>extraValue : () => void
+>() => {} : () => void
+
+})
+
+// As second property, it works fine
+const works2 = () => ({
+>works2 : () => { extraValue: () => void; test: <T = undefined>(value: T) => T; }
+>() => ({    extraValue: () => {},    test: <T = undefined>(value: T): T => value,}) : () => { extraValue: () => void; test: <T = undefined>(value: T) => T; }
+>({    extraValue: () => {},    test: <T = undefined>(value: T): T => value,}) : { extraValue: () => void; test: <T = undefined>(value: T) => T; }
+>{    extraValue: () => {},    test: <T = undefined>(value: T): T => value,} : { extraValue: () => void; test: <T = undefined>(value: T) => T; }
+
+    extraValue: () => {},
+>extraValue : () => void
+>() => {} : () => void
+
+    test: <T = undefined>(value: T): T => value,
+>test : <T = undefined>(value: T) => T
+><T = undefined>(value: T): T => value : <T = undefined>(value: T) => T
+>value : T
+>value : T
+
+})
+
+// The first property _must_ be a function, though
+const fails2 = () => ({
+>fails2 : () => { extraValue: string; test: <T = undefined>(value: T) => T; }
+>() => ({    extraValue: '',    test: <T = undefined>(value: T): T => value,}) : () => { extraValue: string; test: <T = undefined>(value: T) => T; }
+>({    extraValue: '',    test: <T = undefined>(value: T): T => value,}) : { extraValue: string; test: <T = undefined>(value: T) => T; }
+>{    extraValue: '',    test: <T = undefined>(value: T): T => value,} : { extraValue: string; test: <T = undefined>(value: T) => T; }
+
+    extraValue: '',
+>extraValue : string
+>'' : ""
+
+    test: <T = undefined>(value: T): T => value,
+>test : <T = undefined>(value: T) => T
+><T = undefined>(value: T): T => value : <T = undefined>(value: T) => T
+>value : T
+>value : T
+
+})
+

--- a/tests/baselines/reference/arrowFunctionParsingGenericInObject.types
+++ b/tests/baselines/reference/arrowFunctionParsingGenericInObject.types
@@ -1,5 +1,4 @@
 === tests/cases/compiler/arrowFunctionParsingGenericInObject.ts ===
-// Apparent parser error when first property of returned object is generic function with default type
 const fails1 = () => ({
 >fails1 : () => { test: <T = undefined>(value: T) => T; extraValue: () => void; }
 >() => ({    test: <T = undefined>(value: T): T => value,    extraValue: () => {},}) : () => { test: <T = undefined>(value: T) => T; extraValue: () => void; }
@@ -18,7 +17,6 @@ const fails1 = () => ({
 
 })
 
-// Without a default type, it works fine
 const works1 = () => ({
 >works1 : () => { test: <T>(value: T) => T; extraValue: () => void; }
 >() => ({    test: <T>(value: T): T => value,    extraValue: () => {},}) : () => { test: <T>(value: T) => T; extraValue: () => void; }
@@ -37,7 +35,6 @@ const works1 = () => ({
 
 })
 
-// As second property, it works fine
 const works2 = () => ({
 >works2 : () => { extraValue: () => void; test: <T = undefined>(value: T) => T; }
 >() => ({    extraValue: () => {},    test: <T = undefined>(value: T): T => value,}) : () => { extraValue: () => void; test: <T = undefined>(value: T) => T; }
@@ -56,7 +53,6 @@ const works2 = () => ({
 
 })
 
-// The first property _must_ be a function, though
 const fails2 = () => ({
 >fails2 : () => { extraValue: string; test: <T = undefined>(value: T) => T; }
 >() => ({    extraValue: '',    test: <T = undefined>(value: T): T => value,}) : () => { extraValue: string; test: <T = undefined>(value: T) => T; }

--- a/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
+++ b/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
@@ -1,0 +1,14 @@
+// regression test for https://github.com/microsoft/TypeScript/issues/32914
+declare var value: boolean;
+declare var a: any;
+
+const test = () => ({
+    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
+    prop: !value, // remove ! to see that errors will be gone
+    run: () => { //replace arrow function with regular function to see that errors will be gone
+        // comment next line or remove "()" to see that errors will be gone
+        if(!a.b()) { return 'special'; }
+
+        return 'default';
+    }
+}); 

--- a/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
+++ b/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
@@ -1,19 +1,40 @@
-const fails1 = () => ({
+// @target: esnext
+const fn1 = () => ({
     test: <T = undefined>(value: T): T => value,
     extraValue: () => {},
 })
 
-const works1 = () => ({
+const fn1async = () => ({
+    test: async <T = undefined>(value: T): Promise<T> => value,
+    extraValue: () => {},
+})
+
+const fn2 = () => ({
     test: <T>(value: T): T => value,
     extraValue: () => {},
 })
 
-const works2 = () => ({
+const fn2async = () => ({
+    test: async <T>(value: T): Promise<T> => value,
+    extraValue: () => {},
+})
+
+const fn3 = () => ({
     extraValue: () => {},
     test: <T = undefined>(value: T): T => value,
 })
 
-const fails2 = () => ({
+const fn3async = () => ({
+    extraValue: () => {},
+    test: async <T = undefined>(value: T): Promise<T> => value,
+})
+
+const fn4 = () => ({
     extraValue: '',
     test: <T = undefined>(value: T): T => value,
+})
+
+const fn4async = () => ({
+    extraValue: '',
+    test: async <T = undefined>(value: T): Promise<T> => value,
 })

--- a/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
+++ b/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
@@ -1,22 +1,18 @@
-// Apparent parser error when first property of returned object is generic function with default type
 const fails1 = () => ({
     test: <T = undefined>(value: T): T => value,
     extraValue: () => {},
 })
 
-// Without a default type, it works fine
 const works1 = () => ({
     test: <T>(value: T): T => value,
     extraValue: () => {},
 })
 
-// As second property, it works fine
 const works2 = () => ({
     extraValue: () => {},
     test: <T = undefined>(value: T): T => value,
 })
 
-// The first property _must_ be a function, though
 const fails2 = () => ({
     extraValue: '',
     test: <T = undefined>(value: T): T => value,

--- a/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
+++ b/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
@@ -1,0 +1,23 @@
+// Apparent parser error when first property of returned object is generic function with default type
+const fails1 = () => ({
+    test: <T = undefined>(value: T): T => value,
+    extraValue: () => {},
+})
+
+// Without a default type, it works fine
+const works1 = () => ({
+    test: <T>(value: T): T => value,
+    extraValue: () => {},
+})
+
+// As second property, it works fine
+const works2 = () => ({
+    extraValue: () => {},
+    test: <T = undefined>(value: T): T => value,
+})
+
+// The first property _must_ be a function, though
+const fails2 = () => ({
+    extraValue: '',
+    test: <T = undefined>(value: T): T => value,
+})


### PR DESCRIPTION
Fixes #32914
Fixes #48154

This is #39014 but applied by hand back to `main`, which has changed significantly.