### PR TITLE
Implementation for Inlay Hints for Tuple Labels

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8796,6 +8796,10 @@ namespace ts {
         readonly includeInlayPropertyDeclarationTypeHints?: boolean;
         readonly includeInlayFunctionLikeReturnTypeHints?: boolean;
         readonly includeInlayEnumMemberValueHints?: boolean;
+        readonly includeInlayTupleElementAccessLabelHints?: boolean;
+        readonly includeInlayTupleLiteralLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel?: boolean;
     }
 
     /** Represents a bigint literal value without requiring bigint support */

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2589,7 +2589,7 @@ namespace ts.server.protocol {
         body?: SignatureHelpItems;
     }
 
-    export type InlayHintKind = "Type" | "Parameter" | "Enum";
+    export type InlayHintKind = "Type" | "Parameter" | "Enum" | "Tuple";
 
     export interface InlayHintsRequestArgs extends FileRequestArgs {
         /**
@@ -3467,6 +3467,10 @@ namespace ts.server.protocol {
         readonly includeInlayPropertyDeclarationTypeHints?: boolean;
         readonly includeInlayFunctionLikeReturnTypeHints?: boolean;
         readonly includeInlayEnumMemberValueHints?: boolean;
+        readonly includeInlayTupleElementAccessLabelHints?: boolean;
+        readonly includeInlayTupleLiteralLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel?: boolean;
     }
 
     export interface CompilerOptions {

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -65,13 +65,13 @@ namespace ts.InlayHints {
             else if (shouldShowParameterNameHints(preferences) && (isCallExpression(node) || isNewExpression(node))) {
                 visitCallOrNewExpression(node);
             }
-            else if (isElementAccessExpression(node)) {
+            else if (preferences.includeInlayTupleElementAccessLabelHints && isElementAccessExpression(node)) {
                 visitTupleElementAccessExpression(node);
             }
-            else if (isArrayLiteralExpression(node)) {
+            else if (preferences.includeInlayTupleLiteralLabelHints && isArrayLiteralExpression(node)) {
                 visitTupleArrayLiteralExpression(node);
             }
-            else if (isArrayBindingPattern(node)) {
+            else if (preferences.includeInlayTupleBindingLabelHints && isArrayBindingPattern(node)) {
                 visitTupleArrayBindingPattern(node);
             }
             else {
@@ -416,7 +416,10 @@ namespace ts.InlayHints {
                     const labelDecl = labelDecls[i] as NamedTupleMember;
                     if (labelDecl) {
                         Debug.assertNode(labelDecl.name, isIdentifier);
-                        addTupleLabelHints(idText(labelDecl.name), node.elements[i].getStart());
+                        const label = idText(labelDecl.name);
+                        if (!preferences.includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel || label !== bindingElement.name.getText()) {
+                            addTupleLabelHints(label, node.elements[i].getStart());
+                        }
                     }
                     else {
                         addTupleLabelHints(undefinedTupleLabel, node.elements[i].getStart());

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -150,7 +150,7 @@ namespace ts.InlayHints {
             result.push({
                 text: truncation(tupleLabel, maxHintsLength) + ":",
                 position,
-                kind: InlayHintKind.Parameter, // TODO
+                kind: InlayHintKind.Tuple,
                 whitespaceAfter: true
             });
         }
@@ -159,7 +159,7 @@ namespace ts.InlayHints {
             result.push({
                 text: `[${tupleLabels.join(", ")}]:`,
                 position,
-                kind: InlayHintKind.Parameter, // TODO
+                kind: InlayHintKind.Tuple,
                 whitespaceAfter: true
             });
         }
@@ -168,7 +168,7 @@ namespace ts.InlayHints {
             result.push({
                 text: tupleLabels.join(" | ") + ":",
                 position,
-                kind: InlayHintKind.Parameter, // TODO
+                kind: InlayHintKind.Tuple,
                 whitespaceAfter: true
             });
         }

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -3,8 +3,6 @@ namespace ts.InlayHints {
 
     const maxHintsLength = 30;
 
-    const undefinedTupleLabel = "(undefined)";
-
     const leadingParameterNameCommentRegexFactory = (name: string) => {
         return new RegExp(`^\\s?/\\*\\*?\\s?${name}\\s?\\*\\/\\s?$`);
     };
@@ -106,9 +104,6 @@ namespace ts.InlayHints {
                         if (labels.indexOf(label) === -1) {
                             labels.push(truncation(label, maxHintsLength));
                         }
-                    }
-                    else if (labels.indexOf(undefinedTupleLabel) === -1) {
-                        labels.push(undefinedTupleLabel);
                     }
                 }
             }
@@ -348,9 +343,6 @@ namespace ts.InlayHints {
                 Debug.assertNode(labelDecl.name, isIdentifier);
                 addTupleLabelHints(idText(labelDecl.name), node.argumentExpression.getStart());
             }
-            else {
-                addTupleLabelHints(undefinedTupleLabel, node.argumentExpression.getStart());
-            }
         }
 
         function visitTupleArrayLiteralExpression(node: ArrayLiteralExpression) {
@@ -378,9 +370,6 @@ namespace ts.InlayHints {
                 if (labelDecl) {
                     Debug.assertNode(labelDecl.name, isIdentifier);
                     addTupleLabelHints(idText(labelDecl.name), node.elements[i].getStart());
-                }
-                else {
-                    addTupleLabelHints(undefinedTupleLabel, node.elements[i].getStart());
                 }
             }
         }
@@ -420,9 +409,6 @@ namespace ts.InlayHints {
                         if (!preferences.includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel || label !== bindingElement.name.getText()) {
                             addTupleLabelHints(label, node.elements[i].getStart());
                         }
-                    }
-                    else {
-                        addTupleLabelHints(undefinedTupleLabel, node.elements[i].getStart());
                     }
                 }
             }

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -104,7 +104,7 @@ namespace ts.InlayHints {
                         Debug.assertNode(labelDecl.name, isIdentifier);
                         const label = idText(labelDecl.name);
                         if (labels.indexOf(label) === -1) {
-                            labels.push(label);
+                            labels.push(truncation(label, maxHintsLength));
                         }
                     }
                     else if (labels.indexOf(undefinedTupleLabel) === -1) {
@@ -407,7 +407,7 @@ namespace ts.InlayHints {
                     const spreadTupleLabels = spreadType.target.labeledElementDeclarations!
                         .map((labelDecl: NamedTupleMember) => {
                             Debug.assertNode(labelDecl.name, isIdentifier);
-                            return idText(labelDecl.name);
+                            return truncation(idText(labelDecl.name), maxHintsLength);
                         });
 
                     addLabeledTupleVariableHints(spreadTupleLabels, bindingElement.getStart());

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -72,10 +72,28 @@ namespace ts.InlayHints {
                         Debug.assertNode(labelDecl.name, isIdentifier);
                         result.push({
                             text: `(${truncation(idText(labelDecl.name), maxHintsLength)})`,
-                            position: node.argumentExpression.end,
+                            position: node.argumentExpression.getStart(),
                             kind: InlayHintKind.Parameter,
-                            whitespaceBefore: true
+                            whitespaceAfter: true
                         });
+                    }
+                }
+            }
+            else if (isArrayLiteralExpression(node)) {
+                const type = checker.getContextualType(node);
+                if (type && !isModuleReferenceType(type)) {
+                    const labeledElementDeclarations = (type as TupleTypeReference).target.labeledElementDeclarations;
+                    if (labeledElementDeclarations) {
+                        for (let i = 0; i < node.elements.length; i++) {
+                            const labelDecl = labeledElementDeclarations[i] as NamedTupleMember;
+                            Debug.assertNode(labelDecl.name, isIdentifier);
+                            result.push({
+                                text: `(${truncation(idText(labelDecl.name), maxHintsLength)})`,
+                                position: node.elements[i].getStart(),
+                                kind: InlayHintKind.Parameter,
+                                whitespaceAfter: true
+                            });
+                        }
                     }
                 }
             }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -720,6 +720,7 @@ namespace ts {
         Type = "Type",
         Parameter = "Parameter",
         Enum = "Enum",
+        Tuple = "Tuple",
     }
 
     export interface InlayHint {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8980,7 +8980,7 @@ declare namespace ts.server.protocol {
     interface SignatureHelpResponse extends Response {
         body?: SignatureHelpItems;
     }
-    type InlayHintKind = "Type" | "Parameter" | "Enum";
+    type InlayHintKind = "Type" | "Parameter" | "Enum" | "Tuple";
     interface InlayHintsRequestArgs extends FileRequestArgs {
         /**
          * Start position of the span.
@@ -9702,6 +9702,10 @@ declare namespace ts.server.protocol {
         readonly includeInlayPropertyDeclarationTypeHints?: boolean;
         readonly includeInlayFunctionLikeReturnTypeHints?: boolean;
         readonly includeInlayEnumMemberValueHints?: boolean;
+        readonly includeInlayTupleElementAccessLabelHints?: boolean;
+        readonly includeInlayTupleLiteralLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel?: boolean;
     }
     interface CompilerOptions {
         allowJs?: boolean;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4120,6 +4120,10 @@ declare namespace ts {
         readonly includeInlayPropertyDeclarationTypeHints?: boolean;
         readonly includeInlayFunctionLikeReturnTypeHints?: boolean;
         readonly includeInlayEnumMemberValueHints?: boolean;
+        readonly includeInlayTupleElementAccessLabelHints?: boolean;
+        readonly includeInlayTupleLiteralLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel?: boolean;
     }
     /** Represents a bigint literal value without requiring bigint support */
     export interface PseudoBigInt {
@@ -6067,7 +6071,8 @@ declare namespace ts {
     enum InlayHintKind {
         Type = "Type",
         Parameter = "Parameter",
-        Enum = "Enum"
+        Enum = "Enum",
+        Tuple = "Tuple"
     }
     interface InlayHint {
         text: string;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4120,6 +4120,10 @@ declare namespace ts {
         readonly includeInlayPropertyDeclarationTypeHints?: boolean;
         readonly includeInlayFunctionLikeReturnTypeHints?: boolean;
         readonly includeInlayEnumMemberValueHints?: boolean;
+        readonly includeInlayTupleElementAccessLabelHints?: boolean;
+        readonly includeInlayTupleLiteralLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel?: boolean;
     }
     /** Represents a bigint literal value without requiring bigint support */
     export interface PseudoBigInt {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6071,7 +6071,8 @@ declare namespace ts {
     enum InlayHintKind {
         Type = "Type",
         Parameter = "Parameter",
-        Enum = "Enum"
+        Enum = "Enum",
+        Tuple = "Tuple"
     }
     interface InlayHint {
         text: string;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -70,6 +70,7 @@ declare module ts {
         Type = "Type",
         Parameter = "Parameter",
         Enum = "Enum",
+        Tuple = "Tuple",
     }
 
     enum SemicolonPreference {
@@ -669,6 +670,10 @@ declare namespace FourSlashInterface {
         readonly includeInlayPropertyDeclarationTypeHints?: boolean;
         readonly includeInlayFunctionLikeReturnTypeHints?: boolean;
         readonly includeInlayEnumMemberValueHints?: boolean;
+        readonly includeInlayTupleElementAccessLabelHints?: boolean;
+        readonly includeInlayTupleLiteralLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHints?: boolean;
+        readonly includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel?: boolean;
     }
     interface CompletionsOptions {
         readonly marker?: ArrayOrSingle<string | Marker>;

--- a/tests/cases/fourslash/inlayHintsShouldWork67.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork67.ts
@@ -1,0 +1,61 @@
+/// <reference path="fourslash.ts" />
+
+////type Foo = [bar: number, baz: number];
+////
+////let foo: Foo = [/*a*/0, /*b*/0];
+////foo = [/*c*/0, /*d*/0];
+////
+////function useFoo(foo: Foo) { }
+////useFoo([/*e*/0, /*f*/0]);
+////
+////type LongFoo = [longLongLongLongLongLongLongLongLabel: number];
+////
+////let longFoo: LongFoo = [/*g*/0];
+
+const [a, b, c, d, e, f, g] = test.markers();
+verify.getInlayHints([
+    {
+        text: 'bar:',
+        position: a.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'baz:',
+        position: b.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'bar:',
+        position: c.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'baz:',
+        position: d.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'bar:',
+        position: e.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'baz:',
+        position: f.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'longLongLongLongLongLongLon...:',
+        position: g.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+], undefined, {
+    includeInlayTupleLiteralLabelHints: true,
+});

--- a/tests/cases/fourslash/inlayHintsShouldWork68.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork68.ts
@@ -1,0 +1,13 @@
+/// <reference path="fourslash.ts" />
+
+////type Foo = [bar: number, baz: number];
+////
+////let foo: Foo = [0, 0];
+////foo = [0, 0];
+////
+////function useFoo(foo: Foo) { }
+////useFoo([0, 0]);
+
+verify.getInlayHints([], undefined, {
+    includeInlayTupleLiteralLabelHints: false,
+});

--- a/tests/cases/fourslash/inlayHintsShouldWork69.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork69.ts
@@ -1,0 +1,36 @@
+/// <reference path="fourslash.ts" />
+
+////type Foo = [bar: number, baz: number];
+////
+////let foo: Foo;
+////foo[/*a*/0];
+////foo[/*b*/1];
+////
+////type LongFoo = [longLongLongLongLongLongLongLongLabel: number];
+////
+////let longFoo: LongFoo;
+////longFoo[/*c*/0];
+
+const [a, b, c] = test.markers();
+verify.getInlayHints([
+    {
+        text: 'bar:',
+        position: a.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'baz:',
+        position: b.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'longLongLongLongLongLongLon...:',
+        position: c.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+], undefined, {
+    includeInlayTupleElementAccessLabelHints: true,
+});

--- a/tests/cases/fourslash/inlayHintsShouldWork70.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork70.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+////type Foo = [bar: number, baz: number];
+////
+////let foo: Foo;
+////foo[0];
+////foo[1];
+
+verify.getInlayHints([], undefined, {
+    includeInlayTupleElementAccessLabelHints: false,
+});

--- a/tests/cases/fourslash/inlayHintsShouldWork71.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork71.ts
@@ -1,0 +1,74 @@
+/// <reference path="fourslash.ts" />
+
+////type FooA = [type: 'a', bar: number, baz: number];
+////type FooB = [type: 'b', qux: number];
+////type Foo = FooA | FooB;
+////
+////let foo: Foo;
+////foo[/*a*/1];
+////foo[/*b*/2];
+////
+////switch(foo[/*c*/0]) {
+////    case "a":
+////        foo[/*d*/1];
+////        foo[/*e*/2];
+////        break;
+////    case "b":
+////        foo[/*f*/1];
+////        break;
+////}
+////
+////type LongFooA = [aLongLongLongLongLongLongLongLongLabel: number];
+////type LongFooB = [bLongLongLongLongLongLongLongLongLabel: number];
+////type LongFoo = LongFooA | LongFooB;
+////
+////let longFoo: LongFoo;
+////longFoo[/*g*/0];
+
+const [a, b, c, d, e, f, g] = test.markers();
+verify.getInlayHints([
+    {
+        text: 'bar | qux:',
+        position: a.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'baz:',
+        position: b.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'type:',
+        position: c.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'bar:',
+        position: d.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'baz:',
+        position: e.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'qux:',
+        position: f.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'aLongLongLongLongLongLongLo... | bLongLongLongLongLongLongLo...:',
+        position: g.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+], undefined, {
+    includeInlayTupleElementAccessLabelHints: true,
+});

--- a/tests/cases/fourslash/inlayHintsShouldWork72.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork72.ts
@@ -1,0 +1,85 @@
+/// <reference path="fourslash.ts" />
+
+////type Foo = [bar: number, baz: number, qux: number];
+////
+////let foo: Foo;
+////let [bar, baz, qux] = foo;
+////let [/*a*/a, /*b*/b, /*c*/c] = foo;
+////let [/*d*/d, /*e*/...e] = foo;
+////let [/*f*/f, ...[/*g*/g, /*h*/h]] = foo;
+////
+////type LongFoo = [
+////    aLongLongLongLongLongLongLongLongLabel: number,
+////    bLongLongLongLongLongLongLongLongLabel: number,
+////    cLongLongLongLongLongLongLongLongLabel: number,
+////];
+////
+////let longFoo: LongFoo;
+////let [/*i*/i, /*j*/...j] = longFoo;
+
+const [a, b, c, d, e, f, g, h, i, j] = test.markers();
+verify.getInlayHints([
+    {
+        text: 'bar:',
+        position: a.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'baz:',
+        position: b.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'qux:',
+        position: c.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'bar:',
+        position: d.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: '[baz, qux]:',
+        position: e.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'bar:',
+        position: f.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'baz:',
+        position: g.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'qux:',
+        position: h.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'aLongLongLongLongLongLongLo...:',
+        position: i.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: '[bLongLongLongLongLongLongLo..., cLongLongLongLongLongLongLo...]:',
+        position: j.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+], undefined, {
+    includeInlayTupleBindingLabelHints: true,
+    includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel: true,
+});

--- a/tests/cases/fourslash/inlayHintsShouldWork73.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork73.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+////type Foo = [bar: number, baz: number, qux: number];
+////
+////let foo: Foo;
+////let [bar, baz, qux] = foo;
+////let [a, b, c] = foo;
+////let [d, ...e] = foo;
+////let [f, ...[g, h]] = foo;
+
+verify.getInlayHints([], undefined, {
+    includeInlayTupleBindingLabelHints: false,
+    includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel: true,
+});
+verify.getInlayHints([], undefined, {
+    includeInlayTupleBindingLabelHints: false,
+    includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel: false,
+});

--- a/tests/cases/fourslash/inlayHintsShouldWork74.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork74.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+////type Foo = [bar: number, baz: number, qux: number];
+////
+////let foo: Foo;
+////let [/*a*/bar, /*b*/baz, /*c*/qux] = foo;
+
+const [a, b, c] = test.markers();
+verify.getInlayHints([
+    {
+        text: 'bar:',
+        position: a.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'baz:',
+        position: b.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+    {
+        text: 'qux:',
+        position: c.position,
+        kind: ts.InlayHintKind.Tuple,
+        whitespaceAfter: true
+    },
+], undefined, {
+    includeInlayTupleBindingLabelHints: true,
+    includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel: false,
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #48704

For the updated vscode typescript-language-features built-in extension that works with these changes, checkout this [vscode fork](https://github.com/bmdelacruz/vscode/tree/feat-ts-ext-inlay-tuple-labels).

Screenshots:
![image](https://user-images.githubusercontent.com/11897772/163754890-653098ae-1f91-46b6-b530-9e023870759f.png)
![image](https://user-images.githubusercontent.com/11897772/163754979-206af558-b10a-4b2b-8c5f-398336ea7c4d.png)
![image](https://user-images.githubusercontent.com/11897772/163755045-727c8442-0f45-4ec7-9e1e-1dec53550d99.png)
