### PR TITLE
Use changeCompilerHostLikeToUseCache in synchronizeHostData

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -282,7 +282,7 @@ namespace ts {
         }
 
         // directoryExists
-        if (originalDirectoryExists && originalCreateDirectory) {
+        if (originalDirectoryExists) {
             host.directoryExists = directory => {
                 const key = toPath(directory);
                 const value = directoryExistsCache.get(key);
@@ -291,11 +291,14 @@ namespace ts {
                 directoryExistsCache.set(key, !!newValue);
                 return newValue;
             };
-            host.createDirectory = directory => {
-                const key = toPath(directory);
-                directoryExistsCache.delete(key);
-                originalCreateDirectory.call(host, directory);
-            };
+
+            if (originalCreateDirectory) {
+                host.createDirectory = directory => {
+                    const key = toPath(directory);
+                    directoryExistsCache.delete(key);
+                    originalCreateDirectory.call(host, directory);
+                };
+            }
         }
 
         return {


### PR DESCRIPTION
...rather than the older, less thorough, `HostCache`.  The main benefit is caching file and directory existence (and, especially, non-existence) which cuts mui project load time by 1-2% on my (Linux) box.

Alternative to #48942