### PR TITLE
Fix `getExportSymbolOfValueSymbolIfExported`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4109,7 +4109,7 @@ namespace ts {
         function getExportSymbolOfValueSymbolIfExported(symbol: Symbol): Symbol;
         function getExportSymbolOfValueSymbolIfExported(symbol: Symbol | undefined): Symbol | undefined;
         function getExportSymbolOfValueSymbolIfExported(symbol: Symbol | undefined): Symbol | undefined {
-            return getMergedSymbol(symbol && (symbol.flags & SymbolFlags.ExportValue) !== 0 ? symbol.exportSymbol : symbol);
+            return getMergedSymbol(symbol && (symbol.flags & SymbolFlags.ExportValue) !== 0 && symbol.exportSymbol || symbol);
         }
 
         function symbolIsValue(symbol: Symbol): boolean {

--- a/tests/baselines/reference/reExportJsFromTs.js
+++ b/tests/baselines/reference/reExportJsFromTs.js
@@ -1,0 +1,21 @@
+//// [tests/cases/conformance/salsa/reExportJsFromTs.ts] ////
+
+//// [constants.js]
+module.exports = {
+  str: 'x',
+};
+
+//// [constants.ts]
+import * as tsConstants from "../lib/constants";
+export { tsConstants };
+
+//// [constants.js]
+module.exports = {
+    str: 'x'
+};
+//// [constants.js]
+"use strict";
+exports.__esModule = true;
+exports.tsConstants = void 0;
+var tsConstants = require("../lib/constants");
+exports.tsConstants = tsConstants;

--- a/tests/baselines/reference/reExportJsFromTs.symbols
+++ b/tests/baselines/reference/reExportJsFromTs.symbols
@@ -1,0 +1,18 @@
+=== /lib/constants.js ===
+module.exports = {
+>module.exports : Symbol(module.exports, Decl(constants.js, 0, 0))
+>module : Symbol(export=, Decl(constants.js, 0, 0))
+>exports : Symbol(export=, Decl(constants.js, 0, 0))
+
+  str: 'x',
+>str : Symbol(str, Decl(constants.js, 0, 18))
+
+};
+
+=== /src/constants.ts ===
+import * as tsConstants from "../lib/constants";
+>tsConstants : Symbol(tsConstants, Decl(constants.ts, 0, 6))
+
+export { tsConstants };
+>tsConstants : Symbol(tsConstants, Decl(constants.ts, 1, 8))
+

--- a/tests/baselines/reference/reExportJsFromTs.types
+++ b/tests/baselines/reference/reExportJsFromTs.types
@@ -1,0 +1,21 @@
+=== /lib/constants.js ===
+module.exports = {
+>module.exports = {  str: 'x',} : { str: string; }
+>module.exports : { str: string; }
+>module : { exports: { str: string; }; }
+>exports : { str: string; }
+>{  str: 'x',} : { str: string; }
+
+  str: 'x',
+>str : string
+>'x' : "x"
+
+};
+
+=== /src/constants.ts ===
+import * as tsConstants from "../lib/constants";
+>tsConstants : { str: string; }
+
+export { tsConstants };
+>tsConstants : { str: string; }
+

--- a/tests/cases/conformance/salsa/reExportJsFromTs.ts
+++ b/tests/cases/conformance/salsa/reExportJsFromTs.ts
@@ -1,0 +1,11 @@
+// @allowJs: true
+// @outDir: out
+
+// @Filename: /lib/constants.js
+module.exports = {
+  str: 'x',
+};
+
+// @Filename: /src/constants.ts
+import * as tsConstants from "../lib/constants";
+export { tsConstants };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

This function assumes that `SymbolFlags.ExportValue` implies `symbol.exportSymbol`, but that doesn’t always hold. Looking through the binder, it seems more likely that this function is wrong than all the places in the binder that apply `ExportValue` without declaring an `exportSymbol` are wrong, but maybe @sandersn knows more about this.

Fixes #48655
Fixes #48322
