### PR TITLE
[release-4.7] Cherry pick #49560: Properly re-scan `>` token in type argument list determination logic

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5705,10 +5705,11 @@ namespace ts {
             nextToken();
 
             const typeArguments = parseDelimitedList(ParsingContext.TypeArguments, parseType);
-            if (!parseExpected(SyntaxKind.GreaterThanToken)) {
+            if (reScanGreaterToken() !== SyntaxKind.GreaterThanToken) {
                 // If it doesn't have the closing `>` then it's definitely not an type argument list.
                 return undefined;
             }
+            nextToken();
 
             // We successfully parsed a type argument list. The next token determines whether we want to
             // treat it as such. If the type argument list is followed by `(` or a template literal, as in

--- a/tests/baselines/reference/instantiationExpressionErrors.errors.txt
+++ b/tests/baselines/reference/instantiationExpressionErrors.errors.txt
@@ -8,9 +8,40 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpr
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(26,24): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(31,2): error TS2554: Expected 0 arguments, but got 1.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(35,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(48,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(49,1): error TS2304: Cannot find name 'let'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(49,5): error TS1005: ',' expected.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(51,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(52,1): error TS2304: Cannot find name 'interface'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(52,11): error TS1005: ',' expected.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(52,11): error TS7005: Variable 'I' implicitly has an 'any' type.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(52,13): error TS1005: ',' expected.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(54,11): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(55,6): error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(57,11): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(57,11): error TS2365: Operator '>' cannot be applied to types 'boolean' and '() => void'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(60,11): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(60,11): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'typeof C'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(63,11): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(64,1): error TS2304: Cannot find name 'bar'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(66,11): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(67,1): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(67,6): error TS2304: Cannot find name 'bar'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(70,27): error TS2693: 'string' only refers to a type, but is being used as a value here.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(71,5): error TS2304: Cannot find name 'static'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(71,12): error TS1005: ';' expected.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(75,27): error TS2693: 'string' only refers to a type, but is being used as a value here.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(76,5): error TS2304: Cannot find name 'public'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(76,12): error TS1005: ';' expected.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(80,28): error TS2693: 'string' only refers to a type, but is being used as a value here.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(81,5): error TS2304: Cannot find name 'private'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(81,13): error TS1005: ';' expected.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(85,30): error TS2693: 'string' only refers to a type, but is being used as a value here.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(86,5): error TS2304: Cannot find name 'protected'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(86,15): error TS1005: ';' expected.
 
 
-==== tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts (10 errors) ====
+==== tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts (41 errors) ====
     declare let f: { <T>(): T, g<U>(): U };
     
     // Type arguments in member expressions
@@ -77,4 +108,115 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpr
     
     const x4 = f<true>
     if (true) {}
+    
+    const x5 = f<true>
+               ~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+    let yy = 0;
+    ~~~
+!!! error TS2304: Cannot find name 'let'.
+        ~~
+!!! error TS1005: ',' expected.
+    
+    const x6 = f<true>
+               ~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+    interface I {}
+    ~~~~~~~~~
+!!! error TS2304: Cannot find name 'interface'.
+              ~
+!!! error TS1005: ',' expected.
+              ~
+!!! error TS7005: Variable 'I' implicitly has an 'any' type.
+                ~
+!!! error TS1005: ',' expected.
+    
+    let x10 = f<true>
+              ~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+    this.bar()
+         ~~~
+!!! error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+    
+    let x11 = f<true>
+              ~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+              ~~~~~~~
+    function bar() {}
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '() => void'.
+    
+    let x12 = f<true>
+              ~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+              ~~~~~~~
+    class C {}
+    ~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'typeof C'.
+    
+    let x13 = f<true>
+              ~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+    bar()
+    ~~~
+!!! error TS2304: Cannot find name 'bar'.
+    
+    let x14 = f<true>
+              ~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+    void bar()
+    ~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+         ~~~
+!!! error TS2304: Cannot find name 'bar'.
+    
+    class C1 {
+        static specialFoo = f<string>
+                              ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+        static bar = 123
+        ~~~~~~
+!!! error TS2304: Cannot find name 'static'.
+               ~~~
+!!! error TS1005: ';' expected.
+    }
+    
+    class C2 {
+        public specialFoo = f<string>
+                              ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+        public bar = 123
+        ~~~~~~
+!!! error TS2304: Cannot find name 'public'.
+               ~~~
+!!! error TS1005: ';' expected.
+    }
+    
+    class C3 {
+        private specialFoo = f<string>
+                               ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+        private bar = 123
+        ~~~~~~~
+!!! error TS2304: Cannot find name 'private'.
+                ~~~
+!!! error TS1005: ';' expected.
+    }
+    
+    class C4 {
+        protected specialFoo = f<string>
+                                 ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+        protected bar = 123
+        ~~~~~~~~~
+!!! error TS2304: Cannot find name 'protected'.
+                  ~~~
+!!! error TS1005: ';' expected.
+    }
+    
+    // Repro from #49551
+    
+    const enum MyVer { v1 = 1, v2 = 2 }
+    let ver = 21
+    const a = ver < (MyVer.v1 >= MyVer.v2 ? MyVer.v1 : MyVer.v2)
     

--- a/tests/baselines/reference/instantiationExpressionErrors.js
+++ b/tests/baselines/reference/instantiationExpressionErrors.js
@@ -46,6 +46,53 @@ true;
 const x4 = f<true>
 if (true) {}
 
+const x5 = f<true>
+let yy = 0;
+
+const x6 = f<true>
+interface I {}
+
+let x10 = f<true>
+this.bar()
+
+let x11 = f<true>
+function bar() {}
+
+let x12 = f<true>
+class C {}
+
+let x13 = f<true>
+bar()
+
+let x14 = f<true>
+void bar()
+
+class C1 {
+    static specialFoo = f<string>
+    static bar = 123
+}
+
+class C2 {
+    public specialFoo = f<string>
+    public bar = 123
+}
+
+class C3 {
+    private specialFoo = f<string>
+    private bar = 123
+}
+
+class C4 {
+    protected specialFoo = f<string>
+    protected bar = 123
+}
+
+// Repro from #49551
+
+const enum MyVer { v1 = 1, v2 = 2 }
+let ver = 21
+const a = ver < (MyVer.v1 >= MyVer.v2 ? MyVer.v1 : MyVer.v2)
+
 
 //// [instantiationExpressionErrors.js]
 "use strict";
@@ -78,6 +125,57 @@ true;
 // Parsed as instantiation expression
 var x4 = (f);
 if (true) { }
+var x5 = f < true >
+    let, yy = 0;
+var x6 = f < true >
+    interface, I, _c = void 0;
+var x10 = f < true >
+    this.bar();
+var x11 = f < true >
+    function bar() { };
+var x12 = f < true > /** @class */ (function () {
+    function C() {
+    }
+    return C;
+}());
+var x13 = f < true >
+    bar();
+var x14 = f < true >
+    void bar();
+var C1 = /** @class */ (function () {
+    function C1() {
+        this.bar = 123;
+    }
+    C1.specialFoo = f < string >
+        static;
+    return C1;
+}());
+var C2 = /** @class */ (function () {
+    function C2() {
+        this.specialFoo = f < string >
+            public;
+        this.bar = 123;
+    }
+    return C2;
+}());
+var C3 = /** @class */ (function () {
+    function C3() {
+        this.specialFoo = f < string >
+            private;
+        this.bar = 123;
+    }
+    return C3;
+}());
+var C4 = /** @class */ (function () {
+    function C4() {
+        this.specialFoo = f < string >
+            protected;
+        this.bar = 123;
+    }
+    return C4;
+}());
+var ver = 21;
+var a = ver < (1 /* MyVer.v1 */ >= 2 /* MyVer.v2 */ ? 1 /* MyVer.v1 */ : 2 /* MyVer.v2 */);
 
 
 //// [instantiationExpressionErrors.d.ts]
@@ -113,3 +211,32 @@ declare const x4: {
     (): true;
     g<U>(): U;
 };
+declare const x5: boolean, yy = 0;
+declare const x6: boolean, I: any;
+declare let x10: boolean;
+declare let x11: boolean;
+declare let x12: boolean;
+declare let x13: boolean;
+declare let x14: boolean;
+declare class C1 {
+    static specialFoo: boolean;
+    bar: number;
+}
+declare class C2 {
+    specialFoo: boolean;
+    bar: number;
+}
+declare class C3 {
+    private specialFoo;
+    bar: number;
+}
+declare class C4 {
+    protected specialFoo: boolean;
+    bar: number;
+}
+declare const enum MyVer {
+    v1 = 1,
+    v2 = 2
+}
+declare let ver: number;
+declare const a: boolean;

--- a/tests/baselines/reference/instantiationExpressionErrors.symbols
+++ b/tests/baselines/reference/instantiationExpressionErrors.symbols
@@ -107,3 +107,120 @@ const x4 = f<true>
 
 if (true) {}
 
+const x5 = f<true>
+>x5 : Symbol(x5, Decl(instantiationExpressionErrors.ts, 47, 5))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+let yy = 0;
+>yy : Symbol(yy, Decl(instantiationExpressionErrors.ts, 48, 3))
+
+const x6 = f<true>
+>x6 : Symbol(x6, Decl(instantiationExpressionErrors.ts, 50, 5))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+interface I {}
+>I : Symbol(I, Decl(instantiationExpressionErrors.ts, 51, 9))
+
+let x10 = f<true>
+>x10 : Symbol(x10, Decl(instantiationExpressionErrors.ts, 53, 3))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+this.bar()
+>this : Symbol(globalThis)
+
+let x11 = f<true>
+>x11 : Symbol(x11, Decl(instantiationExpressionErrors.ts, 56, 3))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+function bar() {}
+>bar : Symbol(bar, Decl(instantiationExpressionErrors.ts, 56, 17))
+
+let x12 = f<true>
+>x12 : Symbol(x12, Decl(instantiationExpressionErrors.ts, 59, 3))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+class C {}
+>C : Symbol(C, Decl(instantiationExpressionErrors.ts, 59, 17))
+
+let x13 = f<true>
+>x13 : Symbol(x13, Decl(instantiationExpressionErrors.ts, 62, 3))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+bar()
+
+let x14 = f<true>
+>x14 : Symbol(x14, Decl(instantiationExpressionErrors.ts, 65, 3))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+void bar()
+
+class C1 {
+>C1 : Symbol(C1, Decl(instantiationExpressionErrors.ts, 66, 10))
+
+    static specialFoo = f<string>
+>specialFoo : Symbol(C1.specialFoo, Decl(instantiationExpressionErrors.ts, 68, 10))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+    static bar = 123
+>bar : Symbol(C1.bar, Decl(instantiationExpressionErrors.ts, 70, 10))
+}
+
+class C2 {
+>C2 : Symbol(C2, Decl(instantiationExpressionErrors.ts, 71, 1))
+
+    public specialFoo = f<string>
+>specialFoo : Symbol(C2.specialFoo, Decl(instantiationExpressionErrors.ts, 73, 10))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+    public bar = 123
+>bar : Symbol(C2.bar, Decl(instantiationExpressionErrors.ts, 75, 10))
+}
+
+class C3 {
+>C3 : Symbol(C3, Decl(instantiationExpressionErrors.ts, 76, 1))
+
+    private specialFoo = f<string>
+>specialFoo : Symbol(C3.specialFoo, Decl(instantiationExpressionErrors.ts, 78, 10))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+    private bar = 123
+>bar : Symbol(C3.bar, Decl(instantiationExpressionErrors.ts, 80, 11))
+}
+
+class C4 {
+>C4 : Symbol(C4, Decl(instantiationExpressionErrors.ts, 81, 1))
+
+    protected specialFoo = f<string>
+>specialFoo : Symbol(C4.specialFoo, Decl(instantiationExpressionErrors.ts, 83, 10))
+>f : Symbol(f, Decl(instantiationExpressionErrors.ts, 0, 11))
+
+    protected bar = 123
+>bar : Symbol(C4.bar, Decl(instantiationExpressionErrors.ts, 85, 13))
+}
+
+// Repro from #49551
+
+const enum MyVer { v1 = 1, v2 = 2 }
+>MyVer : Symbol(MyVer, Decl(instantiationExpressionErrors.ts, 86, 1))
+>v1 : Symbol(MyVer.v1, Decl(instantiationExpressionErrors.ts, 90, 18))
+>v2 : Symbol(MyVer.v2, Decl(instantiationExpressionErrors.ts, 90, 26))
+
+let ver = 21
+>ver : Symbol(ver, Decl(instantiationExpressionErrors.ts, 91, 3))
+
+const a = ver < (MyVer.v1 >= MyVer.v2 ? MyVer.v1 : MyVer.v2)
+>a : Symbol(a, Decl(instantiationExpressionErrors.ts, 92, 5))
+>ver : Symbol(ver, Decl(instantiationExpressionErrors.ts, 91, 3))
+>MyVer.v1 : Symbol(MyVer.v1, Decl(instantiationExpressionErrors.ts, 90, 18))
+>MyVer : Symbol(MyVer, Decl(instantiationExpressionErrors.ts, 86, 1))
+>v1 : Symbol(MyVer.v1, Decl(instantiationExpressionErrors.ts, 90, 18))
+>MyVer.v2 : Symbol(MyVer.v2, Decl(instantiationExpressionErrors.ts, 90, 26))
+>MyVer : Symbol(MyVer, Decl(instantiationExpressionErrors.ts, 86, 1))
+>v2 : Symbol(MyVer.v2, Decl(instantiationExpressionErrors.ts, 90, 26))
+>MyVer.v1 : Symbol(MyVer.v1, Decl(instantiationExpressionErrors.ts, 90, 18))
+>MyVer : Symbol(MyVer, Decl(instantiationExpressionErrors.ts, 86, 1))
+>v1 : Symbol(MyVer.v1, Decl(instantiationExpressionErrors.ts, 90, 18))
+>MyVer.v2 : Symbol(MyVer.v2, Decl(instantiationExpressionErrors.ts, 90, 26))
+>MyVer : Symbol(MyVer, Decl(instantiationExpressionErrors.ts, 86, 1))
+>v2 : Symbol(MyVer.v2, Decl(instantiationExpressionErrors.ts, 90, 26))
+

--- a/tests/baselines/reference/instantiationExpressionErrors.types
+++ b/tests/baselines/reference/instantiationExpressionErrors.types
@@ -132,3 +132,181 @@ const x4 = f<true>
 if (true) {}
 >true : true
 
+const x5 = f<true>
+>x5 : boolean
+>f<true>let : boolean
+>f<true : boolean
+>f : { <T>(): T; g<U>(): U; }
+>true : true
+
+let yy = 0;
+>let : any
+>yy : 0
+>0 : 0
+
+const x6 = f<true>
+>x6 : boolean
+>f<true>interface : boolean
+>f<true : boolean
+>f : { <T>(): T; g<U>(): U; }
+>true : true
+
+interface I {}
+>interface : any
+>I : any
+
+let x10 = f<true>
+>x10 : boolean
+>f<true>this.bar() : boolean
+>f<true : boolean
+>f : { <T>(): T; g<U>(): U; }
+>true : true
+
+this.bar()
+>this.bar() : any
+>this.bar : any
+>this : typeof globalThis
+>bar : any
+
+let x11 = f<true>
+>x11 : boolean
+>f<true>function bar() {} : boolean
+>f<true : boolean
+>f : { <T>(): T; g<U>(): U; }
+>true : true
+
+function bar() {}
+>function bar() {} : () => void
+>bar : () => void
+
+let x12 = f<true>
+>x12 : boolean
+>f<true>class C {} : boolean
+>f<true : boolean
+>f : { <T>(): T; g<U>(): U; }
+>true : true
+
+class C {}
+>class C {} : typeof C
+>C : typeof C
+
+let x13 = f<true>
+>x13 : boolean
+>f<true>bar() : boolean
+>f<true : boolean
+>f : { <T>(): T; g<U>(): U; }
+>true : true
+
+bar()
+>bar() : any
+>bar : any
+
+let x14 = f<true>
+>x14 : boolean
+>f<true>void bar() : boolean
+>f<true : boolean
+>f : { <T>(): T; g<U>(): U; }
+>true : true
+
+void bar()
+>void bar() : undefined
+>bar() : any
+>bar : any
+
+class C1 {
+>C1 : C1
+
+    static specialFoo = f<string>
+>specialFoo : boolean
+>f<string>    static : boolean
+>f<string : boolean
+>f : { <T>(): T; g<U>(): U; }
+>string : any
+
+    static bar = 123
+>static : any
+>bar : number
+>123 : 123
+}
+
+class C2 {
+>C2 : C2
+
+    public specialFoo = f<string>
+>specialFoo : boolean
+>f<string>    public : boolean
+>f<string : boolean
+>f : { <T>(): T; g<U>(): U; }
+>string : any
+
+    public bar = 123
+>public : any
+>bar : number
+>123 : 123
+}
+
+class C3 {
+>C3 : C3
+
+    private specialFoo = f<string>
+>specialFoo : boolean
+>f<string>    private : boolean
+>f<string : boolean
+>f : { <T>(): T; g<U>(): U; }
+>string : any
+
+    private bar = 123
+>private : any
+>bar : number
+>123 : 123
+}
+
+class C4 {
+>C4 : C4
+
+    protected specialFoo = f<string>
+>specialFoo : boolean
+>f<string>    protected : boolean
+>f<string : boolean
+>f : { <T>(): T; g<U>(): U; }
+>string : any
+
+    protected bar = 123
+>protected : any
+>bar : number
+>123 : 123
+}
+
+// Repro from #49551
+
+const enum MyVer { v1 = 1, v2 = 2 }
+>MyVer : MyVer
+>v1 : MyVer.v1
+>1 : 1
+>v2 : MyVer.v2
+>2 : 2
+
+let ver = 21
+>ver : number
+>21 : 21
+
+const a = ver < (MyVer.v1 >= MyVer.v2 ? MyVer.v1 : MyVer.v2)
+>a : boolean
+>ver < (MyVer.v1 >= MyVer.v2 ? MyVer.v1 : MyVer.v2) : boolean
+>ver : number
+>(MyVer.v1 >= MyVer.v2 ? MyVer.v1 : MyVer.v2) : MyVer
+>MyVer.v1 >= MyVer.v2 ? MyVer.v1 : MyVer.v2 : MyVer
+>MyVer.v1 >= MyVer.v2 : boolean
+>MyVer.v1 : MyVer.v1
+>MyVer : typeof MyVer
+>v1 : MyVer.v1
+>MyVer.v2 : MyVer.v2
+>MyVer : typeof MyVer
+>v2 : MyVer.v2
+>MyVer.v1 : MyVer.v1
+>MyVer : typeof MyVer
+>v1 : MyVer.v1
+>MyVer.v2 : MyVer.v2
+>MyVer : typeof MyVer
+>v2 : MyVer.v2
+

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts
@@ -47,3 +47,50 @@ true;
 
 const x4 = f<true>
 if (true) {}
+
+const x5 = f<true>
+let yy = 0;
+
+const x6 = f<true>
+interface I {}
+
+let x10 = f<true>
+this.bar()
+
+let x11 = f<true>
+function bar() {}
+
+let x12 = f<true>
+class C {}
+
+let x13 = f<true>
+bar()
+
+let x14 = f<true>
+void bar()
+
+class C1 {
+    static specialFoo = f<string>
+    static bar = 123
+}
+
+class C2 {
+    public specialFoo = f<string>
+    public bar = 123
+}
+
+class C3 {
+    private specialFoo = f<string>
+    private bar = 123
+}
+
+class C4 {
+    protected specialFoo = f<string>
+    protected bar = 123
+}
+
+// Repro from #49551
+
+const enum MyVer { v1 = 1, v2 = 2 }
+let ver = 21
+const a = ver < (MyVer.v1 >= MyVer.v2 ? MyVer.v1 : MyVer.v2)


### PR DESCRIPTION
Cherry-pick #49560 to `release-4.7`.

Fixes https://github.com/microsoft/TypeScript/issues/49551 for 4.7.