### PR TITLE
Remove bigint from Object.freeze in es5.d.ts

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -210,7 +210,7 @@ interface ObjectConstructor {
      * Prevents the modification of existing property attributes and values, and prevents the addition of new properties.
      * @param o Object on which to lock the attributes.
      */
-    freeze<T extends {[idx: string]: U | null | undefined | object}, U extends string | bigint | number | boolean | symbol>(o: T): Readonly<T>;
+    freeze<T extends {[idx: string]: U | null | undefined | object}, U extends string | number | boolean | symbol>(o: T): Readonly<T>;
 
     /**
      * Prevents the modification of existing property attributes and values, and prevents the addition of new properties.

--- a/tests/baselines/reference/contextualSignatureInObjectFreeze.js
+++ b/tests/baselines/reference/contextualSignatureInObjectFreeze.js
@@ -1,0 +1,13 @@
+//// [contextualSignatureInObjectFreeze.ts]
+// #49101
+
+Object.freeze({
+    f: function () { }
+})
+
+
+//// [contextualSignatureInObjectFreeze.js]
+// #49101
+Object.freeze({
+    f: function () { }
+});

--- a/tests/baselines/reference/contextualSignatureInObjectFreeze.symbols
+++ b/tests/baselines/reference/contextualSignatureInObjectFreeze.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/contextualSignatureInObjectFreeze.ts ===
+// #49101
+
+Object.freeze({
+>Object.freeze : Symbol(ObjectConstructor.freeze, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>freeze : Symbol(ObjectConstructor.freeze, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    f: function () { }
+>f : Symbol(f, Decl(contextualSignatureInObjectFreeze.ts, 2, 15))
+
+})
+

--- a/tests/baselines/reference/contextualSignatureInObjectFreeze.types
+++ b/tests/baselines/reference/contextualSignatureInObjectFreeze.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/contextualSignatureInObjectFreeze.ts ===
+// #49101
+
+Object.freeze({
+>Object.freeze({    f: function () { }}) : Readonly<{ f: () => void; }>
+>Object.freeze : { <T>(a: T[]): readonly T[]; <T extends Function>(f: T): T; <T extends { [idx: string]: object | U; }, U extends string | number | boolean | symbol>(o: T): Readonly<T>; <T>(o: T): Readonly<T>; }
+>Object : ObjectConstructor
+>freeze : { <T>(a: T[]): readonly T[]; <T extends Function>(f: T): T; <T extends { [idx: string]: object | U; }, U extends string | number | boolean | symbol>(o: T): Readonly<T>; <T>(o: T): Readonly<T>; }
+>{    f: function () { }} : { f: () => void; }
+
+    f: function () { }
+>f : () => void
+>function () { } : () => void
+
+})
+

--- a/tests/cases/compiler/contextualSignatureInObjectFreeze.ts
+++ b/tests/cases/compiler/contextualSignatureInObjectFreeze.ts
@@ -1,0 +1,7 @@
+// #49101
+// @target: es2020
+// @lib: es2019
+
+Object.freeze({
+    f: function () { }
+})


### PR DESCRIPTION
`BigInt` isn't resolved whenever `lib < es2020`, but it's not an error when `target < es2020`. I have a few ideas for improving this situation but for the RC I'm going to remove `bigint` from Object.freeze's signature.

Fixes #49101