### PR TITLE
Improve support for numeric string types

### DIFF
--- a/tests/baselines/reference/numericStringLiteralTypes.js
+++ b/tests/baselines/reference/numericStringLiteralTypes.js
@@ -1,0 +1,80 @@
+//// [numericStringLiteralTypes.ts]
+type T0 = string & `${string}`;  // string
+type T1 = string & `${number}`;  // `${number}
+type T2 = string & `${bigint}`;  // `${bigint}
+type T3<T extends string> = string & `${T}`;  // `${T}
+type T4<T extends string> = string & `${Capitalize<`${T}`>}`;  // `${Capitalize<T>}`
+
+function f1(a: boolean[], x: `${number}`) {
+    let s = a[x];  // boolean
+}
+
+function f2(a: boolean[], x: number | `${number}`) {
+    let s = a[x];  // boolean
+}
+
+type T10 = boolean[][`${number}`];  // boolean
+type T11 = boolean[][number | `${number}`];  // boolean
+
+type T20<T extends number | `${number}`> = T;
+type T21<T extends unknown[]> = { [K in keyof T]: T20<K> };
+
+type Container<T> = {
+    value: T
+}
+
+type UnwrapContainers<T extends Container<unknown>[]> = { [K in keyof T]: T[K]['value'] };
+
+declare function createContainer<T extends unknown>(value: T): Container<T>;
+
+declare function f<T extends Container<unknown>[]>(containers: [...T], callback: (...values: UnwrapContainers<T>) => void): void;
+
+const container1 = createContainer('hi')
+const container2 = createContainer(2)
+
+f([container1, container2], (value1, value2) => {
+    value1;  // string
+    value2;  // number
+});
+
+
+//// [numericStringLiteralTypes.js]
+"use strict";
+function f1(a, x) {
+    var s = a[x]; // boolean
+}
+function f2(a, x) {
+    var s = a[x]; // boolean
+}
+var container1 = createContainer('hi');
+var container2 = createContainer(2);
+f([container1, container2], function (value1, value2) {
+    value1; // string
+    value2; // number
+});
+
+
+//// [numericStringLiteralTypes.d.ts]
+declare type T0 = string & `${string}`;
+declare type T1 = string & `${number}`;
+declare type T2 = string & `${bigint}`;
+declare type T3<T extends string> = string & `${T}`;
+declare type T4<T extends string> = string & `${Capitalize<`${T}`>}`;
+declare function f1(a: boolean[], x: `${number}`): void;
+declare function f2(a: boolean[], x: number | `${number}`): void;
+declare type T10 = boolean[][`${number}`];
+declare type T11 = boolean[][number | `${number}`];
+declare type T20<T extends number | `${number}`> = T;
+declare type T21<T extends unknown[]> = {
+    [K in keyof T]: T20<K>;
+};
+declare type Container<T> = {
+    value: T;
+};
+declare type UnwrapContainers<T extends Container<unknown>[]> = {
+    [K in keyof T]: T[K]['value'];
+};
+declare function createContainer<T extends unknown>(value: T): Container<T>;
+declare function f<T extends Container<unknown>[]>(containers: [...T], callback: (...values: UnwrapContainers<T>) => void): void;
+declare const container1: Container<string>;
+declare const container2: Container<number>;

--- a/tests/baselines/reference/numericStringLiteralTypes.symbols
+++ b/tests/baselines/reference/numericStringLiteralTypes.symbols
@@ -1,0 +1,122 @@
+=== tests/cases/conformance/types/literal/numericStringLiteralTypes.ts ===
+type T0 = string & `${string}`;  // string
+>T0 : Symbol(T0, Decl(numericStringLiteralTypes.ts, 0, 0))
+
+type T1 = string & `${number}`;  // `${number}
+>T1 : Symbol(T1, Decl(numericStringLiteralTypes.ts, 0, 31))
+
+type T2 = string & `${bigint}`;  // `${bigint}
+>T2 : Symbol(T2, Decl(numericStringLiteralTypes.ts, 1, 31))
+
+type T3<T extends string> = string & `${T}`;  // `${T}
+>T3 : Symbol(T3, Decl(numericStringLiteralTypes.ts, 2, 31))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 3, 8))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 3, 8))
+
+type T4<T extends string> = string & `${Capitalize<`${T}`>}`;  // `${Capitalize<T>}`
+>T4 : Symbol(T4, Decl(numericStringLiteralTypes.ts, 3, 44))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 4, 8))
+>Capitalize : Symbol(Capitalize, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 4, 8))
+
+function f1(a: boolean[], x: `${number}`) {
+>f1 : Symbol(f1, Decl(numericStringLiteralTypes.ts, 4, 61))
+>a : Symbol(a, Decl(numericStringLiteralTypes.ts, 6, 12))
+>x : Symbol(x, Decl(numericStringLiteralTypes.ts, 6, 25))
+
+    let s = a[x];  // boolean
+>s : Symbol(s, Decl(numericStringLiteralTypes.ts, 7, 7))
+>a : Symbol(a, Decl(numericStringLiteralTypes.ts, 6, 12))
+>x : Symbol(x, Decl(numericStringLiteralTypes.ts, 6, 25))
+}
+
+function f2(a: boolean[], x: number | `${number}`) {
+>f2 : Symbol(f2, Decl(numericStringLiteralTypes.ts, 8, 1))
+>a : Symbol(a, Decl(numericStringLiteralTypes.ts, 10, 12))
+>x : Symbol(x, Decl(numericStringLiteralTypes.ts, 10, 25))
+
+    let s = a[x];  // boolean
+>s : Symbol(s, Decl(numericStringLiteralTypes.ts, 11, 7))
+>a : Symbol(a, Decl(numericStringLiteralTypes.ts, 10, 12))
+>x : Symbol(x, Decl(numericStringLiteralTypes.ts, 10, 25))
+}
+
+type T10 = boolean[][`${number}`];  // boolean
+>T10 : Symbol(T10, Decl(numericStringLiteralTypes.ts, 12, 1))
+
+type T11 = boolean[][number | `${number}`];  // boolean
+>T11 : Symbol(T11, Decl(numericStringLiteralTypes.ts, 14, 34))
+
+type T20<T extends number | `${number}`> = T;
+>T20 : Symbol(T20, Decl(numericStringLiteralTypes.ts, 15, 43))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 17, 9))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 17, 9))
+
+type T21<T extends unknown[]> = { [K in keyof T]: T20<K> };
+>T21 : Symbol(T21, Decl(numericStringLiteralTypes.ts, 17, 45))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 18, 9))
+>K : Symbol(K, Decl(numericStringLiteralTypes.ts, 18, 35))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 18, 9))
+>T20 : Symbol(T20, Decl(numericStringLiteralTypes.ts, 15, 43))
+>K : Symbol(K, Decl(numericStringLiteralTypes.ts, 18, 35))
+
+type Container<T> = {
+>Container : Symbol(Container, Decl(numericStringLiteralTypes.ts, 18, 59))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 20, 15))
+
+    value: T
+>value : Symbol(value, Decl(numericStringLiteralTypes.ts, 20, 21))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 20, 15))
+}
+
+type UnwrapContainers<T extends Container<unknown>[]> = { [K in keyof T]: T[K]['value'] };
+>UnwrapContainers : Symbol(UnwrapContainers, Decl(numericStringLiteralTypes.ts, 22, 1))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 24, 22))
+>Container : Symbol(Container, Decl(numericStringLiteralTypes.ts, 18, 59))
+>K : Symbol(K, Decl(numericStringLiteralTypes.ts, 24, 59))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 24, 22))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 24, 22))
+>K : Symbol(K, Decl(numericStringLiteralTypes.ts, 24, 59))
+
+declare function createContainer<T extends unknown>(value: T): Container<T>;
+>createContainer : Symbol(createContainer, Decl(numericStringLiteralTypes.ts, 24, 90))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 26, 33))
+>value : Symbol(value, Decl(numericStringLiteralTypes.ts, 26, 52))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 26, 33))
+>Container : Symbol(Container, Decl(numericStringLiteralTypes.ts, 18, 59))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 26, 33))
+
+declare function f<T extends Container<unknown>[]>(containers: [...T], callback: (...values: UnwrapContainers<T>) => void): void;
+>f : Symbol(f, Decl(numericStringLiteralTypes.ts, 26, 76))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 28, 19))
+>Container : Symbol(Container, Decl(numericStringLiteralTypes.ts, 18, 59))
+>containers : Symbol(containers, Decl(numericStringLiteralTypes.ts, 28, 51))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 28, 19))
+>callback : Symbol(callback, Decl(numericStringLiteralTypes.ts, 28, 70))
+>values : Symbol(values, Decl(numericStringLiteralTypes.ts, 28, 82))
+>UnwrapContainers : Symbol(UnwrapContainers, Decl(numericStringLiteralTypes.ts, 22, 1))
+>T : Symbol(T, Decl(numericStringLiteralTypes.ts, 28, 19))
+
+const container1 = createContainer('hi')
+>container1 : Symbol(container1, Decl(numericStringLiteralTypes.ts, 30, 5))
+>createContainer : Symbol(createContainer, Decl(numericStringLiteralTypes.ts, 24, 90))
+
+const container2 = createContainer(2)
+>container2 : Symbol(container2, Decl(numericStringLiteralTypes.ts, 31, 5))
+>createContainer : Symbol(createContainer, Decl(numericStringLiteralTypes.ts, 24, 90))
+
+f([container1, container2], (value1, value2) => {
+>f : Symbol(f, Decl(numericStringLiteralTypes.ts, 26, 76))
+>container1 : Symbol(container1, Decl(numericStringLiteralTypes.ts, 30, 5))
+>container2 : Symbol(container2, Decl(numericStringLiteralTypes.ts, 31, 5))
+>value1 : Symbol(value1, Decl(numericStringLiteralTypes.ts, 33, 29))
+>value2 : Symbol(value2, Decl(numericStringLiteralTypes.ts, 33, 36))
+
+    value1;  // string
+>value1 : Symbol(value1, Decl(numericStringLiteralTypes.ts, 33, 29))
+
+    value2;  // number
+>value2 : Symbol(value2, Decl(numericStringLiteralTypes.ts, 33, 36))
+
+});
+

--- a/tests/baselines/reference/numericStringLiteralTypes.types
+++ b/tests/baselines/reference/numericStringLiteralTypes.types
@@ -1,0 +1,102 @@
+=== tests/cases/conformance/types/literal/numericStringLiteralTypes.ts ===
+type T0 = string & `${string}`;  // string
+>T0 : string
+
+type T1 = string & `${number}`;  // `${number}
+>T1 : `${number}`
+
+type T2 = string & `${bigint}`;  // `${bigint}
+>T2 : `${bigint}`
+
+type T3<T extends string> = string & `${T}`;  // `${T}
+>T3 : `${T}`
+
+type T4<T extends string> = string & `${Capitalize<`${T}`>}`;  // `${Capitalize<T>}`
+>T4 : `${Capitalize<`${T}`>}`
+
+function f1(a: boolean[], x: `${number}`) {
+>f1 : (a: boolean[], x: `${number}`) => void
+>a : boolean[]
+>x : `${number}`
+
+    let s = a[x];  // boolean
+>s : boolean
+>a[x] : boolean
+>a : boolean[]
+>x : `${number}`
+}
+
+function f2(a: boolean[], x: number | `${number}`) {
+>f2 : (a: boolean[], x: number | `${number}`) => void
+>a : boolean[]
+>x : number | `${number}`
+
+    let s = a[x];  // boolean
+>s : boolean
+>a[x] : boolean
+>a : boolean[]
+>x : number | `${number}`
+}
+
+type T10 = boolean[][`${number}`];  // boolean
+>T10 : boolean
+
+type T11 = boolean[][number | `${number}`];  // boolean
+>T11 : boolean
+
+type T20<T extends number | `${number}`> = T;
+>T20 : T
+
+type T21<T extends unknown[]> = { [K in keyof T]: T20<K> };
+>T21 : T21<T>
+
+type Container<T> = {
+>Container : Container<T>
+
+    value: T
+>value : T
+}
+
+type UnwrapContainers<T extends Container<unknown>[]> = { [K in keyof T]: T[K]['value'] };
+>UnwrapContainers : UnwrapContainers<T>
+
+declare function createContainer<T extends unknown>(value: T): Container<T>;
+>createContainer : <T extends unknown>(value: T) => Container<T>
+>value : T
+
+declare function f<T extends Container<unknown>[]>(containers: [...T], callback: (...values: UnwrapContainers<T>) => void): void;
+>f : <T extends Container<unknown>[]>(containers: [...T], callback: (...values: UnwrapContainers<T>) => void) => void
+>containers : [...T]
+>callback : (...values: UnwrapContainers<T>) => void
+>values : UnwrapContainers<T>
+
+const container1 = createContainer('hi')
+>container1 : Container<string>
+>createContainer('hi') : Container<string>
+>createContainer : <T extends unknown>(value: T) => Container<T>
+>'hi' : "hi"
+
+const container2 = createContainer(2)
+>container2 : Container<number>
+>createContainer(2) : Container<number>
+>createContainer : <T extends unknown>(value: T) => Container<T>
+>2 : 2
+
+f([container1, container2], (value1, value2) => {
+>f([container1, container2], (value1, value2) => {    value1;  // string    value2;  // number}) : void
+>f : <T extends Container<unknown>[]>(containers: [...T], callback: (...values: UnwrapContainers<T>) => void) => void
+>[container1, container2] : [Container<string>, Container<number>]
+>container1 : Container<string>
+>container2 : Container<number>
+>(value1, value2) => {    value1;  // string    value2;  // number} : (value1: string, value2: number) => void
+>value1 : string
+>value2 : number
+
+    value1;  // string
+>value1 : string
+
+    value2;  // number
+>value2 : number
+
+});
+

--- a/tests/baselines/reference/templateLiteralTypes1.errors.txt
+++ b/tests/baselines/reference/templateLiteralTypes1.errors.txt
@@ -6,7 +6,7 @@ tests/cases/conformance/types/literal/templateLiteralTypes1.ts(165,15): error TS
 tests/cases/conformance/types/literal/templateLiteralTypes1.ts(197,16): error TS2590: Expression produces a union type that is too complex to represent.
 tests/cases/conformance/types/literal/templateLiteralTypes1.ts(201,16): error TS2590: Expression produces a union type that is too complex to represent.
 tests/cases/conformance/types/literal/templateLiteralTypes1.ts(205,16): error TS2590: Expression produces a union type that is too complex to represent.
-tests/cases/conformance/types/literal/templateLiteralTypes1.ts(251,7): error TS2590: Expression produces a union type that is too complex to represent.
+tests/cases/conformance/types/literal/templateLiteralTypes1.ts(252,7): error TS2590: Expression produces a union type that is too complex to represent.
 
 
 ==== tests/cases/conformance/types/literal/templateLiteralTypes1.ts (7 errors) ====
@@ -242,6 +242,7 @@ tests/cases/conformance/types/literal/templateLiteralTypes1.ts(251,7): error TS2
     // Repro from #40970
     
     type PathKeys<T> =
+        unknown extends T ? never :
         T extends readonly any[] ? Extract<keyof T, `${number}`> | SubKeys<T, Extract<keyof T, `${number}`>> :
         T extends object ? Extract<keyof T, string> | SubKeys<T, Extract<keyof T, string>> :
         never;

--- a/tests/baselines/reference/templateLiteralTypes1.js
+++ b/tests/baselines/reference/templateLiteralTypes1.js
@@ -217,6 +217,7 @@ type BB = AA<-2, -2>;
 // Repro from #40970
 
 type PathKeys<T> =
+    unknown extends T ? never :
     T extends readonly any[] ? Extract<keyof T, `${number}`> | SubKeys<T, Extract<keyof T, `${number}`>> :
     T extends object ? Extract<keyof T, string> | SubKeys<T, Extract<keyof T, string>> :
     never;

--- a/tests/baselines/reference/templateLiteralTypes1.symbols
+++ b/tests/baselines/reference/templateLiteralTypes1.symbols
@@ -878,11 +878,14 @@ type PathKeys<T> =
 >PathKeys : Symbol(PathKeys, Decl(templateLiteralTypes1.ts, 213, 21))
 >T : Symbol(T, Decl(templateLiteralTypes1.ts, 217, 14))
 
+    unknown extends T ? never :
+>T : Symbol(T, Decl(templateLiteralTypes1.ts, 217, 14))
+
     T extends readonly any[] ? Extract<keyof T, `${number}`> | SubKeys<T, Extract<keyof T, `${number}`>> :
 >T : Symbol(T, Decl(templateLiteralTypes1.ts, 217, 14))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
 >T : Symbol(T, Decl(templateLiteralTypes1.ts, 217, 14))
->SubKeys : Symbol(SubKeys, Decl(templateLiteralTypes1.ts, 220, 10))
+>SubKeys : Symbol(SubKeys, Decl(templateLiteralTypes1.ts, 221, 10))
 >T : Symbol(T, Decl(templateLiteralTypes1.ts, 217, 14))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
 >T : Symbol(T, Decl(templateLiteralTypes1.ts, 217, 14))
@@ -891,7 +894,7 @@ type PathKeys<T> =
 >T : Symbol(T, Decl(templateLiteralTypes1.ts, 217, 14))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
 >T : Symbol(T, Decl(templateLiteralTypes1.ts, 217, 14))
->SubKeys : Symbol(SubKeys, Decl(templateLiteralTypes1.ts, 220, 10))
+>SubKeys : Symbol(SubKeys, Decl(templateLiteralTypes1.ts, 221, 10))
 >T : Symbol(T, Decl(templateLiteralTypes1.ts, 217, 14))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
 >T : Symbol(T, Decl(templateLiteralTypes1.ts, 217, 14))
@@ -899,63 +902,63 @@ type PathKeys<T> =
     never;
 
 type SubKeys<T, K extends string> = K extends keyof T ? `${K}.${PathKeys<T[K]>}` : never;
->SubKeys : Symbol(SubKeys, Decl(templateLiteralTypes1.ts, 220, 10))
->T : Symbol(T, Decl(templateLiteralTypes1.ts, 222, 13))
->K : Symbol(K, Decl(templateLiteralTypes1.ts, 222, 15))
->K : Symbol(K, Decl(templateLiteralTypes1.ts, 222, 15))
->T : Symbol(T, Decl(templateLiteralTypes1.ts, 222, 13))
->K : Symbol(K, Decl(templateLiteralTypes1.ts, 222, 15))
+>SubKeys : Symbol(SubKeys, Decl(templateLiteralTypes1.ts, 221, 10))
+>T : Symbol(T, Decl(templateLiteralTypes1.ts, 223, 13))
+>K : Symbol(K, Decl(templateLiteralTypes1.ts, 223, 15))
+>K : Symbol(K, Decl(templateLiteralTypes1.ts, 223, 15))
+>T : Symbol(T, Decl(templateLiteralTypes1.ts, 223, 13))
+>K : Symbol(K, Decl(templateLiteralTypes1.ts, 223, 15))
 >PathKeys : Symbol(PathKeys, Decl(templateLiteralTypes1.ts, 213, 21))
->T : Symbol(T, Decl(templateLiteralTypes1.ts, 222, 13))
->K : Symbol(K, Decl(templateLiteralTypes1.ts, 222, 15))
+>T : Symbol(T, Decl(templateLiteralTypes1.ts, 223, 13))
+>K : Symbol(K, Decl(templateLiteralTypes1.ts, 223, 15))
 
 declare function getProp2<T, P extends PathKeys<T>>(obj: T, path: P): PropType<T, P>;
->getProp2 : Symbol(getProp2, Decl(templateLiteralTypes1.ts, 222, 89))
->T : Symbol(T, Decl(templateLiteralTypes1.ts, 224, 26))
->P : Symbol(P, Decl(templateLiteralTypes1.ts, 224, 28))
+>getProp2 : Symbol(getProp2, Decl(templateLiteralTypes1.ts, 223, 89))
+>T : Symbol(T, Decl(templateLiteralTypes1.ts, 225, 26))
+>P : Symbol(P, Decl(templateLiteralTypes1.ts, 225, 28))
 >PathKeys : Symbol(PathKeys, Decl(templateLiteralTypes1.ts, 213, 21))
->T : Symbol(T, Decl(templateLiteralTypes1.ts, 224, 26))
->obj : Symbol(obj, Decl(templateLiteralTypes1.ts, 224, 52))
->T : Symbol(T, Decl(templateLiteralTypes1.ts, 224, 26))
->path : Symbol(path, Decl(templateLiteralTypes1.ts, 224, 59))
->P : Symbol(P, Decl(templateLiteralTypes1.ts, 224, 28))
+>T : Symbol(T, Decl(templateLiteralTypes1.ts, 225, 26))
+>obj : Symbol(obj, Decl(templateLiteralTypes1.ts, 225, 52))
+>T : Symbol(T, Decl(templateLiteralTypes1.ts, 225, 26))
+>path : Symbol(path, Decl(templateLiteralTypes1.ts, 225, 59))
+>P : Symbol(P, Decl(templateLiteralTypes1.ts, 225, 28))
 >PropType : Symbol(PropType, Decl(templateLiteralTypes1.ts, 138, 69))
->T : Symbol(T, Decl(templateLiteralTypes1.ts, 224, 26))
->P : Symbol(P, Decl(templateLiteralTypes1.ts, 224, 28))
+>T : Symbol(T, Decl(templateLiteralTypes1.ts, 225, 26))
+>P : Symbol(P, Decl(templateLiteralTypes1.ts, 225, 28))
 
 const obj2 = {
->obj2 : Symbol(obj2, Decl(templateLiteralTypes1.ts, 226, 5))
+>obj2 : Symbol(obj2, Decl(templateLiteralTypes1.ts, 227, 5))
 
     name: 'John',
->name : Symbol(name, Decl(templateLiteralTypes1.ts, 226, 14))
+>name : Symbol(name, Decl(templateLiteralTypes1.ts, 227, 14))
 
     age: 42,
->age : Symbol(age, Decl(templateLiteralTypes1.ts, 227, 17))
+>age : Symbol(age, Decl(templateLiteralTypes1.ts, 228, 17))
 
     cars: [
->cars : Symbol(cars, Decl(templateLiteralTypes1.ts, 228, 12))
+>cars : Symbol(cars, Decl(templateLiteralTypes1.ts, 229, 12))
 
         { make: 'Ford', age: 10 },
->make : Symbol(make, Decl(templateLiteralTypes1.ts, 230, 9))
->age : Symbol(age, Decl(templateLiteralTypes1.ts, 230, 23))
+>make : Symbol(make, Decl(templateLiteralTypes1.ts, 231, 9))
+>age : Symbol(age, Decl(templateLiteralTypes1.ts, 231, 23))
 
         { make: 'Trabant', age: 35 }
->make : Symbol(make, Decl(templateLiteralTypes1.ts, 231, 9))
->age : Symbol(age, Decl(templateLiteralTypes1.ts, 231, 26))
+>make : Symbol(make, Decl(templateLiteralTypes1.ts, 232, 9))
+>age : Symbol(age, Decl(templateLiteralTypes1.ts, 232, 26))
 
     ]
 } as const;
 >const : Symbol(const)
 
 let make = getProp2(obj2, 'cars.1.make');  // 'Trabant'
->make : Symbol(make, Decl(templateLiteralTypes1.ts, 235, 3))
->getProp2 : Symbol(getProp2, Decl(templateLiteralTypes1.ts, 222, 89))
->obj2 : Symbol(obj2, Decl(templateLiteralTypes1.ts, 226, 5))
+>make : Symbol(make, Decl(templateLiteralTypes1.ts, 236, 3))
+>getProp2 : Symbol(getProp2, Decl(templateLiteralTypes1.ts, 223, 89))
+>obj2 : Symbol(obj2, Decl(templateLiteralTypes1.ts, 227, 5))
 
 // Repro from #46480
 
 export type Spacing =
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
 
     | `0`
     | `${number}px`
@@ -963,28 +966,28 @@ export type Spacing =
     | `s${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20}`;
 
 const spacing: Spacing = "s12"
->spacing : Symbol(spacing, Decl(templateLiteralTypes1.ts, 245, 5))
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
+>spacing : Symbol(spacing, Decl(templateLiteralTypes1.ts, 246, 5))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
 
 export type SpacingShorthand =
->SpacingShorthand : Symbol(SpacingShorthand, Decl(templateLiteralTypes1.ts, 245, 30))
+>SpacingShorthand : Symbol(SpacingShorthand, Decl(templateLiteralTypes1.ts, 246, 30))
 
     | `${Spacing} ${Spacing}`
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
 
     | `${Spacing} ${Spacing} ${Spacing}`
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
 
     | `${Spacing} ${Spacing} ${Spacing} ${Spacing}`;
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
->Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 235, 41))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
+>Spacing : Symbol(Spacing, Decl(templateLiteralTypes1.ts, 236, 41))
 
 const test1: SpacingShorthand = "0 0 0";
->test1 : Symbol(test1, Decl(templateLiteralTypes1.ts, 252, 5))
->SpacingShorthand : Symbol(SpacingShorthand, Decl(templateLiteralTypes1.ts, 245, 30))
+>test1 : Symbol(test1, Decl(templateLiteralTypes1.ts, 253, 5))
+>SpacingShorthand : Symbol(SpacingShorthand, Decl(templateLiteralTypes1.ts, 246, 30))
 

--- a/tests/baselines/reference/templateLiteralTypes1.types
+++ b/tests/baselines/reference/templateLiteralTypes1.types
@@ -541,6 +541,7 @@ type BB = AA<-2, -2>;
 type PathKeys<T> =
 >PathKeys : PathKeys<T>
 
+    unknown extends T ? never :
     T extends readonly any[] ? Extract<keyof T, `${number}`> | SubKeys<T, Extract<keyof T, `${number}`>> :
     T extends object ? Extract<keyof T, string> | SubKeys<T, Extract<keyof T, string>> :
     never;

--- a/tests/cases/conformance/types/literal/numericStringLiteralTypes.ts
+++ b/tests/cases/conformance/types/literal/numericStringLiteralTypes.ts
@@ -1,0 +1,40 @@
+// @strict: true
+// @declaration: true
+
+type T0 = string & `${string}`;  // string
+type T1 = string & `${number}`;  // `${number}
+type T2 = string & `${bigint}`;  // `${bigint}
+type T3<T extends string> = string & `${T}`;  // `${T}
+type T4<T extends string> = string & `${Capitalize<`${T}`>}`;  // `${Capitalize<T>}`
+
+function f1(a: boolean[], x: `${number}`) {
+    let s = a[x];  // boolean
+}
+
+function f2(a: boolean[], x: number | `${number}`) {
+    let s = a[x];  // boolean
+}
+
+type T10 = boolean[][`${number}`];  // boolean
+type T11 = boolean[][number | `${number}`];  // boolean
+
+type T20<T extends number | `${number}`> = T;
+type T21<T extends unknown[]> = { [K in keyof T]: T20<K> };
+
+type Container<T> = {
+    value: T
+}
+
+type UnwrapContainers<T extends Container<unknown>[]> = { [K in keyof T]: T[K]['value'] };
+
+declare function createContainer<T extends unknown>(value: T): Container<T>;
+
+declare function f<T extends Container<unknown>[]>(containers: [...T], callback: (...values: UnwrapContainers<T>) => void): void;
+
+const container1 = createContainer('hi')
+const container2 = createContainer(2)
+
+f([container1, container2], (value1, value2) => {
+    value1;  // string
+    value2;  // number
+});

--- a/tests/cases/conformance/types/literal/templateLiteralTypes1.ts
+++ b/tests/cases/conformance/types/literal/templateLiteralTypes1.ts
@@ -219,6 +219,7 @@ type BB = AA<-2, -2>;
 // Repro from #40970
 
 type PathKeys<T> =
+    unknown extends T ? never :
     T extends readonly any[] ? Extract<keyof T, `${number}`> | SubKeys<T, Extract<keyof T, `${number}`>> :
     T extends object ? Extract<keyof T, string> | SubKeys<T, Extract<keyof T, string>> :
     never;


### PR DESCRIPTION
TypeScript represents numeric strings using the type `` `${number}` ``. This PR improves support for numeric string types to more accurately reflect that elements of arrays and tuples have numeric string property names. Specifically:

* Numeric index signatures apply when the index type is `${number}`. For example `` `Foo[][`${number}`]`` resolves to `Foo` instead of being an error. This is consistent with our existing rule that index signatures apply when the index type is a numeric string literal. For example `Foo[]['0']` already resolves to `Foo`.
* In a homomorphic mapped type `{ [K in keyof T]: XXX }`, where `T` is constrained to an array or tuple type, `K` has an implied constraint of `` number | `${number}` ``.
* Intersections of type `string` and a template literal type reduce to just the template literal type. For example, `` string & `${number}` `` now reduces to just `` `${number}` ``.

Some examples:

```ts
function f1(a: boolean[], x: `${number}`) {
    let s = a[x];  // boolean
}

function f2(a: boolean[], x: number | `${number}`) {
    let s = a[x];  // boolean
}

type T1 = boolean[][`${number}`];  // boolean
type T2 = boolean[][number | `${number}`];  // boolean

type Container<T> = {
    value: T
}

type UnwrapContainers<T extends Container<unknown>[]> = {
    [K in keyof T]: T[K]['value']  // Ok, but used to be error
};

declare function createContainer<T extends unknown>(value: T): Container<T>;

declare function f<T extends Container<unknown>[]>(containers: [...T], callback: (...values: UnwrapContainers<T>) => void): void;

const container1 = createContainer('hi')
const container2 = createContainer(2)

f([container1, container2], (value1, value2) => {
    value1;  // string
    value2;  // number
});
```

For further context, see discussion in #48599.