### PR TITLE
Fixes #49491: assertion failure in generate get/set accessors when name has escape characters

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2647,7 +2647,7 @@ namespace ts {
             Debug.assert(fileName === renameFilename);
             for (const change of textChanges) {
                 const { span, newText } = change;
-                const index = indexInTextChange(newText, name);
+                const index = indexInTextChange(newText, escapeString(name));
                 if (index !== -1) {
                     lastPos = span.start + delta + index;
 

--- a/tests/cases/fourslash/refactorConvertToGetAccessAndSetAccess41.ts
+++ b/tests/cases/fourslash/refactorConvertToGetAccessAndSetAccess41.ts
@@ -1,0 +1,24 @@
+/// <reference path='fourslash.ts' />
+
+// @strict: true
+
+////class A {
+////    /*a*/"\\foo": "";/*b*/
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Generate 'get' and 'set' accessors",
+    actionName: "Generate 'get' and 'set' accessors",
+    actionDescription: "Generate 'get' and 'set' accessors",
+    newContent:
+`class A {
+    private /*RENAME*/"_\\\\foo": "";
+    public get "\\\\foo"(): "" {
+        return this["_\\\\foo"];
+    }
+    public set "\\\\foo"(value: "") {
+        this["_\\\\foo"] = value;
+    }
+}`
+});

--- a/tests/cases/fourslash/refactorConvertToGetAccessAndSetAccess42.ts
+++ b/tests/cases/fourslash/refactorConvertToGetAccessAndSetAccess42.ts
@@ -1,0 +1,24 @@
+/// <reference path='fourslash.ts' />
+
+// @strict: true
+
+////class A {
+////    /*a*/"\tfoo": "";/*b*/
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Generate 'get' and 'set' accessors",
+    actionName: "Generate 'get' and 'set' accessors",
+    actionDescription: "Generate 'get' and 'set' accessors",
+    newContent:
+`class A {
+    private /*RENAME*/"_\\tfoo": "";
+    public get "\\tfoo"(): "" {
+        return this["_\\tfoo"];
+    }
+    public set "\\tfoo"(value: "") {
+        this["_\\tfoo"] = value;
+    }
+}`
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #49491 
