### PR TITLE
feat(48107) - Support convert string except in top level import to template string

### DIFF
--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -20,7 +20,8 @@ namespace ts.refactor.convertStringOrTemplateLiteral {
         const maybeBinary = getParentBinaryExpression(node);
         const refactorInfo: ApplicableRefactorInfo = { name: refactorName, description: refactorDescription, actions: [] };
 
-        if (isBinaryExpression(maybeBinary) && treeToArray(maybeBinary).isValidConcatenation) {
+        const inTopLevelImport = isImportDeclaration(maybeBinary.parent);
+        if ((isStringLiteral(maybeBinary) && !inTopLevelImport) || (isBinaryExpression(maybeBinary) && treeToArray(maybeBinary).isValidConcatenation)) {
             refactorInfo.actions.push(convertStringAction);
             return [refactorInfo];
         }

--- a/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateBackTick.ts
+++ b/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateBackTick.ts
@@ -3,4 +3,10 @@
 //// const foo = "/*x*/w/*y*/ith back`tick"
 
 goTo.select("x", "y");
-verify.not.refactorAvailable(ts.Diagnostics.Convert_to_template_string.message);
+edit.applyRefactor({
+    refactorName: "Convert to template string",
+    actionName: "Convert to template string",
+    actionDescription: ts.Diagnostics.Convert_to_template_string.message,
+    newContent:
+`const foo = \`with back\\\`tick\``,
+});

--- a/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateSimple.ts
+++ b/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateSimple.ts
@@ -3,4 +3,10 @@
 //// const foo = "/*x*/f/*y*/oobar rocks"
 
 goTo.select("x", "y");
-verify.not.refactorAvailable(ts.Diagnostics.Convert_to_template_string.message);
+edit.applyRefactor({
+    refactorName: "Convert to template string",
+    actionName: "Convert to template string",
+    actionDescription: ts.Diagnostics.Convert_to_template_string.message,
+    newContent:
+`const foo = \`foobar rocks\``,
+});

--- a/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateSingleQuote.ts
+++ b/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateSingleQuote.ts
@@ -3,4 +3,10 @@
 //// const foo = '/*x*/f/*y*/oobar rocks'
 
 goTo.select("x", "y");
-verify.not.refactorAvailable(ts.Diagnostics.Convert_to_template_string.message);
+edit.applyRefactor({
+    refactorName: "Convert to template string",
+    actionName: "Convert to template string",
+    actionDescription: ts.Diagnostics.Convert_to_template_string.message,
+    newContent:
+`const foo = \`foobar rocks\``,
+});


### PR DESCRIPTION
Based on suggestion in #48107

- Convert any string to template string
```js
const hello = "foobar rocks"
// ->
const hello = `foobar rocks`
```
- Except
```js
import { foo } from "bar" // there is no actions when put cursor in "bar"
```
