### PR TITLE
testing package.json and impliedNodeFormat

### DIFF
--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -148,6 +148,7 @@ namespace ts {
         /*@internal*/ buildNextInvalidatedProject(): void;
         /*@internal*/ getAllParsedConfigs(): readonly ParsedCommandLine[];
         /*@internal*/ close(): void;
+        /*@internal*/ getModuleResolutionCache(): ModuleResolutionCache | undefined;
     }
 
     /**
@@ -1992,6 +1993,7 @@ namespace ts {
                 config => isParsedCommandLine(config) ? config : undefined
             )),
             close: () => stopWatching(state),
+            getModuleResolutionCache: ()=> state.moduleResolutionCache,
         };
     }
 

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -147,6 +147,7 @@
         "unittests/tsbuildWatch/noEmitOnError.ts",
         "unittests/tsbuildWatch/programUpdates.ts",
         "unittests/tsbuildWatch/publicApi.ts",
+        "unittests/tsbuildWatch/publicApiImpliedNodeFormat.ts",
         "unittests/tsbuildWatch/reexport.ts",
         "unittests/tsbuildWatch/watchEnvironment.ts",
         "unittests/tsc/composite.ts",

--- a/src/testRunner/unittests/tsbuildWatch/publicApiImpliedNodeFormat.ts
+++ b/src/testRunner/unittests/tsbuildWatch/publicApiImpliedNodeFormat.ts
@@ -1,0 +1,161 @@
+namespace ts.tscWatch {
+    it("unittests:: tsbuildWatch:: watchMode:: Public API with custom transformers / impliedNodeFormat", () => {
+        const solution: File = {
+            path: `${projectRoot}/tsconfig.json`,
+            content: JSON.stringify({
+                references: [
+                    { path: "./shared/tsconfig.json" },
+                    { path: "./webpack/tsconfig.json" }
+                ],
+                files: []
+            })
+        };
+        const sharedConfig: File = {
+            path: `${projectRoot}/shared/tsconfig.json`,
+            content: JSON.stringify({
+                module:"Node12",
+                compilerOptions: { composite: true },
+            })
+        };
+        const sharedPackageJson: File = {
+            path: `${projectRoot}/shared/package.json`,
+            content: JSON.stringify({
+                name:"shared",
+                version:"1.0.0",
+                type:"commonjs",
+            })
+        };
+        const sharedIndex: File = {
+            path: `${projectRoot}/shared/index.ts`,
+            content: `export function f1() { }
+export class c { }
+export enum e { }
+// leading
+export function f2() { } // trailing`
+        };
+        const webpackConfig: File = {
+            path: `${projectRoot}/webpack/tsconfig.json`,
+            content: JSON.stringify({
+                compilerOptions: { composite: true, },
+                references: [{ path: "../shared/tsconfig.json" }]
+            })
+        };
+        const webpackIndex: File = {
+            path: `${projectRoot}/webpack/index.ts`,
+            content: `export function f2() { }
+export class c2 { }
+export enum e2 { }
+// leading
+export function f22() { } // trailing`
+        };
+        const commandLineArgs = ["--b", "--w", /*"--verbose"*/];
+        const { sys, baseline, oldSnap, cb, getPrograms } = createBaseline(createWatchedSystem([libFile, solution, sharedConfig, sharedPackageJson, sharedIndex, webpackConfig, webpackIndex], { currentDirectory: projectRoot }));
+
+        const writeToConsole = true;
+        if (writeToConsole){
+            const origSysWrite = sys.write.bind(sys);
+            sys.write = (message: string)=>{
+                console.log(message);
+                origSysWrite(message);
+            };
+        }
+        type ImpliedNodeFormat = ModuleKind.CommonJS | ModuleKind.ESNext | undefined;
+        const impliedNodeFormatToString = (f: ImpliedNodeFormat)=>(f===undefined)? "undefined" : ModuleKind[f];
+        const lastImpliedNodeFormats = new Map<string,{impliedNodeFormat: ImpliedNodeFormat /*, gotImpledNodeFormat: ImpliedNodeFormat*/}>();
+        function printLastImpliedNodeFormats(){
+            lastImpliedNodeFormats.forEach((x,fileName)=>{
+                sys.write(`fileName:${fileName},impliedNodeFormat:${impliedNodeFormatToString(x.impliedNodeFormat)}`+sys.newLine);
+            });
+        }
+
+        function printModuleResolutionCache(buildr: SolutionBuilder<EmitAndSemanticDiagnosticsBuilderProgram>){
+            const x = { moduleResolutionCache: buildr.getModuleResolutionCache() };
+            sys.write(JSON.stringify(x,undefined,2));
+        }
+
+        const buildHost = createSolutionBuilderWithWatchHostForBaseline(sys, cb);
+        buildHost.getCustomTransformers = getCustomTransformers;
+        const builder = createSolutionBuilderWithWatch(buildHost, [solution.path], { verbose: true });
+
+        builder.build();
+        runWatchBaseline({
+            scenario: "publicApi",
+            subScenario: "with custom transformers",
+            commandLineArgs,
+            sys,
+            baseline,
+            oldSnap,
+            getPrograms,
+            changes: [
+                {
+                    caption: "change to shared",
+                    change: sys => sys.prependFile(sharedIndex.path, "export function fooBar() {}"),
+                    timeouts: sys => {
+                        sys.checkTimeoutQueueLengthAndRun(1); // Shared
+                        sys.checkTimeoutQueueLengthAndRun(1); // webpack
+                        sys.checkTimeoutQueueLengthAndRun(1); // solution
+                        sys.checkTimeoutQueueLength(0);
+                        printLastImpliedNodeFormats();
+                        printModuleResolutionCache(builder);
+                        if (lastImpliedNodeFormats.get("/user/username/projects/myproject/shared/index.ts")?.impliedNodeFormat!==ModuleKind.CommonJS) {
+                            throw new Error(`Expecting impliedNodeFormat for /user/username/projects/myproject/shared/index.ts to be ModuleKind.CommonJS`);
+                        }
+                    }
+                },
+                // {
+                //     caption: "add package.json to shared",
+                //     change: sys => sys.writeFile(sharedPackageJson.path, sharedPackageJson.content),
+                //     timeouts: sys => {
+                //         sys.checkTimeoutQueueLengthAndRun(1); // Shared
+                //         sys.checkTimeoutQueueLengthAndRun(1); // webpack
+                //         sys.checkTimeoutQueueLengthAndRun(1); // solution
+                //         sys.checkTimeoutQueueLength(0);
+                //         printLastImpliedNodeFormats();
+                //     }
+                // }
+            ],
+            watchOrSolution: builder
+        });
+
+        function getCustomTransformers(project: string): CustomTransformers {
+            const before: TransformerFactory<SourceFile> = context => {
+                return file => {
+                    // const gotImpliedNodeFormat = getImpliedNodeFormatForFile(
+                    //     importingSourceFileName, buildHost.getPackageJsonInfoCache?.(), getModuleResolutionHost(host), compilerOptions);;
+
+                    lastImpliedNodeFormats.set(file.fileName,{ impliedNodeFormat : file.impliedNodeFormat });
+                    return visitEachChild(file, visit, context);
+                };
+                function visit(node: Node): VisitResult<Node> {
+                    switch (node.kind) {
+                        case SyntaxKind.FunctionDeclaration:
+                            return visitFunction(node as FunctionDeclaration);
+                        default:
+                            return visitEachChild(node, visit, context);
+                    }
+                }
+                function visitFunction(node: FunctionDeclaration) {
+                    addSyntheticLeadingComment(node, SyntaxKind.MultiLineCommentTrivia, `@before${project}`, /*hasTrailingNewLine*/ true);
+                    return node;
+                }
+            };
+
+            const after: TransformerFactory<SourceFile> = context => {
+                return file => visitEachChild(file, visit, context);
+                function visit(node: Node): VisitResult<Node> {
+                    switch (node.kind) {
+                        case SyntaxKind.VariableStatement:
+                            return visitVariableStatement(node as VariableStatement);
+                        default:
+                            return visitEachChild(node, visit, context);
+                    }
+                }
+                function visitVariableStatement(node: VariableStatement) {
+                    addSyntheticLeadingComment(node, SyntaxKind.SingleLineCommentTrivia, `@after${project}`);
+                    return node;
+                }
+            };
+            return { before: [before], after: [after] };
+        }
+    });
+}


### PR DESCRIPTION
@sheetalkamat  - 

Re your pull #48889

I created a test to check the value of impliedNodeFormat from inside a transformer when 
- tsconfig:module is set to "Node12", and 
- package.json exists and type is "commonjs"

I expected that impliedNodeFormat would be ModuleKind.CommonJS.  However it is currently undefined,
so the test will not pass.

I know there a good chance that I am misunderstanding how it should work. 
If you can help me I would greatly appreciate it.


I created a new test borrowing from `src/testRunner/unittests/tsbuildWatch/publicApi.ts`
It is `src/testRunner/unittests/tsbuildWatch/publicApiImpliedNodeFormat.ts`

I has additional file `shared/package.json`:
```
{
                name:"shared",
                version:"1.0.0",
                type:"commonjs",
}
```
that is added to the list passed to `createWatchedSystem`.

I also added internal `getModuleResolutionCache()` to `SolutionBuilder` just to see what was in it, and it is just an empty object `{}`.  Is that correct?
 
