### PR TITLE
Issue serialization error when attempting to serialize a late-bound name from a mapped type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5619,7 +5619,7 @@ namespace ts {
                     anyType : getNonMissingTypeOfSymbol(propertySymbol);
                 const saveEnclosingDeclaration = context.enclosingDeclaration;
                 context.enclosingDeclaration = undefined;
-                if (context.tracker.trackSymbol && getCheckFlags(propertySymbol) & CheckFlags.Late && isLateBoundName(propertySymbol.escapedName)) {
+                if (context.tracker.trackSymbol && isLateBoundName(propertySymbol.escapedName)) {
                     if (propertySymbol.declarations) {
                         const decl = first(propertySymbol.declarations);
                         if (hasLateBindableName(decl)) {

--- a/tests/baselines/reference/declarationEmitMappedTypeTemplateTypeofSymbol.errors.txt
+++ b/tests/baselines/reference/declarationEmitMappedTypeTemplateTypeofSymbol.errors.txt
@@ -1,0 +1,25 @@
+tests/cases/compiler/b.ts(2,14): error TS4118: The type of this node cannot be serialized because its property '[timestampSymbol]' cannot be serialized.
+tests/cases/compiler/c.ts(3,14): error TS4118: The type of this node cannot be serialized because its property '[timestampSymbol]' cannot be serialized.
+
+
+==== tests/cases/compiler/a.d.ts (0 errors) ====
+    export declare const timestampSymbol: unique symbol;
+    
+    export declare const Timestamp: {
+        [TKey in typeof timestampSymbol]: true;
+    };
+    
+    export declare function now(): typeof Timestamp;
+    
+==== tests/cases/compiler/b.ts (1 errors) ====
+    import * as x from "./a";
+    export const timestamp = x.now();
+                 ~~~~~~~~~
+!!! error TS4118: The type of this node cannot be serialized because its property '[timestampSymbol]' cannot be serialized.
+    
+==== tests/cases/compiler/c.ts (1 errors) ====
+    import { now } from "./a";
+    
+    export const timestamp = now();
+                 ~~~~~~~~~
+!!! error TS4118: The type of this node cannot be serialized because its property '[timestampSymbol]' cannot be serialized.

--- a/tests/baselines/reference/declarationEmitMappedTypeTemplateTypeofSymbol.js
+++ b/tests/baselines/reference/declarationEmitMappedTypeTemplateTypeofSymbol.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/declarationEmitMappedTypeTemplateTypeofSymbol.ts] ////
+
+//// [a.d.ts]
+export declare const timestampSymbol: unique symbol;
+
+export declare const Timestamp: {
+    [TKey in typeof timestampSymbol]: true;
+};
+
+export declare function now(): typeof Timestamp;
+
+//// [b.ts]
+import * as x from "./a";
+export const timestamp = x.now();
+
+//// [c.ts]
+import { now } from "./a";
+
+export const timestamp = now();
+
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+exports.timestamp = void 0;
+var x = require("./a");
+exports.timestamp = x.now();
+//// [c.js]
+"use strict";
+exports.__esModule = true;
+exports.timestamp = void 0;
+var a_1 = require("./a");
+exports.timestamp = (0, a_1.now)();

--- a/tests/baselines/reference/declarationEmitMappedTypeTemplateTypeofSymbol.symbols
+++ b/tests/baselines/reference/declarationEmitMappedTypeTemplateTypeofSymbol.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/a.d.ts ===
+export declare const timestampSymbol: unique symbol;
+>timestampSymbol : Symbol(timestampSymbol, Decl(a.d.ts, 0, 20))
+
+export declare const Timestamp: {
+>Timestamp : Symbol(Timestamp, Decl(a.d.ts, 2, 20))
+
+    [TKey in typeof timestampSymbol]: true;
+>TKey : Symbol(TKey, Decl(a.d.ts, 3, 5))
+>timestampSymbol : Symbol(timestampSymbol, Decl(a.d.ts, 0, 20))
+
+};
+
+export declare function now(): typeof Timestamp;
+>now : Symbol(now, Decl(a.d.ts, 4, 2))
+>Timestamp : Symbol(Timestamp, Decl(a.d.ts, 2, 20))
+
+=== tests/cases/compiler/b.ts ===
+import * as x from "./a";
+>x : Symbol(x, Decl(b.ts, 0, 6))
+
+export const timestamp = x.now();
+>timestamp : Symbol(timestamp, Decl(b.ts, 1, 12))
+>x.now : Symbol(x.now, Decl(a.d.ts, 4, 2))
+>x : Symbol(x, Decl(b.ts, 0, 6))
+>now : Symbol(x.now, Decl(a.d.ts, 4, 2))
+
+=== tests/cases/compiler/c.ts ===
+import { now } from "./a";
+>now : Symbol(now, Decl(c.ts, 0, 8))
+
+export const timestamp = now();
+>timestamp : Symbol(timestamp, Decl(c.ts, 2, 12))
+>now : Symbol(now, Decl(c.ts, 0, 8))
+

--- a/tests/baselines/reference/declarationEmitMappedTypeTemplateTypeofSymbol.types
+++ b/tests/baselines/reference/declarationEmitMappedTypeTemplateTypeofSymbol.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/a.d.ts ===
+export declare const timestampSymbol: unique symbol;
+>timestampSymbol : unique symbol
+
+export declare const Timestamp: {
+>Timestamp : { [timestampSymbol]: true; }
+
+    [TKey in typeof timestampSymbol]: true;
+>timestampSymbol : unique symbol
+>true : true
+
+};
+
+export declare function now(): typeof Timestamp;
+>now : () => typeof Timestamp
+>Timestamp : { [timestampSymbol]: true; }
+
+=== tests/cases/compiler/b.ts ===
+import * as x from "./a";
+>x : typeof x
+
+export const timestamp = x.now();
+>timestamp : { [x.timestampSymbol]: true; }
+>x.now() : { [x.timestampSymbol]: true; }
+>x.now : () => { [x.timestampSymbol]: true; }
+>x : typeof x
+>now : () => { [x.timestampSymbol]: true; }
+
+=== tests/cases/compiler/c.ts ===
+import { now } from "./a";
+>now : () => { [timestampSymbol]: true; }
+
+export const timestamp = now();
+>timestamp : { [timestampSymbol]: true; }
+>now() : { [timestampSymbol]: true; }
+>now : () => { [timestampSymbol]: true; }
+

--- a/tests/cases/compiler/declarationEmitMappedTypeTemplateTypeofSymbol.ts
+++ b/tests/cases/compiler/declarationEmitMappedTypeTemplateTypeofSymbol.ts
@@ -1,0 +1,19 @@
+// @strict: true
+// @declaration: true
+// @filename: a.d.ts
+export declare const timestampSymbol: unique symbol;
+
+export declare const Timestamp: {
+    [TKey in typeof timestampSymbol]: true;
+};
+
+export declare function now(): typeof Timestamp;
+
+// @filename: b.ts
+import * as x from "./a";
+export const timestamp = x.now();
+
+// @filename: c.ts
+import { now } from "./a";
+
+export const timestamp = now();


### PR DESCRIPTION
Fixes #49065 - we now consistently issue an error on the mapped type form of the declaration, just like the anonymous object declaration. (Late bound names fed into mapped types don't get `CheckFlags.Late` set on them because they didn't go through the late binding process, however our output of the type will, so the name being a late bindable name alone is sufficient to need to issue the error)
