### PR TITLE
Fixed an issue with generic naked T not being allowed as async generator's return

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38905,9 +38905,14 @@ namespace ts {
         function unwrapReturnType(returnType: Type, functionFlags: FunctionFlags) {
             const isGenerator = !!(functionFlags & FunctionFlags.Generator);
             const isAsync = !!(functionFlags & FunctionFlags.Async);
-            return isGenerator ? getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Return, returnType, isAsync) || errorType :
-                isAsync ? getAwaitedTypeNoAlias(returnType) || errorType :
-                returnType;
+            if (isGenerator) {
+                const returnIterationType = getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Return, returnType, isAsync);
+                if (!returnIterationType) {
+                    return errorType;
+                }
+                return isAsync ? getAwaitedTypeNoAlias(unwrapAwaitedType(returnIterationType)) : returnIterationType;
+            }
+            return isAsync ? getAwaitedTypeNoAlias(returnType) || errorType : returnType;
         }
 
         function isUnwrappedReturnTypeVoidOrAny(func: SignatureDeclaration, returnType: Type): boolean {

--- a/tests/baselines/reference/asyncGeneratorGenericNonWrappedReturn.symbols
+++ b/tests/baselines/reference/asyncGeneratorGenericNonWrappedReturn.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/generators/asyncGeneratorGenericNonWrappedReturn.ts ===
+// #48966
+
+export async function* test<T>(a: T): AsyncGenerator<T, T, T> {
+>test : Symbol(test, Decl(asyncGeneratorGenericNonWrappedReturn.ts, 0, 0))
+>T : Symbol(T, Decl(asyncGeneratorGenericNonWrappedReturn.ts, 2, 28))
+>a : Symbol(a, Decl(asyncGeneratorGenericNonWrappedReturn.ts, 2, 31))
+>T : Symbol(T, Decl(asyncGeneratorGenericNonWrappedReturn.ts, 2, 28))
+>AsyncGenerator : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+>T : Symbol(T, Decl(asyncGeneratorGenericNonWrappedReturn.ts, 2, 28))
+>T : Symbol(T, Decl(asyncGeneratorGenericNonWrappedReturn.ts, 2, 28))
+>T : Symbol(T, Decl(asyncGeneratorGenericNonWrappedReturn.ts, 2, 28))
+
+  return a // `T` should be allowed here even though the generator's `returnType` is `Awaited<T>`
+>a : Symbol(a, Decl(asyncGeneratorGenericNonWrappedReturn.ts, 2, 31))
+}
+

--- a/tests/baselines/reference/asyncGeneratorGenericNonWrappedReturn.types
+++ b/tests/baselines/reference/asyncGeneratorGenericNonWrappedReturn.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/generators/asyncGeneratorGenericNonWrappedReturn.ts ===
+// #48966
+
+export async function* test<T>(a: T): AsyncGenerator<T, T, T> {
+>test : <T>(a: T) => AsyncGenerator<T, T, T>
+>a : T
+
+  return a // `T` should be allowed here even though the generator's `returnType` is `Awaited<T>`
+>a : T
+}
+

--- a/tests/cases/conformance/generators/asyncGeneratorGenericNonWrappedReturn.ts
+++ b/tests/cases/conformance/generators/asyncGeneratorGenericNonWrappedReturn.ts
@@ -1,0 +1,9 @@
+// @target: esnext
+// @strict: true
+// @noEmit: true
+
+// #48966
+
+export async function* test<T>(a: T): AsyncGenerator<T, T, T> {
+  return a // `T` should be allowed here even though the generator's `returnType` is `Awaited<T>`
+}


### PR DESCRIPTION
fixes #48966

Even though I've initially concluded that maybe wrapping is not good enough ([here](https://github.com/microsoft/TypeScript/issues/48966#issuecomment-1120422129))... I think this is actually the way to go here as I've found this pattern is already used in the codebase in a couple of places. Adding more assignability rules when the target type is conditional (which implies that it hasn't been resolved) is probably very hard.