### PR TITLE
Don’t let other completions shadow type keywords in type locations

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -552,7 +552,7 @@ namespace ts.Completions {
         if (keywordFilters !== KeywordCompletionFilters.None) {
             const entryNames = new Set(entries.map(e => e.name));
             for (const keywordEntry of getKeywordCompletions(keywordFilters, !insideJsDocTagTypeExpression && isSourceFileJS(sourceFile))) {
-                if (isTypeKeyword(stringToToken(keywordEntry.name)!) || !entryNames.has(keywordEntry.name)) {
+                if (isTypeOnlyLocation && isTypeKeyword(stringToToken(keywordEntry.name)!) || !entryNames.has(keywordEntry.name)) {
                     insertSorted(entries, keywordEntry, compareCompletionEntries, /*allowDuplicates*/ true);
                 }
             }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -164,7 +164,7 @@ namespace ts.Completions {
         TypeAssertionKeywords,
         TypeKeywords,
         TypeKeyword,                    // Literally just `type`
-        Last = TypeKeywords
+        Last = TypeKeyword
     }
 
     const enum GlobalsSearch { Continue, Success, Fail }
@@ -552,7 +552,7 @@ namespace ts.Completions {
         if (keywordFilters !== KeywordCompletionFilters.None) {
             const entryNames = new Set(entries.map(e => e.name));
             for (const keywordEntry of getKeywordCompletions(keywordFilters, !insideJsDocTagTypeExpression && isSourceFileJS(sourceFile))) {
-                if (!entryNames.has(keywordEntry.name)) {
+                if (isTypeKeyword(stringToToken(keywordEntry.name)!) || !entryNames.has(keywordEntry.name)) {
                     insertSorted(entries, keywordEntry, compareCompletionEntries, /*allowDuplicates*/ true);
                 }
             }

--- a/tests/cases/fourslash/server/autoImportProvider_namespaceSameNameAsIntrinsic.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_namespaceSameNameAsIntrinsic.ts
@@ -1,0 +1,39 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /node_modules/fp-ts/package.json
+//// { "name": "fp-ts", "version": "0.10.4" }
+
+// @Filename: /node_modules/fp-ts/index.d.ts
+//// export * as string from "./lib/string";
+
+// @Filename: /node_modules/fp-ts/lib/string.d.ts
+//// export declare const fromString: (s: string) => string;
+//// export type SafeString = string;
+
+// @Filename: /package.json
+//// { "dependencies": { "fp-ts": "^0.10.4" } }
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "commonjs" } }
+
+// @Filename: /index.ts
+//// type A = { name: string/**/ }
+
+goTo.marker("");
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "string",
+    sortText: completion.SortText.GlobalsOrKeywords,
+  }, {
+    name: "string",
+    sortText: completion.SortText.AutoImportSuggestions,
+    source: "fp-ts",
+    sourceDisplay: "fp-ts",
+    hasAction: true,
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+  },
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #48075

As part of this fix, I started to implement a lot more keyword filtering than we currently do (type keywords are normally offered in value locations 🤦‍♂️), but stopped when it became clear that it was going to be a significant change late in the release cycle. I hope to pick that back up for 4.8.