### PR TITLE
Improve performance of Debug.format functions

### DIFF
--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -301,19 +301,19 @@ namespace ts {
                 return members.length > 0 && members[0][0] === 0 ? members[0][1] : "0";
             }
             if (isFlags) {
-                let result = "";
+                const result: string[] = [];
                 let remainingFlags = value;
                 for (const [enumValue, enumName] of members) {
                     if (enumValue > value) {
                         break;
                     }
                     if (enumValue !== 0 && enumValue & value) {
-                        result = `${result}${result ? "|" : ""}${enumName}`;
+                        result.push(enumName);
                         remainingFlags &= ~enumValue;
                     }
                 }
                 if (remainingFlags === 0) {
-                    return result;
+                    return result.join("|");
                 }
             }
             else {

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -350,7 +350,6 @@ namespace ts {
             return sorted;
         }
 
-
         export function formatSyntaxKind(kind: SyntaxKind | undefined): string {
             return formatEnum(kind, (ts as any).SyntaxKind, /*isFlags*/ false);
         }


### PR DESCRIPTION
These functions are not normally performance critical, however, the cleanup in #49485 removes the test harness' duplicate `SyntaxKind` formatter in favor of `Debug`'s (which is more accurate, but slower), and this recovers the perf loss this causes.

This technically speeds up tests by 25%, but that is only there because #49485 slows down the tests by 25%. Sigh.