### PR TITLE
Fix meta property symbol lookup

### DIFF
--- a/tests/baselines/reference/importMeta(module=commonjs,target=es5).symbols
+++ b/tests/baselines/reference/importMeta(module=commonjs,target=es5).symbols
@@ -8,6 +8,7 @@
 >URL : Symbol(URL, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >toString : Symbol(URL.toString, Decl(lib.dom.d.ts, --, --))
 
@@ -20,6 +21,7 @@
   const size = import.meta.scriptElement.dataset.size || 300;
 >size : Symbol(size, Decl(example.ts, 5, 7))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
   const image = new Image();
 >image : Symbol(image, Decl(example.ts, 7, 7))
@@ -57,6 +59,7 @@
 export let x = import.meta;
 >x : Symbol(x, Decl(moduleLookingFile01.ts, 0, 10))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 export let y = import.metal;
 >y : Symbol(y, Decl(moduleLookingFile01.ts, 1, 10))
@@ -68,6 +71,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : Symbol(globalA, Decl(scriptLookingFile01.ts, 0, 3))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 let globalB = import.metal;
 >globalB : Symbol(globalB, Decl(scriptLookingFile01.ts, 1, 3))
@@ -80,11 +84,15 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 >ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 import.meta = foo;
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 
 // @Filename augmentations.ts
@@ -108,5 +116,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : Symbol(c, Decl(assignmentTargets.ts, 10, 13))
 >import.meta.wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 

--- a/tests/baselines/reference/importMeta(module=commonjs,target=esnext).symbols
+++ b/tests/baselines/reference/importMeta(module=commonjs,target=esnext).symbols
@@ -8,6 +8,7 @@
 >URL : Symbol(URL, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >toString : Symbol(URL.toString, Decl(lib.dom.d.ts, --, --))
 
@@ -20,6 +21,7 @@
   const size = import.meta.scriptElement.dataset.size || 300;
 >size : Symbol(size, Decl(example.ts, 5, 7))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
   const image = new Image();
 >image : Symbol(image, Decl(example.ts, 7, 7))
@@ -57,6 +59,7 @@
 export let x = import.meta;
 >x : Symbol(x, Decl(moduleLookingFile01.ts, 0, 10))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 export let y = import.metal;
 >y : Symbol(y, Decl(moduleLookingFile01.ts, 1, 10))
@@ -68,6 +71,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : Symbol(globalA, Decl(scriptLookingFile01.ts, 0, 3))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 let globalB = import.metal;
 >globalB : Symbol(globalB, Decl(scriptLookingFile01.ts, 1, 3))
@@ -80,11 +84,15 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 >ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 import.meta = foo;
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 
 // @Filename augmentations.ts
@@ -108,5 +116,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : Symbol(c, Decl(assignmentTargets.ts, 10, 13))
 >import.meta.wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 

--- a/tests/baselines/reference/importMeta(module=es2020,target=es5).symbols
+++ b/tests/baselines/reference/importMeta(module=es2020,target=es5).symbols
@@ -8,6 +8,7 @@
 >URL : Symbol(URL, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >toString : Symbol(URL.toString, Decl(lib.dom.d.ts, --, --))
 
@@ -20,6 +21,7 @@
   const size = import.meta.scriptElement.dataset.size || 300;
 >size : Symbol(size, Decl(example.ts, 5, 7))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
   const image = new Image();
 >image : Symbol(image, Decl(example.ts, 7, 7))
@@ -57,6 +59,7 @@
 export let x = import.meta;
 >x : Symbol(x, Decl(moduleLookingFile01.ts, 0, 10))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 export let y = import.metal;
 >y : Symbol(y, Decl(moduleLookingFile01.ts, 1, 10))
@@ -68,6 +71,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : Symbol(globalA, Decl(scriptLookingFile01.ts, 0, 3))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 let globalB = import.metal;
 >globalB : Symbol(globalB, Decl(scriptLookingFile01.ts, 1, 3))
@@ -80,11 +84,15 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 >ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 import.meta = foo;
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 
 // @Filename augmentations.ts
@@ -108,5 +116,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : Symbol(c, Decl(assignmentTargets.ts, 10, 13))
 >import.meta.wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 

--- a/tests/baselines/reference/importMeta(module=es2020,target=esnext).symbols
+++ b/tests/baselines/reference/importMeta(module=es2020,target=esnext).symbols
@@ -8,6 +8,7 @@
 >URL : Symbol(URL, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >toString : Symbol(URL.toString, Decl(lib.dom.d.ts, --, --))
 
@@ -20,6 +21,7 @@
   const size = import.meta.scriptElement.dataset.size || 300;
 >size : Symbol(size, Decl(example.ts, 5, 7))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
   const image = new Image();
 >image : Symbol(image, Decl(example.ts, 7, 7))
@@ -57,6 +59,7 @@
 export let x = import.meta;
 >x : Symbol(x, Decl(moduleLookingFile01.ts, 0, 10))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 export let y = import.metal;
 >y : Symbol(y, Decl(moduleLookingFile01.ts, 1, 10))
@@ -68,6 +71,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : Symbol(globalA, Decl(scriptLookingFile01.ts, 0, 3))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 let globalB = import.metal;
 >globalB : Symbol(globalB, Decl(scriptLookingFile01.ts, 1, 3))
@@ -80,11 +84,15 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 >ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 import.meta = foo;
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 
 // @Filename augmentations.ts
@@ -108,5 +116,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : Symbol(c, Decl(assignmentTargets.ts, 10, 13))
 >import.meta.wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 

--- a/tests/baselines/reference/importMeta(module=esnext,target=es5).symbols
+++ b/tests/baselines/reference/importMeta(module=esnext,target=es5).symbols
@@ -8,6 +8,7 @@
 >URL : Symbol(URL, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >toString : Symbol(URL.toString, Decl(lib.dom.d.ts, --, --))
 
@@ -20,6 +21,7 @@
   const size = import.meta.scriptElement.dataset.size || 300;
 >size : Symbol(size, Decl(example.ts, 5, 7))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
   const image = new Image();
 >image : Symbol(image, Decl(example.ts, 7, 7))
@@ -57,6 +59,7 @@
 export let x = import.meta;
 >x : Symbol(x, Decl(moduleLookingFile01.ts, 0, 10))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 export let y = import.metal;
 >y : Symbol(y, Decl(moduleLookingFile01.ts, 1, 10))
@@ -68,6 +71,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : Symbol(globalA, Decl(scriptLookingFile01.ts, 0, 3))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 let globalB = import.metal;
 >globalB : Symbol(globalB, Decl(scriptLookingFile01.ts, 1, 3))
@@ -80,11 +84,15 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 >ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 import.meta = foo;
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 
 // @Filename augmentations.ts
@@ -108,5 +116,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : Symbol(c, Decl(assignmentTargets.ts, 10, 13))
 >import.meta.wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 

--- a/tests/baselines/reference/importMeta(module=esnext,target=esnext).symbols
+++ b/tests/baselines/reference/importMeta(module=esnext,target=esnext).symbols
@@ -8,6 +8,7 @@
 >URL : Symbol(URL, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >toString : Symbol(URL.toString, Decl(lib.dom.d.ts, --, --))
 
@@ -20,6 +21,7 @@
   const size = import.meta.scriptElement.dataset.size || 300;
 >size : Symbol(size, Decl(example.ts, 5, 7))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
   const image = new Image();
 >image : Symbol(image, Decl(example.ts, 7, 7))
@@ -57,6 +59,7 @@
 export let x = import.meta;
 >x : Symbol(x, Decl(moduleLookingFile01.ts, 0, 10))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 export let y = import.metal;
 >y : Symbol(y, Decl(moduleLookingFile01.ts, 1, 10))
@@ -68,6 +71,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : Symbol(globalA, Decl(scriptLookingFile01.ts, 0, 3))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 let globalB = import.metal;
 >globalB : Symbol(globalB, Decl(scriptLookingFile01.ts, 1, 3))
@@ -80,11 +84,15 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 >ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 import.meta = foo;
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 
 // @Filename augmentations.ts
@@ -108,5 +116,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : Symbol(c, Decl(assignmentTargets.ts, 10, 13))
 >import.meta.wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 

--- a/tests/baselines/reference/importMeta(module=system,target=es5).symbols
+++ b/tests/baselines/reference/importMeta(module=system,target=es5).symbols
@@ -8,6 +8,7 @@
 >URL : Symbol(URL, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >toString : Symbol(URL.toString, Decl(lib.dom.d.ts, --, --))
 
@@ -20,6 +21,7 @@
   const size = import.meta.scriptElement.dataset.size || 300;
 >size : Symbol(size, Decl(example.ts, 5, 7))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
   const image = new Image();
 >image : Symbol(image, Decl(example.ts, 7, 7))
@@ -57,6 +59,7 @@
 export let x = import.meta;
 >x : Symbol(x, Decl(moduleLookingFile01.ts, 0, 10))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 export let y = import.metal;
 >y : Symbol(y, Decl(moduleLookingFile01.ts, 1, 10))
@@ -68,6 +71,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : Symbol(globalA, Decl(scriptLookingFile01.ts, 0, 3))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 let globalB = import.metal;
 >globalB : Symbol(globalB, Decl(scriptLookingFile01.ts, 1, 3))
@@ -80,11 +84,15 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 >ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 import.meta = foo;
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 
 // @Filename augmentations.ts
@@ -108,5 +116,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : Symbol(c, Decl(assignmentTargets.ts, 10, 13))
 >import.meta.wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 

--- a/tests/baselines/reference/importMeta(module=system,target=esnext).symbols
+++ b/tests/baselines/reference/importMeta(module=system,target=esnext).symbols
@@ -8,6 +8,7 @@
 >URL : Symbol(URL, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >toString : Symbol(URL.toString, Decl(lib.dom.d.ts, --, --))
 
@@ -20,6 +21,7 @@
   const size = import.meta.scriptElement.dataset.size || 300;
 >size : Symbol(size, Decl(example.ts, 5, 7))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
   const image = new Image();
 >image : Symbol(image, Decl(example.ts, 7, 7))
@@ -57,6 +59,7 @@
 export let x = import.meta;
 >x : Symbol(x, Decl(moduleLookingFile01.ts, 0, 10))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 export let y = import.metal;
 >y : Symbol(y, Decl(moduleLookingFile01.ts, 1, 10))
@@ -68,6 +71,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : Symbol(globalA, Decl(scriptLookingFile01.ts, 0, 3))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 let globalB = import.metal;
 >globalB : Symbol(globalB, Decl(scriptLookingFile01.ts, 1, 3))
@@ -80,11 +84,15 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 >ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 
 import.meta = foo;
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(foo, Decl(assignmentTargets.ts, 0, 12))
 
 // @Filename augmentations.ts
@@ -108,5 +116,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : Symbol(c, Decl(assignmentTargets.ts, 10, 13))
 >import.meta.wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(assignmentTargets.ts, 4, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >wellKnownProperty : Symbol(ImportMeta.wellKnownProperty, Decl(assignmentTargets.ts, 5, 24))
 

--- a/tests/baselines/reference/importMetaNarrowing(module=es2020).symbols
+++ b/tests/baselines/reference/importMetaNarrowing(module=es2020).symbols
@@ -7,11 +7,13 @@ declare global { interface ImportMeta {foo?: () => void} };
 if (import.meta.foo) {
 >import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(importMetaNarrowing.ts, 0, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 
   import.meta.foo();
 >import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(importMetaNarrowing.ts, 0, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 }
 

--- a/tests/baselines/reference/importMetaNarrowing(module=esnext).symbols
+++ b/tests/baselines/reference/importMetaNarrowing(module=esnext).symbols
@@ -7,11 +7,13 @@ declare global { interface ImportMeta {foo?: () => void} };
 if (import.meta.foo) {
 >import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(importMetaNarrowing.ts, 0, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 
   import.meta.foo();
 >import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(importMetaNarrowing.ts, 0, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 }
 

--- a/tests/baselines/reference/importMetaNarrowing(module=system).symbols
+++ b/tests/baselines/reference/importMetaNarrowing(module=system).symbols
@@ -7,11 +7,13 @@ declare global { interface ImportMeta {foo?: () => void} };
 if (import.meta.foo) {
 >import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(importMetaNarrowing.ts, 0, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 
   import.meta.foo();
 >import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(importMetaNarrowing.ts, 0, 16))
+>meta : Symbol(ImportMetaExpression.meta)
 >foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
 }
 

--- a/tests/baselines/reference/misspelledNewMetaProperty.symbols
+++ b/tests/baselines/reference/misspelledNewMetaProperty.symbols
@@ -2,5 +2,4 @@
 function foo(){new.targ}
 >foo : Symbol(foo, Decl(misspelledNewMetaProperty.ts, 0, 0))
 >new.targ : Symbol(foo, Decl(misspelledNewMetaProperty.ts, 0, 0))
->targ : Symbol(foo, Decl(misspelledNewMetaProperty.ts, 0, 0))
 

--- a/tests/baselines/reference/nodeModulesAllowJsImportMeta(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsImportMeta(module=node12).symbols
@@ -4,6 +4,7 @@ const x = import.meta.url;
 >x : Symbol(x, Decl(index.js, 1, 5))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 
 export {x};
@@ -15,6 +16,7 @@ const x = import.meta.url;
 >x : Symbol(x, Decl(index.js, 1, 5))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 
 export {x};

--- a/tests/baselines/reference/nodeModulesAllowJsImportMeta(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsImportMeta(module=nodenext).symbols
@@ -4,6 +4,7 @@ const x = import.meta.url;
 >x : Symbol(x, Decl(index.js, 1, 5))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 
 export {x};
@@ -15,6 +16,7 @@ const x = import.meta.url;
 >x : Symbol(x, Decl(index.js, 1, 5))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 
 export {x};

--- a/tests/baselines/reference/nodeModulesImportMeta(module=node12).symbols
+++ b/tests/baselines/reference/nodeModulesImportMeta(module=node12).symbols
@@ -4,6 +4,7 @@ const x = import.meta.url;
 >x : Symbol(x, Decl(index.ts, 1, 5))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 
 export {x};
@@ -15,6 +16,7 @@ const x = import.meta.url;
 >x : Symbol(x, Decl(index.ts, 1, 5))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 
 export {x};

--- a/tests/baselines/reference/nodeModulesImportMeta(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesImportMeta(module=nodenext).symbols
@@ -4,6 +4,7 @@ const x = import.meta.url;
 >x : Symbol(x, Decl(index.ts, 1, 5))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 
 export {x};
@@ -15,6 +16,7 @@ const x = import.meta.url;
 >x : Symbol(x, Decl(index.ts, 1, 5))
 >import.meta.url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 >import.meta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>meta : Symbol(ImportMetaExpression.meta)
 >url : Symbol(ImportMeta.url, Decl(lib.dom.d.ts, --, --))
 
 export {x};

--- a/tests/baselines/reference/plainJSGrammarErrors.symbols
+++ b/tests/baselines/reference/plainJSGrammarErrors.symbols
@@ -455,7 +455,6 @@ export let noMeta = import.metal
 function foo() { new.targe }
 >foo : Symbol(foo, Decl(plainJSGrammarErrors.js, 200, 32))
 >new.targe : Symbol(foo, Decl(plainJSGrammarErrors.js, 200, 32))
->targe : Symbol(foo, Decl(plainJSGrammarErrors.js, 200, 32))
 
 const nullaryDynamicImport = import()
 >nullaryDynamicImport : Symbol(nullaryDynamicImport, Decl(plainJSGrammarErrors.js, 202, 5))

--- a/tests/cases/fourslash/goToDefinitionImportMeta.ts
+++ b/tests/cases/fourslash/goToDefinitionImportMeta.ts
@@ -11,3 +11,5 @@
 ////}
 
 verify.goToDefinition("reference", []);
+
+verify.noErrors();


### PR DESCRIPTION
Fixes #48731

Our tests never caught the bug before we merged the checkers because there's no difference to goto-def between an outright missing symbol and a symbol with no declarations.