### PR TITLE
fix(49546): 'Add missing properties' quick fix incorrectly handles symbol property

### DIFF
--- a/tests/cases/fourslash/codeFixAddMissingProperties22.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties22.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+
+// @lib: es2020
+////const x: Iterable<number> = {}
+
+verify.codeFix({
+    index: 0,
+    description: ts.Diagnostics.Add_missing_properties.message,
+    newFileContent:
+`const x: Iterable<number> = {
+    [Symbol.iterator]: function(): Iterator<number, any, undefined> {
+        throw new Error("Function not implemented.");
+    }
+}`,
+});


### PR DESCRIPTION
Fixes #49546