### PR TITLE
Avoid instantiating all values of an anonymous obj type when index is concrete

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17183,7 +17183,12 @@ namespace ts {
             if (flags & TypeFlags.IndexedAccess) {
                 const newAliasSymbol = aliasSymbol || type.aliasSymbol;
                 const newAliasTypeArguments = aliasSymbol ? aliasTypeArguments : instantiateTypes(type.aliasTypeArguments, mapper);
-                return getIndexedAccessType(instantiateType((type as IndexedAccessType).objectType, mapper), instantiateType((type as IndexedAccessType).indexType, mapper), (type as IndexedAccessType).accessFlags, /*accessNode*/ undefined, newAliasSymbol, newAliasTypeArguments);
+                const instantiatedIndexType = instantiateType((type as IndexedAccessType).indexType, mapper);
+                const objectType = (type as IndexedAccessType).objectType;
+                if (!(getObjectFlags(objectType) & ObjectFlags.Anonymous) || instantiatedIndexType.flags & TypeFlags.Instantiable) {
+                    return getIndexedAccessType(instantiateType(objectType, mapper), instantiatedIndexType, (type as IndexedAccessType).accessFlags, /*accessNode*/ undefined, newAliasSymbol, newAliasTypeArguments);
+                }
+                return instantiateType(getIndexedAccessType(objectType, instantiatedIndexType, (type as IndexedAccessType).accessFlags, /*accessNode*/ undefined, newAliasSymbol, newAliasTypeArguments), mapper);
             }
             if (flags & TypeFlags.Conditional) {
                 return getConditionalTypeInstantiation(type as ConditionalType, combineTypeMappers((type as ConditionalType).mapper, mapper), aliasSymbol, aliasTypeArguments);

--- a/tests/baselines/reference/mappedTypeAsClauses.types
+++ b/tests/baselines/reference/mappedTypeAsClauses.types
@@ -275,7 +275,7 @@ type TS4<T> = keyof { [P in keyof T as NameMap[P & keyof NameMap]]: string };
 >TS4 : keyof { [P in keyof T as NameMap[P & keyof NameMap]]: string; }
 
 type TS5<T> = keyof { [P in keyof T & keyof NameMap as NameMap[P]]: string };
->TS5 : NameMap[keyof T & "a"] | NameMap[keyof T & "b"] | NameMap[keyof T & "c"]
+>TS5 : "x" | "y" | "z"
 
 type TS6<T, U, V> = keyof { [ K in keyof T as V & (K extends U ? K : never)]: string };
 >TS6 : keyof { [K in keyof T as V & (K extends U ? K : never)]: string; }


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/48827
