### PR TITLE
Fix index fallback of CJS package from ESM-mode import when `main` is present but does not resolve

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -2413,8 +2413,8 @@ namespace ts {
                 );
             if (
                 !pathAndExtension && packageInfo
-                && packageInfo.packageJsonContent.exports === undefined
-                && packageInfo.packageJsonContent.main === undefined
+                // eslint-disable-next-line no-null/no-null
+                && (packageInfo.packageJsonContent.exports === undefined || packageInfo.packageJsonContent.exports === null)
                 && state.features & NodeResolutionFeatures.EsmMode
             ) {
                 // EsmMode disables index lookup in `loadNodeModuleFromDirectoryWorker` generally, however non-relative package resolutions still assume

--- a/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution2.errors.txt
+++ b/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution2.errors.txt
@@ -1,0 +1,44 @@
+/index.cts(4,21): error TS2307: Cannot find module 'dedent4' or its corresponding type declarations.
+/index.mts(4,21): error TS2307: Cannot find module 'dedent4' or its corresponding type declarations.
+
+
+==== /node_modules/@types/dedent/package.json (0 errors) ====
+    { "name": "@types/dedent", "version": "1.0.0", "main": "" }
+    
+==== /node_modules/@types/dedent2/package.json (0 errors) ====
+    { "name": "@types/dedent2", "version": "1.0.0", "main": "asdfasdfasdf" }
+    
+==== /node_modules/@types/dedent3/package.json (0 errors) ====
+    { "name": "@types/dedent3", "version": "1.0.0", "main": "asdfasdfasdf", "exports": null }
+    
+==== /node_modules/@types/dedent4/package.json (0 errors) ====
+    { "name": "@types/dedent4", "version": "1.0.0", "main": "asdfasdfasdf", "exports": "./asdfasdfasdf" }
+    
+==== /node_modules/@types/dedent/index.d.ts (0 errors) ====
+    export {};
+    
+==== /node_modules/@types/dedent2/index.d.ts (0 errors) ====
+    export {};
+    
+==== /node_modules/@types/dedent3/index.d.ts (0 errors) ====
+    export {};
+    
+==== /node_modules/@types/dedent4/index.d.ts (0 errors) ====
+    export {};
+    
+==== /index.mts (1 errors) ====
+    import dedent from "dedent";
+    import dedent2 from "dedent2";
+    import dedent3 from "dedent3";
+    import dedent4 from "dedent4"; // Error
+                        ~~~~~~~~~
+!!! error TS2307: Cannot find module 'dedent4' or its corresponding type declarations.
+    
+==== /index.cts (1 errors) ====
+    import dedent from "dedent";
+    import dedent2 from "dedent2";
+    import dedent3 from "dedent3";
+    import dedent4 from "dedent4"; // Error
+                        ~~~~~~~~~
+!!! error TS2307: Cannot find module 'dedent4' or its corresponding type declarations.
+    

--- a/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution2.js
+++ b/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution2.js
@@ -1,0 +1,44 @@
+//// [tests/cases/compiler/nodeNextImportModeImplicitIndexResolution2.ts] ////
+
+//// [package.json]
+{ "name": "@types/dedent", "version": "1.0.0", "main": "" }
+
+//// [package.json]
+{ "name": "@types/dedent2", "version": "1.0.0", "main": "asdfasdfasdf" }
+
+//// [package.json]
+{ "name": "@types/dedent3", "version": "1.0.0", "main": "asdfasdfasdf", "exports": null }
+
+//// [package.json]
+{ "name": "@types/dedent4", "version": "1.0.0", "main": "asdfasdfasdf", "exports": "./asdfasdfasdf" }
+
+//// [index.d.ts]
+export {};
+
+//// [index.d.ts]
+export {};
+
+//// [index.d.ts]
+export {};
+
+//// [index.d.ts]
+export {};
+
+//// [index.mts]
+import dedent from "dedent";
+import dedent2 from "dedent2";
+import dedent3 from "dedent3";
+import dedent4 from "dedent4"; // Error
+
+//// [index.cts]
+import dedent from "dedent";
+import dedent2 from "dedent2";
+import dedent3 from "dedent3";
+import dedent4 from "dedent4"; // Error
+
+
+//// [index.mjs]
+export {};
+//// [index.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution2.symbols
+++ b/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution2.symbols
@@ -1,0 +1,38 @@
+=== /node_modules/@types/dedent/index.d.ts ===
+export {};
+No type information for this code.
+No type information for this code.=== /node_modules/@types/dedent2/index.d.ts ===
+export {};
+No type information for this code.
+No type information for this code.=== /node_modules/@types/dedent3/index.d.ts ===
+export {};
+No type information for this code.
+No type information for this code.=== /node_modules/@types/dedent4/index.d.ts ===
+export {};
+No type information for this code.
+No type information for this code.=== /index.mts ===
+import dedent from "dedent";
+>dedent : Symbol(dedent, Decl(index.mts, 0, 6))
+
+import dedent2 from "dedent2";
+>dedent2 : Symbol(dedent2, Decl(index.mts, 1, 6))
+
+import dedent3 from "dedent3";
+>dedent3 : Symbol(dedent3, Decl(index.mts, 2, 6))
+
+import dedent4 from "dedent4"; // Error
+>dedent4 : Symbol(dedent4, Decl(index.mts, 3, 6))
+
+=== /index.cts ===
+import dedent from "dedent";
+>dedent : Symbol(dedent, Decl(index.cts, 0, 6))
+
+import dedent2 from "dedent2";
+>dedent2 : Symbol(dedent2, Decl(index.cts, 1, 6))
+
+import dedent3 from "dedent3";
+>dedent3 : Symbol(dedent3, Decl(index.cts, 2, 6))
+
+import dedent4 from "dedent4"; // Error
+>dedent4 : Symbol(dedent4, Decl(index.cts, 3, 6))
+

--- a/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution2.types
+++ b/tests/baselines/reference/nodeNextImportModeImplicitIndexResolution2.types
@@ -1,0 +1,38 @@
+=== /node_modules/@types/dedent/index.d.ts ===
+export {};
+No type information for this code.
+No type information for this code.=== /node_modules/@types/dedent2/index.d.ts ===
+export {};
+No type information for this code.
+No type information for this code.=== /node_modules/@types/dedent3/index.d.ts ===
+export {};
+No type information for this code.
+No type information for this code.=== /node_modules/@types/dedent4/index.d.ts ===
+export {};
+No type information for this code.
+No type information for this code.=== /index.mts ===
+import dedent from "dedent";
+>dedent : typeof dedent
+
+import dedent2 from "dedent2";
+>dedent2 : typeof dedent2
+
+import dedent3 from "dedent3";
+>dedent3 : typeof dedent3
+
+import dedent4 from "dedent4"; // Error
+>dedent4 : any
+
+=== /index.cts ===
+import dedent from "dedent";
+>dedent : typeof dedent
+
+import dedent2 from "dedent2";
+>dedent2 : typeof dedent2
+
+import dedent3 from "dedent3";
+>dedent3 : typeof dedent3
+
+import dedent4 from "dedent4"; // Error
+>dedent4 : any
+

--- a/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution2.ts
+++ b/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution2.ts
@@ -1,0 +1,37 @@
+// @module: nodenext
+
+// @Filename: /node_modules/@types/dedent/package.json
+{ "name": "@types/dedent", "version": "1.0.0", "main": "" }
+
+// @Filename: /node_modules/@types/dedent2/package.json
+{ "name": "@types/dedent2", "version": "1.0.0", "main": "asdfasdfasdf" }
+
+// @Filename: /node_modules/@types/dedent3/package.json
+{ "name": "@types/dedent3", "version": "1.0.0", "main": "asdfasdfasdf", "exports": null }
+
+// @Filename: /node_modules/@types/dedent4/package.json
+{ "name": "@types/dedent4", "version": "1.0.0", "main": "asdfasdfasdf", "exports": "./asdfasdfasdf" }
+
+// @Filename: /node_modules/@types/dedent/index.d.ts
+export {};
+
+// @Filename: /node_modules/@types/dedent2/index.d.ts
+export {};
+
+// @Filename: /node_modules/@types/dedent3/index.d.ts
+export {};
+
+// @Filename: /node_modules/@types/dedent4/index.d.ts
+export {};
+
+// @Filename: /index.mts
+import dedent from "dedent";
+import dedent2 from "dedent2";
+import dedent3 from "dedent3";
+import dedent4 from "dedent4"; // Error
+
+// @Filename: /index.cts
+import dedent from "dedent";
+import dedent2 from "dedent2";
+import dedent3 from "dedent3";
+import dedent4 from "dedent4"; // Error


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #49326

To check that this is consistent with Node’s behavior, I tried these package.json modifications in `@types/dedent` and added an `index.js` of `module.exports = "index.js"` and ran

```
node --input-type=module -e 'import dedent from "@types/dedent"; console.log(dedent)'
node -e 'console.log(require("@types/dedent"))'
```

and ensured both log `index.js`. If they did, I assumed that means we should be able to resolve to `index.d.ts`.