### PR TITLE
Run `mocha` using `process.execPath` instead of harcoding `"node"`

### DIFF
--- a/scripts/build/tests.js
+++ b/scripts/build/tests.js
@@ -122,7 +122,9 @@ async function runConsoleTests(runJs, defaultReporter, runInParallel, watchMode,
 
     try {
         setNodeEnvToDevelopment();
-        const { exitCode } = await exec("node", args, { cancelToken });
+        const { exitCode } = await exec(process.execPath, args, {
+            cancelToken,
+        });
         if (exitCode !== 0) {
             errorStatus = exitCode;
             error = new Error(`Process exited with status code ${errorStatus}.`);


### PR DESCRIPTION
This is just a small tooling PR that makes it easier to execute tasks using gulp with alternative `execPath`. Specifically, it makes it easier to record runs with https://www.replay.io/

Note that you are already using the same thing here:
https://github.com/microsoft/TypeScript/blob/fa2ad1a35a7feaab8d118275cf9b3d56f28bde8a/scripts/build/projects.js#L39