### PR TITLE
Fix lints after dep update

### DIFF
--- a/src/testRunner/unittests/services/extract/ranges.ts
+++ b/src/testRunner/unittests/services/extract/ranges.ts
@@ -9,7 +9,7 @@ namespace ts {
             }
             const result = refactor.extractSymbol.getRangeToExtract(file, createTextSpanFromRange(selectionRange), /*userRequested*/ false);
             assert(result.targetRange === undefined, "failure expected");
-            const sortedErrors = result.errors!.map(e => e.messageText as string).sort();
+            const sortedErrors = result.errors.map(e => e.messageText as string).sort();
             assert.deepEqual(sortedErrors, expectedErrors.sort(), "unexpected errors");
         });
     }

--- a/src/testRunner/unittests/tsserver/completionsIncomplete.ts
+++ b/src/testRunner/unittests/tsserver/completionsIncomplete.ts
@@ -135,7 +135,7 @@ namespace ts.projectSystem {
             typeToTriggerCompletions(indexFile.path, "s", completions => {
                 const sigint = completions.entries.find(e => e.name === "SIGINT");
                 assert(sigint);
-                assert(!(sigint!.data as any).moduleSpecifier);
+                assert(!(sigint.data as any).moduleSpecifier);
             })
             .continueTyping("i", completions => {
                 const sigint = completions.entries.find(e => e.name === "SIGINT");
@@ -255,7 +255,7 @@ namespace ts.projectSystem {
 
             assert(details[0]);
             assert(details[0].codeActions);
-            assert(details[0].codeActions![0].changes[0].textChanges[0].newText.includes(`"${(entry.data as any).moduleSpecifier}"`));
+            assert(details[0].codeActions[0].changes[0].textChanges[0].newText.includes(`"${(entry.data as any).moduleSpecifier}"`));
             return details;
         }
     }


### PR DESCRIPTION
These started failing after a previous dependency update commit, which updated chai's types to have chai assertions be type guards.