### PR TITLE
Fix handling of prologue statements when there are parameter property declarations

### DIFF
--- a/tests/baselines/reference/constructorWithParameterPropertiesAndPrivateFields.es2015.js
+++ b/tests/baselines/reference/constructorWithParameterPropertiesAndPrivateFields.es2015.js
@@ -1,0 +1,44 @@
+//// [constructorWithParameterPropertiesAndPrivateFields.es2015.ts]
+// https://github.com/microsoft/TypeScript/issues/48771
+
+class A {
+  readonly #privateField: string;
+
+  constructor(arg: { key: string }, public exposedField: number) {
+    ({ key: this.#privateField } = arg);
+  }
+
+  log() {
+    console.log(this.#privateField);
+    console.log(this.exposedField);
+  }
+}
+
+
+//// [constructorWithParameterPropertiesAndPrivateFields.es2015.js]
+// https://github.com/microsoft/TypeScript/issues/48771
+var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (receiver, state, value, kind, f) {
+    if (kind === "m") throw new TypeError("Private method is not writable");
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+    return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
+};
+var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, state, kind, f) {
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+};
+var _A_privateField;
+class A {
+    constructor(arg, exposedField) {
+        this.exposedField = exposedField;
+        var _a;
+        _A_privateField.set(this, void 0);
+        (_a = this, { key: ({ set value(_b) { __classPrivateFieldSet(_a, _A_privateField, _b, "f"); } }).value } = arg);
+    }
+    log() {
+        console.log(__classPrivateFieldGet(this, _A_privateField, "f"));
+        console.log(this.exposedField);
+    }
+}
+_A_privateField = new WeakMap();

--- a/tests/baselines/reference/constructorWithParameterPropertiesAndPrivateFields.es2015.symbols
+++ b/tests/baselines/reference/constructorWithParameterPropertiesAndPrivateFields.es2015.symbols
@@ -1,0 +1,41 @@
+=== tests/cases/compiler/constructorWithParameterPropertiesAndPrivateFields.es2015.ts ===
+// https://github.com/microsoft/TypeScript/issues/48771
+
+class A {
+>A : Symbol(A, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 0, 0))
+
+  readonly #privateField: string;
+>#privateField : Symbol(A.#privateField, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 2, 9))
+
+  constructor(arg: { key: string }, public exposedField: number) {
+>arg : Symbol(arg, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 5, 14))
+>key : Symbol(key, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 5, 20))
+>exposedField : Symbol(A.exposedField, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 5, 35))
+
+    ({ key: this.#privateField } = arg);
+>key : Symbol(key, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 6, 6))
+>this.#privateField : Symbol(A.#privateField, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 2, 9))
+>this : Symbol(A, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 0, 0))
+>arg : Symbol(arg, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 5, 14))
+  }
+
+  log() {
+>log : Symbol(A.log, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 7, 3))
+
+    console.log(this.#privateField);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>this.#privateField : Symbol(A.#privateField, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 2, 9))
+>this : Symbol(A, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 0, 0))
+
+    console.log(this.exposedField);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>this.exposedField : Symbol(A.exposedField, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 5, 35))
+>this : Symbol(A, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 0, 0))
+>exposedField : Symbol(A.exposedField, Decl(constructorWithParameterPropertiesAndPrivateFields.es2015.ts, 5, 35))
+  }
+}
+

--- a/tests/baselines/reference/constructorWithParameterPropertiesAndPrivateFields.es2015.types
+++ b/tests/baselines/reference/constructorWithParameterPropertiesAndPrivateFields.es2015.types
@@ -1,0 +1,46 @@
+=== tests/cases/compiler/constructorWithParameterPropertiesAndPrivateFields.es2015.ts ===
+// https://github.com/microsoft/TypeScript/issues/48771
+
+class A {
+>A : A
+
+  readonly #privateField: string;
+>#privateField : string
+
+  constructor(arg: { key: string }, public exposedField: number) {
+>arg : { key: string; }
+>key : string
+>exposedField : number
+
+    ({ key: this.#privateField } = arg);
+>({ key: this.#privateField } = arg) : { key: string; }
+>{ key: this.#privateField } = arg : { key: string; }
+>{ key: this.#privateField } : { key: string; }
+>key : string
+>this.#privateField : string
+>this : this
+>arg : { key: string; }
+  }
+
+  log() {
+>log : () => void
+
+    console.log(this.#privateField);
+>console.log(this.#privateField) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>this.#privateField : string
+>this : this
+
+    console.log(this.exposedField);
+>console.log(this.exposedField) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>this.exposedField : number
+>this : this
+>exposedField : number
+  }
+}
+

--- a/tests/cases/compiler/constructorWithParameterPropertiesAndPrivateFields.es2015.ts
+++ b/tests/cases/compiler/constructorWithParameterPropertiesAndPrivateFields.es2015.ts
@@ -1,0 +1,15 @@
+// @target: es2015
+// https://github.com/microsoft/TypeScript/issues/48771
+
+class A {
+  readonly #privateField: string;
+
+  constructor(arg: { key: string }, public exposedField: number) {
+    ({ key: this.#privateField } = arg);
+  }
+
+  log() {
+    console.log(this.#privateField);
+    console.log(this.exposedField);
+  }
+}


### PR DESCRIPTION
Had a chance to have a look into this, and I think I've found the solution to the issue I raised: if there is a prologue (and no super) in a constructor, the prologue won't be skipped when calculating the parameter properties, leading to the prologue being included twice.

Please let me know if I need to update/change anything - I hope I added the tests correctly, all the tests are still passing.

Fixes https://github.com/microsoft/TypeScript/issues/48771