### PR TITLE
Sync fourslash shims and shims-pp

### DIFF
--- a/tests/cases/fourslash/shims-pp/goToDefinitionTypeReferenceDirective.ts
+++ b/tests/cases/fourslash/shims-pp/goToDefinitionTypeReferenceDirective.ts
@@ -1,4 +1,4 @@
-/// <reference path="fourslash.ts"/>
+/// <reference path="../fourslash.ts"/>
 
 // @typeRoots: src/types
 // @Filename: src/types/lib/index.d.ts

--- a/tests/cases/fourslash/shims/getCompletionsAtPosition.ts
+++ b/tests/cases/fourslash/shims/getCompletionsAtPosition.ts
@@ -1,4 +1,4 @@
-/// <reference path='fourslash.ts'/>
+/// <reference path='../fourslash.ts'/>
 
 ////function foo(strOrNum: string | number) {
 ////    /*1*/

--- a/tests/cases/fourslash/shims/getOutliningSpans.ts
+++ b/tests/cases/fourslash/shims/getOutliningSpans.ts
@@ -1,4 +1,4 @@
-/// <reference path="fourslash.ts"/>
+/// <reference path="../fourslash.ts"/>
 
 ////// interface
 ////interface IFoo[| {
@@ -26,7 +26,7 @@
 ////    }|]
 ////}|]
 ////switch(1)[| {
-//// case 1:[| break;|]
+////  case 1:[| break;|]
 ////}|]
 ////
 ////var array =[| [


### PR DESCRIPTION
It appears that they were intended to be identical so, in each case, I updated the side that looked less correct.