### PR TITLE
moduleDetection: auto makes cjs/cts files parse as modules, and ...

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2834,12 +2834,14 @@ namespace ts {
         }
 
         function setCommonJsModuleIndicator(node: Node) {
-            if (file.externalModuleIndicator) {
+            if (file.externalModuleIndicator && file.externalModuleIndicator !== true) {
                 return false;
             }
             if (!file.commonJsModuleIndicator) {
                 file.commonJsModuleIndicator = node;
-                bindSourceFileAsExternalModule();
+                if (!file.externalModuleIndicator) {
+                    bindSourceFileAsExternalModule();
+                }
             }
             return true;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2746,7 +2746,7 @@ namespace ts {
                 return hasExportAssignmentSymbol(moduleSymbol);
             }
             // JS files have a synthetic default if they do not contain ES2015+ module syntax (export = is not valid in js) _and_ do not have an __esModule marker
-            return !file.externalModuleIndicator && !resolveExportByName(moduleSymbol, escapeLeadingUnderscores("__esModule"), /*sourceNode*/ undefined, dontResolveAlias);
+            return typeof file.externalModuleIndicator !== "object" && !resolveExportByName(moduleSymbol, escapeLeadingUnderscores("__esModule"), /*sourceNode*/ undefined, dontResolveAlias);
         }
 
         function getTargetOfImportClause(node: ImportClause, dontResolveAlias: boolean): Symbol | undefined {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6305,8 +6305,9 @@ namespace ts {
      */
     function isFileForcedToBeModuleByFormat(file: SourceFile): true | undefined {
         // Excludes declaration files - they still require an explicit `export {}` or the like
-        // for back compat purposes.
-        return file.impliedNodeFormat === ModuleKind.ESNext && !file.isDeclarationFile ? true : undefined;
+        // for back compat purposes. The only non-declaration files _not_ forced to be a module are `.js` files
+        // that aren't esm-mode (meaning not in a `type: module` scope).
+        return (file.impliedNodeFormat === ModuleKind.ESNext || (fileExtensionIsOneOf(file.fileName, [Extension.Cjs, Extension.Cts]))) && !file.isDeclarationFile ? true : undefined;
     }
 
     export function getSetExternalModuleIndicator(options: CompilerOptions): (file: SourceFile) => void {
@@ -6315,7 +6316,7 @@ namespace ts {
             case ModuleDetectionKind.Force:
                 // All non-declaration files are modules, declaration files still do the usual isFileProbablyExternalModule
                 return (file: SourceFile) => {
-                    file.externalModuleIndicator = !file.isDeclarationFile || isFileProbablyExternalModule(file);
+                    file.externalModuleIndicator = isFileProbablyExternalModule(file) || !file.isDeclarationFile || undefined;
                 };
             case ModuleDetectionKind.Legacy:
                 // Files are modules if they have imports, exports, or import.meta
@@ -6375,7 +6376,8 @@ namespace ts {
     }
 
     export function getEmitModuleDetectionKind(options: CompilerOptions) {
-        return options.moduleDetection || ModuleDetectionKind.Auto;
+        return options.moduleDetection ||
+            (getEmitModuleKind(options) === ModuleKind.Node16 || getEmitModuleKind(options) === ModuleKind.NodeNext ? ModuleDetectionKind.Force : ModuleDetectionKind.Auto);
     }
 
     export function hasJsonModuleEmitEnabled(options: CompilerOptions) {

--- a/tests/baselines/reference/moduleResolutionWithoutExtension8.js
+++ b/tests/baselines/reference/moduleResolutionWithoutExtension8.js
@@ -3,5 +3,7 @@
 import("./foo").then(x => x); // should error, ask for extension
 
 //// [bar.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 // Extensionless relative path dynamic import in a cjs module
 import("./foo").then(x => x); // should error, ask for extension

--- a/tests/baselines/reference/nodeModulesAllowJsExportAssignment(module=node16).js
+++ b/tests/baselines/reference/nodeModulesAllowJsExportAssignment(module=node16).js
@@ -34,6 +34,8 @@ module.exports = a;
 const a = {};
 module.exports = a;
 //// [file.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 // cjs format file
 const a = {};
 module.exports = a;

--- a/tests/baselines/reference/nodeModulesAllowJsExportAssignment(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesAllowJsExportAssignment(module=nodenext).js
@@ -34,6 +34,8 @@ module.exports = a;
 const a = {};
 module.exports = a;
 //// [file.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 // cjs format file
 const a = {};
 module.exports = a;

--- a/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=node16).js
+++ b/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=node16).js
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/node/allowJs/nodeModulesAllowJsExportlessJsModuleDetectionAuto.ts] ////
+
+//// [foo.cjs]
+// this file is a module despite having no imports
+//// [bar.js]
+// however this file is _not_ a module
+
+//// [foo.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+// this file is a module despite having no imports
+//// [bar.js]
+// however this file is _not_ a module

--- a/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=node16).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=node16).symbols
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/node/allowJs/foo.cjs ===
+// this file is a module despite having no imports
+No type information for this code.=== tests/cases/conformance/node/allowJs/bar.js ===
+// however this file is _not_ a module
+No type information for this code.

--- a/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=node16).types
+++ b/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=node16).types
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/node/allowJs/foo.cjs ===
+// this file is a module despite having no imports
+No type information for this code.=== tests/cases/conformance/node/allowJs/bar.js ===
+// however this file is _not_ a module
+No type information for this code.

--- a/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=nodenext).js
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/node/allowJs/nodeModulesAllowJsExportlessJsModuleDetectionAuto.ts] ////
+
+//// [foo.cjs]
+// this file is a module despite having no imports
+//// [bar.js]
+// however this file is _not_ a module
+
+//// [foo.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+// this file is a module despite having no imports
+//// [bar.js]
+// however this file is _not_ a module

--- a/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=nodenext).symbols
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/node/allowJs/foo.cjs ===
+// this file is a module despite having no imports
+No type information for this code.=== tests/cases/conformance/node/allowJs/bar.js ===
+// however this file is _not_ a module
+No type information for this code.

--- a/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesAllowJsExportlessJsModuleDetectionAuto(module=nodenext).types
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/node/allowJs/foo.cjs ===
+// this file is a module despite having no imports
+No type information for this code.=== tests/cases/conformance/node/allowJs/bar.js ===
+// however this file is _not_ a module
+No type information for this code.

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=node16).js
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=node16).js
@@ -14,5 +14,7 @@ interface GlobalThing { a: number }
 const a: GlobalThing = { a: 0 };
 
 //// [usage.js]
+"use strict";
 /// <reference types="pkg" />
+Object.defineProperty(exports, "__esModule", { value: true });
 const a = { a: 0 };

--- a/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=nodenext).js
+++ b/tests/baselines/reference/tripleSlashTypesReferenceWithMissingExports(module=nodenext).js
@@ -14,5 +14,7 @@ interface GlobalThing { a: number }
 const a: GlobalThing = { a: 0 };
 
 //// [usage.js]
+"use strict";
 /// <reference types="pkg" />
+Object.defineProperty(exports, "__esModule", { value: true });
 const a = { a: 0 };

--- a/tests/cases/conformance/node/allowJs/nodeModulesAllowJsExportlessJsModuleDetectionAuto.ts
+++ b/tests/cases/conformance/node/allowJs/nodeModulesAllowJsExportlessJsModuleDetectionAuto.ts
@@ -1,0 +1,8 @@
+// @module: node16,nodenext
+// @allowJs: true
+// @outDir: ./out
+// @moduleDetection: auto
+// @filename: foo.cjs
+// this file is a module despite having no imports
+// @filename: bar.js
+// however this file is _not_ a module


### PR DESCRIPTION
`module: node` sets `moduleDetection: force`, per our discussion at yesterday's design meeting.

Fixes #49207