### PR TITLE
Add `fractionalSecond` part type to DateTimeFormat().formatToParts

### DIFF
--- a/src/lib/es2017.intl.d.ts
+++ b/src/lib/es2017.intl.d.ts
@@ -1,5 +1,20 @@
 declare namespace Intl {
-    type DateTimeFormatPartTypes = "day" | "dayPeriod" | "era" | "hour" | "literal" | "minute" | "month" | "second" | "timeZoneName" | "weekday" | "year";
+
+    interface DateTimeFormatPartTypesRegistry {
+        day: any
+        dayPeriod: any
+        era: any
+        hour: any
+        literal: any
+        minute: any
+        month: any
+        second: any
+        timeZoneName: any
+        weekday: any
+        year: any
+    }
+
+    type DateTimeFormatPartTypes = keyof DateTimeFormatPartTypesRegistry;
 
     interface DateTimeFormatPart {
         type: DateTimeFormatPartTypes;

--- a/src/lib/es2021.intl.d.ts
+++ b/src/lib/es2021.intl.d.ts
@@ -1,5 +1,9 @@
 declare namespace Intl {
 
+    interface DateTimeFormatPartTypesRegistry {
+        fractionalSecond: any
+     }
+
     interface DateTimeFormatOptions {
         formatMatcher?: "basic" | "best fit" | "best fit" | undefined;
         dateStyle?: "full" | "long" | "medium" | "short" | undefined;

--- a/tests/baselines/reference/formatToPartsFractionalSecond.js
+++ b/tests/baselines/reference/formatToPartsFractionalSecond.js
@@ -1,0 +1,5 @@
+//// [formatToPartsFractionalSecond.ts]
+new Intl.DateTimeFormat().formatToParts().find((val) => val.type === 'fractionalSecond')
+
+//// [formatToPartsFractionalSecond.js]
+new Intl.DateTimeFormat().formatToParts().find((val) => val.type === 'fractionalSecond');

--- a/tests/baselines/reference/formatToPartsFractionalSecond.symbols
+++ b/tests/baselines/reference/formatToPartsFractionalSecond.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/formatToPartsFractionalSecond.ts ===
+new Intl.DateTimeFormat().formatToParts().find((val) => val.type === 'fractionalSecond')
+>new Intl.DateTimeFormat().formatToParts().find : Symbol(Array.find, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>new Intl.DateTimeFormat().formatToParts : Symbol(Intl.DateTimeFormat.formatToParts, Decl(lib.es2017.intl.d.ts, --, --))
+>Intl.DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2021.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --) ... and 2 more)
+>DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2021.intl.d.ts, --, --))
+>formatToParts : Symbol(Intl.DateTimeFormat.formatToParts, Decl(lib.es2017.intl.d.ts, --, --))
+>find : Symbol(Array.find, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>val : Symbol(val, Decl(formatToPartsFractionalSecond.ts, 0, 48))
+>val.type : Symbol(Intl.DateTimeFormatPart.type, Decl(lib.es2017.intl.d.ts, --, --))
+>val : Symbol(val, Decl(formatToPartsFractionalSecond.ts, 0, 48))
+>type : Symbol(Intl.DateTimeFormatPart.type, Decl(lib.es2017.intl.d.ts, --, --))
+

--- a/tests/baselines/reference/formatToPartsFractionalSecond.symbols
+++ b/tests/baselines/reference/formatToPartsFractionalSecond.symbols
@@ -3,7 +3,7 @@ new Intl.DateTimeFormat().formatToParts().find((val) => val.type === 'fractional
 >new Intl.DateTimeFormat().formatToParts().find : Symbol(Array.find, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
 >new Intl.DateTimeFormat().formatToParts : Symbol(Intl.DateTimeFormat.formatToParts, Decl(lib.es2017.intl.d.ts, --, --))
 >Intl.DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2021.intl.d.ts, --, --))
->Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --) ... and 2 more)
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --) ... and 3 more)
 >DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2021.intl.d.ts, --, --))
 >formatToParts : Symbol(Intl.DateTimeFormat.formatToParts, Decl(lib.es2017.intl.d.ts, --, --))
 >find : Symbol(Array.find, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))

--- a/tests/baselines/reference/formatToPartsFractionalSecond.types
+++ b/tests/baselines/reference/formatToPartsFractionalSecond.types
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/formatToPartsFractionalSecond.ts ===
+new Intl.DateTimeFormat().formatToParts().find((val) => val.type === 'fractionalSecond')
+>new Intl.DateTimeFormat().formatToParts().find((val) => val.type === 'fractionalSecond') : Intl.DateTimeFormatPart
+>new Intl.DateTimeFormat().formatToParts().find : { <S extends Intl.DateTimeFormatPart>(predicate: (this: void, value: Intl.DateTimeFormatPart, index: number, obj: Intl.DateTimeFormatPart[]) => value is S, thisArg?: any): S; (predicate: (value: Intl.DateTimeFormatPart, index: number, obj: Intl.DateTimeFormatPart[]) => unknown, thisArg?: any): Intl.DateTimeFormatPart; }
+>new Intl.DateTimeFormat().formatToParts() : Intl.DateTimeFormatPart[]
+>new Intl.DateTimeFormat().formatToParts : (date?: number | Date) => Intl.DateTimeFormatPart[]
+>new Intl.DateTimeFormat() : Intl.DateTimeFormat
+>Intl.DateTimeFormat : { (locales?: string | string[], options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat; new (locales?: string | string[], options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat; supportedLocalesOf(locales: string | string[], options?: Intl.DateTimeFormatOptions): string[]; readonly prototype: Intl.DateTimeFormat; }
+>Intl : typeof Intl
+>DateTimeFormat : { (locales?: string | string[], options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat; new (locales?: string | string[], options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat; supportedLocalesOf(locales: string | string[], options?: Intl.DateTimeFormatOptions): string[]; readonly prototype: Intl.DateTimeFormat; }
+>formatToParts : (date?: number | Date) => Intl.DateTimeFormatPart[]
+>find : { <S extends Intl.DateTimeFormatPart>(predicate: (this: void, value: Intl.DateTimeFormatPart, index: number, obj: Intl.DateTimeFormatPart[]) => value is S, thisArg?: any): S; (predicate: (value: Intl.DateTimeFormatPart, index: number, obj: Intl.DateTimeFormatPart[]) => unknown, thisArg?: any): Intl.DateTimeFormatPart; }
+>(val) => val.type === 'fractionalSecond' : (this: void, val: Intl.DateTimeFormatPart) => boolean
+>val : Intl.DateTimeFormatPart
+>val.type === 'fractionalSecond' : boolean
+>val.type : keyof Intl.DateTimeFormatPartTypesRegistry
+>val : Intl.DateTimeFormatPart
+>type : keyof Intl.DateTimeFormatPartTypesRegistry
+>'fractionalSecond' : "fractionalSecond"
+

--- a/tests/cases/compiler/formatToPartsFractionalSecond.ts
+++ b/tests/cases/compiler/formatToPartsFractionalSecond.ts
@@ -1,0 +1,3 @@
+// @target: esnext
+
+new Intl.DateTimeFormat().formatToParts().find((val) => val.type === 'fractionalSecond')


### PR DESCRIPTION
This change adds the fractionalSecond part type as a valid part
to be returned from Intl.DateTimeFormat().formatToParts().

Fixes https://github.com/microsoft/TypeScript/issues/48882
