### PR TITLE
fix(48887) exposing rest helper functions externally

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2866,16 +2866,6 @@ namespace ts {
         return typeParameters && find(typeParameters, p => p.name.escapedText === name);
     }
 
-    export function hasRestParameter(s: SignatureDeclaration | JSDocSignature): boolean {
-        const last = lastOrUndefined<ParameterDeclaration | JSDocParameterTag>(s.parameters);
-        return !!last && isRestParameter(last);
-    }
-
-    export function isRestParameter(node: ParameterDeclaration | JSDocParameterTag): boolean {
-        const type = isJSDocParameterTag(node) ? (node.typeExpression && node.typeExpression.type) : node.type;
-        return (node as ParameterDeclaration).dotDotDotToken !== undefined || !!type && type.kind === SyntaxKind.JSDocVariadicType;
-    }
-
     export function hasTypeArguments(node: Node): node is HasTypeArguments {
         return !!(node as HasTypeArguments).typeArguments;
     }

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -2015,5 +2015,16 @@ namespace ts {
     export function isJSDocLinkLike(node: Node): node is JSDocLink | JSDocLinkCode | JSDocLinkPlain {
         return node.kind === SyntaxKind.JSDocLink || node.kind === SyntaxKind.JSDocLinkCode || node.kind === SyntaxKind.JSDocLinkPlain;
     }
+
+    export function hasRestParameter(s: SignatureDeclaration | JSDocSignature): boolean {
+        const last = lastOrUndefined<ParameterDeclaration | JSDocParameterTag>(s.parameters);
+        return !!last && isRestParameter(last);
+    }
+
+    export function isRestParameter(node: ParameterDeclaration | JSDocParameterTag): boolean {
+        const type = isJSDocParameterTag(node) ? (node.typeExpression && node.typeExpression.type) : node.type;
+        return (node as ParameterDeclaration).dotDotDotToken !== undefined || !!type && type.kind === SyntaxKind.JSDocVariadicType;
+    }
+
     // #endregion
 }

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -1407,7 +1407,7 @@ namespace Harness {
         }
 
         function getBaselineFileChangedErrorMessage(relativeFileName: string): string {
-            return `The baseline file ${relativeFileName} has changed. (You must run "gulp baseline-accept" to confirm that this baseline change as a result of your code change was intended.)`;
+            return `The baseline file ${relativeFileName} has changed. (Run "gulp baseline-accept" if the new baseline is correct.)`;
         }
 
         export function runBaseline(relativeFileName: string, actual: string | null, opts?: BaselineOptions): void {

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -1389,20 +1389,25 @@ namespace Harness {
                 else {
                     IO.writeFile(actualFileName, encodedActual);
                 }
+                const errorMessage = getBaselineFileChangedErrorMessage(relativeFileName);
                 if (!!require && opts && opts.PrintDiff) {
                     const Diff = require("diff");
                     const patch = Diff.createTwoFilesPatch("Expected", "Actual", expected, actual, "The current baseline", "The new version");
-                    throw new Error(`The baseline file ${relativeFileName} has changed.${ts.ForegroundColorEscapeSequences.Grey}\n\n${patch}`);
+                    throw new Error(`${errorMessage}${ts.ForegroundColorEscapeSequences.Grey}\n\n${patch}`);
                 }
                 else {
                     if (!IO.fileExists(expected)) {
                         throw new Error(`New baseline created at ${IO.joinPath("tests", "baselines","local", relativeFileName)}`);
                     }
                     else {
-                        throw new Error(`The baseline file ${relativeFileName} has changed.`);
+                        throw new Error(errorMessage);
                     }
                 }
             }
+        }
+
+        function getBaselineFileChangedErrorMessage(relativeFileName: string): string {
+            return `The baseline file ${relativeFileName} has changed. (You must run "gulp baseline-accept" to confirm that this baseline change as a result of your code change was intended.)`;
         }
 
         export function runBaseline(relativeFileName: string, actual: string | null, opts?: BaselineOptions): void {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4510,6 +4510,8 @@ declare namespace ts {
     function isObjectLiteralElement(node: Node): node is ObjectLiteralElement;
     function isStringLiteralLike(node: Node): node is StringLiteralLike;
     function isJSDocLinkLike(node: Node): node is JSDocLink | JSDocLinkCode | JSDocLinkPlain;
+    function hasRestParameter(s: SignatureDeclaration | JSDocSignature): boolean;
+    function isRestParameter(node: ParameterDeclaration | JSDocParameterTag): boolean;
 }
 declare namespace ts {
     const factory: NodeFactory;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4510,6 +4510,8 @@ declare namespace ts {
     function isObjectLiteralElement(node: Node): node is ObjectLiteralElement;
     function isStringLiteralLike(node: Node): node is StringLiteralLike;
     function isJSDocLinkLike(node: Node): node is JSDocLink | JSDocLinkCode | JSDocLinkPlain;
+    function hasRestParameter(s: SignatureDeclaration | JSDocSignature): boolean;
+    function isRestParameter(node: ParameterDeclaration | JSDocParameterTag): boolean;
 }
 declare namespace ts {
     const factory: NodeFactory;


### PR DESCRIPTION
Fixes #48887.

Also, as a tiny other change, this improves the obscure/confusing error message about baselines, adding a hint for the end-user to run the appropriate gulp command. In order to avoid duplicating the hint, I added a new function to generate the string, which makes the code slightly more DRY.