### PR TITLE
Explicit `types` should prevent ATA from doing package.json discovery

### DIFF
--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -124,7 +124,8 @@ namespace ts.JsTyping {
         packageNameToTypingLocation: ReadonlyESMap<string, CachedTyping>,
         typeAcquisition: TypeAcquisition,
         unresolvedImports: readonly string[],
-        typesRegistry: ReadonlyESMap<string, MapLike<string>>):
+        typesRegistry: ReadonlyESMap<string, MapLike<string>>,
+        compilerOptions: CompilerOptions):
         { cachedTypingPaths: string[], newTypingNames: string[], filesToWatch: string[] } {
 
         if (!typeAcquisition || !typeAcquisition.enable) {
@@ -148,12 +149,15 @@ namespace ts.JsTyping {
         const exclude = typeAcquisition.exclude || [];
 
         // Directories to search for package.json, bower.json and other typing information
-        const possibleSearchDirs = new Set(fileNames.map(getDirectoryPath));
-        possibleSearchDirs.add(projectRootPath);
-        possibleSearchDirs.forEach((searchDir) => {
-            getTypingNames(searchDir, "bower.json", "bower_components", filesToWatch);
-            getTypingNames(searchDir, "package.json", "node_modules", filesToWatch);
-        });
+        if (!compilerOptions.types) {
+            const possibleSearchDirs = new Set(fileNames.map(getDirectoryPath));
+            possibleSearchDirs.add(projectRootPath);
+            possibleSearchDirs.forEach((searchDir) => {
+                getTypingNames(searchDir, "bower.json", "bower_components", filesToWatch);
+                getTypingNames(searchDir, "package.json", "node_modules", filesToWatch);
+            });
+        }
+
         if(!typeAcquisition.disableFilenameBasedTypeAcquisition) {
             getTypingNamesFromSourceFileNames(fileNames);
         }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -1280,7 +1280,8 @@ namespace ts {
                     info.packageNameToTypingLocation,
                     info.typeAcquisition,
                     info.unresolvedImports,
-                    info.typesRegistry);
+                    info.typesRegistry,
+                    emptyOptions);
             });
         }
     }

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -901,10 +901,15 @@ namespace ts.projectSystem {
             checkProjectActualFiles(p, [app.path, cacacheDTS.path, jsconfig.path]);
         });
 
-        it("configured projects discover from node_modules", () => {
-            const app = {
-                path: "/app.js",
-                content: ""
+        function testConfiguredProjectNodeModules({ jsconfigContent, appJsContent, jQueryJsInProjectBeforeInstall, jQueryDtsInProjectAfterInstall }: {
+            jsconfigContent?: object,
+            appJsContent?: string,
+            jQueryJsInProjectBeforeInstall?: boolean,
+            jQueryDtsInProjectAfterInstall?: boolean,
+        } = {}) {
+        const app = {
+            path: "/app.js",
+                content: appJsContent || ""
             };
             const pkgJson = {
                 path: "/package.json",
@@ -916,7 +921,7 @@ namespace ts.projectSystem {
             };
             const jsconfig = {
                 path: "/jsconfig.json",
-                content: JSON.stringify({})
+                content: JSON.stringify(jsconfigContent || {})
             };
             // Should only accept direct dependencies.
             const commander = {
@@ -964,13 +969,49 @@ namespace ts.projectSystem {
 
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
             const p = configuredProjectAt(projectService, 0);
-            checkProjectActualFiles(p, [app.path, jsconfig.path]);
+            const filesBeforeInstall = jQueryJsInProjectBeforeInstall ? [app.path, jquery.path, jsconfig.path] : [app.path, jsconfig.path];
+            checkProjectActualFiles(p, filesBeforeInstall);
 
-            installer.installAll(/*expectedCount*/ 1);
+            installer.installAll(jQueryDtsInProjectAfterInstall ? 1 : 0);
 
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            host.checkTimeoutQueueLengthAndRun(2);
-            checkProjectActualFiles(p, [app.path, jqueryDTS.path, jsconfig.path]);
+            host.checkTimeoutQueueLengthAndRun(jQueryDtsInProjectAfterInstall ? 2 : 0);
+            checkProjectActualFiles(p, jQueryDtsInProjectAfterInstall ? [app.path, jqueryDTS.path, jsconfig.path] : filesBeforeInstall);
+        }
+
+        it("configured projects discover from node_modules", () => {
+            testConfiguredProjectNodeModules({
+                jQueryJsInProjectBeforeInstall: false,
+                jQueryDtsInProjectAfterInstall: true,
+            });
+        });
+
+        it("configured projects discover from node_modules - empty types", () => {
+            // Explicit types prevent automatic inclusion from package.json listing
+            testConfiguredProjectNodeModules({
+                jsconfigContent: { compilerOptions: { types: [] } },
+                jQueryJsInProjectBeforeInstall: false,
+                jQueryDtsInProjectAfterInstall: false,
+            });
+        });
+
+        it("configured projects discover from node_modules - explicit types", () => {
+            // A type reference directive will not resolve to the global typings cache
+            testConfiguredProjectNodeModules({
+                jsconfigContent: { compilerOptions: { types: ["jquery"] } },
+                jQueryJsInProjectBeforeInstall: false,
+                jQueryDtsInProjectAfterInstall: false
+            });
+        });
+
+        it("configured projects discover from node_modules - empty types but has import", () => {
+            // However, explicit types will not prevent unresolved imports from pulling in typings
+            testConfiguredProjectNodeModules({
+                jsconfigContent: { compilerOptions: { types: [] } },
+                appJsContent: `import "jquery";`,
+                jQueryJsInProjectBeforeInstall: true,
+                jQueryDtsInProjectAfterInstall: true,
+            });
         });
 
         it("configured projects discover from bower_components", () => {
@@ -1540,7 +1581,7 @@ namespace ts.projectSystem {
 
             const host = createServerHost([app, jquery, chroma]);
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [app.path, jquery.path, chroma.path], getDirectoryPath(app.path as Path), safeList, emptyMap, { enable: true }, emptyArray, emptyMap);
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path, jquery.path, chroma.path], getDirectoryPath(app.path as Path), safeList, emptyMap, { enable: true }, emptyArray, emptyMap, emptyOptions);
             const finish = logger.finish();
             assert.deepEqual(finish, [
                 'Inferred typings from file names: ["jquery","chroma-js"]',
@@ -1560,7 +1601,7 @@ namespace ts.projectSystem {
 
             for (const name of JsTyping.nodeCoreModuleList) {
                 const logger = trackingLogger();
-                const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(f.path as Path), emptySafeList, cache, { enable: true }, [name, "somename"], emptyMap);
+                const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(f.path as Path), emptySafeList, cache, { enable: true }, [name, "somename"], emptyMap, emptyOptions);
                 assert.deepEqual(logger.finish(), [
                     'Inferred typings from unresolved imports: ["node","somename"]',
                     'Result: {"cachedTypingPaths":[],"newTypingNames":["node","somename"],"filesToWatch":["/a/b/bower_components","/a/b/node_modules"]}',
@@ -1582,7 +1623,7 @@ namespace ts.projectSystem {
             const cache = new Map(getEntries<JsTyping.CachedTyping>({ node: { typingLocation: node.path, version: new Version("1.3.0") } }));
             const registry = createTypesRegistry("node");
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(f.path as Path), emptySafeList, cache, { enable: true }, ["fs", "bar"], registry);
+            const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(f.path as Path), emptySafeList, cache, { enable: true }, ["fs", "bar"], registry, emptyOptions);
             assert.deepEqual(logger.finish(), [
                 'Inferred typings from unresolved imports: ["node","bar"]',
                 'Result: {"cachedTypingPaths":["/a/b/node.d.ts"],"newTypingNames":["bar"],"filesToWatch":["/a/b/bower_components","/a/b/node_modules"]}',
@@ -1603,7 +1644,7 @@ namespace ts.projectSystem {
             const host = createServerHost([f, node]);
             const cache = new Map(getEntries<JsTyping.CachedTyping>({ node: { typingLocation: node.path, version: new Version("1.3.0") } }));
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(f.path as Path), emptySafeList, cache, { enable: true }, ["fs", "bar"], emptyMap);
+            const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(f.path as Path), emptySafeList, cache, { enable: true }, ["fs", "bar"], emptyMap, emptyOptions);
             assert.deepEqual(logger.finish(), [
                 'Inferred typings from unresolved imports: ["node","bar"]',
                 'Result: {"cachedTypingPaths":[],"newTypingNames":["node","bar"],"filesToWatch":["/a/b/bower_components","/a/b/node_modules"]}',
@@ -1628,7 +1669,7 @@ namespace ts.projectSystem {
             const host = createServerHost([app, a, b]);
             const cache = new Map<string, JsTyping.CachedTyping>();
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(app.path as Path), emptySafeList, cache, { enable: true }, /*unresolvedImports*/ [], emptyMap);
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(app.path as Path), emptySafeList, cache, { enable: true }, /*unresolvedImports*/ [], emptyMap, emptyOptions);
             assert.deepEqual(logger.finish(), [
                 'Searching for typing names in /node_modules; all files: ["/node_modules/a/package.json"]',
                 '    Found package names: ["a"]',
@@ -1654,7 +1695,7 @@ namespace ts.projectSystem {
             const host = createServerHost([app, a]);
             const cache = new Map<string, JsTyping.CachedTyping>();
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(app.path as Path), emptySafeList, cache, { enable: true }, /*unresolvedImports*/ [], emptyMap);
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(app.path as Path), emptySafeList, cache, { enable: true }, /*unresolvedImports*/ [], emptyMap, emptyOptions);
             assert.deepEqual(logger.finish(), [
                 'Searching for typing names in /node_modules; all files: ["/node_modules/@a/b/package.json"]',
                 '    Found package names: ["@a/b"]',
@@ -1688,7 +1729,7 @@ namespace ts.projectSystem {
             }));
             const registry = createTypesRegistry("node", "commander");
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(app.path as Path), emptySafeList, cache, { enable: true }, ["http", "commander"], registry);
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(app.path as Path), emptySafeList, cache, { enable: true }, ["http", "commander"], registry, emptyOptions);
             assert.deepEqual(logger.finish(), [
                 'Inferred typings from unresolved imports: ["node","commander"]',
                 'Result: {"cachedTypingPaths":["/a/cache/node_modules/@types/node/index.d.ts"],"newTypingNames":["commander"],"filesToWatch":["/a/bower_components","/a/node_modules"]}',
@@ -1714,7 +1755,7 @@ namespace ts.projectSystem {
             const registry = createTypesRegistry("node");
             registry.delete(`ts${versionMajorMinor}`);
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(app.path as Path), emptySafeList, cache, { enable: true }, ["http"], registry);
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(app.path as Path), emptySafeList, cache, { enable: true }, ["http"], registry, emptyOptions);
             assert.deepEqual(logger.finish(), [
                 'Inferred typings from unresolved imports: ["node"]',
                 'Result: {"cachedTypingPaths":[],"newTypingNames":["node"],"filesToWatch":["/a/bower_components","/a/node_modules"]}',
@@ -1746,7 +1787,7 @@ namespace ts.projectSystem {
             const registry = createTypesRegistry("node", "commander");
             registry.get("node")![`ts${versionMajorMinor}`] = "1.3.0-next.1";
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(app.path as Path), emptySafeList, cache, { enable: true }, ["http", "commander"], registry);
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(app.path as Path), emptySafeList, cache, { enable: true }, ["http", "commander"], registry, emptyOptions);
             assert.deepEqual(logger.finish(), [
                 'Inferred typings from unresolved imports: ["node","commander"]',
                 'Result: {"cachedTypingPaths":[],"newTypingNames":["node","commander"],"filesToWatch":["/a/bower_components","/a/node_modules"]}',

--- a/src/typingsInstallerCore/typingsInstaller.ts
+++ b/src/typingsInstallerCore/typingsInstaller.ts
@@ -172,7 +172,8 @@ namespace ts.server.typingsInstaller {
                 this.packageNameToTypingLocation,
                 req.typeAcquisition,
                 req.unresolvedImports,
-                this.typesRegistry);
+                this.typesRegistry,
+                req.compilerOptions);
 
             if (this.log.isEnabled()) {
                 this.log.writeLine(`Finished typings discovery: ${JSON.stringify(discoverTypingsResult)}`);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #47709

This is a much simpler version of #49275 that I’m much happier with. Thanks @sheetalkamat for the suggestion.

Explicit `types` in a jsconfig/tsconfig does not prevent ATA from pulling in typings for unresolved imports, but it does prevent it from automatically pulling in things just because they’re listed in a package.json file.
