### PR TITLE
Defer indexed accesses on generic potential discriminants

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11934,6 +11934,10 @@ namespace ts {
             });
         }
 
+        /**
+         * Caution: Do you _really_ mean to use this fucntion? It creates fresh property symbols in an uncached manner - if you, the caller,
+         * do not cache the result of this function, you may have very poor performance over large unions.
+         */
         function getAllPossiblePropertiesOfTypes(types: readonly Type[]): Symbol[] {
             const unionType = getUnionType(types);
             if (!(unionType.flags & TypeFlags.Union)) {
@@ -15671,7 +15675,8 @@ namespace ts {
         }
 
         function isUnionWithGenericDiscriminantProperty(type: UnionType) {
-            const props = getAllPossiblePropertiesOfTypes(type.types);
+            getPropertiesOfType(type); // initialize property cache (includes partial props)
+            const props = arrayFrom((type.propertyCache || emptySymbols).values());
             for (const prop of props) {
                 if (isDiscriminantProperty(type, prop.escapedName) === DiscriminantKind.Potential) {
                     return true;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4954,6 +4954,14 @@ namespace ts {
         /* @internal */ assignmentDeclarationMembers?: ESMap<number, Declaration>; // detected late-bound assignment declarations associated with the symbol
     }
 
+
+    /* @internal */
+    export const enum DiscriminantKind {
+        None = 0, // not discriminating
+        Concrete = 1, // "a" | "b"
+        Potential = 2, // T | "a" or more likely (T & "a") | (T & "b")
+    }
+
     /* @internal */
     export interface SymbolLinks {
         immediateTarget?: Symbol;                   // Immediate target of an alias. May be another alias. Do not access directly, use `checker.getImmediateAliasedSymbol` instead.
@@ -4977,7 +4985,7 @@ namespace ts {
         leftSpread?: Symbol;                        // Left source for synthetic spread property
         rightSpread?: Symbol;                       // Right source for synthetic spread property
         syntheticOrigin?: Symbol;                   // For a property on a mapped or spread type, points back to the original property
-        isDiscriminantProperty?: boolean;           // True if discriminant synthetic property
+        isDiscriminantProperty?: DiscriminantKind;  // Set if discriminant synthetic property
         resolvedExports?: SymbolTable;              // Resolved exports of module or combined early- and late-bound static members of a class.
         resolvedMembers?: SymbolTable;              // Combined early- and late-bound members of a symbol
         exportsChecked?: boolean;                   // True if exports of external module have been checked

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -58,7 +58,7 @@ type K00 = keyof any;  // string
 >K00 : string | number | symbol
 
 type K01 = keyof string;  // "toString" | "charAt" | ...
->K01 : number | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "toString" | "valueOf"
+>K01 : number | "length" | "toString" | "concat" | "slice" | "indexOf" | "lastIndexOf" | "charAt" | "charCodeAt" | "localeCompare" | "match" | "replace" | "search" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | "valueOf"
 
 type K02 = keyof number;  // "toString" | "toFixed" | "toExponential" | ...
 >K02 : "toString" | "toLocaleString" | "toFixed" | "toExponential" | "toPrecision" | "valueOf"

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -58,7 +58,7 @@ type K00 = keyof any;  // string
 >K00 : string | number | symbol
 
 type K01 = keyof string;  // "toString" | "charAt" | ...
->K01 : number | "length" | "toString" | "concat" | "slice" | "indexOf" | "lastIndexOf" | "charAt" | "charCodeAt" | "localeCompare" | "match" | "replace" | "search" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | "valueOf"
+>K01 : number | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "toString" | "valueOf"
 
 type K02 = keyof number;  // "toString" | "toFixed" | "toExponential" | ...
 >K02 : "toString" | "toLocaleString" | "toFixed" | "toExponential" | "toPrecision" | "valueOf"

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.types
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.types
@@ -26,19 +26,19 @@ type T01 = keyof Object;
 >T01 : keyof Object
 
 type T02 = keyof keyof Object;
->T02 : number | "length" | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | "valueOf"
+>T02 : number | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "toString" | "valueOf"
 
 type T03 = keyof keyof keyof Object;
 >T03 : "toString" | "valueOf"
 
 type T04 = keyof keyof keyof keyof Object;
->T04 : number | "length" | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | "valueOf"
+>T04 : number | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "toString" | "valueOf"
 
 type T05 = keyof keyof keyof keyof keyof Object;
 >T05 : "toString" | "valueOf"
 
 type T06 = keyof keyof keyof keyof keyof keyof Object;
->T06 : number | "length" | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | "valueOf"
+>T06 : number | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "toString" | "valueOf"
 
 type T10 = Shape["name"];
 >T10 : string

--- a/tests/baselines/reference/mappedTypeSinglePropertyConstrainsProperly.js
+++ b/tests/baselines/reference/mappedTypeSinglePropertyConstrainsProperly.js
@@ -1,0 +1,37 @@
+//// [mappedTypeSinglePropertyConstrainsProperly.ts]
+interface ListElement {
+    condition: boolean;
+    id: string;
+}
+
+const list = [
+    { condition: true, id: "yes" },
+    { condition: false, id: "no" },
+] as const;
+
+type CheckCondition<
+    List extends readonly ListElement[],
+    ID extends List[number]["id"],
+    > = ({ id: ID } & List[number])["condition"]
+
+type Mapped = {
+    [ID in "yes"]: CheckCondition<typeof list, ID>
+}["yes"]
+
+type NotMapped = CheckCondition<typeof list, "yes">
+
+declare const mapped: Mapped
+declare const notMapped: NotMapped
+
+let test: true = true
+test = mapped
+test = notMapped
+
+//// [mappedTypeSinglePropertyConstrainsProperly.js]
+var list = [
+    { condition: true, id: "yes" },
+    { condition: false, id: "no" },
+];
+var test = true;
+test = mapped;
+test = notMapped;

--- a/tests/baselines/reference/mappedTypeSinglePropertyConstrainsProperly.symbols
+++ b/tests/baselines/reference/mappedTypeSinglePropertyConstrainsProperly.symbols
@@ -1,0 +1,76 @@
+=== tests/cases/compiler/mappedTypeSinglePropertyConstrainsProperly.ts ===
+interface ListElement {
+>ListElement : Symbol(ListElement, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 0, 0))
+
+    condition: boolean;
+>condition : Symbol(ListElement.condition, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 0, 23))
+
+    id: string;
+>id : Symbol(ListElement.id, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 1, 23))
+}
+
+const list = [
+>list : Symbol(list, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 5, 5))
+
+    { condition: true, id: "yes" },
+>condition : Symbol(condition, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 6, 5))
+>id : Symbol(id, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 6, 22))
+
+    { condition: false, id: "no" },
+>condition : Symbol(condition, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 7, 5))
+>id : Symbol(id, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 7, 23))
+
+] as const;
+>const : Symbol(const)
+
+type CheckCondition<
+>CheckCondition : Symbol(CheckCondition, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 8, 11))
+
+    List extends readonly ListElement[],
+>List : Symbol(List, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 10, 20))
+>ListElement : Symbol(ListElement, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 0, 0))
+
+    ID extends List[number]["id"],
+>ID : Symbol(ID, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 11, 40))
+>List : Symbol(List, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 10, 20))
+
+    > = ({ id: ID } & List[number])["condition"]
+>id : Symbol(id, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 13, 10))
+>ID : Symbol(ID, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 11, 40))
+>List : Symbol(List, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 10, 20))
+
+type Mapped = {
+>Mapped : Symbol(Mapped, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 13, 48))
+
+    [ID in "yes"]: CheckCondition<typeof list, ID>
+>ID : Symbol(ID, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 16, 5))
+>CheckCondition : Symbol(CheckCondition, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 8, 11))
+>list : Symbol(list, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 5, 5))
+>ID : Symbol(ID, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 16, 5))
+
+}["yes"]
+
+type NotMapped = CheckCondition<typeof list, "yes">
+>NotMapped : Symbol(NotMapped, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 17, 8))
+>CheckCondition : Symbol(CheckCondition, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 8, 11))
+>list : Symbol(list, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 5, 5))
+
+declare const mapped: Mapped
+>mapped : Symbol(mapped, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 21, 13))
+>Mapped : Symbol(Mapped, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 13, 48))
+
+declare const notMapped: NotMapped
+>notMapped : Symbol(notMapped, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 22, 13))
+>NotMapped : Symbol(NotMapped, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 17, 8))
+
+let test: true = true
+>test : Symbol(test, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 24, 3))
+
+test = mapped
+>test : Symbol(test, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 24, 3))
+>mapped : Symbol(mapped, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 21, 13))
+
+test = notMapped
+>test : Symbol(test, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 24, 3))
+>notMapped : Symbol(notMapped, Decl(mappedTypeSinglePropertyConstrainsProperly.ts, 22, 13))
+

--- a/tests/baselines/reference/mappedTypeSinglePropertyConstrainsProperly.types
+++ b/tests/baselines/reference/mappedTypeSinglePropertyConstrainsProperly.types
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/mappedTypeSinglePropertyConstrainsProperly.ts ===
+interface ListElement {
+    condition: boolean;
+>condition : boolean
+
+    id: string;
+>id : string
+}
+
+const list = [
+>list : readonly [{ readonly condition: true; readonly id: "yes"; }, { readonly condition: false; readonly id: "no"; }]
+>[    { condition: true, id: "yes" },    { condition: false, id: "no" },] as const : readonly [{ readonly condition: true; readonly id: "yes"; }, { readonly condition: false; readonly id: "no"; }]
+>[    { condition: true, id: "yes" },    { condition: false, id: "no" },] : readonly [{ readonly condition: true; readonly id: "yes"; }, { readonly condition: false; readonly id: "no"; }]
+
+    { condition: true, id: "yes" },
+>{ condition: true, id: "yes" } : { readonly condition: true; readonly id: "yes"; }
+>condition : true
+>true : true
+>id : "yes"
+>"yes" : "yes"
+
+    { condition: false, id: "no" },
+>{ condition: false, id: "no" } : { readonly condition: false; readonly id: "no"; }
+>condition : false
+>false : false
+>id : "no"
+>"no" : "no"
+
+] as const;
+
+type CheckCondition<
+>CheckCondition : CheckCondition<List, ID>
+
+    List extends readonly ListElement[],
+    ID extends List[number]["id"],
+    > = ({ id: ID } & List[number])["condition"]
+>id : ID
+
+type Mapped = {
+>Mapped : true
+
+    [ID in "yes"]: CheckCondition<typeof list, ID>
+>list : readonly [{ readonly condition: true; readonly id: "yes"; }, { readonly condition: false; readonly id: "no"; }]
+
+}["yes"]
+
+type NotMapped = CheckCondition<typeof list, "yes">
+>NotMapped : true
+>list : readonly [{ readonly condition: true; readonly id: "yes"; }, { readonly condition: false; readonly id: "no"; }]
+
+declare const mapped: Mapped
+>mapped : true
+
+declare const notMapped: NotMapped
+>notMapped : true
+
+let test: true = true
+>test : true
+>true : true
+>true : true
+
+test = mapped
+>test = mapped : true
+>test : true
+>mapped : true
+
+test = notMapped
+>test = notMapped : true
+>test : true
+>notMapped : true
+

--- a/tests/cases/compiler/mappedTypeSinglePropertyConstrainsProperly.ts
+++ b/tests/cases/compiler/mappedTypeSinglePropertyConstrainsProperly.ts
@@ -1,0 +1,27 @@
+interface ListElement {
+    condition: boolean;
+    id: string;
+}
+
+const list = [
+    { condition: true, id: "yes" },
+    { condition: false, id: "no" },
+] as const;
+
+type CheckCondition<
+    List extends readonly ListElement[],
+    ID extends List[number]["id"],
+    > = ({ id: ID } & List[number])["condition"]
+
+type Mapped = {
+    [ID in "yes"]: CheckCondition<typeof list, ID>
+}["yes"]
+
+type NotMapped = CheckCondition<typeof list, "yes">
+
+declare const mapped: Mapped
+declare const notMapped: NotMapped
+
+let test: true = true
+test = mapped
+test = notMapped


### PR DESCRIPTION
The issue was that `{id: ID} & ({id: "yes", ...} | {id: "no", ...})` didn't register as an object type indexed accesses needed to be deferred on. Since instantiating `ID` could discriminate the type upon instantiation, and thus change what types are indexed into, the indexing operation must be deferred, as with other more traditional generic object types.

Fixes #45560