### PR TITLE
Don't skip tests named *Fourslash.ts

### DIFF
--- a/src/testRunner/fourslashRunner.ts
+++ b/src/testRunner/fourslashRunner.ts
@@ -52,7 +52,7 @@ namespace Harness {
                         const testIndex = fn.indexOf("tests/");
                         if (testIndex >= 0) fn = fn.substr(testIndex);
 
-                        if (justName && !justName.match(/fourslash\.ts$/i) && !justName.match(/\.d\.ts$/i)) {
+                        if (justName !== "fourslash.ts") {
                             it(this.testSuiteName + " test " + justName + " runs correctly", () => {
                                 FourSlash.runFourSlashTest(this.basePath, this.testType, fn);
                             });

--- a/tests/cases/fourslash/commentsInterfaceFourslash.ts
+++ b/tests/cases/fourslash/commentsInterfaceFourslash.ts
@@ -81,15 +81,14 @@ verify.quickInfos({
 verify.quickInfoAt("8", "(property) i2.x: number", "this is x");
 verify.completions({
     marker: "8",
-    exact: [
+    exact: completion.functionMembersWithPrototypePlus([
         { name: "x", text: "(property) i2.x: number", documentation: "this is x" },
         { name: "foo", text: "(property) i2.foo: (b: number) => string", documentation: "this is foo" },
         { name: "nc_x", text: "(property) i2.nc_x: number" },
         { name: "nc_foo", text: "(property) i2.nc_foo: (b: number) => string" },
         { name: "fnfoo", text: "(method) i2.fnfoo(b: number): string", documentation: "this is fnfoo" },
         { name: "nc_fnfoo", text: "(method) i2.nc_fnfoo(b: number): string" },
-        ...completion.functionMembersWithPrototype,
-    ],
+    ]),
     isNewIdentifierLocation: true,
 });
 
@@ -199,12 +198,12 @@ verify.quickInfoIs("(method) i3.f(a: number): string", "Function i3 f");
 verify.completions({
     marker: "41",
     exact: [
-        { name: "x", text: "(property) i3.x: number", documentation: "Comment i3 x" },
         { name: "f", text: "(method) i3.f(a: number): string", documentation: "Function i3 f" },
         { name: "l", text: "(property) i3.l: (b: number) => string", documentation: "i3 l" },
-        { name: "nc_x", text: "(property) i3.nc_x: number" },
         { name: "nc_f", text: "(method) i3.nc_f(a: number): string" },
         { name: "nc_l", text: "(property) i3.nc_l: (b: number) => string" },
+        { name: "nc_x", text: "(property) i3.nc_x: number" },
+        { name: "x", text: "(property) i3.x: number", documentation: "Comment i3 x" },
     ],
 });
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

I noticed that I can't run the following tests:
```sh
tests/cases/fourslash/augmentedTypesClass3Fourslash.ts
tests/cases/fourslash/commentsEnumsFourslash.ts
tests/cases/fourslash/commentsExternalModulesFourslash.ts
tests/cases/fourslash/commentsInheritanceFourslash.ts
tests/cases/fourslash/commentsInterfaceFourslash.ts
tests/cases/fourslash/commentsModulesFourslash.ts
tests/cases/fourslash/commentsMultiModuleMultiFileFourslash.ts
tests/cases/fourslash/commentsMultiModuleSingleFileFourslash.ts
tests/cases/fourslash/commentsOverloadsFourslash.ts
```

`fourslashRunner.ts` skips `tests/cases/fourslash/fourslash.ts` (correctly), but the regex isn't anchored, so it also skips `*Fourslash.ts`. It's been like that since [forever](https://github.com/microsoft/TypeScript/commit/214df64e287804577afa1fea0184c18c40f7d1ca): https://github.com/microsoft/TypeScript/blob/214df64e287804577afa1fea0184c18c40f7d1ca/src/harness/fourslashRunner.ts#L30

Also, since there've never been any `tests/cases/fourslash/*.d.ts` files, and the `.d.ts` exemption is unique to this runner, I simplified the condition to just `justName !== "fourslash.ts"`:
```sh
git log 'tests/cases/fourslash/*.d.ts'
# No output