### PR TITLE
Don't have type annotations on suggested object literal methods

### DIFF
--- a/tests/cases/fourslash/completionsObjectLiteralMethod1.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralMethod1.ts
@@ -51,9 +51,9 @@ verify.completions({
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "bar")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
-            insertText: "bar(x: number): void {\n},",
+            insertText: "bar(x) {\n},",
             labelDetails: {
-                detail: "(x: number): void",
+                detail: "(x)",
             },
         },
     ],
@@ -77,9 +77,9 @@ verify.completions({
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "bar")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
-            insertText: "bar(x: number): void {\n},",
+            insertText: "bar(x) {\n},",
             labelDetails: {
-                detail: "(x: number): void",
+                detail: "(x)",
             },
         },
         {
@@ -92,9 +92,9 @@ verify.completions({
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "foo")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
-            insertText: "foo(x: string): string {\n},",
+            insertText: "foo(x) {\n},",
             labelDetails: {
-                detail: "(x: string): string",
+                detail: "(x)",
             },
         },
     ],
@@ -134,9 +134,9 @@ verify.completions({
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "\"space bar\"")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
-            insertText: "\"space bar\"(): string {\n},",
+            insertText: "\"space bar\"() {\n},",
             labelDetails: {
-                detail: "(): string",
+                detail: "()",
             },
         },
     ],
@@ -161,9 +161,9 @@ verify.completions({
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "bar")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             isSnippet: true,
-            insertText: "bar(x: number): void {\n    $0\n},",
+            insertText: "bar(x) {\n    $0\n},",
             labelDetails: {
-                detail: "(x: number): void",
+                detail: "(x)",
             },
         },
     ],
@@ -183,12 +183,12 @@ verify.completions({
             insertText: undefined,
         },
         {
-            name: "bar(x: number): void",
+            name: "bar(x)",
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "bar")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
             isSnippet: true,
-            insertText: "bar(x: number): void {\n    $0\n},",
+            insertText: "bar(x) {\n    $0\n},",
         },
     ],
 });

--- a/tests/cases/fourslash/completionsObjectLiteralMethod2.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralMethod2.ts
@@ -37,29 +37,10 @@ verify.completions({
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "foo")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
-            insertText: "foo(f: IFoo): void {\n},",
-            hasAction: true,
+            insertText: "foo(f) {\n},",
             labelDetails: {
-                detail: "(f: IFoo): void",
+                detail: "(f)",
             },
         },
     ],
-});
-
-verify.applyCodeActionFromCompletion("a", {
-    preferences: {
-        includeCompletionsWithInsertText: true,
-        includeCompletionsWithSnippetText: false,
-        includeCompletionsWithObjectLiteralMethodSnippets: true,
-        useLabelDetailsInCompletionEntries: true,
-    },
-    name: "foo",
-    source: completion.CompletionSource.ObjectLiteralMethodSnippet,
-    description: "Includes imports of types referenced by 'foo'",
-    newFileContent:
-`import { IFoo } from "./a";
-import { IBar } from "./b";
-const obj: IBar = {
-    
-}`
 });

--- a/tests/cases/fourslash/completionsObjectLiteralMethod3.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralMethod3.ts
@@ -52,9 +52,9 @@ verify.completions({
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "M")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
-            insertText: "M(x: number): void {\n},",
+            insertText: "M(x) {\n},",
             labelDetails: {
-                detail: "(x: number): void",
+                detail: "(x)",
             },
         },
     ],
@@ -110,9 +110,9 @@ verify.completions({
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.OptionalMember, "M")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
-            insertText: "M(x: number): void {\n},",
+            insertText: "M(x) {\n},",
             labelDetails: {
-                detail: "(x: number): void",
+                detail: "(x)",
             },
         },
         {
@@ -125,9 +125,9 @@ verify.completions({
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.LocationPriority, "N")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
-            insertText: "N(x: string): void {\n},",
+            insertText: "N(x) {\n},",
             labelDetails: {
-                detail: "(x: string): void",
+                detail: "(x)",
             },
         },
         {
@@ -140,9 +140,9 @@ verify.completions({
             sortText: completion.SortText.SortBelow(
                 completion.SortText.ObjectLiteralProperty(completion.SortText.OptionalMember, "O")),
             source: completion.CompletionSource.ObjectLiteralMethodSnippet,
-            insertText: "O(): void {\n},",
+            insertText: "O() {\n},",
             labelDetails: {
-                detail: "(): void",
+                detail: "()",
             },
         },
     ],


### PR DESCRIPTION
Fixes #48606.

This is what it will look like without the type annotations:
![image](https://user-images.githubusercontent.com/19519347/162341608-2d0ec6aa-d1f4-4250-bb81-8eb767fafa2c.png)
![image](https://user-images.githubusercontent.com/19519347/162341450-716ebdbb-83f2-44fb-9dbc-c7b339769f09.png)
The label details look less pretty now IMO, but I think still good enough to distinguish between non-snippet and snippet completion entries?


