### PR TITLE
In typeof x === object, type parameters extending unknown narrow like unknown itself

### DIFF
--- a/tests/baselines/reference/keyofNonNullableAssignments.js
+++ b/tests/baselines/reference/keyofNonNullableAssignments.js
@@ -1,0 +1,26 @@
+//// [keyofNonNullableAssignments.ts]
+type MyNonNullable<T> = T extends null ? never : T extends undefined ? never : T;
+
+function f<T>(x: T) {
+    const a: keyof T = (null as any as keyof NonNullable<T>);
+    const b: keyof T = (null as any as keyof NonNullable<T & object>);
+    const c: keyof T = (null as any as keyof MyNonNullable<T>);
+    const d: keyof T = (null as any as keyof MyNonNullable<T & object>);
+    const e: keyof T = (null as any as keyof NonNullable<T | undefined>);
+    const f: keyof T = (null as any as keyof NonNullable<(T | undefined) & object>);
+    const g: keyof T = (null as any as keyof MyNonNullable<T | undefined>);
+    const h: keyof T = (null as any as keyof MyNonNullable<(T | undefined) & object>);
+}
+
+//// [keyofNonNullableAssignments.js]
+"use strict";
+function f(x) {
+    var a = null;
+    var b = null;
+    var c = null;
+    var d = null;
+    var e = null;
+    var f = null;
+    var g = null;
+    var h = null;
+}

--- a/tests/baselines/reference/keyofNonNullableAssignments.symbols
+++ b/tests/baselines/reference/keyofNonNullableAssignments.symbols
@@ -1,0 +1,62 @@
+=== tests/cases/compiler/keyofNonNullableAssignments.ts ===
+type MyNonNullable<T> = T extends null ? never : T extends undefined ? never : T;
+>MyNonNullable : Symbol(MyNonNullable, Decl(keyofNonNullableAssignments.ts, 0, 0))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 0, 19))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 0, 19))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 0, 19))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 0, 19))
+
+function f<T>(x: T) {
+>f : Symbol(f, Decl(keyofNonNullableAssignments.ts, 0, 81))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>x : Symbol(x, Decl(keyofNonNullableAssignments.ts, 2, 14))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const a: keyof T = (null as any as keyof NonNullable<T>);
+>a : Symbol(a, Decl(keyofNonNullableAssignments.ts, 3, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const b: keyof T = (null as any as keyof NonNullable<T & object>);
+>b : Symbol(b, Decl(keyofNonNullableAssignments.ts, 4, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const c: keyof T = (null as any as keyof MyNonNullable<T>);
+>c : Symbol(c, Decl(keyofNonNullableAssignments.ts, 5, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>MyNonNullable : Symbol(MyNonNullable, Decl(keyofNonNullableAssignments.ts, 0, 0))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const d: keyof T = (null as any as keyof MyNonNullable<T & object>);
+>d : Symbol(d, Decl(keyofNonNullableAssignments.ts, 6, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>MyNonNullable : Symbol(MyNonNullable, Decl(keyofNonNullableAssignments.ts, 0, 0))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const e: keyof T = (null as any as keyof NonNullable<T | undefined>);
+>e : Symbol(e, Decl(keyofNonNullableAssignments.ts, 7, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const f: keyof T = (null as any as keyof NonNullable<(T | undefined) & object>);
+>f : Symbol(f, Decl(keyofNonNullableAssignments.ts, 8, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const g: keyof T = (null as any as keyof MyNonNullable<T | undefined>);
+>g : Symbol(g, Decl(keyofNonNullableAssignments.ts, 9, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>MyNonNullable : Symbol(MyNonNullable, Decl(keyofNonNullableAssignments.ts, 0, 0))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const h: keyof T = (null as any as keyof MyNonNullable<(T | undefined) & object>);
+>h : Symbol(h, Decl(keyofNonNullableAssignments.ts, 10, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>MyNonNullable : Symbol(MyNonNullable, Decl(keyofNonNullableAssignments.ts, 0, 0))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+}

--- a/tests/baselines/reference/keyofNonNullableAssignments.types
+++ b/tests/baselines/reference/keyofNonNullableAssignments.types
@@ -1,0 +1,65 @@
+=== tests/cases/compiler/keyofNonNullableAssignments.ts ===
+type MyNonNullable<T> = T extends null ? never : T extends undefined ? never : T;
+>MyNonNullable : MyNonNullable<T>
+>null : null
+
+function f<T>(x: T) {
+>f : <T>(x: T) => void
+>x : T
+
+    const a: keyof T = (null as any as keyof NonNullable<T>);
+>a : keyof T
+>(null as any as keyof NonNullable<T>) : keyof NonNullable<T>
+>null as any as keyof NonNullable<T> : keyof NonNullable<T>
+>null as any : any
+>null : null
+
+    const b: keyof T = (null as any as keyof NonNullable<T & object>);
+>b : keyof T
+>(null as any as keyof NonNullable<T & object>) : keyof NonNullable<T & object>
+>null as any as keyof NonNullable<T & object> : keyof NonNullable<T & object>
+>null as any : any
+>null : null
+
+    const c: keyof T = (null as any as keyof MyNonNullable<T>);
+>c : keyof T
+>(null as any as keyof MyNonNullable<T>) : keyof MyNonNullable<T>
+>null as any as keyof MyNonNullable<T> : keyof MyNonNullable<T>
+>null as any : any
+>null : null
+
+    const d: keyof T = (null as any as keyof MyNonNullable<T & object>);
+>d : keyof T
+>(null as any as keyof MyNonNullable<T & object>) : keyof MyNonNullable<T & object>
+>null as any as keyof MyNonNullable<T & object> : keyof MyNonNullable<T & object>
+>null as any : any
+>null : null
+
+    const e: keyof T = (null as any as keyof NonNullable<T | undefined>);
+>e : keyof T
+>(null as any as keyof NonNullable<T | undefined>) : keyof NonNullable<T>
+>null as any as keyof NonNullable<T | undefined> : keyof NonNullable<T>
+>null as any : any
+>null : null
+
+    const f: keyof T = (null as any as keyof NonNullable<(T | undefined) & object>);
+>f : keyof T
+>(null as any as keyof NonNullable<(T | undefined) & object>) : keyof NonNullable<T & object>
+>null as any as keyof NonNullable<(T | undefined) & object> : keyof NonNullable<T & object>
+>null as any : any
+>null : null
+
+    const g: keyof T = (null as any as keyof MyNonNullable<T | undefined>);
+>g : keyof T
+>(null as any as keyof MyNonNullable<T | undefined>) : keyof MyNonNullable<T>
+>null as any as keyof MyNonNullable<T | undefined> : keyof MyNonNullable<T>
+>null as any : any
+>null : null
+
+    const h: keyof T = (null as any as keyof MyNonNullable<(T | undefined) & object>);
+>h : keyof T
+>(null as any as keyof MyNonNullable<(T | undefined) & object>) : keyof MyNonNullable<T & object>
+>null as any as keyof MyNonNullable<(T | undefined) & object> : keyof MyNonNullable<T & object>
+>null as any : any
+>null : null
+}

--- a/tests/baselines/reference/mappedTypes4.types
+++ b/tests/baselines/reference/mappedTypes4.types
@@ -26,19 +26,19 @@ function boxify<T>(obj: T): Boxified<T> {
 >{} : {}
 
         for (let k in obj) {
->k : Extract<keyof T, string>
->obj : T
+>k : Extract<keyof NonNullable<T & object>, string>
+>obj : T & (object | null)
 
             result[k] = { value: obj[k] };
->result[k] = { value: obj[k] } : { value: T[Extract<keyof T, string>]; }
->result[k] : Boxified<T>[Extract<keyof T, string>]
+>result[k] = { value: obj[k] } : { value: NonNullable<T & object>[Extract<keyof NonNullable<T & object>, string>]; }
+>result[k] : Boxified<T>[Extract<keyof NonNullable<T & object>, string>]
 >result : Boxified<T>
->k : Extract<keyof T, string>
->{ value: obj[k] } : { value: T[Extract<keyof T, string>]; }
->value : T[Extract<keyof T, string>]
->obj[k] : T[Extract<keyof T, string>]
->obj : T
->k : Extract<keyof T, string>
+>k : Extract<keyof NonNullable<T & object>, string>
+>{ value: obj[k] } : { value: NonNullable<T & object>[Extract<keyof NonNullable<T & object>, string>]; }
+>value : NonNullable<T & object>[Extract<keyof NonNullable<T & object>, string>]
+>obj[k] : NonNullable<T & object>[Extract<keyof NonNullable<T & object>, string>]
+>obj : NonNullable<T & object>
+>k : Extract<keyof NonNullable<T & object>, string>
         }
         return result;
 >result : Boxified<T>

--- a/tests/baselines/reference/unconstrainedTypeParameterNarrowing.js
+++ b/tests/baselines/reference/unconstrainedTypeParameterNarrowing.js
@@ -11,6 +11,20 @@ function f2<T extends unknown>(x: T) {
     }
 }
 
+// #48468 but with an explicit constraint so as to not trigger the `{}` and unconstrained type parameter bug
+function deepEquals<T extends unknown>(a: T, b: T) {
+    if (typeof a !== "object" || typeof b !== "object" || !a || !b) {
+        return false;
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+        return false;
+    }
+    if (Object.keys(a).length !== Object.keys(b).length) {
+        return false;
+    }
+    return true;
+}
+
 function g(x: object) {}
 
 //// [unconstrainedTypeParameterNarrowing.js]
@@ -24,5 +38,18 @@ function f2(x) {
     if (typeof x === "object" && x) {
         g(x);
     }
+}
+// #48468 but with an explicit constraint so as to not trigger the `{}` and unconstrained type parameter bug
+function deepEquals(a, b) {
+    if (typeof a !== "object" || typeof b !== "object" || !a || !b) {
+        return false;
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+        return false;
+    }
+    if (Object.keys(a).length !== Object.keys(b).length) {
+        return false;
+    }
+    return true;
 }
 function g(x) { }

--- a/tests/baselines/reference/unconstrainedTypeParameterNarrowing.js
+++ b/tests/baselines/reference/unconstrainedTypeParameterNarrowing.js
@@ -1,0 +1,28 @@
+//// [unconstrainedTypeParameterNarrowing.ts]
+function f1<T>(x: T) {
+    if (typeof x === "object" && x) {
+        g(x);
+    }
+}
+
+function f2<T extends unknown>(x: T) {
+    if (typeof x === "object" && x) {
+        g(x);
+    }
+}
+
+function g(x: object) {}
+
+//// [unconstrainedTypeParameterNarrowing.js]
+"use strict";
+function f1(x) {
+    if (typeof x === "object" && x) {
+        g(x);
+    }
+}
+function f2(x) {
+    if (typeof x === "object" && x) {
+        g(x);
+    }
+}
+function g(x) { }

--- a/tests/baselines/reference/unconstrainedTypeParameterNarrowing.symbols
+++ b/tests/baselines/reference/unconstrainedTypeParameterNarrowing.symbols
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/unconstrainedTypeParameterNarrowing.ts ===
+function f1<T>(x: T) {
+>f1 : Symbol(f1, Decl(unconstrainedTypeParameterNarrowing.ts, 0, 0))
+>T : Symbol(T, Decl(unconstrainedTypeParameterNarrowing.ts, 0, 12))
+>x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 0, 15))
+>T : Symbol(T, Decl(unconstrainedTypeParameterNarrowing.ts, 0, 12))
+
+    if (typeof x === "object" && x) {
+>x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 0, 15))
+>x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 0, 15))
+
+        g(x);
+>g : Symbol(g, Decl(unconstrainedTypeParameterNarrowing.ts, 10, 1))
+>x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 0, 15))
+    }
+}
+
+function f2<T extends unknown>(x: T) {
+>f2 : Symbol(f2, Decl(unconstrainedTypeParameterNarrowing.ts, 4, 1))
+>T : Symbol(T, Decl(unconstrainedTypeParameterNarrowing.ts, 6, 12))
+>x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 6, 31))
+>T : Symbol(T, Decl(unconstrainedTypeParameterNarrowing.ts, 6, 12))
+
+    if (typeof x === "object" && x) {
+>x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 6, 31))
+>x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 6, 31))
+
+        g(x);
+>g : Symbol(g, Decl(unconstrainedTypeParameterNarrowing.ts, 10, 1))
+>x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 6, 31))
+    }
+}
+
+function g(x: object) {}
+>g : Symbol(g, Decl(unconstrainedTypeParameterNarrowing.ts, 10, 1))
+>x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 12, 11))
+

--- a/tests/baselines/reference/unconstrainedTypeParameterNarrowing.symbols
+++ b/tests/baselines/reference/unconstrainedTypeParameterNarrowing.symbols
@@ -10,7 +10,7 @@ function f1<T>(x: T) {
 >x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 0, 15))
 
         g(x);
->g : Symbol(g, Decl(unconstrainedTypeParameterNarrowing.ts, 10, 1))
+>g : Symbol(g, Decl(unconstrainedTypeParameterNarrowing.ts, 24, 1))
 >x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 0, 15))
     }
 }
@@ -26,12 +26,60 @@ function f2<T extends unknown>(x: T) {
 >x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 6, 31))
 
         g(x);
->g : Symbol(g, Decl(unconstrainedTypeParameterNarrowing.ts, 10, 1))
+>g : Symbol(g, Decl(unconstrainedTypeParameterNarrowing.ts, 24, 1))
 >x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 6, 31))
     }
 }
 
+// #48468 but with an explicit constraint so as to not trigger the `{}` and unconstrained type parameter bug
+function deepEquals<T extends unknown>(a: T, b: T) {
+>deepEquals : Symbol(deepEquals, Decl(unconstrainedTypeParameterNarrowing.ts, 10, 1))
+>T : Symbol(T, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 20))
+>a : Symbol(a, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 39))
+>T : Symbol(T, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 20))
+>b : Symbol(b, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 44))
+>T : Symbol(T, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 20))
+
+    if (typeof a !== "object" || typeof b !== "object" || !a || !b) {
+>a : Symbol(a, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 39))
+>b : Symbol(b, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 44))
+>a : Symbol(a, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 39))
+>b : Symbol(b, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 44))
+
+        return false;
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+>Array.isArray : Symbol(ArrayConstructor.isArray, Decl(lib.es5.d.ts, --, --))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>isArray : Symbol(ArrayConstructor.isArray, Decl(lib.es5.d.ts, --, --))
+>a : Symbol(a, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 39))
+>Array.isArray : Symbol(ArrayConstructor.isArray, Decl(lib.es5.d.ts, --, --))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>isArray : Symbol(ArrayConstructor.isArray, Decl(lib.es5.d.ts, --, --))
+>b : Symbol(b, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 44))
+
+        return false;
+    }
+    if (Object.keys(a).length !== Object.keys(b).length) {
+>Object.keys(a).length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>Object.keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --))
+>a : Symbol(a, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 39))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>Object.keys(b).length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>Object.keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --))
+>b : Symbol(b, Decl(unconstrainedTypeParameterNarrowing.ts, 13, 44))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+        return false;
+    }
+    return true;
+}
+
 function g(x: object) {}
->g : Symbol(g, Decl(unconstrainedTypeParameterNarrowing.ts, 10, 1))
->x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 12, 11))
+>g : Symbol(g, Decl(unconstrainedTypeParameterNarrowing.ts, 24, 1))
+>x : Symbol(x, Decl(unconstrainedTypeParameterNarrowing.ts, 26, 11))
 

--- a/tests/baselines/reference/unconstrainedTypeParameterNarrowing.types
+++ b/tests/baselines/reference/unconstrainedTypeParameterNarrowing.types
@@ -37,6 +37,72 @@ function f2<T extends unknown>(x: T) {
     }
 }
 
+// #48468 but with an explicit constraint so as to not trigger the `{}` and unconstrained type parameter bug
+function deepEquals<T extends unknown>(a: T, b: T) {
+>deepEquals : <T extends unknown>(a: T, b: T) => boolean
+>a : T
+>b : T
+
+    if (typeof a !== "object" || typeof b !== "object" || !a || !b) {
+>typeof a !== "object" || typeof b !== "object" || !a || !b : boolean
+>typeof a !== "object" || typeof b !== "object" || !a : boolean
+>typeof a !== "object" || typeof b !== "object" : boolean
+>typeof a !== "object" : boolean
+>typeof a : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>a : T
+>"object" : "object"
+>typeof b !== "object" : boolean
+>typeof b : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>b : T
+>"object" : "object"
+>!a : boolean
+>a : T & (object | null)
+>!b : boolean
+>b : T & (object | null)
+
+        return false;
+>false : false
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+>Array.isArray(a) || Array.isArray(b) : boolean
+>Array.isArray(a) : boolean
+>Array.isArray : (arg: any) => arg is any[]
+>Array : ArrayConstructor
+>isArray : (arg: any) => arg is any[]
+>a : T & object
+>Array.isArray(b) : boolean
+>Array.isArray : (arg: any) => arg is any[]
+>Array : ArrayConstructor
+>isArray : (arg: any) => arg is any[]
+>b : T & object
+
+        return false;
+>false : false
+    }
+    if (Object.keys(a).length !== Object.keys(b).length) {
+>Object.keys(a).length !== Object.keys(b).length : boolean
+>Object.keys(a).length : number
+>Object.keys(a) : string[]
+>Object.keys : (o: object) => string[]
+>Object : ObjectConstructor
+>keys : (o: object) => string[]
+>a : T & object
+>length : number
+>Object.keys(b).length : number
+>Object.keys(b) : string[]
+>Object.keys : (o: object) => string[]
+>Object : ObjectConstructor
+>keys : (o: object) => string[]
+>b : T & object
+>length : number
+
+        return false;
+>false : false
+    }
+    return true;
+>true : true
+}
+
 function g(x: object) {}
 >g : (x: object) => void
 >x : object

--- a/tests/baselines/reference/unconstrainedTypeParameterNarrowing.types
+++ b/tests/baselines/reference/unconstrainedTypeParameterNarrowing.types
@@ -1,0 +1,43 @@
+=== tests/cases/compiler/unconstrainedTypeParameterNarrowing.ts ===
+function f1<T>(x: T) {
+>f1 : <T>(x: T) => void
+>x : T
+
+    if (typeof x === "object" && x) {
+>typeof x === "object" && x : false | (T & (object | null))
+>typeof x === "object" : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : T
+>"object" : "object"
+>x : T & (object | null)
+
+        g(x);
+>g(x) : void
+>g : (x: object) => void
+>x : T & object
+    }
+}
+
+function f2<T extends unknown>(x: T) {
+>f2 : <T extends unknown>(x: T) => void
+>x : T
+
+    if (typeof x === "object" && x) {
+>typeof x === "object" && x : false | (T & (object | null))
+>typeof x === "object" : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : T
+>"object" : "object"
+>x : T & (object | null)
+
+        g(x);
+>g(x) : void
+>g : (x: object) => void
+>x : T & object
+    }
+}
+
+function g(x: object) {}
+>g : (x: object) => void
+>x : object
+

--- a/tests/cases/compiler/keyofNonNullableAssignments.ts
+++ b/tests/cases/compiler/keyofNonNullableAssignments.ts
@@ -1,0 +1,13 @@
+// @strict: true
+type MyNonNullable<T> = T extends null ? never : T extends undefined ? never : T;
+
+function f<T>(x: T) {
+    const a: keyof T = (null as any as keyof NonNullable<T>);
+    const b: keyof T = (null as any as keyof NonNullable<T & object>);
+    const c: keyof T = (null as any as keyof MyNonNullable<T>);
+    const d: keyof T = (null as any as keyof MyNonNullable<T & object>);
+    const e: keyof T = (null as any as keyof NonNullable<T | undefined>);
+    const f: keyof T = (null as any as keyof NonNullable<(T | undefined) & object>);
+    const g: keyof T = (null as any as keyof MyNonNullable<T | undefined>);
+    const h: keyof T = (null as any as keyof MyNonNullable<(T | undefined) & object>);
+}

--- a/tests/cases/compiler/unconstrainedTypeParameterNarrowing.ts
+++ b/tests/cases/compiler/unconstrainedTypeParameterNarrowing.ts
@@ -11,4 +11,18 @@ function f2<T extends unknown>(x: T) {
     }
 }
 
+// #48468 but with an explicit constraint so as to not trigger the `{}` and unconstrained type parameter bug
+function deepEquals<T extends unknown>(a: T, b: T) {
+    if (typeof a !== "object" || typeof b !== "object" || !a || !b) {
+        return false;
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+        return false;
+    }
+    if (Object.keys(a).length !== Object.keys(b).length) {
+        return false;
+    }
+    return true;
+}
+
 function g(x: object) {}

--- a/tests/cases/compiler/unconstrainedTypeParameterNarrowing.ts
+++ b/tests/cases/compiler/unconstrainedTypeParameterNarrowing.ts
@@ -1,0 +1,14 @@
+// @strict: true
+function f1<T>(x: T) {
+    if (typeof x === "object" && x) {
+        g(x);
+    }
+}
+
+function f2<T extends unknown>(x: T) {
+    if (typeof x === "object" && x) {
+        g(x);
+    }
+}
+
+function g(x: object) {}


### PR DESCRIPTION
In addition, improves relating `keyof T` and `keyof NonNullable<T>`-like types (to allow the relation) so that the impacts of, eg, chaining a `typeof x === "object"` and a truthiness check still produce compatible types.

Should fix #48468 even after the `{}` and unconstrained type parameter change is back in. 