### PR TITLE
Invert check for for-in and handle generic constraints

### DIFF
--- a/tests/baselines/reference/forInGenericPrimitive.errors.txt
+++ b/tests/baselines/reference/forInGenericPrimitive.errors.txt
@@ -1,0 +1,31 @@
+tests/cases/compiler/forInGenericPrimitive.ts(15,21): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'B'.
+tests/cases/compiler/forInGenericPrimitive.ts(16,21): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'C'.
+tests/cases/compiler/forInGenericPrimitive.ts(17,21): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'D'.
+
+
+==== tests/cases/compiler/forInGenericPrimitive.ts (3 errors) ====
+    function f<
+    A,
+    B extends { a: number } | string,
+    C extends string | void,
+    D extends number | { s: string } | null | string,
+    E extends { x: number },
+    >(
+        a: A,
+        b: B,
+        c: C,
+        d: D,
+        e: E,
+    ) {
+        for (const _ in a) { }
+        for (const _ in b) { }
+                        ~
+!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'B'.
+        for (const _ in c) { }
+                        ~
+!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'C'.
+        for (const _ in d) { }
+                        ~
+!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'D'.
+        for (const _ in e) { }
+    }

--- a/tests/baselines/reference/forInGenericPrimitive.js
+++ b/tests/baselines/reference/forInGenericPrimitive.js
@@ -1,0 +1,30 @@
+//// [forInGenericPrimitive.ts]
+function f<
+A,
+B extends { a: number } | string,
+C extends string | void,
+D extends number | { s: string } | null | string,
+E extends { x: number },
+>(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+) {
+    for (const _ in a) { }
+    for (const _ in b) { }
+    for (const _ in c) { }
+    for (const _ in d) { }
+    for (const _ in e) { }
+}
+
+//// [forInGenericPrimitive.js]
+"use strict";
+function f(a, b, c, d, e) {
+    for (var _ in a) { }
+    for (var _ in b) { }
+    for (var _ in c) { }
+    for (var _ in d) { }
+    for (var _ in e) { }
+}

--- a/tests/baselines/reference/forInGenericPrimitive.symbols
+++ b/tests/baselines/reference/forInGenericPrimitive.symbols
@@ -1,0 +1,64 @@
+=== tests/cases/compiler/forInGenericPrimitive.ts ===
+function f<
+>f : Symbol(f, Decl(forInGenericPrimitive.ts, 0, 0))
+
+A,
+>A : Symbol(A, Decl(forInGenericPrimitive.ts, 0, 11))
+
+B extends { a: number } | string,
+>B : Symbol(B, Decl(forInGenericPrimitive.ts, 1, 2))
+>a : Symbol(a, Decl(forInGenericPrimitive.ts, 2, 11))
+
+C extends string | void,
+>C : Symbol(C, Decl(forInGenericPrimitive.ts, 2, 33))
+
+D extends number | { s: string } | null | string,
+>D : Symbol(D, Decl(forInGenericPrimitive.ts, 3, 24))
+>s : Symbol(s, Decl(forInGenericPrimitive.ts, 4, 20))
+
+E extends { x: number },
+>E : Symbol(E, Decl(forInGenericPrimitive.ts, 4, 49))
+>x : Symbol(x, Decl(forInGenericPrimitive.ts, 5, 11))
+
+>(
+    a: A,
+>a : Symbol(a, Decl(forInGenericPrimitive.ts, 6, 2))
+>A : Symbol(A, Decl(forInGenericPrimitive.ts, 0, 11))
+
+    b: B,
+>b : Symbol(b, Decl(forInGenericPrimitive.ts, 7, 9))
+>B : Symbol(B, Decl(forInGenericPrimitive.ts, 1, 2))
+
+    c: C,
+>c : Symbol(c, Decl(forInGenericPrimitive.ts, 8, 9))
+>C : Symbol(C, Decl(forInGenericPrimitive.ts, 2, 33))
+
+    d: D,
+>d : Symbol(d, Decl(forInGenericPrimitive.ts, 9, 9))
+>D : Symbol(D, Decl(forInGenericPrimitive.ts, 3, 24))
+
+    e: E,
+>e : Symbol(e, Decl(forInGenericPrimitive.ts, 10, 9))
+>E : Symbol(E, Decl(forInGenericPrimitive.ts, 4, 49))
+
+) {
+    for (const _ in a) { }
+>_ : Symbol(_, Decl(forInGenericPrimitive.ts, 13, 14))
+>a : Symbol(a, Decl(forInGenericPrimitive.ts, 6, 2))
+
+    for (const _ in b) { }
+>_ : Symbol(_, Decl(forInGenericPrimitive.ts, 14, 14))
+>b : Symbol(b, Decl(forInGenericPrimitive.ts, 7, 9))
+
+    for (const _ in c) { }
+>_ : Symbol(_, Decl(forInGenericPrimitive.ts, 15, 14))
+>c : Symbol(c, Decl(forInGenericPrimitive.ts, 8, 9))
+
+    for (const _ in d) { }
+>_ : Symbol(_, Decl(forInGenericPrimitive.ts, 16, 14))
+>d : Symbol(d, Decl(forInGenericPrimitive.ts, 9, 9))
+
+    for (const _ in e) { }
+>_ : Symbol(_, Decl(forInGenericPrimitive.ts, 17, 14))
+>e : Symbol(e, Decl(forInGenericPrimitive.ts, 10, 9))
+}

--- a/tests/baselines/reference/forInGenericPrimitive.types
+++ b/tests/baselines/reference/forInGenericPrimitive.types
@@ -1,0 +1,53 @@
+=== tests/cases/compiler/forInGenericPrimitive.ts ===
+function f<
+>f : <A, B extends string | { a: number; }, C extends string | void, D extends string | number | { s: string; } | null, E extends { x: number; }>(a: A, b: B, c: C, d: D, e: E) => void
+
+A,
+B extends { a: number } | string,
+>a : number
+
+C extends string | void,
+D extends number | { s: string } | null | string,
+>s : string
+>null : null
+
+E extends { x: number },
+>x : number
+
+>(
+    a: A,
+>a : A
+
+    b: B,
+>b : B
+
+    c: C,
+>c : C
+
+    d: D,
+>d : D
+
+    e: E,
+>e : E
+
+) {
+    for (const _ in a) { }
+>_ : Extract<keyof A, string>
+>a : A
+
+    for (const _ in b) { }
+>_ : Extract<keyof B, string>
+>b : B
+
+    for (const _ in c) { }
+>_ : Extract<keyof C, string>
+>c : C
+
+    for (const _ in d) { }
+>_ : Extract<keyof D, string>
+>d : D
+
+    for (const _ in e) { }
+>_ : Extract<keyof E, string>
+>e : E
+}

--- a/tests/cases/compiler/forInGenericPrimitive.ts
+++ b/tests/cases/compiler/forInGenericPrimitive.ts
@@ -1,0 +1,20 @@
+// @strict: true
+function f<
+A,
+B extends { a: number } | string,
+C extends string | void,
+D extends number | { s: string } | null | string,
+E extends { x: number },
+>(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+) {
+    for (const _ in a) { }
+    for (const _ in b) { }
+    for (const _ in c) { }
+    for (const _ in d) { }
+    for (const _ in e) { }
+}


### PR DESCRIPTION
Potential alternative to #49193 that makes the check for primitives apply better to generics. A good follow-up to this would be adjusting the error message to better reflect the check. (Something like `Expression has type 'A' which is possibly 'string'`?).