### PR TITLE
fix(48851): Document highlights on 'in' in mapped type causes debug failure 

### DIFF
--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -93,6 +93,8 @@ namespace ts {
                     return highlightSpans(getAsyncAndAwaitOccurrences(node));
                 case SyntaxKind.YieldKeyword:
                     return highlightSpans(getYieldOccurrences(node));
+                case SyntaxKind.InKeyword:
+                    return undefined;
                 default:
                     return isModifierKind(node.kind) && (isDeclaration(node.parent) || isVariableStatement(node.parent))
                         ? highlightSpans(getModifierOccurrences(node.kind, node.parent))

--- a/tests/cases/fourslash/documentHighlightInKeyword.ts
+++ b/tests/cases/fourslash/documentHighlightInKeyword.ts
@@ -1,0 +1,13 @@
+﻿/// <reference path='fourslash.ts'/>
+
+////export type Foo<T> = {
+////    [K [|in|] keyof T]: any;
+////}
+////
+////"a" [|in|] {};
+////
+////for (let a [|in|] {}) {}
+
+for (let range of test.ranges()) {
+    verify.noDocumentHighlights(range);
+}


### PR DESCRIPTION
Fixes #48851