### PR TITLE
fix: `getDefaultLibFilePath` should normalize `__dirname`

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2880,7 +2880,7 @@ namespace ts {
     export function getDefaultLibFilePath(options: CompilerOptions): string {
         // Check __dirname is defined and that we are on a node.js system.
         if (typeof __dirname !== "undefined") {
-            return __dirname + directorySeparator + getDefaultLibFileName(options);
+            return combinePaths(__dirname, getDefaultLibFileName(options));
         }
 
         throw new Error("getDefaultLibFilePath is only supported when consumed as a node module. ");


### PR DESCRIPTION
## Summary

Fixes a bug (#49050) where `getDefaultLibFilePath` returns mixed path separators on Windows

## Details

- this currently causes a bug on Windows with mixed path separators
  - it returns a POSIX backslash path for `__dirname`, and then adds a forward slash from the `directorySeparator`, causing mixed separators
    - TS [uses `/` internally](https://github.com/microsoft/TypeScript/blob/7f022c58fb8b7253f23c49f0d9eee6fde82b477b/src/compiler/path.ts#L4) and lets the host convert if needed, so I assume this should be normalized to all forward slashses instead
  - example of the bug from [my tests](https://github.com/ezolenko/rollup-plugin-typescript2/pull/321#discussion_r868823333):
    ```
    Expected: "D:\\a\\rollup-plugin-typescript2\\rollup-plugin-typescript2\\node_modules\\typescript\\lib\\lib.d.ts"
    Received: "D:\\a\\rollup-plugin-typescript2\\rollup-plugin-typescript2\\node_modules\\typescript\\lib/lib.d.ts"
    ```

- every other use of `__dirname` in the codebase seems to be normalized except for this one
  - could use `normalizeSlashes` for this, but I figure `combinePaths` is more appropriate since that will handle it and combine properly as well without any `+ directorySeparator +` stuff

## Testing

All existing tests pass, but I couldn't find an existing unit test for [`getDefaultLibFilePath`](https://github.com/microsoft/TypeScript/search?q=getdefaultlibfilepath), and the `APISample` tests are meant to be 1-to-1 with the Wiki, so I didn't think that was the right place for them either.
It seemed like [nearly all of the tests](https://github.com/microsoft/TypeScript/tree/v4.7-beta/tests) were integration tests and did not directly test single files or functions such as this one, at least as far as I could tell -- please let me know if that's incorrect! I did find a [`unittests` dir](https://github.com/microsoft/TypeScript/tree/v4.7-beta/tests/cases/unittests), but there was only one file in it, so not sure if that's the right place for a test for this either.

The `CONTRIBUTING.md` seems to only cover [adding fixtures/integration tests](https://github.com/microsoft/TypeScript/blob/v4.7-beta/CONTRIBUTING.md#adding-a-test) (not sure what the "proper" word for it is in this codebase since testing terminology is a bit team-dependent I find), and not a unit test of a function like this.

Please direct me as to where it would be best to add a test for this!

## References

Fixes #49050 
Also fixes downstream https://github.com/ezolenko/rollup-plugin-typescript2/pull/321#discussion_r868823333

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**) -- has no labels yet
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change -- actually not sure where to put a unit test??

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->
