### PR TITLE
Add tests case for function check type being correctly paranthesized in quick info

### DIFF
--- a/tests/cases/fourslash/quickInfoFunctionCheckType.ts
+++ b/tests/cases/fourslash/quickInfoFunctionCheckType.ts
@@ -1,0 +1,6 @@
+///<reference path="fourslash.ts" />
+
+////export type /**/Tail<T extends any[]> = ((...t: T) => void) extends (h: any, ...rest: infer R) => void ? R : never;
+
+verify.quickInfoAt("", "type Tail<T extends any[]> = ((...t: T) => void) extends (h: any, ...rest: infer R) => void ? R : never");
+


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/48729

I've noticed that this already works in nightly and narrowed it down to `4.7.0-dev.20220406`, see [the playground](https://www.typescriptlang.org/play?isolatedModules=false&ts=4.7.0-dev.20220406#code/C4TwDgpgBAKghgSwDYB4ZQgD2BAdgEwGco5cQBtAXQD4oBeKACkYDo3gAuWASntoDcA9gny8sOAsUYBYAFBQoACy6kQAGjkK2LAE4RCnKAlwAzCDqgAlObzoDh+TVAD8Vp11wR+5gNxygA).

Then I was able to bisect this to https://github.com/microsoft/TypeScript/commit/7da80d79e2b9a320f98697e2bbe389d5e3485e56 introduced by https://github.com/microsoft/TypeScript/pull/48112 . I think that the improvement comes from refactoring common `parenthesizeMemberOfConditionalType` into specialized functions like `parenthesizeCheckTypeOfConditionalType` & co.

I didn't see any specific test case added/adjusted in this PR that would be specific to this situation so I've decided to add one, cc @rbuckton 