### PR TITLE
Preserve the distributivity of inlined conditional types in declaration emit

### DIFF
--- a/tests/baselines/reference/declarationEmitInlinedDistributiveConditional.js
+++ b/tests/baselines/reference/declarationEmitInlinedDistributiveConditional.js
@@ -1,0 +1,57 @@
+//// [tests/cases/compiler/declarationEmitInlinedDistributiveConditional.ts] ////
+
+//// [test.ts]
+import {dropPrivateProps1, dropPrivateProps2} from './api';
+const a = dropPrivateProps1({foo: 42, _bar: 'secret'}); // type is {foo: number}
+//a._bar                                                // error: _bar does not exist           <===== as expected
+const b = dropPrivateProps2({foo: 42, _bar: 'secret'}); // type is {foo: number, _bar: string}
+//b._bar                                                // no error, type of b._bar is string   <===== NOT expected
+
+//// [api.ts]
+import {excludePrivateKeys1, excludePrivateKeys2} from './internal';
+export const dropPrivateProps1 = <Obj>(obj: Obj) => excludePrivateKeys1(obj);
+export const dropPrivateProps2 = <Obj>(obj: Obj) => excludePrivateKeys2(obj);
+
+//// [internal.ts]
+export declare function excludePrivateKeys1<Obj>(obj: Obj): {[K in PublicKeys1<keyof Obj>]: Obj[K]};
+export declare function excludePrivateKeys2<Obj>(obj: Obj): {[K in PublicKeys2<keyof Obj>]: Obj[K]};
+export type PublicKeys1<T> = T extends `_${string}` ? never : T;
+type PublicKeys2<T>        = T extends `_${string}` ? never : T;
+
+//// [internal.js]
+"use strict";
+exports.__esModule = true;
+//// [api.js]
+"use strict";
+exports.__esModule = true;
+exports.dropPrivateProps2 = exports.dropPrivateProps1 = void 0;
+var internal_1 = require("./internal");
+var dropPrivateProps1 = function (obj) { return (0, internal_1.excludePrivateKeys1)(obj); };
+exports.dropPrivateProps1 = dropPrivateProps1;
+var dropPrivateProps2 = function (obj) { return (0, internal_1.excludePrivateKeys2)(obj); };
+exports.dropPrivateProps2 = dropPrivateProps2;
+//// [test.js]
+"use strict";
+exports.__esModule = true;
+var api_1 = require("./api");
+var a = (0, api_1.dropPrivateProps1)({ foo: 42, _bar: 'secret' }); // type is {foo: number}
+//a._bar                                                // error: _bar does not exist           <===== as expected
+var b = (0, api_1.dropPrivateProps2)({ foo: 42, _bar: 'secret' }); // type is {foo: number, _bar: string}
+//b._bar                                                // no error, type of b._bar is string   <===== NOT expected
+
+
+//// [internal.d.ts]
+export declare function excludePrivateKeys1<Obj>(obj: Obj): {
+    [K in PublicKeys1<keyof Obj>]: Obj[K];
+};
+export declare function excludePrivateKeys2<Obj>(obj: Obj): {
+    [K in PublicKeys2<keyof Obj>]: Obj[K];
+};
+export declare type PublicKeys1<T> = T extends `_${string}` ? never : T;
+declare type PublicKeys2<T> = T extends `_${string}` ? never : T;
+export {};
+//// [api.d.ts]
+export declare const dropPrivateProps1: <Obj>(obj: Obj) => { [K in import("./internal").PublicKeys1<keyof Obj>]: Obj[K]; };
+export declare const dropPrivateProps2: <Obj>(obj: Obj) => { [K in keyof Obj extends infer T ? T extends keyof Obj ? T extends `_${string}` ? never : T : never : never]: Obj[K]; };
+//// [test.d.ts]
+export {};

--- a/tests/baselines/reference/declarationEmitInlinedDistributiveConditional.symbols
+++ b/tests/baselines/reference/declarationEmitInlinedDistributiveConditional.symbols
@@ -1,0 +1,76 @@
+=== tests/cases/compiler/test.ts ===
+import {dropPrivateProps1, dropPrivateProps2} from './api';
+>dropPrivateProps1 : Symbol(dropPrivateProps1, Decl(test.ts, 0, 8))
+>dropPrivateProps2 : Symbol(dropPrivateProps2, Decl(test.ts, 0, 26))
+
+const a = dropPrivateProps1({foo: 42, _bar: 'secret'}); // type is {foo: number}
+>a : Symbol(a, Decl(test.ts, 1, 5))
+>dropPrivateProps1 : Symbol(dropPrivateProps1, Decl(test.ts, 0, 8))
+>foo : Symbol(foo, Decl(test.ts, 1, 29))
+>_bar : Symbol(_bar, Decl(test.ts, 1, 37))
+
+//a._bar                                                // error: _bar does not exist           <===== as expected
+const b = dropPrivateProps2({foo: 42, _bar: 'secret'}); // type is {foo: number, _bar: string}
+>b : Symbol(b, Decl(test.ts, 3, 5))
+>dropPrivateProps2 : Symbol(dropPrivateProps2, Decl(test.ts, 0, 26))
+>foo : Symbol(foo, Decl(test.ts, 3, 29))
+>_bar : Symbol(_bar, Decl(test.ts, 3, 37))
+
+//b._bar                                                // no error, type of b._bar is string   <===== NOT expected
+
+=== tests/cases/compiler/api.ts ===
+import {excludePrivateKeys1, excludePrivateKeys2} from './internal';
+>excludePrivateKeys1 : Symbol(excludePrivateKeys1, Decl(api.ts, 0, 8))
+>excludePrivateKeys2 : Symbol(excludePrivateKeys2, Decl(api.ts, 0, 28))
+
+export const dropPrivateProps1 = <Obj>(obj: Obj) => excludePrivateKeys1(obj);
+>dropPrivateProps1 : Symbol(dropPrivateProps1, Decl(api.ts, 1, 12))
+>Obj : Symbol(Obj, Decl(api.ts, 1, 34))
+>obj : Symbol(obj, Decl(api.ts, 1, 39))
+>Obj : Symbol(Obj, Decl(api.ts, 1, 34))
+>excludePrivateKeys1 : Symbol(excludePrivateKeys1, Decl(api.ts, 0, 8))
+>obj : Symbol(obj, Decl(api.ts, 1, 39))
+
+export const dropPrivateProps2 = <Obj>(obj: Obj) => excludePrivateKeys2(obj);
+>dropPrivateProps2 : Symbol(dropPrivateProps2, Decl(api.ts, 2, 12))
+>Obj : Symbol(Obj, Decl(api.ts, 2, 34))
+>obj : Symbol(obj, Decl(api.ts, 2, 39))
+>Obj : Symbol(Obj, Decl(api.ts, 2, 34))
+>excludePrivateKeys2 : Symbol(excludePrivateKeys2, Decl(api.ts, 0, 28))
+>obj : Symbol(obj, Decl(api.ts, 2, 39))
+
+=== tests/cases/compiler/internal.ts ===
+export declare function excludePrivateKeys1<Obj>(obj: Obj): {[K in PublicKeys1<keyof Obj>]: Obj[K]};
+>excludePrivateKeys1 : Symbol(excludePrivateKeys1, Decl(internal.ts, 0, 0))
+>Obj : Symbol(Obj, Decl(internal.ts, 0, 44))
+>obj : Symbol(obj, Decl(internal.ts, 0, 49))
+>Obj : Symbol(Obj, Decl(internal.ts, 0, 44))
+>K : Symbol(K, Decl(internal.ts, 0, 62))
+>PublicKeys1 : Symbol(PublicKeys1, Decl(internal.ts, 1, 100))
+>Obj : Symbol(Obj, Decl(internal.ts, 0, 44))
+>Obj : Symbol(Obj, Decl(internal.ts, 0, 44))
+>K : Symbol(K, Decl(internal.ts, 0, 62))
+
+export declare function excludePrivateKeys2<Obj>(obj: Obj): {[K in PublicKeys2<keyof Obj>]: Obj[K]};
+>excludePrivateKeys2 : Symbol(excludePrivateKeys2, Decl(internal.ts, 0, 100))
+>Obj : Symbol(Obj, Decl(internal.ts, 1, 44))
+>obj : Symbol(obj, Decl(internal.ts, 1, 49))
+>Obj : Symbol(Obj, Decl(internal.ts, 1, 44))
+>K : Symbol(K, Decl(internal.ts, 1, 62))
+>PublicKeys2 : Symbol(PublicKeys2, Decl(internal.ts, 2, 64))
+>Obj : Symbol(Obj, Decl(internal.ts, 1, 44))
+>Obj : Symbol(Obj, Decl(internal.ts, 1, 44))
+>K : Symbol(K, Decl(internal.ts, 1, 62))
+
+export type PublicKeys1<T> = T extends `_${string}` ? never : T;
+>PublicKeys1 : Symbol(PublicKeys1, Decl(internal.ts, 1, 100))
+>T : Symbol(T, Decl(internal.ts, 2, 24))
+>T : Symbol(T, Decl(internal.ts, 2, 24))
+>T : Symbol(T, Decl(internal.ts, 2, 24))
+
+type PublicKeys2<T>        = T extends `_${string}` ? never : T;
+>PublicKeys2 : Symbol(PublicKeys2, Decl(internal.ts, 2, 64))
+>T : Symbol(T, Decl(internal.ts, 3, 17))
+>T : Symbol(T, Decl(internal.ts, 3, 17))
+>T : Symbol(T, Decl(internal.ts, 3, 17))
+

--- a/tests/baselines/reference/declarationEmitInlinedDistributiveConditional.types
+++ b/tests/baselines/reference/declarationEmitInlinedDistributiveConditional.types
@@ -1,0 +1,64 @@
+=== tests/cases/compiler/test.ts ===
+import {dropPrivateProps1, dropPrivateProps2} from './api';
+>dropPrivateProps1 : <Obj>(obj: Obj) => { [K in import("tests/cases/compiler/internal").PublicKeys1<keyof Obj>]: Obj[K]; }
+>dropPrivateProps2 : <Obj>(obj: Obj) => { [K in keyof Obj extends `_${string}` ? never : keyof Obj]: Obj[K]; }
+
+const a = dropPrivateProps1({foo: 42, _bar: 'secret'}); // type is {foo: number}
+>a : { foo: number; }
+>dropPrivateProps1({foo: 42, _bar: 'secret'}) : { foo: number; }
+>dropPrivateProps1 : <Obj>(obj: Obj) => { [K in import("tests/cases/compiler/internal").PublicKeys1<keyof Obj>]: Obj[K]; }
+>{foo: 42, _bar: 'secret'} : { foo: number; _bar: string; }
+>foo : number
+>42 : 42
+>_bar : string
+>'secret' : "secret"
+
+//a._bar                                                // error: _bar does not exist           <===== as expected
+const b = dropPrivateProps2({foo: 42, _bar: 'secret'}); // type is {foo: number, _bar: string}
+>b : { foo: number; }
+>dropPrivateProps2({foo: 42, _bar: 'secret'}) : { foo: number; }
+>dropPrivateProps2 : <Obj>(obj: Obj) => { [K in keyof Obj extends `_${string}` ? never : keyof Obj]: Obj[K]; }
+>{foo: 42, _bar: 'secret'} : { foo: number; _bar: string; }
+>foo : number
+>42 : 42
+>_bar : string
+>'secret' : "secret"
+
+//b._bar                                                // no error, type of b._bar is string   <===== NOT expected
+
+=== tests/cases/compiler/api.ts ===
+import {excludePrivateKeys1, excludePrivateKeys2} from './internal';
+>excludePrivateKeys1 : <Obj>(obj: Obj) => { [K in import("tests/cases/compiler/internal").PublicKeys1<keyof Obj>]: Obj[K]; }
+>excludePrivateKeys2 : <Obj>(obj: Obj) => { [K in keyof Obj extends `_${string}` ? never : keyof Obj]: Obj[K]; }
+
+export const dropPrivateProps1 = <Obj>(obj: Obj) => excludePrivateKeys1(obj);
+>dropPrivateProps1 : <Obj>(obj: Obj) => { [K in import("tests/cases/compiler/internal").PublicKeys1<keyof Obj>]: Obj[K]; }
+><Obj>(obj: Obj) => excludePrivateKeys1(obj) : <Obj>(obj: Obj) => { [K in import("tests/cases/compiler/internal").PublicKeys1<keyof Obj>]: Obj[K]; }
+>obj : Obj
+>excludePrivateKeys1(obj) : { [K in import("tests/cases/compiler/internal").PublicKeys1<keyof Obj>]: Obj[K]; }
+>excludePrivateKeys1 : <Obj>(obj: Obj) => { [K in import("tests/cases/compiler/internal").PublicKeys1<keyof Obj>]: Obj[K]; }
+>obj : Obj
+
+export const dropPrivateProps2 = <Obj>(obj: Obj) => excludePrivateKeys2(obj);
+>dropPrivateProps2 : <Obj>(obj: Obj) => { [K in keyof Obj extends `_${string}` ? never : keyof Obj]: Obj[K]; }
+><Obj>(obj: Obj) => excludePrivateKeys2(obj) : <Obj>(obj: Obj) => { [K in keyof Obj extends `_${string}` ? never : keyof Obj]: Obj[K]; }
+>obj : Obj
+>excludePrivateKeys2(obj) : { [K in keyof Obj extends `_${string}` ? never : keyof Obj]: Obj[K]; }
+>excludePrivateKeys2 : <Obj>(obj: Obj) => { [K in keyof Obj extends `_${string}` ? never : keyof Obj]: Obj[K]; }
+>obj : Obj
+
+=== tests/cases/compiler/internal.ts ===
+export declare function excludePrivateKeys1<Obj>(obj: Obj): {[K in PublicKeys1<keyof Obj>]: Obj[K]};
+>excludePrivateKeys1 : <Obj>(obj: Obj) => { [K in PublicKeys1<keyof Obj>]: Obj[K]; }
+>obj : Obj
+
+export declare function excludePrivateKeys2<Obj>(obj: Obj): {[K in PublicKeys2<keyof Obj>]: Obj[K]};
+>excludePrivateKeys2 : <Obj>(obj: Obj) => { [K in PublicKeys2<keyof Obj>]: Obj[K]; }
+>obj : Obj
+
+export type PublicKeys1<T> = T extends `_${string}` ? never : T;
+>PublicKeys1 : PublicKeys1<T>
+
+type PublicKeys2<T>        = T extends `_${string}` ? never : T;
+>PublicKeys2 : PublicKeys2<T>
+

--- a/tests/cases/compiler/declarationEmitInlinedDistributiveConditional.ts
+++ b/tests/cases/compiler/declarationEmitInlinedDistributiveConditional.ts
@@ -1,0 +1,18 @@
+// @declaration: true
+// @filename: test.ts
+import {dropPrivateProps1, dropPrivateProps2} from './api';
+const a = dropPrivateProps1({foo: 42, _bar: 'secret'}); // type is {foo: number}
+//a._bar                                                // error: _bar does not exist           <===== as expected
+const b = dropPrivateProps2({foo: 42, _bar: 'secret'}); // type is {foo: number, _bar: string}
+//b._bar                                                // no error, type of b._bar is string   <===== NOT expected
+
+// @filename: api.ts
+import {excludePrivateKeys1, excludePrivateKeys2} from './internal';
+export const dropPrivateProps1 = <Obj>(obj: Obj) => excludePrivateKeys1(obj);
+export const dropPrivateProps2 = <Obj>(obj: Obj) => excludePrivateKeys2(obj);
+
+// @filename: internal.ts
+export declare function excludePrivateKeys1<Obj>(obj: Obj): {[K in PublicKeys1<keyof Obj>]: Obj[K]};
+export declare function excludePrivateKeys2<Obj>(obj: Obj): {[K in PublicKeys2<keyof Obj>]: Obj[K]};
+export type PublicKeys1<T> = T extends `_${string}` ? never : T;
+type PublicKeys2<T>        = T extends `_${string}` ? never : T;


### PR DESCRIPTION
By wrapping them in _two_ more layers of conditionals - one to establish a local type parameter for distributivity, one to constrain said type parameter so it remains usable as the instantiated check type.

This means something like `type PrivateFields<Keys> = Keys extends _${string} ? Keys : undefined;` when used as `PrivateFields<keyof Obj>` will be inlined to `keyof Obj extends infer T ? T extends keyof Obj ? T extends _${string}  ? T : never`, to retain the distributive behavior, rather than the erroneous `keyof Obj extends _${string} ? keyof Obj : never`.

Fixes #48140