### PR TITLE
fix(30003): formatter deletes comment after trailing comma (again)

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -836,11 +836,9 @@ namespace ts.formatting {
                 if (listEndToken !== SyntaxKind.Unknown && formattingScanner.isOnToken() && formattingScanner.getStartPos() < originalRange.end) {
                     let tokenInfo: TokenInfo | undefined = formattingScanner.readTokenInfo(parent);
                     if (tokenInfo.token.kind === SyntaxKind.CommaToken && isCallLikeExpression(parent)) {
-                        const commaTokenLine = sourceFile.getLineAndCharacterOfPosition(tokenInfo.token.pos).line;
-                        if (startLine !== commaTokenLine) {
-                            formattingScanner.advance();
-                            tokenInfo = formattingScanner.isOnToken() ? formattingScanner.readTokenInfo(parent) : undefined;
-                        }
+                        // consume the comma
+                        consumeTokenAndAdvanceScanner(tokenInfo, parent, listDynamicIndentation, parent);
+                        tokenInfo = formattingScanner.isOnToken() ? formattingScanner.readTokenInfo(parent) : undefined;
                     }
 
                     // consume the list end token only if it is still belong to the parent

--- a/tests/cases/fourslash/formatNoSpaceBeforeCloseBrace3.ts
+++ b/tests/cases/fourslash/formatNoSpaceBeforeCloseBrace3.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts"/>
+
+////foo( 
+//// 1, /* comment */    );
+
+format.document();
+verify.currentFileContentIs(`foo(
+    1, /* comment */);`);

--- a/tests/cases/fourslash/formatNoSpaceBeforeCloseBrace4.ts
+++ b/tests/cases/fourslash/formatNoSpaceBeforeCloseBrace4.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts"/>
+
+////new Foo(1
+////, /* comment */    );
+
+format.document();
+verify.currentFileContentIs(`new Foo(1
+    , /* comment */);`);

--- a/tests/cases/fourslash/formatNoSpaceBeforeCloseBrace5.ts
+++ b/tests/cases/fourslash/formatNoSpaceBeforeCloseBrace5.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts"/>
+
+////new Foo(1, 
+////    /* comment */    );
+
+format.document();
+verify.currentFileContentIs(`new Foo(1,
+    /* comment */);`);

--- a/tests/cases/fourslash/formatNoSpaceBeforeCloseBrace6.ts
+++ b/tests/cases/fourslash/formatNoSpaceBeforeCloseBrace6.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts"/>
+
+////new Foo(1, /* comment */  
+////  );
+
+format.document();
+verify.currentFileContentIs(`new Foo(1, /* comment */
+);`);


### PR DESCRIPTION
Fixes #30003 again.

As I mentioned in https://github.com/microsoft/TypeScript/issues/30003#issuecomment-1129914842, the original fix, PR #36674, only checks for cases where the trailing comma is on the same line as `(`, failing on cases like
```ts
fu(
    5, /*afsd*/);
```

The problem originates from that when the `NoSpaceBeforeCloseParen` rule was applied, the relevant tokens were `5` and `)`, making the rule treat everything in between as whitespace to be deleted. This happened because the comma was only `advance`'d over, not consumed, so not recorded:
https://github.com/microsoft/TypeScript/blob/ce85d647ef88183c019588bcf398320ce29b625a/src/services/formatting/formatting.ts#L836-L844
This PR tries to fix the problem by `consumeTokenAndAdvanceScanner`'ing the comma instead of `advance`ing over it.
