### PR TITLE
 On branch condalias-49075-pull

### DIFF
--- a/tests/baselines/reference/controlFlowOptionalChain.errors.txt
+++ b/tests/baselines/reference/controlFlowOptionalChain.errors.txt
@@ -4,6 +4,7 @@ tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(18,1): error TS2
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(22,1): error TS2454: Variable 'd' is used before being assigned.
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(35,5): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(39,1): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(51,9): error TS2339: Property 'f' does not exist on type 'never'.
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(52,5): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(57,1): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(68,5): error TS2532: Object is possibly 'undefined'.
@@ -16,6 +17,7 @@ tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(105,5): error TS
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(111,1): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(112,1): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(112,1): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(129,9): error TS2339: Property 'f' does not exist on type 'never'.
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(130,5): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(134,1): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(208,9): error TS2532: Object is possibly 'undefined'.
@@ -61,7 +63,7 @@ tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(518,13): error T
 tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(567,21): error TS2532: Object is possibly 'undefined'.
 
 
-==== tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts (61 errors) ====
+==== tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts (63 errors) ====
     // assignments in shortcutting chain
     declare const o: undefined | {
         [key: string]: any;
@@ -125,6 +127,8 @@ tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(567,21): error T
         x;
         o2;
         o2?.f;
+            ~
+!!! error TS2339: Property 'f' does not exist on type 'never'.
         o2.f;
         ~~
 !!! error TS2532: Object is possibly 'undefined'.
@@ -227,6 +231,8 @@ tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts(567,21): error T
     else {
         o6;
         o6?.f;
+            ~
+!!! error TS2339: Property 'f' does not exist on type 'never'.
         o6.f;
         ~~
 !!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/controlFlowOptionalChain.symbols
+++ b/tests/baselines/reference/controlFlowOptionalChain.symbols
@@ -145,14 +145,10 @@ else {
 >o2 : Symbol(o2, Decl(controlFlowOptionalChain.ts, 40, 13))
 
     o2?.f;
->o2?.f : Symbol(f, Decl(controlFlowOptionalChain.ts, 40, 19))
 >o2 : Symbol(o2, Decl(controlFlowOptionalChain.ts, 40, 13))
->f : Symbol(f, Decl(controlFlowOptionalChain.ts, 40, 19))
 
     o2.f;
->o2.f : Symbol(f, Decl(controlFlowOptionalChain.ts, 40, 19))
 >o2 : Symbol(o2, Decl(controlFlowOptionalChain.ts, 40, 13))
->f : Symbol(f, Decl(controlFlowOptionalChain.ts, 40, 19))
 }
 x;
 >x : Symbol(x, Decl(controlFlowOptionalChain.ts, 25, 13))
@@ -514,14 +510,10 @@ else {
 >o6 : Symbol(o6, Decl(controlFlowOptionalChain.ts, 121, 13))
 
     o6?.f;
->o6?.f : Symbol(Base.f, Decl(controlFlowOptionalChain.ts, 113, 16))
 >o6 : Symbol(o6, Decl(controlFlowOptionalChain.ts, 121, 13))
->f : Symbol(Base.f, Decl(controlFlowOptionalChain.ts, 113, 16))
 
     o6.f;
->o6.f : Symbol(Base.f, Decl(controlFlowOptionalChain.ts, 113, 16))
 >o6 : Symbol(o6, Decl(controlFlowOptionalChain.ts, 121, 13))
->f : Symbol(Base.f, Decl(controlFlowOptionalChain.ts, 113, 16))
 }
 o6;
 >o6 : Symbol(o6, Decl(controlFlowOptionalChain.ts, 121, 13))

--- a/tests/baselines/reference/controlFlowOptionalChain.types
+++ b/tests/baselines/reference/controlFlowOptionalChain.types
@@ -142,7 +142,7 @@ if (o2?.f(x)) {
 >x : string | number
 
     x; // number
->x : number
+>x : string | number
 
     o2.f; // (x: any) => x is number
 >o2.f : (x: any) => x is number
@@ -159,24 +159,24 @@ if (o2?.f(x)) {
 >o2?.f : (x: any) => x is number
 >o2 : { f(x: any): x is number; }
 >f : (x: any) => x is number
->x : number
+>x : string | number
 }
 else {
     x;
 >x : string | number
 
     o2;
->o2 : { f(x: any): x is number; } | undefined
+>o2 : undefined
 
     o2?.f;
->o2?.f : ((x: any) => x is number) | undefined
->o2 : { f(x: any): x is number; } | undefined
->f : ((x: any) => x is number) | undefined
+>o2?.f : any
+>o2 : undefined
+>f : any
 
     o2.f;
->o2.f : (x: any) => x is number
->o2 : { f(x: any): x is number; } | undefined
->f : (x: any) => x is number
+>o2.f : any
+>o2 : undefined
+>f : any
 }
 x;
 >x : string | number
@@ -522,26 +522,26 @@ if (o6?.f()) {
 >f : (() => this is Derived) | undefined
 
     o6; // Derived
->o6 : Derived
+>o6 : Base
 
     o6.f;
 >o6.f : () => this is Derived
->o6 : Derived
+>o6 : Base
 >f : () => this is Derived
 }
 else {
     o6;
->o6 : Base | undefined
+>o6 : undefined
 
     o6?.f;
->o6?.f : (() => this is Derived) | undefined
->o6 : Base | undefined
->f : (() => this is Derived) | undefined
+>o6?.f : any
+>o6 : undefined
+>f : any
 
     o6.f;
->o6.f : () => this is Derived
->o6 : Base | undefined
->f : () => this is Derived
+>o6.f : any
+>o6 : undefined
+>f : any
 }
 o6;
 >o6 : Base | undefined

--- a/tests/baselines/reference/controlFlowOptionalChainAlias.js
+++ b/tests/baselines/reference/controlFlowOptionalChainAlias.js
@@ -1,0 +1,31 @@
+//// [controlFlowOptionalChainAlias.ts]
+interface Foodb {
+    getValues(): number[];
+}
+
+declare const foodb: Foodb | undefined;
+
+const valsb = foodb?.getValues();
+if (valsb) {
+    foodb; // before: Foodb|undefined after: Foodb 
+    foodb.getValues; // before: error, after: OK
+    foodb.getValues(); // before: error, after: OK
+}
+
+
+//// [controlFlowOptionalChainAlias.js]
+"use strict";
+var valsb = foodb === null || foodb === void 0 ? void 0 : foodb.getValues();
+if (valsb) {
+    foodb; // before: Foodb|undefined after: Foodb 
+    foodb.getValues; // before: error, after: OK
+    foodb.getValues(); // before: error, after: OK
+}
+
+
+//// [controlFlowOptionalChainAlias.d.ts]
+interface Foodb {
+    getValues(): number[];
+}
+declare const foodb: Foodb | undefined;
+declare const valsb: number[] | undefined;

--- a/tests/baselines/reference/controlFlowOptionalChainAlias.symbols
+++ b/tests/baselines/reference/controlFlowOptionalChainAlias.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/conformance/controlFlow/controlFlowOptionalChainAlias.ts ===
+interface Foodb {
+>Foodb : Symbol(Foodb, Decl(controlFlowOptionalChainAlias.ts, 0, 0))
+
+    getValues(): number[];
+>getValues : Symbol(Foodb.getValues, Decl(controlFlowOptionalChainAlias.ts, 0, 17))
+}
+
+declare const foodb: Foodb | undefined;
+>foodb : Symbol(foodb, Decl(controlFlowOptionalChainAlias.ts, 4, 13))
+>Foodb : Symbol(Foodb, Decl(controlFlowOptionalChainAlias.ts, 0, 0))
+
+const valsb = foodb?.getValues();
+>valsb : Symbol(valsb, Decl(controlFlowOptionalChainAlias.ts, 6, 5))
+>foodb?.getValues : Symbol(Foodb.getValues, Decl(controlFlowOptionalChainAlias.ts, 0, 17))
+>foodb : Symbol(foodb, Decl(controlFlowOptionalChainAlias.ts, 4, 13))
+>getValues : Symbol(Foodb.getValues, Decl(controlFlowOptionalChainAlias.ts, 0, 17))
+
+if (valsb) {
+>valsb : Symbol(valsb, Decl(controlFlowOptionalChainAlias.ts, 6, 5))
+
+    foodb; // before: Foodb|undefined after: Foodb 
+>foodb : Symbol(foodb, Decl(controlFlowOptionalChainAlias.ts, 4, 13))
+
+    foodb.getValues; // before: error, after: OK
+>foodb.getValues : Symbol(Foodb.getValues, Decl(controlFlowOptionalChainAlias.ts, 0, 17))
+>foodb : Symbol(foodb, Decl(controlFlowOptionalChainAlias.ts, 4, 13))
+>getValues : Symbol(Foodb.getValues, Decl(controlFlowOptionalChainAlias.ts, 0, 17))
+
+    foodb.getValues(); // before: error, after: OK
+>foodb.getValues : Symbol(Foodb.getValues, Decl(controlFlowOptionalChainAlias.ts, 0, 17))
+>foodb : Symbol(foodb, Decl(controlFlowOptionalChainAlias.ts, 4, 13))
+>getValues : Symbol(Foodb.getValues, Decl(controlFlowOptionalChainAlias.ts, 0, 17))
+}
+

--- a/tests/baselines/reference/controlFlowOptionalChainAlias.types
+++ b/tests/baselines/reference/controlFlowOptionalChainAlias.types
@@ -1,0 +1,34 @@
+=== tests/cases/conformance/controlFlow/controlFlowOptionalChainAlias.ts ===
+interface Foodb {
+    getValues(): number[];
+>getValues : () => number[]
+}
+
+declare const foodb: Foodb | undefined;
+>foodb : Foodb | undefined
+
+const valsb = foodb?.getValues();
+>valsb : number[] | undefined
+>foodb?.getValues() : number[] | undefined
+>foodb?.getValues : (() => number[]) | undefined
+>foodb : Foodb | undefined
+>getValues : (() => number[]) | undefined
+
+if (valsb) {
+>valsb : number[] | undefined
+
+    foodb; // before: Foodb|undefined after: Foodb 
+>foodb : Foodb
+
+    foodb.getValues; // before: error, after: OK
+>foodb.getValues : () => number[]
+>foodb : Foodb
+>getValues : () => number[]
+
+    foodb.getValues(); // before: error, after: OK
+>foodb.getValues() : number[]
+>foodb.getValues : () => number[]
+>foodb : Foodb
+>getValues : () => number[]
+}
+

--- a/tests/baselines/reference/controlFlowOptionalChainAlias2.errors.txt
+++ b/tests/baselines/reference/controlFlowOptionalChainAlias2.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/conformance/controlFlow/controlFlowOptionalChainAlias2.ts(11,5): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/controlFlow/controlFlowOptionalChainAlias2.ts (1 errors) ====
+    interface Food2b {
+        bard?: {
+            getValues(): number[];
+        }
+    }
+    declare const food2b: Food2b | undefined;
+    const bards = food2b?.bard?.getValues();
+    if (bards) {
+        food2b; // type Food2b, OK  
+        food2b.bard; // type { getValues(): number[] } | undefined. --- BUG 
+        food2b.bard.getValues(); // error --- BUG
+        ~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    }
+    
+    

--- a/tests/baselines/reference/controlFlowOptionalChainAlias2.js
+++ b/tests/baselines/reference/controlFlowOptionalChainAlias2.js
@@ -1,0 +1,35 @@
+//// [controlFlowOptionalChainAlias2.ts]
+interface Food2b {
+    bard?: {
+        getValues(): number[];
+    }
+}
+declare const food2b: Food2b | undefined;
+const bards = food2b?.bard?.getValues();
+if (bards) {
+    food2b; // type Food2b, OK  
+    food2b.bard; // type { getValues(): number[] } | undefined. --- BUG 
+    food2b.bard.getValues(); // error --- BUG
+}
+
+
+
+//// [controlFlowOptionalChainAlias2.js]
+"use strict";
+var _a;
+var bards = (_a = food2b === null || food2b === void 0 ? void 0 : food2b.bard) === null || _a === void 0 ? void 0 : _a.getValues();
+if (bards) {
+    food2b; // type Food2b, OK  
+    food2b.bard; // type { getValues(): number[] } | undefined. --- BUG 
+    food2b.bard.getValues(); // error --- BUG
+}
+
+
+//// [controlFlowOptionalChainAlias2.d.ts]
+interface Food2b {
+    bard?: {
+        getValues(): number[];
+    };
+}
+declare const food2b: Food2b | undefined;
+declare const bards: number[] | undefined;

--- a/tests/baselines/reference/controlFlowOptionalChainAlias2.symbols
+++ b/tests/baselines/reference/controlFlowOptionalChainAlias2.symbols
@@ -1,0 +1,43 @@
+=== tests/cases/conformance/controlFlow/controlFlowOptionalChainAlias2.ts ===
+interface Food2b {
+>Food2b : Symbol(Food2b, Decl(controlFlowOptionalChainAlias2.ts, 0, 0))
+
+    bard?: {
+>bard : Symbol(Food2b.bard, Decl(controlFlowOptionalChainAlias2.ts, 0, 18))
+
+        getValues(): number[];
+>getValues : Symbol(getValues, Decl(controlFlowOptionalChainAlias2.ts, 1, 12))
+    }
+}
+declare const food2b: Food2b | undefined;
+>food2b : Symbol(food2b, Decl(controlFlowOptionalChainAlias2.ts, 5, 13))
+>Food2b : Symbol(Food2b, Decl(controlFlowOptionalChainAlias2.ts, 0, 0))
+
+const bards = food2b?.bard?.getValues();
+>bards : Symbol(bards, Decl(controlFlowOptionalChainAlias2.ts, 6, 5))
+>food2b?.bard?.getValues : Symbol(getValues, Decl(controlFlowOptionalChainAlias2.ts, 1, 12))
+>food2b?.bard : Symbol(Food2b.bard, Decl(controlFlowOptionalChainAlias2.ts, 0, 18))
+>food2b : Symbol(food2b, Decl(controlFlowOptionalChainAlias2.ts, 5, 13))
+>bard : Symbol(Food2b.bard, Decl(controlFlowOptionalChainAlias2.ts, 0, 18))
+>getValues : Symbol(getValues, Decl(controlFlowOptionalChainAlias2.ts, 1, 12))
+
+if (bards) {
+>bards : Symbol(bards, Decl(controlFlowOptionalChainAlias2.ts, 6, 5))
+
+    food2b; // type Food2b, OK  
+>food2b : Symbol(food2b, Decl(controlFlowOptionalChainAlias2.ts, 5, 13))
+
+    food2b.bard; // type { getValues(): number[] } | undefined. --- BUG 
+>food2b.bard : Symbol(Food2b.bard, Decl(controlFlowOptionalChainAlias2.ts, 0, 18))
+>food2b : Symbol(food2b, Decl(controlFlowOptionalChainAlias2.ts, 5, 13))
+>bard : Symbol(Food2b.bard, Decl(controlFlowOptionalChainAlias2.ts, 0, 18))
+
+    food2b.bard.getValues(); // error --- BUG
+>food2b.bard.getValues : Symbol(getValues, Decl(controlFlowOptionalChainAlias2.ts, 1, 12))
+>food2b.bard : Symbol(Food2b.bard, Decl(controlFlowOptionalChainAlias2.ts, 0, 18))
+>food2b : Symbol(food2b, Decl(controlFlowOptionalChainAlias2.ts, 5, 13))
+>bard : Symbol(Food2b.bard, Decl(controlFlowOptionalChainAlias2.ts, 0, 18))
+>getValues : Symbol(getValues, Decl(controlFlowOptionalChainAlias2.ts, 1, 12))
+}
+
+

--- a/tests/baselines/reference/controlFlowOptionalChainAlias2.types
+++ b/tests/baselines/reference/controlFlowOptionalChainAlias2.types
@@ -1,0 +1,42 @@
+=== tests/cases/conformance/controlFlow/controlFlowOptionalChainAlias2.ts ===
+interface Food2b {
+    bard?: {
+>bard : { getValues(): number[]; } | undefined
+
+        getValues(): number[];
+>getValues : () => number[]
+    }
+}
+declare const food2b: Food2b | undefined;
+>food2b : Food2b | undefined
+
+const bards = food2b?.bard?.getValues();
+>bards : number[] | undefined
+>food2b?.bard?.getValues() : number[] | undefined
+>food2b?.bard?.getValues : (() => number[]) | undefined
+>food2b?.bard : { getValues(): number[]; } | undefined
+>food2b : Food2b | undefined
+>bard : { getValues(): number[]; } | undefined
+>getValues : (() => number[]) | undefined
+
+if (bards) {
+>bards : number[] | undefined
+
+    food2b; // type Food2b, OK  
+>food2b : Food2b
+
+    food2b.bard; // type { getValues(): number[] } | undefined. --- BUG 
+>food2b.bard : { getValues(): number[]; } | undefined
+>food2b : Food2b
+>bard : { getValues(): number[]; } | undefined
+
+    food2b.bard.getValues(); // error --- BUG
+>food2b.bard.getValues() : number[]
+>food2b.bard.getValues : () => number[]
+>food2b.bard : { getValues(): number[]; } | undefined
+>food2b : Food2b
+>bard : { getValues(): number[]; } | undefined
+>getValues : () => number[]
+}
+
+

--- a/tests/cases/conformance/controlFlow/controlFlowOptionalChainAlias.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowOptionalChainAlias.ts
@@ -1,0 +1,15 @@
+// @strict: true
+// @declaration: true
+
+interface Foodb {
+    getValues(): number[];
+}
+
+declare const foodb: Foodb | undefined;
+
+const valsb = foodb?.getValues();
+if (valsb) {
+    foodb; // before: Foodb|undefined after: Foodb 
+    foodb.getValues; // before: error, after: OK
+    foodb.getValues(); // before: error, after: OK
+}

--- a/tests/cases/conformance/controlFlow/controlFlowOptionalChainAlias2.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowOptionalChainAlias2.ts
@@ -1,0 +1,15 @@
+// @strict: true
+// @declaration: true
+interface Food2b {
+    bard?: {
+        getValues(): number[];
+    }
+}
+declare const food2b: Food2b | undefined;
+const bards = food2b?.bard?.getValues();
+if (bards) {
+    food2b; // type Food2b, OK  
+    food2b.bard; // type { getValues(): number[] } | undefined. --- BUG 
+    food2b.bard.getValues(); // error --- BUG
+}
+


### PR DESCRIPTION
<s>Fixes #49075</s>

Oops., I'm noticing some errors on the auto-checking, compiling typescript itself.
I have to check if that is related to this pull - I guess it must be?


The original bug issue #49075 listed this:
```
// @strict: true
// @declaration: true

interface Foodb {
    getValues(): number[];
}
declare const foodb: Foodb | undefined;
const valsb = foodb?.getValues();
if (valsb) {
    foodb; // before: Foodb|undefined after: Foodb 
    foodb.getValues; // before: error, after: OK
    foodb.getValues(); // before: error, after: OK
}
```
This pull fixes that.  
There are some changes to results for the `controlFlowOptionalChain.ts` where a previously possible non-undefined root is now definitely undefined: e.g., 
```
   declare const o2: { f(x: any): x is number; } | undefined;
    if (o2?.f(x)) {
        ...
    }
    else {
        o2?.f;    // wasn't error before when o2 was incorrectly considered possibly not-undefined
            ~
       !!! error TS2339: Property 'f' does not exist on type 'never'.
}
```

However I found another related pre-existing error class that needs to be fixed
```
// @strict: true
// @declaration: true
interface Food2b {
    bard?: {
        getValues(): number[];
    }
}
declare const food2b: Food2b | undefined;
const bards = food2b?.bard?.getValues();
if (bards) {
    food2b; // (after this pull) type Food2b, OK  
    food2b.bard; // type { getValues(): number[] } | undefined. --- BUG 
    food2b.bard.getValues(); // error --- BUG
}
```
so I will continue to work on that, regardless of whether or not this pull is accepted as is.

