### PR TITLE
Improve generic keyof relationship checking for generic conditionals with keyless branch types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19269,6 +19269,21 @@ namespace ts {
                 return result;
             }
 
+            function removeIntersectionMembersWithoutKeys(type: Type) {
+                if (!(type.flags & TypeFlags.Intersection)) {
+                    return type;
+                }
+                return getIntersectionType(filter((type as IntersectionType).types, t => !isKeylessType(t)));
+            }
+
+            function isKeylessType(type: Type) {
+                return !!(getIndexType(type).flags & TypeFlags.Never);
+            }
+
+            function isConditionalFilteringKeylessTypes(type: Type) {
+                return !!(type.flags & TypeFlags.Conditional) && (type as ConditionalType).root.isDistributive && everyType((type as ConditionalType).extendsType, isKeylessType);
+            }
+
             function structuredTypeRelatedTo(source: Type, target: Type, reportErrors: boolean, intersectionState: IntersectionState): Ternary {
                 if (intersectionState & IntersectionState.PropertyCheck) {
                     return propertiesRelatedTo(source, target, reportErrors, /*excludedProperties*/ undefined, IntersectionState.None);
@@ -19411,8 +19426,33 @@ namespace ts {
                     const targetType = (target as IndexType).type;
                     // A keyof S is related to a keyof T if T is related to S.
                     if (sourceFlags & TypeFlags.Index) {
-                        if (result = isRelatedTo(targetType, (source as IndexType).type, RecursionFlags.Both, /*reportErrors*/ false)) {
+                        let sourceType = (source as IndexType).type;
+                        if (result = isRelatedTo(targetType, sourceType, RecursionFlags.Both, /*reportErrors*/ false)) {
                             return result;
+                        }
+                        // If the source is a filtering conditional that removes only keyless sources, eg, `NonNullable<T>`,
+                        // then it doesn't affect the `keyof` query, and we can unwrap the conditional and relate the unwrapped source and target.
+                        // There may be multiple stacked conditionals, such as `T extends null ? never : T extends undefined ? never : T : T`, so
+                        // we need to repeat the unwrapping process.
+                        while (isConditionalFilteringKeylessTypes(sourceType)) {
+                            const lastSource = sourceType;
+                            sourceType = getDefaultConstraintOfConditionalType(sourceType as ConditionalType);
+                            if (sourceType === lastSource) {
+                                break;
+                            }
+                            if (result = isRelatedTo(targetType, sourceType, RecursionFlags.Both, /*reportErrors*/ false)) {
+                                return result;
+                            }
+                            const simplifiedSource = sourceType;
+                            // In addition, `keyof (T & U)` is equivalent to `keyof T | keyof U`, so if `keyof U` is always `never`, we can omit
+                            // it from the relationship. This allows, eg, `keyof (T & object)` to be related to `keyof T`.
+                            sourceType = removeIntersectionMembersWithoutKeys(sourceType);
+                            if (sourceType === simplifiedSource) {
+                                continue;
+                            }
+                            if (result = isRelatedTo(targetType, sourceType, RecursionFlags.Both, /*reportErrors*/ false)) {
+                                return result;
+                            }
                         }
                     }
                     if (isTupleType(targetType)) {

--- a/tests/baselines/reference/keyofNonNullableAssignments.js
+++ b/tests/baselines/reference/keyofNonNullableAssignments.js
@@ -1,0 +1,27 @@
+//// [keyofNonNullableAssignments.ts]
+type MyNonNullable<T> = T extends null ? never : T extends undefined ? never : T;
+
+function f<T>(x: T) {
+    const a: keyof T = (null as any as keyof NonNullable<T>);
+    const b: keyof T = (null as any as keyof NonNullable<T & object>);
+    const c: keyof T = (null as any as keyof MyNonNullable<T>);
+    const d: keyof T = (null as any as keyof MyNonNullable<T & object>);
+    const e: keyof T = (null as any as keyof NonNullable<T | undefined>);
+    const f: keyof T = (null as any as keyof NonNullable<(T | undefined) & object>);
+    const g: keyof T = (null as any as keyof MyNonNullable<T | undefined>);
+    const h: keyof T = (null as any as keyof MyNonNullable<(T | undefined) & object>);
+}
+
+
+//// [keyofNonNullableAssignments.js]
+"use strict";
+function f(x) {
+    var a = null;
+    var b = null;
+    var c = null;
+    var d = null;
+    var e = null;
+    var f = null;
+    var g = null;
+    var h = null;
+}

--- a/tests/baselines/reference/keyofNonNullableAssignments.symbols
+++ b/tests/baselines/reference/keyofNonNullableAssignments.symbols
@@ -1,0 +1,63 @@
+=== tests/cases/compiler/keyofNonNullableAssignments.ts ===
+type MyNonNullable<T> = T extends null ? never : T extends undefined ? never : T;
+>MyNonNullable : Symbol(MyNonNullable, Decl(keyofNonNullableAssignments.ts, 0, 0))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 0, 19))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 0, 19))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 0, 19))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 0, 19))
+
+function f<T>(x: T) {
+>f : Symbol(f, Decl(keyofNonNullableAssignments.ts, 0, 81))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>x : Symbol(x, Decl(keyofNonNullableAssignments.ts, 2, 14))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const a: keyof T = (null as any as keyof NonNullable<T>);
+>a : Symbol(a, Decl(keyofNonNullableAssignments.ts, 3, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const b: keyof T = (null as any as keyof NonNullable<T & object>);
+>b : Symbol(b, Decl(keyofNonNullableAssignments.ts, 4, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const c: keyof T = (null as any as keyof MyNonNullable<T>);
+>c : Symbol(c, Decl(keyofNonNullableAssignments.ts, 5, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>MyNonNullable : Symbol(MyNonNullable, Decl(keyofNonNullableAssignments.ts, 0, 0))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const d: keyof T = (null as any as keyof MyNonNullable<T & object>);
+>d : Symbol(d, Decl(keyofNonNullableAssignments.ts, 6, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>MyNonNullable : Symbol(MyNonNullable, Decl(keyofNonNullableAssignments.ts, 0, 0))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const e: keyof T = (null as any as keyof NonNullable<T | undefined>);
+>e : Symbol(e, Decl(keyofNonNullableAssignments.ts, 7, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const f: keyof T = (null as any as keyof NonNullable<(T | undefined) & object>);
+>f : Symbol(f, Decl(keyofNonNullableAssignments.ts, 8, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const g: keyof T = (null as any as keyof MyNonNullable<T | undefined>);
+>g : Symbol(g, Decl(keyofNonNullableAssignments.ts, 9, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>MyNonNullable : Symbol(MyNonNullable, Decl(keyofNonNullableAssignments.ts, 0, 0))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+
+    const h: keyof T = (null as any as keyof MyNonNullable<(T | undefined) & object>);
+>h : Symbol(h, Decl(keyofNonNullableAssignments.ts, 10, 9))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+>MyNonNullable : Symbol(MyNonNullable, Decl(keyofNonNullableAssignments.ts, 0, 0))
+>T : Symbol(T, Decl(keyofNonNullableAssignments.ts, 2, 11))
+}
+

--- a/tests/baselines/reference/keyofNonNullableAssignments.types
+++ b/tests/baselines/reference/keyofNonNullableAssignments.types
@@ -1,0 +1,66 @@
+=== tests/cases/compiler/keyofNonNullableAssignments.ts ===
+type MyNonNullable<T> = T extends null ? never : T extends undefined ? never : T;
+>MyNonNullable : MyNonNullable<T>
+>null : null
+
+function f<T>(x: T) {
+>f : <T>(x: T) => void
+>x : T
+
+    const a: keyof T = (null as any as keyof NonNullable<T>);
+>a : keyof T
+>(null as any as keyof NonNullable<T>) : keyof T
+>null as any as keyof NonNullable<T> : keyof T
+>null as any : any
+>null : null
+
+    const b: keyof T = (null as any as keyof NonNullable<T & object>);
+>b : keyof T
+>(null as any as keyof NonNullable<T & object>) : keyof T
+>null as any as keyof NonNullable<T & object> : keyof T
+>null as any : any
+>null : null
+
+    const c: keyof T = (null as any as keyof MyNonNullable<T>);
+>c : keyof T
+>(null as any as keyof MyNonNullable<T>) : keyof MyNonNullable<T>
+>null as any as keyof MyNonNullable<T> : keyof MyNonNullable<T>
+>null as any : any
+>null : null
+
+    const d: keyof T = (null as any as keyof MyNonNullable<T & object>);
+>d : keyof T
+>(null as any as keyof MyNonNullable<T & object>) : keyof MyNonNullable<T & object>
+>null as any as keyof MyNonNullable<T & object> : keyof MyNonNullable<T & object>
+>null as any : any
+>null : null
+
+    const e: keyof T = (null as any as keyof NonNullable<T | undefined>);
+>e : keyof T
+>(null as any as keyof NonNullable<T | undefined>) : keyof T
+>null as any as keyof NonNullable<T | undefined> : keyof T
+>null as any : any
+>null : null
+
+    const f: keyof T = (null as any as keyof NonNullable<(T | undefined) & object>);
+>f : keyof T
+>(null as any as keyof NonNullable<(T | undefined) & object>) : keyof T
+>null as any as keyof NonNullable<(T | undefined) & object> : keyof T
+>null as any : any
+>null : null
+
+    const g: keyof T = (null as any as keyof MyNonNullable<T | undefined>);
+>g : keyof T
+>(null as any as keyof MyNonNullable<T | undefined>) : keyof MyNonNullable<T>
+>null as any as keyof MyNonNullable<T | undefined> : keyof MyNonNullable<T>
+>null as any : any
+>null : null
+
+    const h: keyof T = (null as any as keyof MyNonNullable<(T | undefined) & object>);
+>h : keyof T
+>(null as any as keyof MyNonNullable<(T | undefined) & object>) : keyof MyNonNullable<T & object>
+>null as any as keyof MyNonNullable<(T | undefined) & object> : keyof MyNonNullable<T & object>
+>null as any : any
+>null : null
+}
+

--- a/tests/cases/compiler/keyofNonNullableAssignments.ts
+++ b/tests/cases/compiler/keyofNonNullableAssignments.ts
@@ -1,0 +1,13 @@
+// @strict: true
+type MyNonNullable<T> = T extends null ? never : T extends undefined ? never : T;
+
+function f<T>(x: T) {
+    const a: keyof T = (null as any as keyof NonNullable<T>);
+    const b: keyof T = (null as any as keyof NonNullable<T & object>);
+    const c: keyof T = (null as any as keyof MyNonNullable<T>);
+    const d: keyof T = (null as any as keyof MyNonNullable<T & object>);
+    const e: keyof T = (null as any as keyof NonNullable<T | undefined>);
+    const f: keyof T = (null as any as keyof NonNullable<(T | undefined) & object>);
+    const g: keyof T = (null as any as keyof MyNonNullable<T | undefined>);
+    const h: keyof T = (null as any as keyof MyNonNullable<(T | undefined) & object>);
+}


### PR DESCRIPTION
Originally from #49091. This essentially applies `keyof` to the constraint of a conditional in a deferred way, ignoring branches which don't contribute to the final result set of keys. This allows, eg, `keyof (T extends null ? never : T)` to be related to `keyof T`. In addition, intersection members for whom `keyof` returns `never` are omitted from the relationship check, allowing a deferred effective `keyof (T & object)` to be related to `keyof T` (which already works when not indirected via a conditional via construction).

So in total, given a type like
```ts
type FilterNull<T> = T extends null ? never : T;
```
then `keyof FilterNull<(T & object) | null>` is now able to be related to `keyof T`.

Practically, I initially looked into this to support using the conditional-based `NonNullable` in more places, but now that it's just an intersection, this is moreso just for users using `keyof` over their own filtering conditionals (as is common in `react` libraries nowadays).