### PR TITLE
Stop tag after @callback from crashing

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -8579,7 +8579,8 @@ namespace ts {
                     if (!comment) {
                         comment = parseTrailingTagComments(start, getNodePos(), indent, indentText);
                     }
-                    return finishNode(factory.createJSDocCallbackTag(tagName, typeExpression, fullName, comment), start);
+                    const end = comment !== undefined ? getNodePos() : typeExpression.end;
+                    return finishNode(factory.createJSDocCallbackTag(tagName, typeExpression, fullName, comment), start, end);
                 }
 
                 function escapedTextsEqual(a: EntityName, b: EntityName): boolean {

--- a/tests/cases/fourslash/jsTagAfterCallback1.ts
+++ b/tests/cases/fourslash/jsTagAfterCallback1.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+// @Filename: foo.js
+// @allowJs: true
+// @checkJs: true
+//// /** @callback Listener @yeturn {ListenerBlock} */
+//// /**
+////  * The function used
+////  * /*1*/ settings
+////  */
+//// class /*2*/ListenerBlock {
+//// }
+
+// Force a syntax tree to be created.
+verify.noMatchingBracePositionInCurrentFile(0);
+
+goTo.marker('1');
+edit.insert('fenster');
+
+verify.quickInfoAt('2', 'class ListenerBlock', 'The function used\nfenster settings')

--- a/tests/cases/fourslash/jsTagAfterCallback2.ts
+++ b/tests/cases/fourslash/jsTagAfterCallback2.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+// @Filename: foo.js
+// @allowJs: true
+// @checkJs: true
+//// /** @callback Listener @param x @yeturn {ListenerBlock} */
+//// /**
+////  * The function used
+////  * /*1*/ settings
+////  */
+//// class /*2*/ListenerBlock {
+//// }
+
+// Force a syntax tree to be created.
+verify.noMatchingBracePositionInCurrentFile(0);
+
+goTo.marker('1');
+edit.insert('fenster');
+
+verify.quickInfoAt('2', 'class ListenerBlock', 'The function used\nfenster settings')

--- a/tests/cases/fourslash/jsTagAfterTypedef1.ts
+++ b/tests/cases/fourslash/jsTagAfterTypedef1.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+// @Filename: foo.js
+// @allowJs: true
+// @checkJs: true
+//// /** @typedef Lister @property p @yeturn {ListenerBlock} */
+//// /**
+////  * The function used
+////  * /*1*/ settings
+////  */
+//// class /*2*/ListenerBlock {
+//// }
+
+// Force a syntax tree to be created.
+verify.noMatchingBracePositionInCurrentFile(0);
+
+goTo.marker('1');
+edit.insert('fenster');
+
+verify.quickInfoAt('2', 'class ListenerBlock', 'The function used\nfenster settings')


### PR DESCRIPTION
By copying the kludge in @typedef. @callback's order is simpler, so the kludge is simpler. However, it's wrong here, and in @typedef. Parsing tag comments is normally supposed to happen at the end of a tag, but in @callback and @typedef happens *before* parsing the nested @param/@property tags.

I still need to figure out what a real fix is -- but for the beta, copying the existing crash-avoidance kludge from @typedef is best anyway. I added a test case for typedefs for future use as well.

Fixes #48327