### PR TITLE
Fix explicit `"types"` list being overridden by ATA files

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1114,8 +1114,8 @@ namespace ts.server {
                 // If typing files changed, then only schedule project update
                 this.typingFiles = typingFiles;
                 // Invalidate files with unresolved imports
+                this.resolutionCache.invalidateTypingsFiles();
                 this.resolutionCache.setFilesWithInvalidatedNonRelativeUnresolvedImports(this.cachedUnresolvedImportsPerFile);
-                this.scheduleInvalidateResolutionsOfFailedLookupLocations();
                 this.projectService.delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles(this);
             }
         }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -404,7 +404,7 @@ namespace ts.server {
                 }
             });
 
-            return addRange(result, this.typingFiles) || ts.emptyArray;
+            return addRange(result, this.compilerOptions.types ? undefined : this.typingFiles) || ts.emptyArray;
         }
 
         private getOrCreateScriptInfoAndAttachToProject(fileName: string) {
@@ -1115,6 +1115,7 @@ namespace ts.server {
                 this.typingFiles = typingFiles;
                 // Invalidate files with unresolved imports
                 this.resolutionCache.setFilesWithInvalidatedNonRelativeUnresolvedImports(this.cachedUnresolvedImportsPerFile);
+                this.scheduleInvalidateResolutionsOfFailedLookupLocations();
                 this.projectService.delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles(this);
             }
         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

This is still a bit of a mess, but wanted to put something up to see if @sheetalkamat thinks this is headed in the right direction.

If `compilerOptions.types` is set, we do not return files from ATA as part of the root files of the project. Instead, we allow the automatic type reference directives to resolve from the global typings cache, the same way we do for non-relative imports. Making the resolution work was very easy, but invalidating the previously failed resolutions was a little tricky—there may be a more elegant solution. Comments inline.

Fixes #47709
