### PR TITLE
Fix auto-import completions sometimes not updating existing imports

### DIFF
--- a/tests/cases/fourslash/completionsImport_preferUpdatingExistingImport.ts
+++ b/tests/cases/fourslash/completionsImport_preferUpdatingExistingImport.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+
+// @Filename: /deep/module/why/you/want/this/path.ts
+//// export const x = 0;
+//// export const y = 1;
+
+// @Filename: /nice/reexport.ts
+//// import { x, y } from "../deep/module/why/you/want/this/path";
+//// export { x, y };
+
+// @Filename: /index.ts
+//// import { x } from "./deep/module/why/you/want/this/path";
+////
+//// y/**/
+
+verify.completions({
+  marker: "",
+  exact: completion.globalsPlus(["x", {
+    name: "y",
+    source: "./deep/module/why/you/want/this/path",
+    sourceDisplay: "./deep/module/why/you/want/this/path",
+    sortText: completion.SortText.AutoImportSuggestions,
+    hasAction: true,
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+  },
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #47779

I also suspect this will address at least some of the crashes we’ve seen [here](https://github.com/microsoft/TypeScript/issues/39766), as I noticed that the auto-import computation for completion details has always used `getImportFixes`, while the computation for the completion list mistakenly used `getNewImportFixes` which doesn’t try to reuse existing imports. That inconsistency could definitely cause problems, as the details request is essentially supposed to continue the same work that the list request started.
