### PR TITLE
Fix emit for undefined SourceFile

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5651,6 +5651,7 @@ namespace ts {
         }
 
         function forEachLeadingCommentWithoutDetachedComments(cb: (commentPos: number, commentEnd: number, kind: SyntaxKind, hasTrailingNewLine: boolean, rangePos: number) => void) {
+            if (!currentSourceFile) return;
             // get the leading comments from detachedPos
             const pos = last(detachedCommentsInfo!).detachedCommentEndPos;
             if (detachedCommentsInfo!.length - 1) {
@@ -5660,7 +5661,6 @@ namespace ts {
                 detachedCommentsInfo = undefined;
             }
 
-            Debug.assertIsDefined(currentSourceFile);
             forEachLeadingCommentRange(currentSourceFile.text, pos, cb, /*state*/ pos);
         }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4702,7 +4702,7 @@ namespace ts {
                             includeComments => getLinesBetweenPositionAndPrecedingNonWhitespaceCharacter(
                                 firstChild.pos,
                                 parentNode.pos,
-                                Debug.checkDefined(currentSourceFile),
+                                currentSourceFile!,
                                 includeComments));
                     }
                     return rangeStartPositionsAreOnSameLine(parentNode, firstChild, currentSourceFile) ? 0 : 1;
@@ -4729,7 +4729,7 @@ namespace ts {
                             includeComments => getLinesBetweenRangeEndAndRangeStart(
                                 previousNode,
                                 nextNode,
-                                Debug.checkDefined(currentSourceFile),
+                                currentSourceFile!,
                                 includeComments));
                     }
                     // If `preserveSourceNewlines` is `false` we do not intend to preserve the effective lines between the
@@ -4771,7 +4771,7 @@ namespace ts {
                             includeComments => getLinesBetweenPositionAndNextNonWhitespaceCharacter(
                                 end,
                                 parentNode.end,
-                                Debug.checkDefined(currentSourceFile),
+                                currentSourceFile!,
                                 includeComments));
                     }
                     return rangeEndPositionsAreOnSameLine(parentNode, lastChild, currentSourceFile) ? 0 : 1;
@@ -4858,7 +4858,7 @@ namespace ts {
                         includeComments => getLinesBetweenRangeEndAndRangeStart(
                             node1,
                             node2,
-                            Debug.checkDefined(currentSourceFile),
+                            currentSourceFile!,
                             includeComments));
                 }
                 return rangeEndIsOnSameLineAsRangeStart(node1, node2, currentSourceFile) ? 0 : 1;

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2881,7 +2881,7 @@ namespace ts {
             emitExpression(node.expression, parenthesizer.parenthesizeExpressionOfExpressionStatement);
             // Emit semicolon in non json files
             // or if json file that created synthesized expression(eg.define expression statement when --out and amd code generation)
-            if (currentSourceFile && !isJsonSourceFile(currentSourceFile) || nodeIsSynthesized(node.expression)) {
+            if (!currentSourceFile || !isJsonSourceFile(currentSourceFile) || nodeIsSynthesized(node.expression)) {
                 writeTrailingSemicolon();
             }
         }
@@ -5542,8 +5542,7 @@ namespace ts {
         }
 
         function emitLeadingComment(commentPos: number, commentEnd: number, kind: SyntaxKind, hasTrailingNewLine: boolean, rangePos: number) {
-            Debug.assertIsDefined(currentSourceFile);
-            if (!shouldWriteComment(currentSourceFile.text, commentPos)) return;
+            if (!currentSourceFile || !shouldWriteComment(currentSourceFile.text, commentPos)) return;
             if (!hasWrittenComment) {
                 emitNewLineBeforeLeadingCommentOfPosition(getCurrentLineMap(), writer, rangePos, commentPos);
                 hasWrittenComment = true;
@@ -5575,8 +5574,7 @@ namespace ts {
         }
 
         function emitTrailingComment(commentPos: number, commentEnd: number, _kind: SyntaxKind, hasTrailingNewLine: boolean) {
-            Debug.assertIsDefined(currentSourceFile);
-            if (!shouldWriteComment(currentSourceFile.text, commentPos)) return;
+            if (!currentSourceFile || !shouldWriteComment(currentSourceFile.text, commentPos)) return;
             // trailing comments are emitted at space/*trailing comment1 */space/*trailing comment2*/
             if (!writer.isAtStartOfLine()) {
                 writer.writeSpace(" ");
@@ -5601,7 +5599,7 @@ namespace ts {
         }
 
         function emitTrailingCommentOfPositionNoNewline(commentPos: number, commentEnd: number, kind: SyntaxKind) {
-            Debug.assertIsDefined(currentSourceFile);
+            if (!currentSourceFile) return;
             // trailing comments of a position are emitted at /*trailing comment1 */space/*trailing comment*/space
 
             emitPos(commentPos);
@@ -5614,7 +5612,7 @@ namespace ts {
         }
 
         function emitTrailingCommentOfPosition(commentPos: number, commentEnd: number, _kind: SyntaxKind, hasTrailingNewLine: boolean) {
-            Debug.assertIsDefined(currentSourceFile);
+            if(!currentSourceFile) return;
             // trailing comments of a position are emitted at /*trailing comment1 */space/*trailing comment*/space
 
             emitPos(commentPos);
@@ -5667,8 +5665,7 @@ namespace ts {
         }
 
         function emitDetachedCommentsAndUpdateCommentsInfo(range: TextRange) {
-            Debug.assertIsDefined(currentSourceFile);
-            const currentDetachedCommentInfo = emitDetachedComments(currentSourceFile.text, getCurrentLineMap(), writer, emitComment, range, newLine, commentsDisabled);
+            const currentDetachedCommentInfo = currentSourceFile && emitDetachedComments(currentSourceFile.text, getCurrentLineMap(), writer, emitComment, range, newLine, commentsDisabled);
             if (currentDetachedCommentInfo) {
                 if (detachedCommentsInfo) {
                     detachedCommentsInfo.push(currentDetachedCommentInfo);
@@ -5680,8 +5677,7 @@ namespace ts {
         }
 
         function emitComment(text: string, lineMap: number[], writer: EmitTextWriter, commentPos: number, commentEnd: number, newLine: string) {
-            Debug.assertIsDefined(currentSourceFile);
-            if (!shouldWriteComment(currentSourceFile.text, commentPos)) return;
+            if (!currentSourceFile || !shouldWriteComment(currentSourceFile.text, commentPos)) return;
             emitPos(commentPos);
             writeCommentRange(text, lineMap, writer, commentPos, commentEnd, newLine);
             emitPos(commentEnd);
@@ -5693,8 +5689,7 @@ namespace ts {
          * @return true if the comment is a triple-slash comment else false
          */
         function isTripleSlashComment(commentPos: number, commentEnd: number) {
-            Debug.assertIsDefined(currentSourceFile);
-            return isRecognizedTripleSlashComment(currentSourceFile.text, commentPos, commentEnd);
+            return !!currentSourceFile && isRecognizedTripleSlashComment(currentSourceFile.text, commentPos, commentEnd);
         }
 
         // Source Maps

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1170,8 +1170,7 @@ namespace ts {
         }
 
         function getCurrentLineMap() {
-            Debug.assertIsDefined(currentSourceFile);
-            return currentLineMap || (currentLineMap = getLineStarts(currentSourceFile));
+            return currentLineMap || (currentLineMap = getLineStarts(Debug.checkDefined(currentSourceFile)));
         }
 
         function emit(node: Node, parenthesizerRule?: (node: Node) => Node): void;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -656,10 +656,10 @@ namespace ts {
         AllowNumericSeparator = 1 << 3
     }
 
-    export function getLiteralText(node: LiteralLikeNode, sourceFile: SourceFile, flags: GetLiteralTextFlags) {
+    export function getLiteralText(node: LiteralLikeNode, sourceFile: SourceFile | undefined, flags: GetLiteralTextFlags) {
         // If we don't need to downlevel and we can reach the original source text using
         // the node's parent reference, then simply get the text as it was originally written.
-        if (canUseOriginalText(node, flags)) {
+        if (sourceFile && canUseOriginalText(node, flags)) {
             return getSourceTextOfNodeFromSourceFile(sourceFile, node);
         }
 


### PR DESCRIPTION
I like to print out the AST when debugging to see what I'm doing, but when it's not a "real" AST from a source file, things crash, even though they shouldn't. Remove all of the `!` from emit and actually handle a missing source file, allowing `printNode` and such to actually print a tree without a source file.

Arguably, I could change the signature of `printNode` and co to explicitly note that they can have an undefined `SourceFile` (matching `writeNode` and so on), but maybe that's not a good idea, or something that should be internal.