### PR TITLE
Replace ts.hasOwnProperty.call(...) with hasProperty(...)

### DIFF
--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -366,7 +366,7 @@ namespace ts {
         }
         let str = "{";
         for (const key in value) {
-            if (ts.hasOwnProperty.call(value, key)) { // eslint-disable-line @typescript-eslint/no-unnecessary-qualifier
+            if (hasProperty(value, key)) {
                 str += `${key}: ${compilerOptionValueToString((value as any)[key])}`;
             }
         }


### PR DESCRIPTION
This was introduced in #48389; it relies on the fact that `ts` is an object to get access to this commonly-used helper, but this confuses the module transform into thinking it can actually import this from the TS namespace (I'm working around it for now). Just use the helper we have in `core.ts` instead.