### PR TITLE
fix(49178): Inlay hints doesn't appear when calling function after extends keyword in Typescript files

### DIFF
--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -47,7 +47,7 @@ namespace ts.InlayHints {
                 return;
             }
 
-            if (isTypeNode(node)) {
+            if (isTypeNode(node) && !isExpressionWithTypeArguments(node)) {
                 return;
             }
 

--- a/tests/cases/fourslash/inlayHintsShouldWork68.ts
+++ b/tests/cases/fourslash/inlayHintsShouldWork68.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+////const foo = (a = 1) => class { }
+////
+////const C1 = class extends foo(/*1*/1) { }
+////class C2 extends foo(/*2*/1) { }
+
+const markers = test.markers();
+
+verify.getInlayHints([
+    {
+        text: 'a:',
+        position: markers[0].position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+    {
+        text: 'a:',
+        position: markers[1].position,
+        kind: ts.InlayHintKind.Parameter,
+        whitespaceAfter: true
+    },
+], undefined, {
+    includeInlayParameterNameHints: "literals"
+});


### PR DESCRIPTION
Fixes #49178