### PR TITLE
Key validity of import=require in module: node off of module and not target

### DIFF
--- a/src/compiler/transformers/module/esnextAnd2015.ts
+++ b/src/compiler/transformers/module/esnextAnd2015.ts
@@ -72,7 +72,7 @@ namespace ts {
                     // Though an error in es2020 modules, in node-flavor es2020 modules, we can helpfully transform this to a synthetic `require` call
                     // To give easy access to a synchronous `require` in node-flavor esm. We do the transform even in scenarios where we error, but `import.meta.url`
                     // is available, just because the output is reasonable for a node-like runtime.
-                    return getEmitScriptTarget(compilerOptions) >= ModuleKind.ES2020 ? visitImportEqualsDeclaration(node as ImportEqualsDeclaration) : undefined;
+                    return getEmitModuleKind(compilerOptions) >= ModuleKind.Node16 ? visitImportEqualsDeclaration(node as ImportEqualsDeclaration) : undefined;
                 case SyntaxKind.ExportAssignment:
                     return visitExportAssignment(node as ExportAssignment);
                 case SyntaxKind.ExportDeclaration:

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2016).js
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2016).js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/moduleNodeImportRequireEmit.ts] ////
+
+//// [package.json]
+{
+    "type": "module"
+}
+//// [mod.d.ts]
+declare module "foo";
+//// [index.ts]
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+foo;
+
+//// [index.js]
+import { createRequire as _createRequire } from "module";
+const __require = _createRequire(import.meta.url);
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+const foo = __require("foo");
+foo;

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2016).symbols
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2016).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/index.ts ===
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+>foo : Symbol(foo, Decl(index.ts, 0, 0))
+
+foo;
+>foo : Symbol(foo, Decl(index.ts, 0, 0))
+
+=== tests/cases/compiler/mod.d.ts ===
+declare module "foo";
+>"foo" : Symbol("foo", Decl(mod.d.ts, 0, 0))
+

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2016).types
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2016).types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/index.ts ===
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+>foo : any
+
+foo;
+>foo : any
+
+=== tests/cases/compiler/mod.d.ts ===
+declare module "foo";
+>"foo" : any
+

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2020).js
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2020).js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/moduleNodeImportRequireEmit.ts] ////
+
+//// [package.json]
+{
+    "type": "module"
+}
+//// [mod.d.ts]
+declare module "foo";
+//// [index.ts]
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+foo;
+
+//// [index.js]
+import { createRequire as _createRequire } from "module";
+const __require = _createRequire(import.meta.url);
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+const foo = __require("foo");
+foo;

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2020).symbols
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2020).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/index.ts ===
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+>foo : Symbol(foo, Decl(index.ts, 0, 0))
+
+foo;
+>foo : Symbol(foo, Decl(index.ts, 0, 0))
+
+=== tests/cases/compiler/mod.d.ts ===
+declare module "foo";
+>"foo" : Symbol("foo", Decl(mod.d.ts, 0, 0))
+

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2020).types
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=es2020).types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/index.ts ===
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+>foo : any
+
+foo;
+>foo : any
+
+=== tests/cases/compiler/mod.d.ts ===
+declare module "foo";
+>"foo" : any
+

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=es5).js
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=es5).js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/moduleNodeImportRequireEmit.ts] ////
+
+//// [package.json]
+{
+    "type": "module"
+}
+//// [mod.d.ts]
+declare module "foo";
+//// [index.ts]
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+foo;
+
+//// [index.js]
+import { createRequire as _createRequire } from "module";
+var __require = _createRequire(import.meta.url);
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+var foo = __require("foo");
+foo;

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=es5).symbols
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=es5).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/index.ts ===
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+>foo : Symbol(foo, Decl(index.ts, 0, 0))
+
+foo;
+>foo : Symbol(foo, Decl(index.ts, 0, 0))
+
+=== tests/cases/compiler/mod.d.ts ===
+declare module "foo";
+>"foo" : Symbol("foo", Decl(mod.d.ts, 0, 0))
+

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=es5).types
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=es5).types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/index.ts ===
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+>foo : any
+
+foo;
+>foo : any
+
+=== tests/cases/compiler/mod.d.ts ===
+declare module "foo";
+>"foo" : any
+

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=esnext).js
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=esnext).js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/moduleNodeImportRequireEmit.ts] ////
+
+//// [package.json]
+{
+    "type": "module"
+}
+//// [mod.d.ts]
+declare module "foo";
+//// [index.ts]
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+foo;
+
+//// [index.js]
+import { createRequire as _createRequire } from "module";
+const __require = _createRequire(import.meta.url);
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+const foo = __require("foo");
+foo;

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=esnext).symbols
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=esnext).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/index.ts ===
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+>foo : Symbol(foo, Decl(index.ts, 0, 0))
+
+foo;
+>foo : Symbol(foo, Decl(index.ts, 0, 0))
+
+=== tests/cases/compiler/mod.d.ts ===
+declare module "foo";
+>"foo" : Symbol("foo", Decl(mod.d.ts, 0, 0))
+

--- a/tests/baselines/reference/moduleNodeImportRequireEmit(target=esnext).types
+++ b/tests/baselines/reference/moduleNodeImportRequireEmit(target=esnext).types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/index.ts ===
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+>foo : any
+
+foo;
+>foo : any
+
+=== tests/cases/compiler/mod.d.ts ===
+declare module "foo";
+>"foo" : any
+

--- a/tests/cases/compiler/moduleNodeImportRequireEmit.ts
+++ b/tests/cases/compiler/moduleNodeImportRequireEmit.ts
@@ -1,0 +1,13 @@
+// @target: es5,es2016,es2020,esnext
+// @module: nodenext
+// @filename: package.json
+{
+    "type": "module"
+}
+// @filename: mod.d.ts
+declare module "foo";
+// @filename: index.ts
+/// <reference path="./mod.d.ts" />
+// This should emit a call to createRequire(import.meta.url)
+import foo = require("foo");
+foo;


### PR DESCRIPTION
Since `import.meta` itself is keyed off `module` and not `target` (and thus should always be allowed in esm files in `node` module targets).


Fixes #48876
