### PR TITLE
Eliminate (ts as any).SyntaxKind (and similar) in favor of Debug.format functions

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -391,7 +391,7 @@ namespace ts {
                 case SyntaxKind.Parameter:
                     // Parameters with names are handled at the top of this function.  Parameters
                     // without names can only come from JSDocFunctionTypes.
-                    Debug.assert(node.parent.kind === SyntaxKind.JSDocFunctionType, "Impossible parameter parent kind", () => `parent is: ${(ts as any).SyntaxKind ? (ts as any).SyntaxKind[node.parent.kind] : node.parent.kind}, expected JSDocFunctionType`);
+                    Debug.assert(node.parent.kind === SyntaxKind.JSDocFunctionType, "Impossible parameter parent kind", () => `parent is: ${Debug.formatSyntaxKind(node.parent.kind)}, expected JSDocFunctionType`);
                     const functionType = node.parent as JSDocFunctionType;
                     const index = functionType.parameters.indexOf(node as ParameterDeclaration);
                     return "arg" + index as __String;

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -817,7 +817,7 @@ namespace ts {
             while (length(lateMarkedStatements)) {
                 const i = lateMarkedStatements!.shift()!;
                 if (!isLateVisibilityPaintedStatement(i)) {
-                    return Debug.fail(`Late replaced statement was found which is not handled by the declaration transformer!: ${(ts as any).SyntaxKind ? (ts as any).SyntaxKind[(i as any).kind] : (i as any).kind}`);
+                    return Debug.fail(`Late replaced statement was found which is not handled by the declaration transformer!: ${Debug.formatSyntaxKind((i as Node).kind)}`);
                 }
                 const priorNeedsDeclare = needsDeclare;
                 needsDeclare = i.parent && isSourceFile(i.parent) && !(isExternalModule(i.parent) && isBundledEmit);
@@ -1067,7 +1067,7 @@ namespace ts {
                             input.isTypeOf
                         ));
                     }
-                    default: Debug.assertNever(input, `Attempted to process unhandled node kind: ${(ts as any).SyntaxKind[(input as any).kind]}`);
+                    default: Debug.assertNever(input, `Attempted to process unhandled node kind: ${Debug.formatSyntaxKind((input as Node).kind)}`);
                 }
             }
 
@@ -1481,7 +1481,7 @@ namespace ts {
                 }
             }
             // Anything left unhandled is an error, so this should be unreachable
-            return Debug.assertNever(input, `Unhandled top-level node in declaration emit: ${(ts as any).SyntaxKind[(input as any).kind]}`);
+            return Debug.assertNever(input, `Unhandled top-level node in declaration emit: ${Debug.formatSyntaxKind((input as Node).kind)}`);
 
             function cleanup<T extends Node>(node: T | undefined): T | undefined {
                 if (isEnclosingDeclaration(input)) {

--- a/src/compiler/transformers/declarations/diagnostics.ts
+++ b/src/compiler/transformers/declarations/diagnostics.ts
@@ -157,7 +157,7 @@ namespace ts {
             return getTypeAliasDeclarationVisibilityError;
         }
         else {
-            return Debug.assertNever(node, `Attempted to set a declaration diagnostic context for unhandled node kind: ${(ts as any).SyntaxKind[(node as any).kind]}`);
+            return Debug.assertNever(node, `Attempted to set a declaration diagnostic context for unhandled node kind: ${Debug.formatSyntaxKind((node as Node).kind)}`);
         }
 
         function getVariableDeclarationTypeVisibilityDiagnosticMessage(symbolAccessibilityResult: SymbolAccessibilityResult) {
@@ -386,7 +386,7 @@ namespace ts {
                         Diagnostics.Parameter_0_of_accessor_has_or_is_using_private_name_1;
 
                 default:
-                    return Debug.fail(`Unknown parent for parameter: ${(ts as any).SyntaxKind[node.parent.kind]}`);
+                    return Debug.fail(`Unknown parent for parameter: ${Debug.formatSyntaxKind(node.parent.kind)}`);
             }
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -379,8 +379,9 @@ namespace ts {
         JSDocFunctionType,
         JSDocVariadicType,
         JSDocNamepathType, // https://jsdoc.app/about-namepaths.html
+        JSDoc,
         /** @deprecated Use SyntaxKind.JSDoc */
-        JSDocComment,
+        JSDocComment = JSDoc,
         JSDocText,
         JSDocTypeLiteral,
         JSDocSignature,
@@ -457,7 +458,6 @@ namespace ts {
         LastJSDocTagNode = JSDocPropertyTag,
         /* @internal */ FirstContextualKeyword = AbstractKeyword,
         /* @internal */ LastContextualKeyword = OfKeyword,
-        JSDoc = JSDocComment,
     }
 
     export type TriviaSyntaxKind =

--- a/src/harness/harnessUtils.ts
+++ b/src/harness/harnessUtils.ts
@@ -141,7 +141,7 @@ namespace Utils {
                     const child = (node as any)[childName];
                     if (isNodeOrArray(child)) {
                         assert.isFalse(childNodesAndArrays.indexOf(child) < 0,
-                            "Missing child when forEach'ing over node: " + (ts as any).SyntaxKind[node.kind] + "-" + childName);
+                            "Missing child when forEach'ing over node: " + ts.Debug.formatSyntaxKind(node.kind) + "-" + childName);
                     }
                 }
             }
@@ -169,54 +169,15 @@ namespace Utils {
     export function sourceFileToJSON(file: ts.Node): string {
         return JSON.stringify(file, (_, v) => isNodeOrArray(v) ? serializeNode(v) : v, "    ");
 
-        function getKindName(k: number | string): string {
-            if (ts.isString(k)) {
+        function getKindName(k: number | string | undefined): string | undefined {
+            if (k === undefined || ts.isString(k)) {
                 return k;
             }
-
-            // For some markers in SyntaxKind, we should print its original syntax name instead of
-            // the marker name in tests.
-            if (k === (ts as any).SyntaxKind.FirstJSDocNode ||
-                k === (ts as any).SyntaxKind.LastJSDocNode ||
-                k === (ts as any).SyntaxKind.FirstJSDocTagNode ||
-                k === (ts as any).SyntaxKind.LastJSDocTagNode) {
-                for (const kindName in (ts as any).SyntaxKind) {
-                    if ((ts as any).SyntaxKind[kindName] === k) {
-                        return kindName;
-                    }
-                }
-            }
-
-            return (ts as any).SyntaxKind[k];
-        }
-
-        function getFlagName(flags: any, f: number): any {
-            if (f === 0) {
-                return 0;
-            }
-
-            let result = "";
-            ts.forEach(Object.getOwnPropertyNames(flags), (v: any) => {
-                if (isFinite(v)) {
-                    v = +v;
-                    if (f === +v) {
-                        result = flags[v];
-                        return true;
-                    }
-                    else if ((f & v) > 0) {
-                        if (result.length) {
-                            result += " | ";
-                        }
-                        result += flags[v];
-                        return false;
-                    }
-                }
-            });
-            return result;
+            return ts.Debug.formatSyntaxKind(k);
         }
 
         function getNodeFlagName(f: number) {
-            return getFlagName((ts as any).NodeFlags, f);
+            return ts.Debug.formatNodeFlags(f);
         }
 
         function serializeNode(n: ts.Node): any {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@link tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@link tags.json
@@ -99,7 +99,7 @@
                     "modifierFlagsCache": 0,
                     "transformFlags": 0,
                     "name": {
-                        "kind": "FirstNode",
+                        "kind": "QualifiedName",
                         "pos": 86,
                         "end": 97,
                         "modifierFlagsCache": 0,
@@ -194,7 +194,7 @@
                     "modifierFlagsCache": 0,
                     "transformFlags": 0,
                     "name": {
-                        "kind": "FirstNode",
+                        "kind": "QualifiedName",
                         "pos": 163,
                         "end": 181,
                         "modifierFlagsCache": 0,
@@ -273,7 +273,7 @@
                     "modifierFlagsCache": 0,
                     "transformFlags": 0,
                     "name": {
-                        "kind": "FirstNode",
+                        "kind": "QualifiedName",
                         "pos": 333,
                         "end": 338,
                         "modifierFlagsCache": 0,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
@@ -64,7 +64,7 @@
                                 }
                             },
                             "name": {
-                                "kind": "FirstNode",
+                                "kind": "QualifiedName",
                                 "pos": 50,
                                 "end": 53,
                                 "modifierFlagsCache": 0,

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.newType1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.newType1.json
@@ -31,7 +31,7 @@
                 "modifierFlagsCache": 0,
                 "transformFlags": 1,
                 "typeName": {
-                    "kind": "FirstNode",
+                    "kind": "QualifiedName",
                     "pos": 14,
                     "end": 17,
                     "flags": "JSDoc",

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.thisType1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.thisType1.json
@@ -31,7 +31,7 @@
                 "modifierFlagsCache": 0,
                 "transformFlags": 1,
                 "typeName": {
-                    "kind": "FirstNode",
+                    "kind": "QualifiedName",
                     "pos": 15,
                     "end": 18,
                     "flags": "JSDoc",

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference3.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference3.json
@@ -6,7 +6,7 @@
     "modifierFlagsCache": 0,
     "transformFlags": 1,
     "typeName": {
-        "kind": "FirstNode",
+        "kind": "QualifiedName",
         "pos": 1,
         "end": 11,
         "flags": "JSDoc",

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -425,6 +425,7 @@ declare namespace ts {
         JSDocFunctionType = 317,
         JSDocVariadicType = 318,
         JSDocNamepathType = 319,
+        JSDoc = 320,
         /** @deprecated Use SyntaxKind.JSDoc */
         JSDocComment = 320,
         JSDocText = 321,
@@ -493,7 +494,6 @@ declare namespace ts {
         LastJSDocNode = 347,
         FirstJSDocTagNode = 327,
         LastJSDocTagNode = 347,
-        JSDoc = 320
     }
     export type TriviaSyntaxKind = SyntaxKind.SingleLineCommentTrivia | SyntaxKind.MultiLineCommentTrivia | SyntaxKind.NewLineTrivia | SyntaxKind.WhitespaceTrivia | SyntaxKind.ShebangTrivia | SyntaxKind.ConflictMarkerTrivia;
     export type LiteralSyntaxKind = SyntaxKind.NumericLiteral | SyntaxKind.BigIntLiteral | SyntaxKind.StringLiteral | SyntaxKind.JsxText | SyntaxKind.JsxTextAllWhiteSpaces | SyntaxKind.RegularExpressionLiteral | SyntaxKind.NoSubstitutionTemplateLiteral;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -425,6 +425,7 @@ declare namespace ts {
         JSDocFunctionType = 317,
         JSDocVariadicType = 318,
         JSDocNamepathType = 319,
+        JSDoc = 320,
         /** @deprecated Use SyntaxKind.JSDoc */
         JSDocComment = 320,
         JSDocText = 321,
@@ -493,7 +494,6 @@ declare namespace ts {
         LastJSDocNode = 347,
         FirstJSDocTagNode = 327,
         LastJSDocTagNode = 347,
-        JSDoc = 320
     }
     export type TriviaSyntaxKind = SyntaxKind.SingleLineCommentTrivia | SyntaxKind.MultiLineCommentTrivia | SyntaxKind.NewLineTrivia | SyntaxKind.WhitespaceTrivia | SyntaxKind.ShebangTrivia | SyntaxKind.ConflictMarkerTrivia;
     export type LiteralSyntaxKind = SyntaxKind.NumericLiteral | SyntaxKind.BigIntLiteral | SyntaxKind.StringLiteral | SyntaxKind.JsxText | SyntaxKind.JsxTextAllWhiteSpaces | SyntaxKind.RegularExpressionLiteral | SyntaxKind.NoSubstitutionTemplateLiteral;


### PR DESCRIPTION
This is a change pulled off of my module transform branch; these uses of `ts` are often the only uses of `ts` in a file, so it's advantageous to remove them.

But it also has the benefit of not duplicating logic to get the name of a `SyntaxKind` or similar; you can see in the baselines that there are nodes that are incorrectly printed as "FirstNode". The harness code previously duplicated its own SyntaxKind printer and hardcoded a couple of markers, but `formatSyntaxKind` is smart enough to do that on its own.