### PR TITLE
Instantiate conditional types within contextual type instantiation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27001,7 +27001,7 @@ namespace ts {
                 if (inferenceContext && some(inferenceContext.inferences, hasInferenceCandidates)) {
                     // For contextual signatures we incorporate all inferences made so far, e.g. from return
                     // types as well as arguments to the left in a function call.
-                    if (contextFlags && contextFlags & ContextFlags.Signature) {
+                    if (contextFlags && contextFlags & ContextFlags.Signature || maybeTypeOfKind(contextualType, TypeFlags.Conditional)) {
                         return instantiateInstantiableTypes(contextualType, inferenceContext.nonFixingMapper);
                     }
                     // For other purposes (e.g. determining whether to produce literal types) we only

--- a/tests/baselines/reference/contextualInnerCallFromConditionalContextualType.js
+++ b/tests/baselines/reference/contextualInnerCallFromConditionalContextualType.js
@@ -1,0 +1,49 @@
+//// [contextualInnerCallFromConditionalContextualType.ts]
+interface EventObject { type: string; }
+interface TypegenDisabled { "@@xstate/typegen": false; }
+interface TypegenEnabled { "@@xstate/typegen": true; }
+
+type TypegenConstraint = TypegenEnabled | TypegenDisabled;
+
+interface ActionObject<TEvent extends EventObject> {
+  type: string;
+  _TE?: TEvent;
+}
+
+declare function assign<TEvent extends EventObject>(
+  assignment: (ev: TEvent) => void
+): ActionObject<TEvent>;
+
+declare function createMachine<
+  TTypesMeta extends TypegenConstraint = TypegenDisabled
+>(
+  config: {
+    types?: TTypesMeta;
+  },
+  action?: TTypesMeta extends TypegenEnabled
+    ? { action: ActionObject<{ type: "WITH_TYPEGEN" }> }
+    : { action: ActionObject<{ type: "WITHOUT_TYPEGEN" }> }
+): void;
+
+createMachine(
+  {
+    types: {} as TypegenEnabled,
+  },
+  {
+    action: assign((event) => {
+      event.type // should be 'WITH_TYPEGEN'
+    }),
+  }
+);
+
+
+
+//// [contextualInnerCallFromConditionalContextualType.js]
+"use strict";
+createMachine({
+    types: {}
+}, {
+    action: assign(function (event) {
+        event.type; // should be 'WITH_TYPEGEN'
+    })
+});

--- a/tests/baselines/reference/contextualInnerCallFromConditionalContextualType.symbols
+++ b/tests/baselines/reference/contextualInnerCallFromConditionalContextualType.symbols
@@ -1,0 +1,103 @@
+=== tests/cases/compiler/contextualInnerCallFromConditionalContextualType.ts ===
+interface EventObject { type: string; }
+>EventObject : Symbol(EventObject, Decl(contextualInnerCallFromConditionalContextualType.ts, 0, 0))
+>type : Symbol(EventObject.type, Decl(contextualInnerCallFromConditionalContextualType.ts, 0, 23))
+
+interface TypegenDisabled { "@@xstate/typegen": false; }
+>TypegenDisabled : Symbol(TypegenDisabled, Decl(contextualInnerCallFromConditionalContextualType.ts, 0, 39))
+>"@@xstate/typegen" : Symbol(TypegenDisabled["@@xstate/typegen"], Decl(contextualInnerCallFromConditionalContextualType.ts, 1, 27))
+
+interface TypegenEnabled { "@@xstate/typegen": true; }
+>TypegenEnabled : Symbol(TypegenEnabled, Decl(contextualInnerCallFromConditionalContextualType.ts, 1, 56))
+>"@@xstate/typegen" : Symbol(TypegenEnabled["@@xstate/typegen"], Decl(contextualInnerCallFromConditionalContextualType.ts, 2, 26))
+
+type TypegenConstraint = TypegenEnabled | TypegenDisabled;
+>TypegenConstraint : Symbol(TypegenConstraint, Decl(contextualInnerCallFromConditionalContextualType.ts, 2, 54))
+>TypegenEnabled : Symbol(TypegenEnabled, Decl(contextualInnerCallFromConditionalContextualType.ts, 1, 56))
+>TypegenDisabled : Symbol(TypegenDisabled, Decl(contextualInnerCallFromConditionalContextualType.ts, 0, 39))
+
+interface ActionObject<TEvent extends EventObject> {
+>ActionObject : Symbol(ActionObject, Decl(contextualInnerCallFromConditionalContextualType.ts, 4, 58))
+>TEvent : Symbol(TEvent, Decl(contextualInnerCallFromConditionalContextualType.ts, 6, 23))
+>EventObject : Symbol(EventObject, Decl(contextualInnerCallFromConditionalContextualType.ts, 0, 0))
+
+  type: string;
+>type : Symbol(ActionObject.type, Decl(contextualInnerCallFromConditionalContextualType.ts, 6, 52))
+
+  _TE?: TEvent;
+>_TE : Symbol(ActionObject._TE, Decl(contextualInnerCallFromConditionalContextualType.ts, 7, 15))
+>TEvent : Symbol(TEvent, Decl(contextualInnerCallFromConditionalContextualType.ts, 6, 23))
+}
+
+declare function assign<TEvent extends EventObject>(
+>assign : Symbol(assign, Decl(contextualInnerCallFromConditionalContextualType.ts, 9, 1))
+>TEvent : Symbol(TEvent, Decl(contextualInnerCallFromConditionalContextualType.ts, 11, 24))
+>EventObject : Symbol(EventObject, Decl(contextualInnerCallFromConditionalContextualType.ts, 0, 0))
+
+  assignment: (ev: TEvent) => void
+>assignment : Symbol(assignment, Decl(contextualInnerCallFromConditionalContextualType.ts, 11, 52))
+>ev : Symbol(ev, Decl(contextualInnerCallFromConditionalContextualType.ts, 12, 15))
+>TEvent : Symbol(TEvent, Decl(contextualInnerCallFromConditionalContextualType.ts, 11, 24))
+
+): ActionObject<TEvent>;
+>ActionObject : Symbol(ActionObject, Decl(contextualInnerCallFromConditionalContextualType.ts, 4, 58))
+>TEvent : Symbol(TEvent, Decl(contextualInnerCallFromConditionalContextualType.ts, 11, 24))
+
+declare function createMachine<
+>createMachine : Symbol(createMachine, Decl(contextualInnerCallFromConditionalContextualType.ts, 13, 24))
+
+  TTypesMeta extends TypegenConstraint = TypegenDisabled
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextualInnerCallFromConditionalContextualType.ts, 15, 31))
+>TypegenConstraint : Symbol(TypegenConstraint, Decl(contextualInnerCallFromConditionalContextualType.ts, 2, 54))
+>TypegenDisabled : Symbol(TypegenDisabled, Decl(contextualInnerCallFromConditionalContextualType.ts, 0, 39))
+
+>(
+  config: {
+>config : Symbol(config, Decl(contextualInnerCallFromConditionalContextualType.ts, 17, 2))
+
+    types?: TTypesMeta;
+>types : Symbol(types, Decl(contextualInnerCallFromConditionalContextualType.ts, 18, 11))
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextualInnerCallFromConditionalContextualType.ts, 15, 31))
+
+  },
+  action?: TTypesMeta extends TypegenEnabled
+>action : Symbol(action, Decl(contextualInnerCallFromConditionalContextualType.ts, 20, 4))
+>TTypesMeta : Symbol(TTypesMeta, Decl(contextualInnerCallFromConditionalContextualType.ts, 15, 31))
+>TypegenEnabled : Symbol(TypegenEnabled, Decl(contextualInnerCallFromConditionalContextualType.ts, 1, 56))
+
+    ? { action: ActionObject<{ type: "WITH_TYPEGEN" }> }
+>action : Symbol(action, Decl(contextualInnerCallFromConditionalContextualType.ts, 22, 7))
+>ActionObject : Symbol(ActionObject, Decl(contextualInnerCallFromConditionalContextualType.ts, 4, 58))
+>type : Symbol(type, Decl(contextualInnerCallFromConditionalContextualType.ts, 22, 30))
+
+    : { action: ActionObject<{ type: "WITHOUT_TYPEGEN" }> }
+>action : Symbol(action, Decl(contextualInnerCallFromConditionalContextualType.ts, 23, 7))
+>ActionObject : Symbol(ActionObject, Decl(contextualInnerCallFromConditionalContextualType.ts, 4, 58))
+>type : Symbol(type, Decl(contextualInnerCallFromConditionalContextualType.ts, 23, 30))
+
+): void;
+
+createMachine(
+>createMachine : Symbol(createMachine, Decl(contextualInnerCallFromConditionalContextualType.ts, 13, 24))
+  {
+    types: {} as TypegenEnabled,
+>types : Symbol(types, Decl(contextualInnerCallFromConditionalContextualType.ts, 27, 3))
+>TypegenEnabled : Symbol(TypegenEnabled, Decl(contextualInnerCallFromConditionalContextualType.ts, 1, 56))
+
+  },
+  {
+    action: assign((event) => {
+>action : Symbol(action, Decl(contextualInnerCallFromConditionalContextualType.ts, 30, 3))
+>assign : Symbol(assign, Decl(contextualInnerCallFromConditionalContextualType.ts, 9, 1))
+>event : Symbol(event, Decl(contextualInnerCallFromConditionalContextualType.ts, 31, 20))
+
+      event.type // should be 'WITH_TYPEGEN'
+>event.type : Symbol(type, Decl(contextualInnerCallFromConditionalContextualType.ts, 22, 30))
+>event : Symbol(event, Decl(contextualInnerCallFromConditionalContextualType.ts, 31, 20))
+>type : Symbol(type, Decl(contextualInnerCallFromConditionalContextualType.ts, 22, 30))
+
+    }),
+  }
+);
+
+

--- a/tests/baselines/reference/contextualInnerCallFromConditionalContextualType.types
+++ b/tests/baselines/reference/contextualInnerCallFromConditionalContextualType.types
@@ -1,0 +1,89 @@
+=== tests/cases/compiler/contextualInnerCallFromConditionalContextualType.ts ===
+interface EventObject { type: string; }
+>type : string
+
+interface TypegenDisabled { "@@xstate/typegen": false; }
+>"@@xstate/typegen" : false
+>false : false
+
+interface TypegenEnabled { "@@xstate/typegen": true; }
+>"@@xstate/typegen" : true
+>true : true
+
+type TypegenConstraint = TypegenEnabled | TypegenDisabled;
+>TypegenConstraint : TypegenDisabled | TypegenEnabled
+
+interface ActionObject<TEvent extends EventObject> {
+  type: string;
+>type : string
+
+  _TE?: TEvent;
+>_TE : TEvent | undefined
+}
+
+declare function assign<TEvent extends EventObject>(
+>assign : <TEvent extends EventObject>(assignment: (ev: TEvent) => void) => ActionObject<TEvent>
+
+  assignment: (ev: TEvent) => void
+>assignment : (ev: TEvent) => void
+>ev : TEvent
+
+): ActionObject<TEvent>;
+
+declare function createMachine<
+>createMachine : <TTypesMeta extends TypegenConstraint = TypegenDisabled>(config: {    types?: TTypesMeta;}, action?: TTypesMeta extends TypegenEnabled ? {    action: ActionObject<{        type: "WITH_TYPEGEN";    }>;} : {    action: ActionObject<{        type: "WITHOUT_TYPEGEN";    }>;}) => void
+
+  TTypesMeta extends TypegenConstraint = TypegenDisabled
+>(
+  config: {
+>config : { types?: TTypesMeta | undefined; }
+
+    types?: TTypesMeta;
+>types : TTypesMeta | undefined
+
+  },
+  action?: TTypesMeta extends TypegenEnabled
+>action : (TTypesMeta extends TypegenEnabled ? { action: ActionObject<{    type: "WITH_TYPEGEN";}>; } : { action: ActionObject<{    type: "WITHOUT_TYPEGEN";}>; }) | undefined
+
+    ? { action: ActionObject<{ type: "WITH_TYPEGEN" }> }
+>action : ActionObject<{ type: "WITH_TYPEGEN"; }>
+>type : "WITH_TYPEGEN"
+
+    : { action: ActionObject<{ type: "WITHOUT_TYPEGEN" }> }
+>action : ActionObject<{ type: "WITHOUT_TYPEGEN"; }>
+>type : "WITHOUT_TYPEGEN"
+
+): void;
+
+createMachine(
+>createMachine(  {    types: {} as TypegenEnabled,  },  {    action: assign((event) => {      event.type // should be 'WITH_TYPEGEN'    }),  }) : void
+>createMachine : <TTypesMeta extends TypegenConstraint = TypegenDisabled>(config: { types?: TTypesMeta | undefined; }, action?: (TTypesMeta extends TypegenEnabled ? { action: ActionObject<{ type: "WITH_TYPEGEN"; }>; } : { action: ActionObject<{ type: "WITHOUT_TYPEGEN"; }>; }) | undefined) => void
+  {
+>{    types: {} as TypegenEnabled,  } : { types: TypegenEnabled; }
+
+    types: {} as TypegenEnabled,
+>types : TypegenEnabled
+>{} as TypegenEnabled : TypegenEnabled
+>{} : {}
+
+  },
+  {
+>{    action: assign((event) => {      event.type // should be 'WITH_TYPEGEN'    }),  } : { action: ActionObject<{ type: "WITH_TYPEGEN"; }>; }
+
+    action: assign((event) => {
+>action : ActionObject<{ type: "WITH_TYPEGEN"; }>
+>assign((event) => {      event.type // should be 'WITH_TYPEGEN'    }) : ActionObject<{ type: "WITH_TYPEGEN"; }>
+>assign : <TEvent extends EventObject>(assignment: (ev: TEvent) => void) => ActionObject<TEvent>
+>(event) => {      event.type // should be 'WITH_TYPEGEN'    } : (event: { type: "WITH_TYPEGEN"; }) => void
+>event : { type: "WITH_TYPEGEN"; }
+
+      event.type // should be 'WITH_TYPEGEN'
+>event.type : "WITH_TYPEGEN"
+>event : { type: "WITH_TYPEGEN"; }
+>type : "WITH_TYPEGEN"
+
+    }),
+  }
+);
+
+

--- a/tests/cases/compiler/contextualInnerCallFromConditionalContextualType.ts
+++ b/tests/cases/compiler/contextualInnerCallFromConditionalContextualType.ts
@@ -1,0 +1,39 @@
+// @strict: true
+
+interface EventObject { type: string; }
+interface TypegenDisabled { "@@xstate/typegen": false; }
+interface TypegenEnabled { "@@xstate/typegen": true; }
+
+type TypegenConstraint = TypegenEnabled | TypegenDisabled;
+
+interface ActionObject<TEvent extends EventObject> {
+  type: string;
+  _TE?: TEvent;
+}
+
+declare function assign<TEvent extends EventObject>(
+  assignment: (ev: TEvent) => void
+): ActionObject<TEvent>;
+
+declare function createMachine<
+  TTypesMeta extends TypegenConstraint = TypegenDisabled
+>(
+  config: {
+    types?: TTypesMeta;
+  },
+  action?: TTypesMeta extends TypegenEnabled
+    ? { action: ActionObject<{ type: "WITH_TYPEGEN" }> }
+    : { action: ActionObject<{ type: "WITHOUT_TYPEGEN" }> }
+): void;
+
+createMachine(
+  {
+    types: {} as TypegenEnabled,
+  },
+  {
+    action: assign((event) => {
+      event.type // should be 'WITH_TYPEGEN'
+    }),
+  }
+);
+


### PR DESCRIPTION
Fixes #46201
Highly related to #48823

The problem was that in this case, even though there were some inference candidates here, the conditional type was not instantiated "soon enough". It was especially surprising to me, as a user, as changing the position of this conditional type was fixing the issue:
```diff
   assignment: (ev: TEvent) => void
 ): ActionObject<TEvent>;
 
+type NoOp<T> = { [K in keyof T]: T[K] };
+
 declare function createMachine<
   TTypesMeta extends TypegenConstraint = TypegenDisabled
 >(
   config: {
     types?: TTypesMeta;
   },
-  action?: TTypesMeta extends TypegenEnabled
-    ? { action: ActionObject<{ type: 'WITH_TYPEGEN' }> }
-    : { action: ActionObject<{ type: 'WITHOUT_TYPEGEN' }> }
+  action?: {
+    action: TTypesMeta extends TypegenEnabled
+      ? ActionObject<{ type: "WITH_TYPEGEN" }>
+      : ActionObject<{ type: "WITHOUT_TYPEGEN" }>;
+  >
 ): void;
```

You can checkout the playground with both variants [here](https://www.typescriptlang.org/play?ts=4.6.2#code/JYOwLgpgTgZghgYwgAgKIDcLgPICMBWECYyA3gFDLJgCeADhAFzIDOYUoA5gNzkC+5cqEixEKACr0InLABFgLOLgA2EACZlKyAEQABXQA82cSAHpaDGSG3N4ylhF4Dh0eEmSTLWVCCWqNFFR6hsZmFtJYNtRQAK6O-ILhHlJWAMIA9iBsUHDCyAC8yV4gPn7qyAA+RREg8ooq6rxC4K5iyACCxMCZeITEADziGFgkEAaQIGosaJg4BERgAHyaVOHM2Vy8VAD6QwD8zEOzYE6CakTKcFAoMDEgXZnIcCwswJwgg8PgyGMTUzMjXoLRYACi0z1e7wAtiNmCCIOhDl8wABKArLdDpYBqcgo5idMDdEBAgZHEaLJrnBCXa7IW73QmPBDXEwQACyiAAFqAIP0tOJPBAWGyIGA4D9xlh-oK0plsrlvoUZXIFGUcaCtAhMjA3sxAlRqFIWAcPILhaK4FtkHwADTgh4gE0Co0isUSv7TZUlXwNHEG5B7MhPB34h0ksD9UiGhjMbQAdQAkuIABK7ACaAAVUABxVAAOW01uWAn9euDjJAoYr4cj0aYOkTKewAFVxOms7mC0XrbjmJjsU1mRBWRyENyQBAwVR9asjXq+E9PSlvD7-HaqLatDPkKZTMgAAaICv75B0KDpBhQWjIBTIdIwJ7ILVQa7EOvIAC0N9GBgYxGm+4EkSNZRmsDZJqm4iZjm+aFnwxb7loVBHkSzAQm8IAgvCxxovkyzblQu7ILgMQkGAnIoEk97UNyAHoe8J6cs8xEQFgN4gDA0DXBoYDpAeQE9PMAygVIsaNsmLZtlBHawdalRBmB8YQe2MFdvBiH+oRe4sHx+4IiMjHQCgt7UUk+4iTG4FNq2KmdnB8kWfWSkprZsl8BpmlYdsiBIHQYBicp0mqdouH4XwKLYSMAB04QolaG4ouuPZxWcFxXDcdwOk+LKQKO44QAATHyVDOgw5pur8UpLsUGRZOwCokEqy61KqvrkBqVBahxuorAa4TGocZqupaWibshDomtuRHACQADu6RQAA1tMz6vmAyg0DeD6zSgY5EItNEoPupVCsNJ63FeFFQMgajpLNICHcg55wH6BooZkg0uha7pVdUVilG1mkBh0YZCRGjkBS5QV2UWSEGlWwFg7WiniZJrlqRSo29sg-ZqIOOXslyPIFVOvWzmV86Ln9K5qklY1k+WqGLpCmGReAoUM1QXk+RAfmQ5B0F2RzpDhWzYAxVIKX+uFdO4rwQA).

So how both of those cases were different?

The working variant was able to retrieve the `contextualType` within `inferTypeArguments` as:
```ts
TTypesMeta extends TypegenEnabled ? ActionObject<{ type: "WITH_TYPEGEN"; }> : ActionObject<{ type: "WITHOUT_TYPEGEN"; }>
```
Where within `getContextualTypeForObjectLiteralElement`  the `getApparentTypeOfContextualType` was returning:
```ts
{ action: TTypesMeta extends TypegenEnabled ? ActionObject<{ type: "WITH_TYPEGEN"; }> : ActionObject<{ type: "WITHOUT_TYPEGEN"; }>; } | undefined
```
and from that type a type for the `action` property was unpackages by `getTypeOfPropertyOfContextualType`. So a conditional type itself, as a type for this property, was returned to `inferTypeArguments` and it was simply instantiated using `instantiateType(contextualType, outerMapper)`, so the correct type was computed just fine here.

The problem with the broken variant was that the conditional type wasn't instantiated in `getApparentTypeOfContextualType` (while the `contextualType` there was this conditional type) and it was passed to `mapType(instantiatedType, getApparentType, true)`. This converted the conditional type to a union of its branches:
```ts
{ action: ActionObject<{ type: "WITH_TYPEGEN"; }>; } | { action: ActionObject<{ type: "WITHOUT_TYPEGEN"; }>; } | undefined
```

This has lost the relation between the condition and those union members.

So my idea is that we could just instantiate conditional types early to avoid such situations because if we can evaluate the condition it should always be better to focus on the resulting branch than to unionize both of them.