### PR TITLE
Typo in description for "baseUrl" compiler option

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -5050,7 +5050,7 @@
         "category": "Error",
         "code": 6258
     },
-      "Found 1 error in {1}": {
+    "Found 1 error in {1}": {
         "category": "Message",
         "code": 6259
     },
@@ -5363,7 +5363,7 @@
         "category": "Message",
         "code": 6606
     },
-    "Specify the base directory to resolve non-relative module names.": {
+    "Specify the base directory to resolve non-absolute module names.": {
         "category": "Message",
         "code": 6607
     },
@@ -5920,9 +5920,9 @@
         "category": "Message",
         "code": 6930
     },
-    "List of file name suffixes to search when resolving a module." : {
-      "category": "Error",
-      "code": 6931
+    "List of file name suffixes to search when resolving a module.": {
+        "category": "Error",
+        "code": 6931
     },
 
     "Variable '{0}' implicitly has an '{1}' type.": {
@@ -7235,7 +7235,6 @@
         "category": "Message",
         "code": 95173
     },
-
 
     "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer.": {
         "category": "Error",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

The [baseUrl](https://www.typescriptlang.org/tsconfig#baseUrl) compiler option: "specify the base directory to resolve **non-absolute** module names". Or if you prefer: *to resolve **relative** module names*.
But the current description found in the comments of an automatically generated `tsconfig.json` says "to resolve **non-relative** module names", which is the opposite. And the same description pops up when you hover over the option.

Now, I tried to do something about it, but I need some help.
In the repo there are few places with files containing the wrong description outlined above:
- a few `.js` files in `lib/`, which I am not sure if they need to be touched as the `CONTRIVUTING.md` says : 
  > "The files in `lib/` are used to bootstrap compilation and usually **should not** be updated unless publishing a new version or updating the LKG."
- a `src/compiler/diagnosticMessages.json` and a `src/loc/lcl/chs/diagnosticMessages/diagnosticMessages.generated.json.lcl`. The `CONTRIBUTING.md` here says:
  > All strings the user may see are stored in [`diagnosticMessages.json`](./src/compiler/diagnosticMessages.json).
If you make changes to it, run `gulp generate-diagnostics` to push them to the `Diagnostic` interface in `diagnosticInformationMap.generated.ts`.

  But after modifying `diagnosticMessages.json` and running `gulp generate-diagnostics` no changes are made to the repo.
  <details>
  <summary>Here is the output of the command</summary>
  <pre>
  sheikyerbouty@myhardware:~/Desktop/PR/TypeScript (main)$ gulp generate-diagnostics
  [22:17:06] Using gulpfile ~/Desktop/PR/TypeScript/Gulpfile.js
  [22:17:06] Starting 'generate-diagnostics'...
  [22:17:06] Starting 'buildScripts'...
  [22:17:06] Finished 'buildScripts' after 337 ms
  [22:17:06] Starting 'generateDiagnostics'...
  [22:17:06] > /home/sheikyerbouty/.nvm/versions/node/v16.14.0/bin/node scripts/processDiagnosticMessages.js 
  src/compiler/diagnosticMessages.json
  Reading diagnostics from src/compiler/diagnosticMessages.json
  [22:17:06] Finished 'generateDiagnostics' after 180 ms
  [22:17:06] Finished 'generate-diagnostics' after 521 ms
  </pre>
  </details>
- a few `tsconfig.json` in `tests/baselines/reference/tsConfig/` and a few `.js` files in `tests/baselines/reference/tscWatch/programUpdates/`, which since are in a `tests` folder I guess they should not be modified before making changes that need to be tested.

Speaking of tests, running `gulp runtests-parallel` froze my laptop for 52 minutes, reporting three tests failing because of a 40 seconds timeout.

Anyway so far I only fixed the description in `src/compiler/diagnosticMessages.json`.
What else should be done here?