### PR TITLE
Ensure scripts compile, are checked in strict mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -409,6 +409,15 @@
             "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
             "dev": true
         },
+        "@types/fs-extra": {
+            "version": "9.0.13",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+            "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -6643,7 +6652,7 @@
         "vinyl-sourcemaps-apply": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-            "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+            "integrity": "sha512-+oDh3KYZBoZC8hfocrbrxbLUeaYtQK7J5WU5Br9VqWqmCll3tFJqKp97GC9GmMsVIL0qnx2DgEDVxdo5EZ5sSw==",
             "dev": true,
             "requires": {
                 "source-map": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "@octokit/rest": "latest",
         "@types/chai": "latest",
         "@types/convert-source-map": "latest",
+        "@types/fs-extra": "^9.0.13",
         "@types/glob": "latest",
         "@types/gulp": "^4.0.9",
         "@types/gulp-concat": "latest",

--- a/scripts/buildProtocol.ts
+++ b/scripts/buildProtocol.ts
@@ -159,7 +159,7 @@ function writeProtocolFile(outputFile: string, protocolTs: string, typeScriptSer
             if (fileName === protocolFileName) {
                 return ts.createSourceFile(fileName, protocolDts, options.target);
             }
-            return originalGetSourceFile.apply(host, [fileName]);
+            return originalGetSourceFile.apply(host, [fileName, ts.ScriptTarget.Latest]);
         };
         const rootFiles = includeTypeScriptServices ? [protocolFileName, typeScriptServicesDts] : [protocolFileName];
         return ts.createProgram(rootFiles, options, host);

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "strictNullChecks": true,
+        "strict": true,
         "removeComments": false,
         "declaration": false,
         "sourceMap": true,


### PR DESCRIPTION
While fixing something else, I noticed that the code in scripts doesn't compile (and also is not strict, so masked a missing dependency). Fix these.

I manually tested `buildProtocol.ts`, and it seems to still be correct. I assume that it used to be that passing no script target meant the latest, but if that's not the case, I can switch it.