### PR TITLE
Fix module specifier generation crash from typesVersions

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -810,6 +810,7 @@ namespace ts.moduleSpecifiers {
     function removeExtensionAndIndexPostFix(fileName: string, ending: Ending, options: CompilerOptions, host?: ModuleSpecifierResolutionHost): string {
         if (fileExtensionIsOneOf(fileName, [Extension.Json, Extension.Mjs, Extension.Cjs])) return fileName;
         const noExtension = removeFileExtension(fileName);
+        if (fileName === noExtension) return fileName;
         if (fileExtensionIsOneOf(fileName, [Extension.Dmts, Extension.Mts, Extension.Dcts, Extension.Cts])) return noExtension + getJSExtensionForFile(fileName, options);
         switch (ending) {
             case Ending.Minimal:

--- a/tests/cases/fourslash/importNameCodeFix_typesVersions.ts
+++ b/tests/cases/fourslash/importNameCodeFix_typesVersions.ts
@@ -1,0 +1,34 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+// @checkJs: true
+
+// @Filename: /node_modules/unified/package.json
+//// {
+////   "name": "unified",
+////   "types": "types/ts3.4/index.d.ts",
+////   "typesVersions": {
+////     ">=4.0": {
+////       "types/ts3.4/*": [
+////         "types/ts4.0/*"
+////       ]
+////     }
+////   }
+//// }
+
+// @Filename: /node_modules/unified/types/ts3.4/index.d.ts
+//// export declare const x: number;
+
+// @Filename: /node_modules/unified/types/ts4.0/index.d.ts
+//// export declare const x: number;
+
+// @Filename: /foo.js
+//// import {} from "unified";
+
+// @Filename: /index.js
+//// x/**/
+
+verify.importFixModuleSpecifiers("", [
+  "unified",
+  "unified/types/ts3.4/", // TODO: this is wrong #49034
+], { importModuleSpecifierEnding: "js" });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/tsserverfuzzer/issues/409 introduced by #48995

Also discovered #49034, but will fix that separately as it’s been the behavior at least since 4.5 (probably for years)
