### PR TITLE
fix(49483): Plain JS files don't issue error on await inside non-async function

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -998,6 +998,7 @@ namespace ts {
         Diagnostics.let_is_not_allowed_to_be_used_as_a_name_in_let_or_const_declarations.code,
         Diagnostics.Class_constructor_may_not_be_a_generator.code,
         Diagnostics.Class_constructor_may_not_be_an_accessor.code,
+        Diagnostics.await_expressions_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules.code,
     ]);
 
     /**

--- a/tests/baselines/reference/plainJSGrammarErrors3.errors.txt
+++ b/tests/baselines/reference/plainJSGrammarErrors3.errors.txt
@@ -1,0 +1,13 @@
+/a.js(2,5): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
+
+
+==== tests/cases/conformance/salsa/plainJSGrammarErrors3.js (0 errors) ====
+    
+==== /a.js (1 errors) ====
+    function foo() {
+        await new Promise(undefined);
+        ~~~~~
+!!! error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
+!!! related TS1356 /a.js:1:10: Did you mean to mark this function as 'async'?
+    }
+    

--- a/tests/baselines/reference/plainJSGrammarErrors3.js
+++ b/tests/baselines/reference/plainJSGrammarErrors3.js
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/salsa/plainJSGrammarErrors3.ts] ////
+
+//// [plainJSGrammarErrors3.js]
+
+//// [a.js]
+function foo() {
+    await new Promise(undefined);
+}
+
+
+//// [plainJSGrammarErrors3.js]
+//// [a.js]
+function foo() {
+    await new Promise(undefined);
+}

--- a/tests/baselines/reference/plainJSGrammarErrors3.symbols
+++ b/tests/baselines/reference/plainJSGrammarErrors3.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/salsa/plainJSGrammarErrors3.js ===
+
+No type information for this code.=== /a.js ===
+function foo() {
+>foo : Symbol(foo, Decl(a.js, 0, 0))
+
+    await new Promise(undefined);
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>undefined : Symbol(undefined)
+}
+

--- a/tests/baselines/reference/plainJSGrammarErrors3.types
+++ b/tests/baselines/reference/plainJSGrammarErrors3.types
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/salsa/plainJSGrammarErrors3.js ===
+
+No type information for this code.=== /a.js ===
+function foo() {
+>foo : () => void
+
+    await new Promise(undefined);
+>await new Promise(undefined) : any
+>new Promise(undefined) : Promise<any>
+>Promise : PromiseConstructor
+>undefined : undefined
+}
+

--- a/tests/cases/conformance/salsa/plainJSGrammarErrors3.ts
+++ b/tests/cases/conformance/salsa/plainJSGrammarErrors3.ts
@@ -1,0 +1,10 @@
+// @outdir: out/
+// @target: esnext
+// @module: esnext
+// @allowJs: true
+// @filename: plainJSGrammarErrors3.js
+
+// @filename: /a.js
+function foo() {
+    await new Promise(undefined);
+}


### PR DESCRIPTION
Fixes #49483