### PR TITLE
fix: Fix for of loop to check right hand side if left hand side is omitted expression.

### DIFF
--- a/src/testRunner/unittests/evaluation/forOf.ts
+++ b/src/testRunner/unittests/evaluation/forOf.ts
@@ -69,6 +69,19 @@ describe("unittests:: evaluation:: forOfEvaluation", () => {
         assert.throws(() => result.main(), /cannot read property.*Symbol\(Symbol\.iterator\).*/i);
     });
 
+    it("es5 over undefined with Symbol with destructuring binding element", () => {
+        const result = evaluator.evaluateTypeScript(`
+        export function main() {
+            let x = undefined;
+
+            for (let [,] of x) {
+            }
+        }
+    `, { downlevelIteration: true, target: ts.ScriptTarget.ES5 });
+
+        assert.throws(() => result.main(), /cannot read property.*Symbol\(Symbol\.iterator\).*/i);
+    });
+
     it("es5 over object with no Symbol.iterator with no Symbol", () => {
         const result = evaluator.evaluateTypeScript(`
         Symbol = undefined;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #48630 

For the checkVariableLikeDeclaration function, instead of checking the right hand side of the element is valid only when the binding element is encountered. This fix will now also check if the right hand side of the for of loop is valid even if the variable of the left hand side is omitted expression.
