### PR TITLE
fix(48907): Fix first parameter's type of `JSON.parse`, and fix jsdoc.

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1087,11 +1087,11 @@ declare var URIError: URIErrorConstructor;
 interface JSON {
     /**
      * Converts a JavaScript Object Notation (JSON) string into an object.
-     * @param text A valid JSON string.
+     * @param text A valid JSON string, or can be converted to a valid JSON string.
      * @param reviver A function that transforms the results. This function is called for each member of the object.
      * If a member contains nested objects, the nested objects are transformed before the parent object is.
      */
-    parse(text: string, reviver?: (this: any, key: string, value: any) => any): any;
+    parse(text: any, reviver?: (this: any, key: string, value: any) => any): any;
     /**
      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
      * @param value A JavaScript value, usually an object or array, to be converted.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #48907
