### PR TITLE
Fix formatter's processChildNodes

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -778,6 +778,13 @@ namespace ts.formatting {
 
                 let listDynamicIndentation = parentDynamicIndentation;
                 let startLine = parentStartLine;
+                // node range is outside the target range - do not dive inside
+                if (!rangeOverlapsWithStartEnd(originalRange, nodes.pos, nodes.end)) {
+                    if (nodes.end < originalRange.pos) {
+                        formattingScanner.skipToEndOf(nodes);
+                    }
+                    return;
+                }
 
                 if (listStartToken !== SyntaxKind.Unknown) {
                     // introduce a new indentation scope for lists (including list start and end tokens)

--- a/src/services/formatting/formattingScanner.ts
+++ b/src/services/formatting/formattingScanner.ts
@@ -12,7 +12,7 @@ namespace ts.formatting {
         readEOFTokenRange(): TextRangeWithKind;
         getCurrentLeadingTrivia(): TextRangeWithKind[] | undefined;
         lastTrailingTriviaWasNewLine(): boolean;
-        skipToEndOf(node: Node): void;
+        skipToEndOf(node: Node | NodeArray<Node>): void;
         skipToStartOf(node: Node): void;
     }
 
@@ -286,7 +286,7 @@ namespace ts.formatting {
             return tokenInfo;
         }
 
-        function skipToEndOf(node: Node): void {
+        function skipToEndOf(node: Node | NodeArray<Node>): void {
             scanner.setTextPos(node.end);
             savedPos = scanner.getStartPos();
             lastScanAction = undefined;

--- a/tests/cases/fourslash/formatAfterPasteInString.ts
+++ b/tests/cases/fourslash/formatAfterPasteInString.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+
+//// /*2*/const x = f('aa/*1*/a').x()
+
+goTo.marker('1');
+edit.paste("bb");
+format.document();
+goTo.marker('2');
+verify.currentLineContentIs("const x = f('aabba').x()");


### PR DESCRIPTION
processChildNodes needs to skip processing when the node array is outside the target range, just like processChildNode already does for a single node.

The new code is copied from processChildNode and `skipToEndOf` changes to allow `Node | NodeArray`.

Fixes #48006