### PR TITLE
Add JS-specific diagnostic message for `resolve()` in Promise where type argument can't be inferred

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30414,7 +30414,7 @@ namespace ts {
                 : min < max ? min + "-" + max
                 : min;
             const error = hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_1
-                : parameterRange === 1 && args.length === 0 && isPromiseResolveArityError(node) ? Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise
+                : parameterRange === 1 && args.length === 0 && isPromiseResolveArityError(node) ? Diagnostics.Expected_0_arguments_but_got_1_TypeScript_may_need_a_JSDoc_hint_that_the_call_to_new_Promise_produces_a_Promise_void
                 : Diagnostics.Expected_0_arguments_but_got_1;
             if (min < args.length && args.length < max) {
                 // between min and max, but with no matching overload

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30413,11 +30413,15 @@ namespace ts {
             const parameterRange = hasRestParameter ? min
                 : min < max ? min + "-" + max
                 : min;
-            const error = hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_1
-                : parameterRange === 1 && args.length === 0 && isPromiseResolveArityError(node) ? isInJSFile(node)
-                    ? Diagnostics.Expected_0_arguments_but_got_1_TypeScript_may_need_a_JSDoc_hint_that_the_call_to_new_Promise_produces_a_Promise_void
-                    : Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise
-                : Diagnostics.Expected_0_arguments_but_got_1;
+            const isVoidPromiseError = !hasRestParameter && parameterRange === 1 && args.length === 0 && isPromiseResolveArityError(node);
+            if (isVoidPromiseError && isInJSFile(node)) {
+                return getDiagnosticForCallNode(node, Diagnostics.Expected_1_argument_but_got_0_new_Promise_needs_a_JSDoc_hint_to_produce_a_resolve_that_can_be_called_without_arguments);
+            }
+            const error = hasRestParameter
+                ? Diagnostics.Expected_at_least_0_arguments_but_got_1
+                : isVoidPromiseError
+                    ? Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise
+                    : Diagnostics.Expected_0_arguments_but_got_1;
             if (min < args.length && args.length < max) {
                 // between min and max, but with no matching overload
                 return getDiagnosticForCallNode(node, Diagnostics.No_overload_expects_0_arguments_but_overloads_do_exist_that_expect_either_1_or_2_arguments, args.length, maxBelow, minAbove);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30414,7 +30414,9 @@ namespace ts {
                 : min < max ? min + "-" + max
                 : min;
             const error = hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_1
-                : parameterRange === 1 && args.length === 0 && isPromiseResolveArityError(node) ? Diagnostics.Expected_0_arguments_but_got_1_TypeScript_may_need_a_JSDoc_hint_that_the_call_to_new_Promise_produces_a_Promise_void
+                : parameterRange === 1 && args.length === 0 && isPromiseResolveArityError(node) ? isInJSFile(node)
+                    ? Diagnostics.Expected_0_arguments_but_got_1_TypeScript_may_need_a_JSDoc_hint_that_the_call_to_new_Promise_produces_a_Promise_void
+                    : Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise
                 : Diagnostics.Expected_0_arguments_but_got_1;
             if (min < args.length && args.length < max) {
                 // between min and max, but with no matching overload

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3369,7 +3369,7 @@
         "category": "Error",
         "code": 2809
     },
-    "Expected {0} arguments, but got {1}. TypeScript may need a JSDoc hint that the call to 'new Promise()' produces a 'Promise<void>'": {
+    "Expected 1 argument, but got 0. 'new Promise()' needs a JSDoc hint to produce a 'resolve' that can be called without arguments.": {
         "category": "Error",
         "code": 2810
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3309,7 +3309,7 @@
         "category": "Error",
         "code": 2793
     },
-    "Expected {0} arguments, but got {1}. TypeScript may need a JSDoc hint that the call to 'new Promise()' produces a 'Promise<void>'": {
+    "Expected {0} arguments, but got {1}. Did you forget to include 'void' in your type argument to 'Promise'?": {
         "category": "Error",
         "code": 2794
     },
@@ -3368,6 +3368,10 @@
     "Declaration or statement expected. This '=' follows a block of statements, so if you intended to write a destructuring assignment, you might need to wrap the the whole assignment in parentheses.": {
         "category": "Error",
         "code": 2809
+    },
+    "Expected {0} arguments, but got {1}. TypeScript may need a JSDoc hint that the call to 'new Promise()' produces a 'Promise<void>'": {
+        "category": "Error",
+        "code": 2810
     },
     "Initializer for property '{0}'": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3309,7 +3309,7 @@
         "category": "Error",
         "code": 2793
     },
-    "Expected {0} arguments, but got {1}. Did you forget to include 'void' in your type argument to 'Promise'?": {
+    "Expected {0} arguments, but got {1}. TypeScript may need a JSDoc hint that the call to 'new Promise()' produces a 'Promise<void>'": {
         "category": "Error",
         "code": 2794
     },

--- a/src/services/codefixes/fixAddVoidToPromise.ts
+++ b/src/services/codefixes/fixAddVoidToPromise.ts
@@ -3,7 +3,7 @@ namespace ts.codefix {
     const fixName = "addVoidToPromise";
     const fixId = "addVoidToPromise";
     const errorCodes = [
-        Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise.code
+        Diagnostics.Expected_0_arguments_but_got_1_TypeScript_may_need_a_JSDoc_hint_that_the_call_to_new_Promise_produces_a_Promise_void.code
     ];
     registerCodeFix({
         errorCodes,

--- a/src/services/codefixes/fixAddVoidToPromise.ts
+++ b/src/services/codefixes/fixAddVoidToPromise.ts
@@ -3,7 +3,7 @@ namespace ts.codefix {
     const fixName = "addVoidToPromise";
     const fixId = "addVoidToPromise";
     const errorCodes = [
-        Diagnostics.Expected_0_arguments_but_got_1_TypeScript_may_need_a_JSDoc_hint_that_the_call_to_new_Promise_produces_a_Promise_void.code,
+        Diagnostics.Expected_1_argument_but_got_0_new_Promise_needs_a_JSDoc_hint_to_produce_a_resolve_that_can_be_called_without_arguments.code,
         Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise.code
     ];
     registerCodeFix({

--- a/src/services/codefixes/fixAddVoidToPromise.ts
+++ b/src/services/codefixes/fixAddVoidToPromise.ts
@@ -3,7 +3,8 @@ namespace ts.codefix {
     const fixName = "addVoidToPromise";
     const fixId = "addVoidToPromise";
     const errorCodes = [
-        Diagnostics.Expected_0_arguments_but_got_1_TypeScript_may_need_a_JSDoc_hint_that_the_call_to_new_Promise_produces_a_Promise_void.code
+        Diagnostics.Expected_0_arguments_but_got_1_TypeScript_may_need_a_JSDoc_hint_that_the_call_to_new_Promise_produces_a_Promise_void.code,
+        Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise.code
     ];
     registerCodeFix({
         errorCodes,

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.1.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.1.ts
@@ -9,7 +9,7 @@
 ////const p1 = new Promise(resolve => resolve());
 
 verify.codeFix({
-    errorCode: 2794,
+    errorCode: 2810,
     description: "Add 'void' to Promise resolved without a value",
     index: 2,
     newFileContent: `const p1 = /** @type {Promise<void>} */(new Promise(resolve => resolve()));`

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.2.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.2.ts
@@ -9,7 +9,7 @@
 ////const p2 = /** @type {Promise<number>} */(new Promise(resolve => resolve()));
 
 verify.codeFix({
-    errorCode: 2794,
+    errorCode: 2810,
     description: "Add 'void' to Promise resolved without a value",
     index: 2,
     newFileContent: `const p2 = /** @type {Promise<number | void>} */(new Promise(resolve => resolve()));`

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.3.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.3.ts
@@ -9,7 +9,7 @@
 ////const p3 = /** @type {Promise<number | string>} */(new Promise(resolve => resolve()));
 
 verify.codeFix({
-    errorCode: 2794,
+    errorCode: 2810,
     description: "Add 'void' to Promise resolved without a value",
     index: 2,
     newFileContent: `const p3 = /** @type {Promise<number | string | void>} */(new Promise(resolve => resolve()));`

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.4.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.4.ts
@@ -9,7 +9,7 @@
 ////const p4 = /** @type {Promise<{ x: number } & { y: string }>} */(new Promise(resolve => resolve()));
 
 verify.codeFix({
-    errorCode: 2794,
+    errorCode: 2810,
     description: "Add 'void' to Promise resolved without a value",
     index: 2,
     newFileContent: `const p4 = /** @type {Promise<({ x: number } & { y: string }) | void>} */(new Promise(resolve => resolve()));`


### PR DESCRIPTION
Fixes: https://github.com/microsoft/TypeScript/issues/46570

Continues https://github.com/microsoft/TypeScript/pull/46637
I have cherry picked the commit from there.
Address the comments of the above PR, restricting the change to JS files.