### PR TITLE
Format completion snippet text before escaping

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1251,6 +1251,7 @@ namespace ts.Completions {
             list: NodeArray<Node>,
             sourceFile: SourceFile | undefined,
         ): string {
+            escapes = undefined;
             writer.clear();
             printer.writeList(format, list, sourceFile, writer);
             return writer.getText();

--- a/tests/cases/fourslash/completionsOverridingMethod2.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod2.ts
@@ -5,6 +5,9 @@
 // Case: Snippet text needs escaping
 ////interface DollarSign {
 ////    "$usd"(a: number): number;
+////    $cad(b: number): number;
+////    cla$$y(c: number): number;
+////    isDollarAmountString(s: string): s is `$${number}`
 ////}
 ////class USD implements DollarSign {
 ////    /*a*/
@@ -25,6 +28,24 @@ verify.completions({
             sortText: completion.SortText.ClassMemberSnippets,
             isSnippet: true,
             insertText: "\"\\$usd\"(a: number): number {\n    $0\n}",
-        }
+        },
+        {
+            name: "$cad",
+            sortText: completion.SortText.ClassMemberSnippets,
+            isSnippet: true,
+            insertText: "\\$cad(b: number): number {\n    $0\n}",
+        },
+        {
+            name: "cla$$y",
+            sortText: completion.SortText.ClassMemberSnippets,
+            isSnippet: true,
+            insertText: "cla\\$\\$y(c: number): number {\n    $0\n}",
+        },
+        {
+            name: "isDollarAmountString",
+            sortText: completion.SortText.ClassMemberSnippets,
+            isSnippet: true,
+            insertText: "isDollarAmountString(s: string): s is `\\$\\${number}` {\n    $0\n}"
+        },
     ],
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #48139
Fixes #48215

I briefly tried to make the formatting scanner and/or actual scanner tolerant of `\$` and `\\`, but it quickly became apparent that this approach would be easier.
