### PR TITLE
Use symbolic GitHub Actions Node.js versions

### DIFF
--- a/.github/workflows/accept-baselines-fix-lints.yaml
+++ b/.github/workflows/accept-baselines-fix-lints.yaml
@@ -9,11 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use node version 14
-      uses: actions/setup-node@v3
-      with:
-        node-version: 14
-        registry-url: https://registry.npmjs.org/
+    - uses: actions/setup-node@v3
 
     - name: Configure Git, Run Tests, Update Baselines, Apply Fixes
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        # Test the latest version of Node.js plus the last two LTS versions.
+        node-version:
+          - "*"
+          - lts/*
+          - lts/-1
 
     steps:
     - uses: actions/checkout@v3
@@ -26,6 +30,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+        check-latest: true
     - name: Remove existing TypeScript
       run: |
         npm uninstall typescript --no-save
@@ -47,4 +52,3 @@ jobs:
 
     - name: Validate the browser can import TypeScript
       run: gulp test-browser-integration
-

--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -9,10 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Use node version 14.x
-      uses: actions/setup-node@v3
-      with:
-        node-version: 14.x
+    - uses: actions/setup-node@v3
     - uses: actions/checkout@v2
       with:
         fetch-depth: 5

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -15,11 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use node version 14
-      uses: actions/setup-node@v3
-      with:
-        node-version: 14
-        registry-url: https://registry.npmjs.org/
+    - uses: actions/setup-node@v3
     - name: Setup and publish nightly
       run: |
         npm whoami
@@ -30,6 +26,4 @@ jobs:
         gulp clean
         npm publish --tag next
       env:
-        NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-        CI: true
-    
+        NPM_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -11,10 +11,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use node version 14
-      uses: actions/setup-node@v3
-      with:
-        node-version: 14
+    - uses: actions/setup-node@v3
     - name: Remove existing TypeScript
       run: |
         npm uninstall typescript --no-save
@@ -23,10 +20,8 @@ jobs:
       run: |
         npm ci
         npm test
-      env:
-        CI: true
     - name: Adding playwright
-      run: npm install --no-save --no-package-lock playwright    
+      run: npm install --no-save --no-package-lock playwright
     - name: Validate the browser can import TypeScript
       run: gulp test-browser-integration
     - name: LKG, clean, and pack
@@ -35,8 +30,6 @@ jobs:
         gulp clean
         npm pack ./
         mv typescript-*.tgz typescript.tgz
-      env:
-        CI: true
     - name: Upload built tarfile
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -20,8 +20,6 @@ jobs:
           fetch-depth: 5
 
       - uses: actions/setup-node@v3
-        with:
-          node-version: 14
 
       - name: Install dependencies
         run:  npm ci

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -9,10 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Use node version 14.x
-      uses: actions/setup-node@v3
-      with:
-        node-version: 14.x
+    - uses: actions/setup-node@v3
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.branch_name }}

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -14,10 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Use node version 14.x
-      uses: actions/setup-node@v3
-      with:
-        node-version: 14.x
+    - uses: actions/setup-node@v3
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}

--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -23,12 +23,11 @@ jobs:
     if: ${{ github.repository == 'microsoft/TypeScript' && !github.event.label && !github.event.inputs.bisect_issue }}
     runs-on: ubuntu-latest
     steps:
-    - name: Use node
-      uses: actions/setup-node@v3
+    - uses: actions/setup-node@v3
     - uses: microsoft/TypeScript-Twoslash-Repro-Action@master
-      with: 
+      with:
         github-token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
-  
+
   bisect:
     if: ${{ github.event.label.name == 'Bisect Repro' || github.event.inputs.bisect_issue }}
     runs-on: ubuntu-latest
@@ -37,9 +36,7 @@ jobs:
       with:
         fetch-depth: 0
     - uses: actions/setup-node@v3
-      with:
-        node-version: 16
     - uses: microsoft/TypeScript-Twoslash-Repro-Action@master
-      with: 
+      with:
         github-token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
         bisect: ${{ github.event.issue.number || github.event.inputs.bisect_issue }}

--- a/.github/workflows/update-lkg.yml
+++ b/.github/workflows/update-lkg.yml
@@ -9,11 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use node version 14
-      uses: actions/setup-node@v3
-      with:
-        node-version: 14
-        registry-url: https://registry.npmjs.org/
+    - uses: actions/setup-node@v3
 
     - name: Configure Git and Update LKG
       run: |

--- a/.github/workflows/update-package-lock.yaml
+++ b/.github/workflows/update-package-lock.yaml
@@ -15,9 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v3
-      with:
-        node-version: 14
-        registry-url: https://registry.npmjs.org/
 
     - name: Configure git and update package-lock.json
       run: |


### PR DESCRIPTION
What I did was, in the CI workflow, replace Node.js v18 with "\*", v16 -> `lts/*` and v14 -> `lts/-1`. This will continue to test on [the latest version of Node.js plus the last two LTS versions](https://github.com/microsoft/TypeScript/pull/48824#issuecomment-1108890002), but without updating the workflow when Node.js is released.

"\*" will be v18 until October, when [v19 is scheduled to be released](https://nodejs.org/en/about/releases/), then v20 next April. `lts/*` and `lts/-1` will be v16 and v14 until v18 enters LTS (also in October).

In the other workflows where we use a single version of Node.js I dropped the `node-version` actions/setup-node input, which will use the version that comes with the runner ([currently v16](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#:~:text=15.0%2Fbin%2FMSBuild.dll%29-,node%2016.15.0,-Perl%205.30.0)).

While I was editing the actions/setup-node inputs I also dropped `registry-url: https://registry.npmjs.org/` because:
- It's [the default npm registry](https://docs.npmjs.com/cli/v8/using-npm/registry#:~:text=npm%20is%20configured%20to%20use%20the%20npm%20public%20registry%20at%20https%3A%2F%2Fregistry.npmjs.org%20by%20default.), [even on GitHub Actions](https://github.com/microsoft/TypeScript/commit/57df4663adb6ae181e8981a784b2556fa11823d9), as far as I can tell?
- As a side effect, the `registry-url` input [sets up authentication](https://github.com/actions/setup-node/blob/78148dae5052c4942d5b0f92719061df122a3b1c/action.yml#L9), however the only workflow that runs `npm publish` is the nightly workflow, and we can do the same thing without actions/setup-node, using the [`NPM_TOKEN` environment variable](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#set-the-token-as-an-environment-variable-on-the-cicd-server).

I also dropped the `CI: true` environment variable because it's [always set by GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/environment-variables#:~:text=Description-,CI,set%20to%20true.,-GITHUB_ACTION).

/cc @andrewbranch and @weswigham