### PR TITLE
Handle `this` in isEntityNameVisible

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4664,6 +4664,9 @@ namespace ts {
             if (symbol && symbol.flags & SymbolFlags.TypeParameter && meaning & SymbolFlags.Type) {
                 return { accessibility: SymbolAccessibility.Accessible };
             }
+            if (!symbol && isThisIdentifier(firstIdentifier) && isSymbolAccessible(getSymbolOfNode(getThisContainer(firstIdentifier, /*includeArrowFunctions*/ false)), firstIdentifier, meaning, /*computeAliases*/ false).accessibility === SymbolAccessibility.Accessible) {
+                return { accessibility: SymbolAccessibility.Accessible };
+            }
 
             // Verify if the symbol is accessible
             return (symbol && hasVisibleDeclarations(symbol, /*shouldComputeAliasToMakeVisible*/ true)) || {

--- a/tests/baselines/reference/declarationEmitTypeofThisInClass.js
+++ b/tests/baselines/reference/declarationEmitTypeofThisInClass.js
@@ -1,0 +1,20 @@
+//// [declarationEmitTypeofThisInClass.ts]
+class Foo {
+    public foo!: string
+    public bar!: typeof this.foo //Public property 'bar' of exported class has or is using private name 'this'.(4031)
+}
+
+//// [declarationEmitTypeofThisInClass.js]
+"use strict";
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    return Foo;
+}());
+
+
+//// [declarationEmitTypeofThisInClass.d.ts]
+declare class Foo {
+    foo: string;
+    bar: typeof this.foo;
+}

--- a/tests/baselines/reference/declarationEmitTypeofThisInClass.symbols
+++ b/tests/baselines/reference/declarationEmitTypeofThisInClass.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/declarationEmitTypeofThisInClass.ts ===
+class Foo {
+>Foo : Symbol(Foo, Decl(declarationEmitTypeofThisInClass.ts, 0, 0))
+
+    public foo!: string
+>foo : Symbol(Foo.foo, Decl(declarationEmitTypeofThisInClass.ts, 0, 11))
+
+    public bar!: typeof this.foo //Public property 'bar' of exported class has or is using private name 'this'.(4031)
+>bar : Symbol(Foo.bar, Decl(declarationEmitTypeofThisInClass.ts, 1, 23))
+>this.foo : Symbol(Foo.foo, Decl(declarationEmitTypeofThisInClass.ts, 0, 11))
+>this : Symbol(Foo, Decl(declarationEmitTypeofThisInClass.ts, 0, 0))
+>foo : Symbol(Foo.foo, Decl(declarationEmitTypeofThisInClass.ts, 0, 11))
+}

--- a/tests/baselines/reference/declarationEmitTypeofThisInClass.types
+++ b/tests/baselines/reference/declarationEmitTypeofThisInClass.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/declarationEmitTypeofThisInClass.ts ===
+class Foo {
+>Foo : Foo
+
+    public foo!: string
+>foo : string
+
+    public bar!: typeof this.foo //Public property 'bar' of exported class has or is using private name 'this'.(4031)
+>bar : string
+>this.foo : string
+>this : this
+>foo : string
+}

--- a/tests/cases/compiler/declarationEmitTypeofThisInClass.ts
+++ b/tests/cases/compiler/declarationEmitTypeofThisInClass.ts
@@ -1,0 +1,6 @@
+// @declaration: true
+// @strict: true
+class Foo {
+    public foo!: string
+    public bar!: typeof this.foo //Public property 'bar' of exported class has or is using private name 'this'.(4031)
+}


### PR DESCRIPTION
Since `resolveName` never resolves `this`, it needs to be explicitly handled.

Fixes #49451
