### PR TITLE
Ensure late painted statements are only transformed once, so inner substitutions are consistently read

### DIFF
--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -1163,6 +1163,17 @@ namespace ts {
         }
 
         function transformTopLevelDeclaration(input: LateVisibilityPaintedStatement) {
+            if (lateMarkedStatements) {
+                while (true) {
+                    const idx: number = lateMarkedStatements.indexOf(input);
+                    if (idx > -1) {
+                        // remove this statement from the late-marked list if it's still there, in case it's been added multiple times
+                        lateMarkedStatements.splice(idx, 1);
+                        continue;
+                    }
+                    break;
+                }
+            }
             if (shouldStripInternal(input)) return;
             switch (input.kind) {
                 case SyntaxKind.ImportEqualsDeclaration: {

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -1164,15 +1164,7 @@ namespace ts {
 
         function transformTopLevelDeclaration(input: LateVisibilityPaintedStatement) {
             if (lateMarkedStatements) {
-                while (true) {
-                    const idx: number = lateMarkedStatements.indexOf(input);
-                    if (idx > -1) {
-                        // remove this statement from the late-marked list if it's still there, in case it's been added multiple times
-                        lateMarkedStatements.splice(idx, 1);
-                        continue;
-                    }
-                    break;
-                }
+                while (orderedRemoveItem(lateMarkedStatements, input)) { }
             }
             if (shouldStripInternal(input)) return;
             switch (input.kind) {

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -1164,7 +1164,7 @@ namespace ts {
 
         function transformTopLevelDeclaration(input: LateVisibilityPaintedStatement) {
             if (lateMarkedStatements) {
-                while (orderedRemoveItem(lateMarkedStatements, input)) { }
+                while (orderedRemoveItem(lateMarkedStatements, input));
             }
             if (shouldStripInternal(input)) return;
             switch (input.kind) {

--- a/tests/baselines/reference/declarationEmitNamespaceMergedWithInterfaceNestedFunction.js
+++ b/tests/baselines/reference/declarationEmitNamespaceMergedWithInterfaceNestedFunction.js
@@ -1,0 +1,38 @@
+//// [declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts]
+export interface Foo {
+    item: Bar;
+}
+
+interface Bar {
+    baz(): void;
+}
+
+namespace Bar {
+    export function biz() {
+        return 0;
+    }
+}
+
+//// [declarationEmitNamespaceMergedWithInterfaceNestedFunction.js]
+"use strict";
+exports.__esModule = true;
+var Bar;
+(function (Bar) {
+    function biz() {
+        return 0;
+    }
+    Bar.biz = biz;
+})(Bar || (Bar = {}));
+
+
+//// [declarationEmitNamespaceMergedWithInterfaceNestedFunction.d.ts]
+export interface Foo {
+    item: Bar;
+}
+interface Bar {
+    baz(): void;
+}
+declare namespace Bar {
+    function biz(): number;
+}
+export {};

--- a/tests/baselines/reference/declarationEmitNamespaceMergedWithInterfaceNestedFunction.symbols
+++ b/tests/baselines/reference/declarationEmitNamespaceMergedWithInterfaceNestedFunction.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts ===
+export interface Foo {
+>Foo : Symbol(Foo, Decl(declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts, 0, 0))
+
+    item: Bar;
+>item : Symbol(Foo.item, Decl(declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts, 0, 22))
+>Bar : Symbol(Bar, Decl(declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts, 2, 1), Decl(declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts, 6, 1))
+}
+
+interface Bar {
+>Bar : Symbol(Bar, Decl(declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts, 2, 1), Decl(declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts, 6, 1))
+
+    baz(): void;
+>baz : Symbol(Bar.baz, Decl(declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts, 4, 15))
+}
+
+namespace Bar {
+>Bar : Symbol(Bar, Decl(declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts, 2, 1), Decl(declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts, 6, 1))
+
+    export function biz() {
+>biz : Symbol(biz, Decl(declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts, 8, 15))
+
+        return 0;
+    }
+}

--- a/tests/baselines/reference/declarationEmitNamespaceMergedWithInterfaceNestedFunction.types
+++ b/tests/baselines/reference/declarationEmitNamespaceMergedWithInterfaceNestedFunction.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts ===
+export interface Foo {
+    item: Bar;
+>item : Bar
+}
+
+interface Bar {
+    baz(): void;
+>baz : () => void
+}
+
+namespace Bar {
+>Bar : typeof Bar
+
+    export function biz() {
+>biz : () => number
+
+        return 0;
+>0 : 0
+    }
+}

--- a/tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts
+++ b/tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts
@@ -1,0 +1,14 @@
+// @declaration: true
+export interface Foo {
+    item: Bar;
+}
+
+interface Bar {
+    baz(): void;
+}
+
+namespace Bar {
+    export function biz() {
+        return 0;
+    }
+}


### PR DESCRIPTION
Fixes #48525