### PR TITLE
Use node's algorithm for calculating the longest matching export/import pattern

### DIFF
--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=node16).errors.txt
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=node16).errors.txt
@@ -1,0 +1,123 @@
+tests/cases/conformance/node/allowJs/index.cjs(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.cjs(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.cjs(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.js(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.js(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.js(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.mjs(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.mjs(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.mjs(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/node/allowJs/index.js (3 errors) ====
+    // esm format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+==== tests/cases/conformance/node/allowJs/index.mjs (3 errors) ====
+    // esm format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+==== tests/cases/conformance/node/allowJs/index.cjs (3 errors) ====
+    // cjs format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+==== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts (3 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts (3 errors) ====
+    // esm format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts (3 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/allowJs/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module"
+    }
+==== tests/cases/conformance/node/allowJs/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "exports": {
+            "./cjs/*": "./*.cjs",
+            "./cjs/exclude/*": null,
+            "./mjs/*": "./*.mjs",
+            "./mjs/exclude/*": null,
+            "./js/*": "./*.js",
+            "./js/exclude/*": null
+        }
+    } 

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=node16).js
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=node16).js
@@ -1,0 +1,127 @@
+//// [tests/cases/conformance/node/allowJs/nodeModulesAllowJsPackagePatternExportsExclude.ts] ////
+
+//// [index.js]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+//// [index.mjs]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+//// [index.cjs]
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+//// [index.d.ts]
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.mts]
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.cts]
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "exports": {
+        "./cjs/*": "./*.cjs",
+        "./cjs/exclude/*": null,
+        "./mjs/*": "./*.mjs",
+        "./mjs/exclude/*": null,
+        "./js/*": "./*.js",
+        "./js/exclude/*": null
+    }
+} 
+
+//// [index.js]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+//// [index.mjs]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+//// [index.cjs]
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// cjs format file
+const cjsi = __importStar(require("inner/cjs/exclude/index"));
+const mjsi = __importStar(require("inner/mjs/exclude/index"));
+const typei = __importStar(require("inner/js/exclude/index"));
+cjsi;
+mjsi;
+typei;
+
+
+//// [index.d.ts]
+export {};
+//// [index.d.mts]
+export {};
+//// [index.d.cts]
+export {};

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=node16).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=node16).symbols
@@ -1,0 +1,120 @@
+=== tests/cases/conformance/node/allowJs/index.js ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.js, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.js, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.js, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.js, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.js, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.js, 3, 6))
+
+=== tests/cases/conformance/node/allowJs/index.mjs ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.mjs, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.mjs, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.mjs, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.mjs, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.mjs, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.mjs, 3, 6))
+
+=== tests/cases/conformance/node/allowJs/index.cjs ===
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.cjs, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.cjs, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.cjs, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.cjs, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.cjs, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.cjs, 3, 6))
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.ts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.ts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.ts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.ts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.ts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.ts, 6, 8))
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.mts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.mts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.mts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.mts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.mts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.mts, 6, 8))
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.cts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.cts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.cts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.cts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.cts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.cts, 6, 8))
+

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=node16).types
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=node16).types
@@ -1,0 +1,120 @@
+=== tests/cases/conformance/node/allowJs/index.js ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+=== tests/cases/conformance/node/allowJs/index.mjs ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+=== tests/cases/conformance/node/allowJs/index.cjs ===
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=nodenext).errors.txt
@@ -1,0 +1,123 @@
+tests/cases/conformance/node/allowJs/index.cjs(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.cjs(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.cjs(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.js(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.js(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.js(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.mjs(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.mjs(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/index.mjs(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/node/allowJs/index.js (3 errors) ====
+    // esm format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+==== tests/cases/conformance/node/allowJs/index.mjs (3 errors) ====
+    // esm format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+==== tests/cases/conformance/node/allowJs/index.cjs (3 errors) ====
+    // cjs format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+==== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts (3 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts (3 errors) ====
+    // esm format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts (3 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/allowJs/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module"
+    }
+==== tests/cases/conformance/node/allowJs/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "exports": {
+            "./cjs/*": "./*.cjs",
+            "./cjs/exclude/*": null,
+            "./mjs/*": "./*.mjs",
+            "./mjs/exclude/*": null,
+            "./js/*": "./*.js",
+            "./js/exclude/*": null
+        }
+    } 

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=nodenext).js
@@ -1,0 +1,127 @@
+//// [tests/cases/conformance/node/allowJs/nodeModulesAllowJsPackagePatternExportsExclude.ts] ////
+
+//// [index.js]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+//// [index.mjs]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+//// [index.cjs]
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+//// [index.d.ts]
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.mts]
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.cts]
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "exports": {
+        "./cjs/*": "./*.cjs",
+        "./cjs/exclude/*": null,
+        "./mjs/*": "./*.mjs",
+        "./mjs/exclude/*": null,
+        "./js/*": "./*.js",
+        "./js/exclude/*": null
+    }
+} 
+
+//// [index.js]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+//// [index.mjs]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+//// [index.cjs]
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// cjs format file
+const cjsi = __importStar(require("inner/cjs/exclude/index"));
+const mjsi = __importStar(require("inner/mjs/exclude/index"));
+const typei = __importStar(require("inner/js/exclude/index"));
+cjsi;
+mjsi;
+typei;
+
+
+//// [index.d.ts]
+export {};
+//// [index.d.mts]
+export {};
+//// [index.d.cts]
+export {};

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=nodenext).symbols
@@ -1,0 +1,120 @@
+=== tests/cases/conformance/node/allowJs/index.js ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.js, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.js, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.js, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.js, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.js, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.js, 3, 6))
+
+=== tests/cases/conformance/node/allowJs/index.mjs ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.mjs, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.mjs, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.mjs, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.mjs, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.mjs, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.mjs, 3, 6))
+
+=== tests/cases/conformance/node/allowJs/index.cjs ===
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.cjs, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.cjs, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.cjs, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.cjs, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.cjs, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.cjs, 3, 6))
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.ts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.ts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.ts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.ts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.ts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.ts, 6, 8))
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.mts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.mts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.mts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.mts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.mts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.mts, 6, 8))
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.cts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.cts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.cts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.cts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.cts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.cts, 6, 8))
+

--- a/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesAllowJsPackagePatternExportsExclude(module=nodenext).types
@@ -1,0 +1,120 @@
+=== tests/cases/conformance/node/allowJs/index.js ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+=== tests/cases/conformance/node/allowJs/index.mjs ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+=== tests/cases/conformance/node/allowJs/index.cjs ===
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+
+=== tests/cases/conformance/node/allowJs/node_modules/inner/exclude/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+

--- a/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=node16).errors.txt
+++ b/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=node16).errors.txt
@@ -1,0 +1,177 @@
+tests/cases/conformance/node/index.cts(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.cts(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.cts(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.cts(9,24): error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+tests/cases/conformance/node/index.mts(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.mts(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.mts(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/index.d.cts(3,22): error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+tests/cases/conformance/node/node_modules/inner/index.d.ts(2,13): error TS2303: Circular definition of import alias 'cjs'.
+tests/cases/conformance/node/node_modules/inner/index.d.ts(3,22): error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+
+
+==== tests/cases/conformance/node/index.ts (3 errors) ====
+    // esm format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+    import * as cjsi2 from "inner/cjs/index";
+    import * as mjsi2 from "inner/mjs/index";
+    import * as typei2 from "inner/js/index";
+    cjsi2;
+    mjsi2;
+    typei2;
+==== tests/cases/conformance/node/index.mts (3 errors) ====
+    // esm format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+    import * as cjsi2 from "inner/cjs/index";
+    import * as mjsi2 from "inner/mjs/index";
+    import * as typei2 from "inner/js/index";
+    cjsi2;
+    mjsi2;
+    typei2;
+==== tests/cases/conformance/node/index.cts (4 errors) ====
+    // cjs format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+    import * as cjsi2 from "inner/cjs/index";
+    import * as mjsi2 from "inner/mjs/index";
+                           ~~~~~~~~~~~~~~~~~
+!!! error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+    import * as typei2 from "inner/js/index";
+    cjsi2;
+    mjsi2;
+    typei2;
+==== tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts (3 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts (3 errors) ====
+    // esm format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts (3 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/node_modules/inner/index.d.ts (2 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/index";
+                ~~~
+!!! error TS2303: Circular definition of import alias 'cjs'.
+    import * as mjs from "inner/mjs/index";
+                         ~~~~~~~~~~~~~~~~~
+!!! error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+    import * as type from "inner/js/index";
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/node_modules/inner/index.d.mts (0 errors) ====
+    // esm format file
+    import * as cjs from "inner/cjs/index";
+    import * as mjs from "inner/mjs/index";
+    import * as type from "inner/js/index";
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/node_modules/inner/index.d.cts (1 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/index";
+    import * as mjs from "inner/mjs/index";
+                         ~~~~~~~~~~~~~~~~~
+!!! error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+    import * as type from "inner/js/index";
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module"
+    }
+==== tests/cases/conformance/node/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "exports": {
+            "./cjs/*": "./*.cjs",
+            "./cjs/exclude/*": null,
+            "./mjs/*": "./*.mjs",
+            "./mjs/exclude/*": null,
+            "./js/*": "./*.js",
+            "./js/exclude/*": null
+        }
+    } 

--- a/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=node16).js
+++ b/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=node16).js
@@ -1,0 +1,187 @@
+//// [tests/cases/conformance/node/nodeModulesPackagePatternExportsExclude.ts] ////
+
+//// [index.ts]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+//// [index.mts]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+//// [index.cts]
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+//// [index.d.ts]
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.mts]
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.cts]
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.ts]
+// cjs format file
+import * as cjs from "inner/cjs/index";
+import * as mjs from "inner/mjs/index";
+import * as type from "inner/js/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.mts]
+// esm format file
+import * as cjs from "inner/cjs/index";
+import * as mjs from "inner/mjs/index";
+import * as type from "inner/js/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.cts]
+// cjs format file
+import * as cjs from "inner/cjs/index";
+import * as mjs from "inner/mjs/index";
+import * as type from "inner/js/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "exports": {
+        "./cjs/*": "./*.cjs",
+        "./cjs/exclude/*": null,
+        "./mjs/*": "./*.mjs",
+        "./mjs/exclude/*": null,
+        "./js/*": "./*.js",
+        "./js/exclude/*": null
+    }
+} 
+
+//// [index.js]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+//// [index.mjs]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+//// [index.cjs]
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// cjs format file
+const cjsi = __importStar(require("inner/cjs/exclude/index"));
+const mjsi = __importStar(require("inner/mjs/exclude/index"));
+const typei = __importStar(require("inner/js/exclude/index"));
+cjsi;
+mjsi;
+typei;
+const cjsi2 = __importStar(require("inner/cjs/index"));
+const mjsi2 = __importStar(require("inner/mjs/index"));
+const typei2 = __importStar(require("inner/js/index"));
+cjsi2;
+mjsi2;
+typei2;
+
+
+//// [index.d.ts]
+export {};
+//// [index.d.mts]
+export {};
+//// [index.d.cts]
+export {};

--- a/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=node16).symbols
+++ b/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=node16).symbols
@@ -1,0 +1,234 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.ts, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.ts, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.ts, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.ts, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.ts, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.ts, 3, 6))
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : Symbol(cjsi2, Decl(index.ts, 7, 6))
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : Symbol(mjsi2, Decl(index.ts, 8, 6))
+
+import * as typei2 from "inner/js/index";
+>typei2 : Symbol(typei2, Decl(index.ts, 9, 6))
+
+cjsi2;
+>cjsi2 : Symbol(cjsi2, Decl(index.ts, 7, 6))
+
+mjsi2;
+>mjsi2 : Symbol(mjsi2, Decl(index.ts, 8, 6))
+
+typei2;
+>typei2 : Symbol(typei2, Decl(index.ts, 9, 6))
+
+=== tests/cases/conformance/node/index.mts ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.mts, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.mts, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.mts, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.mts, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.mts, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.mts, 3, 6))
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : Symbol(cjsi2, Decl(index.mts, 7, 6))
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : Symbol(mjsi2, Decl(index.mts, 8, 6))
+
+import * as typei2 from "inner/js/index";
+>typei2 : Symbol(typei2, Decl(index.mts, 9, 6))
+
+cjsi2;
+>cjsi2 : Symbol(cjsi2, Decl(index.mts, 7, 6))
+
+mjsi2;
+>mjsi2 : Symbol(mjsi2, Decl(index.mts, 8, 6))
+
+typei2;
+>typei2 : Symbol(typei2, Decl(index.mts, 9, 6))
+
+=== tests/cases/conformance/node/index.cts ===
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.cts, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.cts, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.cts, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.cts, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.cts, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.cts, 3, 6))
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : Symbol(cjsi2, Decl(index.cts, 7, 6))
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : Symbol(mjsi2, Decl(index.cts, 8, 6))
+
+import * as typei2 from "inner/js/index";
+>typei2 : Symbol(typei2, Decl(index.cts, 9, 6))
+
+cjsi2;
+>cjsi2 : Symbol(cjsi2, Decl(index.cts, 7, 6))
+
+mjsi2;
+>mjsi2 : Symbol(mjsi2, Decl(index.cts, 8, 6))
+
+typei2;
+>typei2 : Symbol(typei2, Decl(index.cts, 9, 6))
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.ts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.ts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.ts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.ts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.ts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.ts, 6, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.mts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.mts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.mts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.mts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.mts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.mts, 6, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.cts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.cts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.cts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.cts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.cts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.cts, 6, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/index";
+>cjs : Symbol(cjs, Decl(index.d.ts, 1, 6))
+
+import * as mjs from "inner/mjs/index";
+>mjs : Symbol(mjs, Decl(index.d.ts, 2, 6))
+
+import * as type from "inner/js/index";
+>type : Symbol(type, Decl(index.d.ts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+
+export { type };
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/index";
+>cjs : Symbol(cjs, Decl(index.d.mts, 1, 6))
+
+import * as mjs from "inner/mjs/index";
+>mjs : Symbol(mjs, Decl(index.d.mts, 2, 6))
+
+import * as type from "inner/js/index";
+>type : Symbol(type, Decl(index.d.mts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+
+export { type };
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/index";
+>cjs : Symbol(cjs, Decl(index.d.cts, 1, 6))
+
+import * as mjs from "inner/mjs/index";
+>mjs : Symbol(mjs, Decl(index.d.cts, 2, 6))
+
+import * as type from "inner/js/index";
+>type : Symbol(type, Decl(index.d.cts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs.cjs, Decl(index.d.cts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(cjs.mjs, Decl(index.d.cts, 5, 8))
+
+export { type };
+>type : Symbol(cjs.type, Decl(index.d.cts, 6, 8))
+

--- a/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=node16).types
+++ b/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=node16).types
@@ -1,0 +1,234 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : typeof cjsi2
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : typeof cjsi2.cjs.mjs
+
+import * as typei2 from "inner/js/index";
+>typei2 : typeof typei2
+
+cjsi2;
+>cjsi2 : typeof cjsi2
+
+mjsi2;
+>mjsi2 : typeof cjsi2.cjs.mjs
+
+typei2;
+>typei2 : typeof typei2
+
+=== tests/cases/conformance/node/index.mts ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : typeof cjsi2
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : typeof cjsi2.cjs.mjs
+
+import * as typei2 from "inner/js/index";
+>typei2 : typeof typei2
+
+cjsi2;
+>cjsi2 : typeof cjsi2
+
+mjsi2;
+>mjsi2 : typeof cjsi2.cjs.mjs
+
+typei2;
+>typei2 : typeof typei2
+
+=== tests/cases/conformance/node/index.cts ===
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : typeof cjsi2
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : typeof cjsi2.mjs
+
+import * as typei2 from "inner/js/index";
+>typei2 : typeof cjsi2.mjs.cjs.type
+
+cjsi2;
+>cjsi2 : typeof cjsi2
+
+mjsi2;
+>mjsi2 : typeof cjsi2.mjs
+
+typei2;
+>typei2 : typeof cjsi2.mjs.cjs.type
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/index";
+>mjs : typeof mjs
+
+import * as type from "inner/js/index";
+>type : typeof mjs.cjs.cjs.type
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : typeof mjs
+
+export { type };
+>type : typeof mjs.cjs.cjs.type
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/index";
+>cjs : typeof cjs
+
+import * as mjs from "inner/mjs/index";
+>mjs : typeof cjs.cjs.mjs
+
+import * as type from "inner/js/index";
+>type : typeof cjs.cjs.mjs.type
+
+export { cjs };
+>cjs : typeof cjs
+
+export { mjs };
+>mjs : typeof cjs.cjs.mjs
+
+export { type };
+>type : typeof cjs.cjs.mjs.type
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/index";
+>cjs : typeof cjs
+
+import * as mjs from "inner/mjs/index";
+>mjs : typeof cjs.mjs
+
+import * as type from "inner/js/index";
+>type : typeof cjs.mjs.cjs.type
+
+export { cjs };
+>cjs : typeof cjs
+
+export { mjs };
+>mjs : typeof cjs.mjs
+
+export { type };
+>type : typeof cjs.mjs.cjs.type
+

--- a/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=nodenext).errors.txt
@@ -1,0 +1,177 @@
+tests/cases/conformance/node/index.cts(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.cts(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.cts(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.cts(9,24): error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+tests/cases/conformance/node/index.mts(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.mts(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.mts(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(2,23): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(3,23): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/index.ts(4,24): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts(2,22): error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts(3,22): error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts(4,23): error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+tests/cases/conformance/node/node_modules/inner/index.d.cts(3,22): error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+tests/cases/conformance/node/node_modules/inner/index.d.ts(2,13): error TS2303: Circular definition of import alias 'cjs'.
+tests/cases/conformance/node/node_modules/inner/index.d.ts(3,22): error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+
+
+==== tests/cases/conformance/node/index.ts (3 errors) ====
+    // esm format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+    import * as cjsi2 from "inner/cjs/index";
+    import * as mjsi2 from "inner/mjs/index";
+    import * as typei2 from "inner/js/index";
+    cjsi2;
+    mjsi2;
+    typei2;
+==== tests/cases/conformance/node/index.mts (3 errors) ====
+    // esm format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+    import * as cjsi2 from "inner/cjs/index";
+    import * as mjsi2 from "inner/mjs/index";
+    import * as typei2 from "inner/js/index";
+    cjsi2;
+    mjsi2;
+    typei2;
+==== tests/cases/conformance/node/index.cts (4 errors) ====
+    // cjs format file
+    import * as cjsi from "inner/cjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjsi from "inner/mjs/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as typei from "inner/js/exclude/index";
+                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    cjsi;
+    mjsi;
+    typei;
+    import * as cjsi2 from "inner/cjs/index";
+    import * as mjsi2 from "inner/mjs/index";
+                           ~~~~~~~~~~~~~~~~~
+!!! error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+    import * as typei2 from "inner/js/index";
+    cjsi2;
+    mjsi2;
+    typei2;
+==== tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts (3 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts (3 errors) ====
+    // esm format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts (3 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/cjs/exclude/index' or its corresponding type declarations.
+    import * as mjs from "inner/mjs/exclude/index";
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/mjs/exclude/index' or its corresponding type declarations.
+    import * as type from "inner/js/exclude/index";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'inner/js/exclude/index' or its corresponding type declarations.
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/node_modules/inner/index.d.ts (2 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/index";
+                ~~~
+!!! error TS2303: Circular definition of import alias 'cjs'.
+    import * as mjs from "inner/mjs/index";
+                         ~~~~~~~~~~~~~~~~~
+!!! error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+    import * as type from "inner/js/index";
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/node_modules/inner/index.d.mts (0 errors) ====
+    // esm format file
+    import * as cjs from "inner/cjs/index";
+    import * as mjs from "inner/mjs/index";
+    import * as type from "inner/js/index";
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/node_modules/inner/index.d.cts (1 errors) ====
+    // cjs format file
+    import * as cjs from "inner/cjs/index";
+    import * as mjs from "inner/mjs/index";
+                         ~~~~~~~~~~~~~~~~~
+!!! error TS1471: Module 'inner/mjs/index' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported synchronously. Use dynamic import instead.
+    import * as type from "inner/js/index";
+    export { cjs };
+    export { mjs };
+    export { type };
+==== tests/cases/conformance/node/package.json (0 errors) ====
+    {
+        "name": "package",
+        "private": true,
+        "type": "module"
+    }
+==== tests/cases/conformance/node/node_modules/inner/package.json (0 errors) ====
+    {
+        "name": "inner",
+        "private": true,
+        "exports": {
+            "./cjs/*": "./*.cjs",
+            "./cjs/exclude/*": null,
+            "./mjs/*": "./*.mjs",
+            "./mjs/exclude/*": null,
+            "./js/*": "./*.js",
+            "./js/exclude/*": null
+        }
+    } 

--- a/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=nodenext).js
@@ -1,0 +1,187 @@
+//// [tests/cases/conformance/node/nodeModulesPackagePatternExportsExclude.ts] ////
+
+//// [index.ts]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+//// [index.mts]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+//// [index.cts]
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+//// [index.d.ts]
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.mts]
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.cts]
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.ts]
+// cjs format file
+import * as cjs from "inner/cjs/index";
+import * as mjs from "inner/mjs/index";
+import * as type from "inner/js/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.mts]
+// esm format file
+import * as cjs from "inner/cjs/index";
+import * as mjs from "inner/mjs/index";
+import * as type from "inner/js/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [index.d.cts]
+// cjs format file
+import * as cjs from "inner/cjs/index";
+import * as mjs from "inner/mjs/index";
+import * as type from "inner/js/index";
+export { cjs };
+export { mjs };
+export { type };
+//// [package.json]
+{
+    "name": "package",
+    "private": true,
+    "type": "module"
+}
+//// [package.json]
+{
+    "name": "inner",
+    "private": true,
+    "exports": {
+        "./cjs/*": "./*.cjs",
+        "./cjs/exclude/*": null,
+        "./mjs/*": "./*.mjs",
+        "./mjs/exclude/*": null,
+        "./js/*": "./*.js",
+        "./js/exclude/*": null
+    }
+} 
+
+//// [index.js]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+//// [index.mjs]
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+//// [index.cjs]
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// cjs format file
+const cjsi = __importStar(require("inner/cjs/exclude/index"));
+const mjsi = __importStar(require("inner/mjs/exclude/index"));
+const typei = __importStar(require("inner/js/exclude/index"));
+cjsi;
+mjsi;
+typei;
+const cjsi2 = __importStar(require("inner/cjs/index"));
+const mjsi2 = __importStar(require("inner/mjs/index"));
+const typei2 = __importStar(require("inner/js/index"));
+cjsi2;
+mjsi2;
+typei2;
+
+
+//// [index.d.ts]
+export {};
+//// [index.d.mts]
+export {};
+//// [index.d.cts]
+export {};

--- a/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=nodenext).symbols
+++ b/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=nodenext).symbols
@@ -1,0 +1,234 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.ts, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.ts, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.ts, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.ts, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.ts, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.ts, 3, 6))
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : Symbol(cjsi2, Decl(index.ts, 7, 6))
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : Symbol(mjsi2, Decl(index.ts, 8, 6))
+
+import * as typei2 from "inner/js/index";
+>typei2 : Symbol(typei2, Decl(index.ts, 9, 6))
+
+cjsi2;
+>cjsi2 : Symbol(cjsi2, Decl(index.ts, 7, 6))
+
+mjsi2;
+>mjsi2 : Symbol(mjsi2, Decl(index.ts, 8, 6))
+
+typei2;
+>typei2 : Symbol(typei2, Decl(index.ts, 9, 6))
+
+=== tests/cases/conformance/node/index.mts ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.mts, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.mts, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.mts, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.mts, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.mts, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.mts, 3, 6))
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : Symbol(cjsi2, Decl(index.mts, 7, 6))
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : Symbol(mjsi2, Decl(index.mts, 8, 6))
+
+import * as typei2 from "inner/js/index";
+>typei2 : Symbol(typei2, Decl(index.mts, 9, 6))
+
+cjsi2;
+>cjsi2 : Symbol(cjsi2, Decl(index.mts, 7, 6))
+
+mjsi2;
+>mjsi2 : Symbol(mjsi2, Decl(index.mts, 8, 6))
+
+typei2;
+>typei2 : Symbol(typei2, Decl(index.mts, 9, 6))
+
+=== tests/cases/conformance/node/index.cts ===
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : Symbol(cjsi, Decl(index.cts, 1, 6))
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : Symbol(mjsi, Decl(index.cts, 2, 6))
+
+import * as typei from "inner/js/exclude/index";
+>typei : Symbol(typei, Decl(index.cts, 3, 6))
+
+cjsi;
+>cjsi : Symbol(cjsi, Decl(index.cts, 1, 6))
+
+mjsi;
+>mjsi : Symbol(mjsi, Decl(index.cts, 2, 6))
+
+typei;
+>typei : Symbol(typei, Decl(index.cts, 3, 6))
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : Symbol(cjsi2, Decl(index.cts, 7, 6))
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : Symbol(mjsi2, Decl(index.cts, 8, 6))
+
+import * as typei2 from "inner/js/index";
+>typei2 : Symbol(typei2, Decl(index.cts, 9, 6))
+
+cjsi2;
+>cjsi2 : Symbol(cjsi2, Decl(index.cts, 7, 6))
+
+mjsi2;
+>mjsi2 : Symbol(mjsi2, Decl(index.cts, 8, 6))
+
+typei2;
+>typei2 : Symbol(typei2, Decl(index.cts, 9, 6))
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.ts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.ts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.ts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.ts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.ts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.ts, 6, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.mts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.mts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.mts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.mts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.mts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.mts, 6, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : Symbol(cjs, Decl(index.d.cts, 1, 6))
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : Symbol(mjs, Decl(index.d.cts, 2, 6))
+
+import * as type from "inner/js/exclude/index";
+>type : Symbol(type, Decl(index.d.cts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs, Decl(index.d.cts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs, Decl(index.d.cts, 5, 8))
+
+export { type };
+>type : Symbol(type, Decl(index.d.cts, 6, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/index";
+>cjs : Symbol(cjs, Decl(index.d.ts, 1, 6))
+
+import * as mjs from "inner/mjs/index";
+>mjs : Symbol(mjs, Decl(index.d.ts, 2, 6))
+
+import * as type from "inner/js/index";
+>type : Symbol(type, Decl(index.d.ts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(mjs.cjs.cjs.type.cjs, Decl(index.d.ts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(mjs.cjs.cjs.type.mjs, Decl(index.d.ts, 5, 8))
+
+export { type };
+>type : Symbol(mjs.cjs.cjs.type.type, Decl(index.d.ts, 6, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/index";
+>cjs : Symbol(cjs, Decl(index.d.mts, 1, 6))
+
+import * as mjs from "inner/mjs/index";
+>mjs : Symbol(mjs, Decl(index.d.mts, 2, 6))
+
+import * as type from "inner/js/index";
+>type : Symbol(type, Decl(index.d.mts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs.cjs.mjs.cjs, Decl(index.d.mts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(cjs.cjs.mjs.mjs, Decl(index.d.mts, 5, 8))
+
+export { type };
+>type : Symbol(cjs.cjs.mjs.type, Decl(index.d.mts, 6, 8))
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/index";
+>cjs : Symbol(cjs, Decl(index.d.cts, 1, 6))
+
+import * as mjs from "inner/mjs/index";
+>mjs : Symbol(mjs, Decl(index.d.cts, 2, 6))
+
+import * as type from "inner/js/index";
+>type : Symbol(type, Decl(index.d.cts, 3, 6))
+
+export { cjs };
+>cjs : Symbol(cjs.cjs, Decl(index.d.cts, 4, 8))
+
+export { mjs };
+>mjs : Symbol(cjs.mjs, Decl(index.d.cts, 5, 8))
+
+export { type };
+>type : Symbol(cjs.type, Decl(index.d.cts, 6, 8))
+

--- a/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesPackagePatternExportsExclude(module=nodenext).types
@@ -1,0 +1,234 @@
+=== tests/cases/conformance/node/index.ts ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : typeof cjsi2
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : typeof cjsi2.cjs.mjs
+
+import * as typei2 from "inner/js/index";
+>typei2 : typeof typei2
+
+cjsi2;
+>cjsi2 : typeof cjsi2
+
+mjsi2;
+>mjsi2 : typeof cjsi2.cjs.mjs
+
+typei2;
+>typei2 : typeof typei2
+
+=== tests/cases/conformance/node/index.mts ===
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : typeof cjsi2
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : typeof cjsi2.cjs.mjs
+
+import * as typei2 from "inner/js/index";
+>typei2 : typeof typei2
+
+cjsi2;
+>cjsi2 : typeof cjsi2
+
+mjsi2;
+>mjsi2 : typeof cjsi2.cjs.mjs
+
+typei2;
+>typei2 : typeof typei2
+
+=== tests/cases/conformance/node/index.cts ===
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+>cjsi : any
+
+import * as mjsi from "inner/mjs/exclude/index";
+>mjsi : any
+
+import * as typei from "inner/js/exclude/index";
+>typei : any
+
+cjsi;
+>cjsi : any
+
+mjsi;
+>mjsi : any
+
+typei;
+>typei : any
+
+import * as cjsi2 from "inner/cjs/index";
+>cjsi2 : typeof cjsi2
+
+import * as mjsi2 from "inner/mjs/index";
+>mjsi2 : typeof cjsi2.mjs
+
+import * as typei2 from "inner/js/index";
+>typei2 : typeof cjsi2.mjs.cjs.type
+
+cjsi2;
+>cjsi2 : typeof cjsi2
+
+mjsi2;
+>mjsi2 : typeof cjsi2.mjs
+
+typei2;
+>typei2 : typeof cjsi2.mjs.cjs.type
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+
+=== tests/cases/conformance/node/node_modules/inner/exclude/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/exclude/index";
+>mjs : any
+
+import * as type from "inner/js/exclude/index";
+>type : any
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : any
+
+export { type };
+>type : any
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.ts ===
+// cjs format file
+import * as cjs from "inner/cjs/index";
+>cjs : any
+
+import * as mjs from "inner/mjs/index";
+>mjs : typeof mjs
+
+import * as type from "inner/js/index";
+>type : typeof mjs.cjs.cjs.type
+
+export { cjs };
+>cjs : any
+
+export { mjs };
+>mjs : typeof mjs
+
+export { type };
+>type : typeof mjs.cjs.cjs.type
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.mts ===
+// esm format file
+import * as cjs from "inner/cjs/index";
+>cjs : typeof cjs
+
+import * as mjs from "inner/mjs/index";
+>mjs : typeof cjs.cjs.mjs
+
+import * as type from "inner/js/index";
+>type : typeof cjs.cjs.mjs.type
+
+export { cjs };
+>cjs : typeof cjs
+
+export { mjs };
+>mjs : typeof cjs.cjs.mjs
+
+export { type };
+>type : typeof cjs.cjs.mjs.type
+
+=== tests/cases/conformance/node/node_modules/inner/index.d.cts ===
+// cjs format file
+import * as cjs from "inner/cjs/index";
+>cjs : typeof cjs
+
+import * as mjs from "inner/mjs/index";
+>mjs : typeof cjs.mjs
+
+import * as type from "inner/js/index";
+>type : typeof cjs.mjs.cjs.type
+
+export { cjs };
+>cjs : typeof cjs
+
+export { mjs };
+>mjs : typeof cjs.mjs
+
+export { type };
+>type : typeof cjs.mjs.cjs.type
+

--- a/tests/cases/conformance/node/allowJs/nodeModulesAllowJsPackagePatternExportsExclude.ts
+++ b/tests/cases/conformance/node/allowJs/nodeModulesAllowJsPackagePatternExportsExclude.ts
@@ -1,0 +1,72 @@
+// @module: node16,nodenext
+// @declaration: true
+// @allowJs: true
+// @checkJs: true
+// @outDir: out
+// @filename: index.js
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+// @filename: index.mjs
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+// @filename: index.cjs
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+// @filename: node_modules/inner/exclude/index.d.ts
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+// @filename: node_modules/inner/exclude/index.d.mts
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+// @filename: node_modules/inner/exclude/index.d.cts
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+// @filename: package.json
+{
+    "name": "package",
+    "private": true,
+    "type": "module"
+}
+// @filename: node_modules/inner/package.json
+{
+    "name": "inner",
+    "private": true,
+    "exports": {
+        "./cjs/*": "./*.cjs",
+        "./cjs/exclude/*": null,
+        "./mjs/*": "./*.mjs",
+        "./mjs/exclude/*": null,
+        "./js/*": "./*.js",
+        "./js/exclude/*": null
+    }
+} 

--- a/tests/cases/conformance/node/nodeModulesPackagePatternExportsExclude.ts
+++ b/tests/cases/conformance/node/nodeModulesPackagePatternExportsExclude.ts
@@ -1,0 +1,112 @@
+// @module: node16,nodenext
+// @declaration: true
+// @outDir: out
+// @filename: index.ts
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+// @filename: index.mts
+// esm format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+// @filename: index.cts
+// cjs format file
+import * as cjsi from "inner/cjs/exclude/index";
+import * as mjsi from "inner/mjs/exclude/index";
+import * as typei from "inner/js/exclude/index";
+cjsi;
+mjsi;
+typei;
+import * as cjsi2 from "inner/cjs/index";
+import * as mjsi2 from "inner/mjs/index";
+import * as typei2 from "inner/js/index";
+cjsi2;
+mjsi2;
+typei2;
+// @filename: node_modules/inner/exclude/index.d.ts
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+// @filename: node_modules/inner/exclude/index.d.mts
+// esm format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+// @filename: node_modules/inner/exclude/index.d.cts
+// cjs format file
+import * as cjs from "inner/cjs/exclude/index";
+import * as mjs from "inner/mjs/exclude/index";
+import * as type from "inner/js/exclude/index";
+export { cjs };
+export { mjs };
+export { type };
+// @filename: node_modules/inner/index.d.ts
+// cjs format file
+import * as cjs from "inner/cjs/index";
+import * as mjs from "inner/mjs/index";
+import * as type from "inner/js/index";
+export { cjs };
+export { mjs };
+export { type };
+// @filename: node_modules/inner/index.d.mts
+// esm format file
+import * as cjs from "inner/cjs/index";
+import * as mjs from "inner/mjs/index";
+import * as type from "inner/js/index";
+export { cjs };
+export { mjs };
+export { type };
+// @filename: node_modules/inner/index.d.cts
+// cjs format file
+import * as cjs from "inner/cjs/index";
+import * as mjs from "inner/mjs/index";
+import * as type from "inner/js/index";
+export { cjs };
+export { mjs };
+export { type };
+// @filename: package.json
+{
+    "name": "package",
+    "private": true,
+    "type": "module"
+}
+// @filename: node_modules/inner/package.json
+{
+    "name": "inner",
+    "private": true,
+    "exports": {
+        "./cjs/*": "./*.cjs",
+        "./cjs/exclude/*": null,
+        "./mjs/*": "./*.mjs",
+        "./mjs/exclude/*": null,
+        "./js/*": "./*.js",
+        "./js/exclude/*": null
+    }
+} 


### PR DESCRIPTION
Fixes #49308

Thanks to @PaperStrike for the research and initial tests - in addition to the sort just being backwards, node's sorting for pattern keys (`PATTERN_KEY_COMPARE` in the resolution docs) is way more complex now that pattern trailers are a thing, and this sort was never updated to account for that, so now we just use node's algorithm pretty much verbatim.