### PR TITLE
Add es2018.intl ref to es2020.intl

### DIFF
--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -1,3 +1,4 @@
+/// <reference lib="es2018.intl" />
 declare namespace Intl {
 
     /**

--- a/tests/baselines/reference/es2020IntlAPIs.errors.txt
+++ b/tests/baselines/reference/es2020IntlAPIs.errors.txt
@@ -53,22 +53,22 @@ tests/cases/conformance/es2020/es2020IntlAPIs.ts(50,29): error TS2345: Argument 
     new Intl.Locale(); // should error
     ~~~~~~~~~~~~~~~~~
 !!! error TS2554: Expected 1-2 arguments, but got 0.
-!!! related TS6210 /.ts/lib.es2020.intl.d.ts:335:14: An argument for 'tag' was not provided.
+!!! related TS6210 /.ts/lib.es2020.intl.d.ts:336:14: An argument for 'tag' was not provided.
     new Intl.Locale(new Intl.Locale('en-US'));
     
     new Intl.DisplayNames(); // TypeError: invalid_argument
     ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2554: Expected 2 arguments, but got 0.
-!!! related TS6210 /.ts/lib.es2020.intl.d.ts:414:13: An argument for 'locales' was not provided.
+!!! related TS6210 /.ts/lib.es2020.intl.d.ts:415:13: An argument for 'locales' was not provided.
     new Intl.DisplayNames('en'); // TypeError: invalid_argument
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2554: Expected 2 arguments, but got 1.
-!!! related TS6210 /.ts/lib.es2020.intl.d.ts:414:39: An argument for 'options' was not provided.
+!!! related TS6210 /.ts/lib.es2020.intl.d.ts:415:39: An argument for 'options' was not provided.
     new Intl.DisplayNames('en', {}); // TypeError: invalid_argument
                                 ~~
 !!! error TS2345: Argument of type '{}' is not assignable to parameter of type 'DisplayNamesOptions'.
 !!! error TS2345:   Property 'type' is missing in type '{}' but required in type 'DisplayNamesOptions'.
-!!! related TS2728 /.ts/lib.es2020.intl.d.ts:357:9: 'type' is declared here.
+!!! related TS2728 /.ts/lib.es2020.intl.d.ts:358:9: 'type' is declared here.
     console.log((new Intl.DisplayNames(undefined, {type: 'language'})).of('en-GB')); // "British English"
     
     const localesArg = ["es-ES", new Intl.Locale("en-US")];


### PR DESCRIPTION
es2020.intl refers to NumberFormatPartTypes declared in es2018.intl as of #46508.

I'm not sure how to test this; it repros on Definitely Typed in types/ndarray, but when I copy the same files into a compiler test it passes without a problem.

Fixes 3 test failures on DT's overnight run.