### PR TITLE
Remove all checks on for/in RHS

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38199,12 +38199,6 @@ namespace ts {
                 }
             }
 
-            // unknownType is returned i.e. if node.expression is identifier whose name cannot be resolved
-            // in this case error about missing name is already reported - do not report extra one
-            if (rightType === neverType || !isTypeAssignableToKind(rightType, TypeFlags.NonPrimitive | TypeFlags.InstantiableNonPrimitive)) {
-                error(node.expression, Diagnostics.The_right_hand_side_of_a_for_in_statement_must_be_of_type_any_an_object_type_or_a_type_parameter_but_here_has_type_0, typeToString(rightType));
-            }
-
             checkSourceElement(node.statement);
             if (node.locals) {
                 registerForUnusedIdentifiersCheck(node);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1944,10 +1944,6 @@
         "category": "Error",
         "code": 2406
     },
-    "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type '{0}'.": {
-        "category": "Error",
-        "code": 2407
-    },
     "Setters cannot return a value.": {
         "category": "Error",
         "code": 2408

--- a/tests/baselines/reference/for-inStatements.errors.txt
+++ b/tests/baselines/reference/for-inStatements.errors.txt
@@ -1,9 +1,8 @@
 tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(33,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
 tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(50,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
-tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(79,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'Color.Blue'.
 
 
-==== tests/cases/conformance/statements/for-inStatements/for-inStatements.ts (3 errors) ====
+==== tests/cases/conformance/statements/for-inStatements/for-inStatements.ts (2 errors) ====
     var aString: string;
     for (aString in {}) { }
     
@@ -89,6 +88,4 @@ tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(79,15): 
     
     for (var x in Color) { }
     for (var x in Color.Blue) { }
-                  ~~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'Color.Blue'.
     

--- a/tests/baselines/reference/for-inStatementsInvalid.errors.txt
+++ b/tests/baselines/reference/for-inStatementsInvalid.errors.txt
@@ -2,22 +2,11 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(2
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(5,6): error TS2405: The left-hand side of a 'for...in' statement must be of type 'string' or 'any'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(8,6): error TS2405: The left-hand side of a 'for...in' statement must be of type 'string' or 'any'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(10,10): error TS2404: The left-hand side of a 'for...in' statement cannot use a type annotation.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(13,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'void'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(17,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(18,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(19,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(20,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(22,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(29,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(31,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(38,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(46,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(48,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(51,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(62,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
 
 
-==== tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts (17 errors) ====
+==== tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts (6 errors) ====
     var aNumber: number;
     for (aNumber in {}) { }
          ~~~~~~~
@@ -39,27 +28,15 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
     
     function fn(): void { }
     for (var x in fn()) { }
-                  ~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'void'.
     
     var c : string, d:string, e;
     
     for (var x in c || d) { }
-                  ~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
     for (var x in e ? c : d) { }
-                  ~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
     for (var x in 42 ? c : d) { }
-                  ~~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
     for (var x in '' ? c : d) { }
-                  ~~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
     for (var x in 42 ? d[x] : c[x]) { }
     for (var x in c[23]) { }
-                  ~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
     
     for (var x in (<T>(x: T) => x)) { }
     for (var x in function (x: string, y: number) { return x + y }) { }
@@ -67,8 +44,6 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
     class A {
         biz() : number{
             for (var x in this.biz()) { }
-                          ~~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
             for (var x in this.biz) { }
             for (var x in this) { }
                      ~
@@ -81,8 +56,6 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
             for (var x in this) { }
             for (var x in this.baz) { }
             for (var x in this.baz()) { }
-                          ~~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
     
             return null;
         }
@@ -91,8 +64,6 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
     class B extends A {
         boz() {
             for (var x in this.biz()) { }
-                          ~~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
             for (var x in this.biz) { }
             for (var x in this) { }
                      ~
@@ -101,8 +72,6 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
     
             for (var x in super.biz) { }
             for (var x in super.biz()) { }
-                          ~~~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
             return null;
         }
     }
@@ -114,6 +83,4 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
     var i: I;
     
     for (var x in i[42]) { } 
-                  ~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
     

--- a/tests/baselines/reference/forIn2.errors.txt
+++ b/tests/baselines/reference/forIn2.errors.txt
@@ -1,8 +1,0 @@
-tests/cases/compiler/forIn2.ts(1,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type '1'.
-
-
-==== tests/cases/compiler/forIn2.ts (1 errors) ====
-    for (var i in 1) {
-                  ~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type '1'.
-    }

--- a/tests/baselines/reference/forInStatement2.errors.txt
+++ b/tests/baselines/reference/forInStatement2.errors.txt
@@ -1,9 +1,0 @@
-tests/cases/compiler/forInStatement2.ts(2,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
-
-
-==== tests/cases/compiler/forInStatement2.ts (1 errors) ====
-    var expr: number;
-    for (var a in expr) {
-                  ~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
-    }

--- a/tests/baselines/reference/neverTypeErrors1.errors.txt
+++ b/tests/baselines/reference/neverTypeErrors1.errors.txt
@@ -10,10 +10,9 @@ tests/cases/conformance/types/never/neverTypeErrors1.ts(13,5): error TS2322: Typ
 tests/cases/conformance/types/never/neverTypeErrors1.ts(17,5): error TS2322: Type 'number' is not assignable to type 'never'.
 tests/cases/conformance/types/never/neverTypeErrors1.ts(20,16): error TS2534: A function returning 'never' cannot have a reachable end point.
 tests/cases/conformance/types/never/neverTypeErrors1.ts(23,17): error TS2488: Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.
-tests/cases/conformance/types/never/neverTypeErrors1.ts(24,17): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'never'.
 
 
-==== tests/cases/conformance/types/never/neverTypeErrors1.ts (12 errors) ====
+==== tests/cases/conformance/types/never/neverTypeErrors1.ts (11 errors) ====
     function f1() {
         let x: never;
         x = 1;
@@ -61,8 +60,6 @@ tests/cases/conformance/types/never/neverTypeErrors1.ts(24,17): error TS2407: Th
                     ~~~~
 !!! error TS2488: Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.
     for (const n in f4()) {}
-                    ~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'never'.
     
     function f5() {
         let x: never[] = [];  // Ok

--- a/tests/baselines/reference/neverTypeErrors2.errors.txt
+++ b/tests/baselines/reference/neverTypeErrors2.errors.txt
@@ -10,10 +10,9 @@ tests/cases/conformance/types/never/neverTypeErrors2.ts(13,5): error TS2322: Typ
 tests/cases/conformance/types/never/neverTypeErrors2.ts(17,5): error TS2322: Type 'number' is not assignable to type 'never'.
 tests/cases/conformance/types/never/neverTypeErrors2.ts(20,16): error TS2534: A function returning 'never' cannot have a reachable end point.
 tests/cases/conformance/types/never/neverTypeErrors2.ts(23,17): error TS2488: Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.
-tests/cases/conformance/types/never/neverTypeErrors2.ts(24,17): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'never'.
 
 
-==== tests/cases/conformance/types/never/neverTypeErrors2.ts (12 errors) ====
+==== tests/cases/conformance/types/never/neverTypeErrors2.ts (11 errors) ====
     function f1() {
         let x: never;
         x = 1;
@@ -61,8 +60,6 @@ tests/cases/conformance/types/never/neverTypeErrors2.ts(24,17): error TS2407: Th
                     ~~~~
 !!! error TS2488: Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.
     for (const n in f4()) {}
-                    ~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'never'.
     
     function f5() {
         let x: never[] = [];  // Ok

--- a/tests/baselines/reference/privateNameInInExpression(target=es2022).errors.txt
+++ b/tests/baselines/reference/privateNameInInExpression(target=es2022).errors.txt
@@ -2,12 +2,11 @@ tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.t
 tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(23,19): error TS2339: Property '#fiel' does not exist on type 'any'.
 tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(25,20): error TS1451: Private identifiers are only allowed in class bodies and may only be used as part of a class member declaration, property access, or on the left-hand-side of an 'in' expression
 tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(27,14): error TS2406: The left-hand side of a 'for...in' statement must be a variable or a property access.
-tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(29,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'boolean'.
 tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(43,27): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(114,12): error TS18016: Private identifiers are not allowed outside class bodies.
 
 
-==== tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts (7 errors) ====
+==== tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts (6 errors) ====
     class Foo {
         #field = 1;
         static #staticField = 2;
@@ -45,8 +44,6 @@ tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.t
 !!! error TS2406: The left-hand side of a 'for...in' statement must be a variable or a property access.
     
             for (let d in #field in v) { /**/ } // Bad - rhs of in should be a object/any
-                          ~~~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'boolean'.
         }
         whitespace(v: any) {
             const a = v && /*0*/#field/*1*/

--- a/tests/baselines/reference/privateNameInInExpression(target=esnext).errors.txt
+++ b/tests/baselines/reference/privateNameInInExpression(target=esnext).errors.txt
@@ -2,12 +2,11 @@ tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.t
 tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(23,19): error TS2339: Property '#fiel' does not exist on type 'any'.
 tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(25,20): error TS1451: Private identifiers are only allowed in class bodies and may only be used as part of a class member declaration, property access, or on the left-hand-side of an 'in' expression
 tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(27,14): error TS2406: The left-hand side of a 'for...in' statement must be a variable or a property access.
-tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(29,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'boolean'.
 tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(43,27): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts(114,12): error TS18016: Private identifiers are not allowed outside class bodies.
 
 
-==== tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts (7 errors) ====
+==== tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.ts (6 errors) ====
     class Foo {
         #field = 1;
         static #staticField = 2;
@@ -45,8 +44,6 @@ tests/cases/conformance/classes/members/privateNames/privateNameInInExpression.t
 !!! error TS2406: The left-hand side of a 'for...in' statement must be a variable or a property access.
     
             for (let d in #field in v) { /**/ } // Bad - rhs of in should be a object/any
-                          ~~~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'boolean'.
         }
         whitespace(v: any) {
             const a = v && /*0*/#field/*1*/

--- a/tests/baselines/reference/symbolType13.errors.txt
+++ b/tests/baselines/reference/symbolType13.errors.txt
@@ -1,9 +1,7 @@
 tests/cases/conformance/es6/Symbols/symbolType13.ts(4,6): error TS2405: The left-hand side of a 'for...in' statement must be of type 'string' or 'any'.
-tests/cases/conformance/es6/Symbols/symbolType13.ts(5,11): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'symbol'.
-tests/cases/conformance/es6/Symbols/symbolType13.ts(6,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'symbol'.
 
 
-==== tests/cases/conformance/es6/Symbols/symbolType13.ts (3 errors) ====
+==== tests/cases/conformance/es6/Symbols/symbolType13.ts (1 errors) ====
     var s = Symbol();
     var x: any;
     
@@ -11,8 +9,4 @@ tests/cases/conformance/es6/Symbols/symbolType13.ts(6,15): error TS2407: The rig
          ~
 !!! error TS2405: The left-hand side of a 'for...in' statement must be of type 'string' or 'any'.
     for (x in s) { }
-              ~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'symbol'.
     for (var y in s) { }
-                  ~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'symbol'.


### PR DESCRIPTION
Our previous rules here were *very* odd in practice. Per offline discussion, we agreed to just remove all checks entirely here since `for...in` never throws