### PR TITLE
Correct node used for isDefinition calculation

### DIFF
--- a/tests/baselines/reference/findAllRefsExportEquals.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefsExportEquals.baseline.jsonc
@@ -271,7 +271,7 @@
           "length": 16
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {

--- a/tests/baselines/reference/findAllRefs_importType_exportEquals.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefs_importType_exportEquals.baseline.jsonc
@@ -774,7 +774,7 @@
           "length": 16
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -787,7 +787,7 @@
           "length": 43
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {

--- a/tests/baselines/reference/referencesForDeclarationKeywords.baseline.jsonc
+++ b/tests/baselines/reference/referencesForDeclarationKeywords.baseline.jsonc
@@ -132,7 +132,7 @@
           "length": 13
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -220,7 +220,7 @@
           "length": 25
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -329,7 +329,7 @@ undefined
           "length": 21
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -342,7 +342,7 @@ undefined
           "length": 11
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -440,7 +440,7 @@ undefined
           "length": 21
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -453,7 +453,7 @@ undefined
           "length": 11
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -523,7 +523,7 @@ undefined
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -593,7 +593,7 @@ undefined
           "length": 13
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -703,7 +703,7 @@ undefined
           "length": 12
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -773,7 +773,7 @@ undefined
           "length": 10
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -843,7 +843,7 @@ undefined
           "length": 15
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -913,7 +913,7 @@ undefined
           "length": 12
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -1085,7 +1085,7 @@ undefined
           "length": 6
         },
         "isWriteAccess": false,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -1167,7 +1167,7 @@ undefined
           "length": 6
         },
         "isWriteAccess": false,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -1249,7 +1249,7 @@ undefined
           "length": 12
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }

--- a/tests/baselines/reference/referencesForExpressionKeywords.baseline.jsonc
+++ b/tests/baselines/reference/referencesForExpressionKeywords.baseline.jsonc
@@ -57,7 +57,7 @@
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -203,7 +203,7 @@
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -349,7 +349,7 @@
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -495,7 +495,7 @@
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -641,7 +641,7 @@
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -787,7 +787,7 @@
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -933,7 +933,7 @@
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -1079,7 +1079,7 @@
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -1253,7 +1253,7 @@
           "length": 13
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {

--- a/tests/baselines/reference/referencesForModifiers.baseline.jsonc
+++ b/tests/baselines/reference/referencesForModifiers.baseline.jsonc
@@ -54,7 +54,7 @@
           "length": 105
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -116,7 +116,7 @@
           "length": 105
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -206,7 +206,7 @@
           "length": 9
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -296,7 +296,7 @@
           "length": 11
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -386,7 +386,7 @@
           "length": 9
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -476,7 +476,7 @@
           "length": 12
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -566,7 +566,7 @@
           "length": 10
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -636,7 +636,7 @@
           "length": 16
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -730,7 +730,7 @@
           "length": 22
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -792,7 +792,7 @@
           "length": 26
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }

--- a/tests/baselines/reference/referencesForStatementKeywords.baseline.jsonc
+++ b/tests/baselines/reference/referencesForStatementKeywords.baseline.jsonc
@@ -95,7 +95,7 @@
           "length": 26
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -289,7 +289,7 @@
           "length": 14
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -399,7 +399,7 @@
           "length": 25
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   },
@@ -555,7 +555,7 @@
           "length": 25
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   },
@@ -747,7 +747,7 @@
           "length": 30
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -822,7 +822,7 @@
           "length": 30
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -897,7 +897,7 @@
           "length": 30
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -1078,7 +1078,7 @@
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   },
@@ -1234,7 +1234,7 @@
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   },
@@ -1545,7 +1545,7 @@ undefined
           "length": 40
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -1904,7 +1904,7 @@ undefined
           "length": 30
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -1979,7 +1979,7 @@ undefined
           "length": 30
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -2054,7 +2054,7 @@ undefined
           "length": 30
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -2235,7 +2235,7 @@ undefined
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   },
@@ -2391,7 +2391,7 @@ undefined
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   },
@@ -2702,7 +2702,7 @@ undefined
           "length": 40
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -2806,7 +2806,7 @@ undefined
           "length": 19
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -2910,7 +2910,7 @@ undefined
           "length": 19
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -2989,7 +2989,7 @@ undefined
           "length": 29
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -3058,7 +3058,7 @@ undefined
           "length": 13
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -3140,7 +3140,7 @@ undefined
           "length": 13
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {

--- a/tests/baselines/reference/referencesForTypeKeywords.baseline.jsonc
+++ b/tests/baselines/reference/referencesForTypeKeywords.baseline.jsonc
@@ -50,7 +50,7 @@
           "length": 14
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -165,7 +165,7 @@
         },
         "fileName": "/tests/cases/fourslash/referencesForTypeKeywords.ts",
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -232,7 +232,7 @@
         },
         "fileName": "/tests/cases/fourslash/referencesForTypeKeywords.ts",
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -298,7 +298,7 @@
           "length": 12
         },
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       }
     ]
   }
@@ -392,7 +392,7 @@
         },
         "fileName": "/tests/cases/fourslash/referencesForTypeKeywords.ts",
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {
@@ -495,7 +495,7 @@
         },
         "fileName": "/tests/cases/fourslash/referencesForTypeKeywords.ts",
         "isWriteAccess": true,
-        "isDefinition": false
+        "isDefinition": true
       },
       {
         "textSpan": {


### PR DESCRIPTION
It should be adjusted as in `getReferencedSymbolsForNode`.  The baseline changes show that it was incorrectly returning false at keywords preceding definitions.