### PR TITLE
Fix more tests missing 'it' call in 'describe'

### DIFF
--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -180,30 +180,34 @@ describe("unittests:: Public APIs:: validateLocaleAndSetLanguage", () => {
 });
 
 describe("unittests:: Public APIs :: forEachChild of @param comments in JSDoc", () => {
-    const content = `
+    it("finds correct children", () => {
+        const content = `
 /**
  * @param The {@link TypeReferencesInAedoc}.
  */
 var x
 `;
-    const sourceFile = ts.createSourceFile("/file.ts", content, ts.ScriptTarget.ESNext, /*setParentNodes*/ true);
-    const paramTag = sourceFile.getChildren()[0].getChildren()[0].getChildren()[0].getChildren()[0];
-    const kids = paramTag.getChildren();
-    const seen: Set<ts.Node> = new Set();
-    ts.forEachChild(paramTag, n => {
-        assert.strictEqual(/*actual*/ false, seen.has(n), "Found a duplicate-added child");
-        seen.add(n);
+        const sourceFile = ts.createSourceFile("/file.ts", content, ts.ScriptTarget.ESNext, /*setParentNodes*/ true);
+        const paramTag = sourceFile.getChildren()[0].getChildren()[0].getChildren()[0].getChildren()[0];
+        const kids = paramTag.getChildren();
+        const seen: Set<ts.Node> = new Set();
+        ts.forEachChild(paramTag, n => {
+            assert.strictEqual(/*actual*/ false, seen.has(n), "Found a duplicate-added child");
+            seen.add(n);
+        });
+        assert.equal(5, kids.length);
     });
-    assert.equal(5, kids.length);
 });
 
 describe("unittests:: Public APIs:: getChild* methods on EndOfFileToken with JSDoc", () => {
-    const content = `
+    it("finds correct children", () => {
+        const content = `
 /** jsdoc comment attached to EndOfFileToken */
 `;
-    const sourceFile = ts.createSourceFile("/file.ts", content, ts.ScriptTarget.ESNext, /*setParentNodes*/ true);
-    const endOfFileToken = sourceFile.getChildren()[1];
-    assert.equal(endOfFileToken.getChildren().length, 1);
-    assert.equal(endOfFileToken.getChildCount(), 1);
-    assert.notEqual(endOfFileToken.getChildAt(0), /*expected*/ undefined);
+        const sourceFile = ts.createSourceFile("/file.ts", content, ts.ScriptTarget.ESNext, /*setParentNodes*/ true);
+        const endOfFileToken = sourceFile.getChildren()[1];
+        assert.equal(endOfFileToken.getChildren().length, 1);
+        assert.equal(endOfFileToken.getChildCount(), 1);
+        assert.notEqual(endOfFileToken.getChildAt(0), /*expected*/ undefined);
+    });
 });


### PR DESCRIPTION
I found more of these while debugging the parser. `describe` calls _need_ to have an `it` call in them, otherwise all of that code runs _before_ the tests are filtered, e.g. when debugging or running a single test, which is super annoying.

I tried adding `--fail-zero` to our `mocha` thing, but it doesn't seem to catch this because it was only designed to catch when you accidentally remove every test, not when a "suite" is missing any tests. Feels like this is worth a lint rule.