### PR TITLE
Fix crash when circular reference in variance annotations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20640,11 +20640,9 @@ namespace ts {
         function createMarkerType(symbol: Symbol, source: TypeParameter, target: Type) {
             const mapper = makeUnaryTypeMapper(source, target);
             const type = getDeclaredTypeOfSymbol(symbol);
-
             if (isErrorType(type)) {
                 return type;
             }
-
             const result = symbol.flags & SymbolFlags.TypeAlias ?
                 getTypeAliasInstantiation(symbol, instantiateTypes(getSymbolLinks(symbol).typeParameters!, mapper)) :
                 createTypeReference(type as GenericType, instantiateTypes((type as GenericType).typeParameters, mapper));

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20640,6 +20640,11 @@ namespace ts {
         function createMarkerType(symbol: Symbol, source: TypeParameter, target: Type) {
             const mapper = makeUnaryTypeMapper(source, target);
             const type = getDeclaredTypeOfSymbol(symbol);
+
+            if (isErrorType(type)) {
+                return type;
+            }
+
             const result = symbol.flags & SymbolFlags.TypeAlias ?
                 getTypeAliasInstantiation(symbol, instantiateTypes(getSymbolLinks(symbol).typeParameters!, mapper)) :
                 createTypeReference(type as GenericType, instantiateTypes((type as GenericType).typeParameters, mapper));

--- a/tests/baselines/reference/varianceAnnotationsWithCircularlyReferencesError.errors.txt
+++ b/tests/baselines/reference/varianceAnnotationsWithCircularlyReferencesError.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotationsWithCircularlyReferencesError.ts(1,6): error TS2456: Type alias 'T1' circularly references itself.
+tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotationsWithCircularlyReferencesError.ts(1,11): error TS2300: Duplicate identifier '(Missing)'.
+tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotationsWithCircularlyReferencesError.ts(1,12): error TS1359: Identifier expected. 'in' is a reserved word that cannot be used here.
+tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotationsWithCircularlyReferencesError.ts(2,6): error TS2456: Type alias 'T2' circularly references itself.
+
+
+==== tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotationsWithCircularlyReferencesError.ts (4 errors) ====
+    type T1<in in> = T1 // Error: circularly references 
+         ~~
+!!! error TS2456: Type alias 'T1' circularly references itself.
+              
+!!! error TS2300: Duplicate identifier '(Missing)'.
+               ~~
+!!! error TS1359: Identifier expected. 'in' is a reserved word that cannot be used here.
+    type T2<out out> = T2 // Error: circularly references 
+         ~~
+!!! error TS2456: Type alias 'T2' circularly references itself.

--- a/tests/baselines/reference/varianceAnnotationsWithCircularlyReferencesError.js
+++ b/tests/baselines/reference/varianceAnnotationsWithCircularlyReferencesError.js
@@ -1,0 +1,11 @@
+//// [varianceAnnotationsWithCircularlyReferencesError.ts]
+type T1<in in> = T1 // Error: circularly references 
+type T2<out out> = T2 // Error: circularly references 
+
+//// [varianceAnnotationsWithCircularlyReferencesError.js]
+"use strict";
+
+
+//// [varianceAnnotationsWithCircularlyReferencesError.d.ts]
+declare type T1<in , > = T1;
+declare type T2<out out> = T2;

--- a/tests/baselines/reference/varianceAnnotationsWithCircularlyReferencesError.symbols
+++ b/tests/baselines/reference/varianceAnnotationsWithCircularlyReferencesError.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotationsWithCircularlyReferencesError.ts ===
+type T1<in in> = T1 // Error: circularly references 
+>T1 : Symbol(T1, Decl(varianceAnnotationsWithCircularlyReferencesError.ts, 0, 0))
+> : Symbol((Missing), Decl(varianceAnnotationsWithCircularlyReferencesError.ts, 0, 8), Decl(varianceAnnotationsWithCircularlyReferencesError.ts, 0, 10))
+> : Symbol((Missing), Decl(varianceAnnotationsWithCircularlyReferencesError.ts, 0, 8), Decl(varianceAnnotationsWithCircularlyReferencesError.ts, 0, 10))
+>T1 : Symbol(T1, Decl(varianceAnnotationsWithCircularlyReferencesError.ts, 0, 0))
+
+type T2<out out> = T2 // Error: circularly references 
+>T2 : Symbol(T2, Decl(varianceAnnotationsWithCircularlyReferencesError.ts, 0, 19))
+>out : Symbol(out, Decl(varianceAnnotationsWithCircularlyReferencesError.ts, 1, 8))
+>T2 : Symbol(T2, Decl(varianceAnnotationsWithCircularlyReferencesError.ts, 0, 19))
+

--- a/tests/baselines/reference/varianceAnnotationsWithCircularlyReferencesError.types
+++ b/tests/baselines/reference/varianceAnnotationsWithCircularlyReferencesError.types
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotationsWithCircularlyReferencesError.ts ===
+type T1<in in> = T1 // Error: circularly references 
+>T1 : any
+
+type T2<out out> = T2 // Error: circularly references 
+>T2 : any
+

--- a/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotationsWithCircularlyReferencesError.ts
+++ b/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotationsWithCircularlyReferencesError.ts
@@ -1,0 +1,5 @@
+// @strict: true
+// @declaration: true
+
+type T1<in in> = T1 // Error: circularly references 
+type T2<out out> = T2 // Error: circularly references 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

- Fixes #48537 
