### PR TITLE
Run API tests with 'strict' and 'exactOptionalProperties'.

### DIFF
--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -17,8 +17,13 @@ describe("unittests:: Public APIs", () => {
             const fs = vfs.createFromFileSystem(Harness.IO, /*ignoreCase*/ false);
             fs.linkSync(`${vfs.builtFolder}/${fileName}`, `${vfs.srcFolder}/${fileName}`);
             const sys = new fakes.System(fs);
-            const host = new fakes.CompilerHost(sys);
-            const result = compiler.compileFiles(host, [`${vfs.srcFolder}/${fileName}`], {});
+            const options: ts.CompilerOptions = {
+                ...ts.getDefaultCompilerOptions(),
+                strict: true,
+                exactOptionalPropertyTypes: true,
+            };
+            const host = new fakes.CompilerHost(sys, options);
+            const result = compiler.compileFiles(host, [`${vfs.srcFolder}/${fileName}`], options);
             assert(!result.diagnostics || !result.diagnostics.length, Harness.Compiler.minimalDiagnosticsToString(result.diagnostics, /*pretty*/ true));
         });
     }


### PR DESCRIPTION
Follow-up from @weswigham's comment in #48505.

Getting the compiler to adopt these settings would be ideal; but we should validate that whatever we generate is consumable in `--strict` and `--exactOptionalProperties` anyway.

I've confirmed that this change would have caught https://github.com/microsoft/TypeScript/issues/48504 by undoing the change in #48505.