### PR TITLE
Add check for reference-compared literals to JS files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37028,7 +37028,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // control flow analysis it is possible for operands to temporarily have narrower types, and those narrower
                 // types may cause the operands to not be comparable. We don't want such errors reported (see #46475).
                 if (!(checkMode && checkMode & CheckMode.TypeOnly)) {
-                    if (isLiteralExpressionOfObject(left) || isLiteralExpressionOfObject(right)) {
+                    if (
+                        (isLiteralExpressionOfObject(left) || isLiteralExpressionOfObject(right)) &&
+                        // only report for === and !== in JS, not == or !=
+                        (!isInJSFile(left) || (operator === SyntaxKind.EqualsEqualsEqualsToken || operator === SyntaxKind.ExclamationEqualsEqualsToken))
+                    ) {
                         const eqType = operator === SyntaxKind.EqualsEqualsToken || operator === SyntaxKind.EqualsEqualsEqualsToken;
                         error(errorNode, Diagnostics.This_condition_will_always_return_0_since_JavaScript_compares_objects_by_reference_not_value, eqType ? "false" : "true");
                     }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1430,6 +1430,8 @@ export const plainJSErrors: Set<number> = new Set([
     Diagnostics.Class_constructor_may_not_be_a_generator.code,
     Diagnostics.Class_constructor_may_not_be_an_accessor.code,
     Diagnostics.await_expressions_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules.code,
+    // Type errors
+    Diagnostics.This_condition_will_always_return_0_since_JavaScript_compares_objects_by_reference_not_value.code,
 ]);
 
 /**

--- a/tests/baselines/reference/plainJSTypeErrors.errors.txt
+++ b/tests/baselines/reference/plainJSTypeErrors.errors.txt
@@ -1,0 +1,12 @@
+plainJSTypeErrors.js(2,5): error TS2839: This condition will always return 'false' since JavaScript compares objects by reference, not value.
+
+
+==== plainJSTypeErrors.js (1 errors) ====
+    // should error
+    if ({} === {}) {}
+        ~~~~~~~~~
+!!! error TS2839: This condition will always return 'false' since JavaScript compares objects by reference, not value.
+    
+    // should not error
+    if ({} == {}) {}
+    

--- a/tests/baselines/reference/plainJSTypeErrors.js
+++ b/tests/baselines/reference/plainJSTypeErrors.js
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/salsa/plainJSTypeErrors.ts] ////
+
+//// [plainJSTypeErrors.js]
+// should error
+if ({} === {}) {}
+
+// should not error
+if ({} == {}) {}
+
+
+//// [plainJSTypeErrors.js]
+// should error
+if ({} === {}) { }
+// should not error
+if ({} == {}) { }

--- a/tests/baselines/reference/plainJSTypeErrors.symbols
+++ b/tests/baselines/reference/plainJSTypeErrors.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/salsa/plainJSTypeErrors.ts] ////
+
+=== plainJSTypeErrors.js ===
+
+// should error
+if ({} === {}) {}
+
+// should not error
+if ({} == {}) {}
+

--- a/tests/baselines/reference/plainJSTypeErrors.types
+++ b/tests/baselines/reference/plainJSTypeErrors.types
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/salsa/plainJSTypeErrors.ts] ////
+
+=== plainJSTypeErrors.js ===
+// should error
+if ({} === {}) {}
+>{} === {} : boolean
+>{} : {}
+>{} : {}
+
+// should not error
+if ({} == {}) {}
+>{} == {} : boolean
+>{} : {}
+>{} : {}
+

--- a/tests/cases/conformance/salsa/plainJSTypeErrors.ts
+++ b/tests/cases/conformance/salsa/plainJSTypeErrors.ts
@@ -1,0 +1,10 @@
+// @outdir: out/
+// @target: esnext
+// @allowJS: true
+// @filename: plainJSTypeErrors.js
+
+// should error
+if ({} === {}) {}
+
+// should not error
+if ({} == {}) {}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

I don't know where I can add a test for JS files.

According to discussion in https://github.com/microsoft/TypeScript/pull/45978, I open this PR to also check JavaScript files.
