### PR TITLE
Tune FAR aggregation

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -382,7 +382,7 @@ namespace ts.server {
         // correct results to all other projects.
 
         const defaultProjectResults = perProjectResults.get(defaultProject);
-        if (defaultProjectResults?.[0].references[0]?.isDefinition === undefined) {
+        if (defaultProjectResults?.[0]?.references[0]?.isDefinition === undefined) {
             // Clear all isDefinition properties
             perProjectResults.forEach(projectResults => {
                 if (projectResults) {
@@ -545,10 +545,9 @@ namespace ts.server {
                 if (cancellationToken.isCancellationRequested()) break onCancellation;
 
                 let skipCount = 0;
-                for (; skipCount < queue.length && resultsMap.has(queue[skipCount].project); skipCount++) {
-                }
+                for (; skipCount < queue.length && resultsMap.has(queue[skipCount].project); skipCount++);
 
-                if (skipCount == queue.length) {
+                if (skipCount === queue.length) {
                     queue.length = 0;
                     break;
                 }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -531,26 +531,36 @@ namespace ts.server {
             defaultDefinition :
             defaultProject.getLanguageService().getSourceMapper().tryGetSourcePosition(defaultDefinition!));
 
-        // Track which projects we have already searched so that we don't repeat searches.
-        // We store the project key, rather than the project, because that's what `loadAncestorProjectTree` wants.
-        // (For that same reason, we don't use `resultsMap` for this check.)
-        const searchedProjects = new Set<string>();
+        // The keys of resultsMap allow us to check which projects have already been searched, but we also
+        // maintain a set of strings because that's what `loadAncestorProjectTree` wants.
+        const searchedProjectKeys = new Set<string>();
 
         onCancellation:
         while (queue.length) {
             while (queue.length) {
                 if (cancellationToken.isCancellationRequested()) break onCancellation;
 
+                let skipCount = 0;
+                for (; skipCount < queue.length && resultsMap.has(queue[skipCount].project); skipCount++) {
+                }
+
+                if (skipCount == queue.length) {
+                    queue.length = 0;
+                    break;
+                }
+
+                if (skipCount > 0) {
+                    queue.splice(0, skipCount);
+                }
+
+                // NB: we may still skip if it's a project reference redirect
                 const { project, location } = queue.shift()!;
 
                 if (isLocationProjectReferenceRedirect(project, location)) continue;
 
-                if (!tryAddToSet(searchedProjects, getProjectKey(project))) continue;
-
                 const projectResults = searchPosition(project, location);
-                if (projectResults) {
-                    resultsMap.set(project, projectResults);
-                }
+                resultsMap.set(project, projectResults ?? emptyArray);
+                searchedProjectKeys.add(getProjectKey(project));
             }
 
             // At this point, we know about all projects passed in as arguments and any projects in which
@@ -559,10 +569,10 @@ namespace ts.server {
             // containing `initialLocation`.
             if (defaultDefinition) {
                 // This seems to mean "load all projects downstream from any member of `seenProjects`".
-                projectService.loadAncestorProjectTree(searchedProjects);
+                projectService.loadAncestorProjectTree(searchedProjectKeys);
                 projectService.forEachEnabledProject(project => {
                     if (cancellationToken.isCancellationRequested()) return; // There's no mechanism for skipping the remaining projects
-                    if (searchedProjects.has(getProjectKey(project))) return; // Can loop forever without this (enqueue here, dequeue above, repeat)
+                    if (resultsMap.has(project)) return; // Can loop forever without this (enqueue here, dequeue above, repeat)
                     const location = mapDefinitionInProject(defaultDefinition, project, getGeneratedDefinition, getSourceDefinition);
                     if (location) {
                         queue.push({ project, location });
@@ -573,7 +583,7 @@ namespace ts.server {
 
         // In the common case where there's only one project, return a simpler result to make
         // it easier for the caller to skip post-processing.
-        if (searchedProjects.size === 1) {
+        if (resultsMap.size === 1) {
             const it = resultsMap.values().next();
             return it.done ? emptyArray : it.value; // There may not be any results at all
         }
@@ -593,7 +603,7 @@ namespace ts.server {
                     const originalScriptInfo = projectService.getScriptInfo(originalLocation.fileName)!;
 
                     for (const project of originalScriptInfo.containingProjects) {
-                        if (!project.isOrphan()) {
+                        if (!project.isOrphan() && !resultsMap.has(project)) { // Optimization: don't enqueue if will be discarded
                             queue.push({ project, location: originalLocation });
                         }
                     }
@@ -602,7 +612,7 @@ namespace ts.server {
                     if (symlinkedProjectsMap) {
                         symlinkedProjectsMap.forEach((symlinkedProjects, symlinkedPath) => {
                             for (const symlinkedProject of symlinkedProjects) {
-                                if (!symlinkedProject.isOrphan()) {
+                                if (!symlinkedProject.isOrphan() && !resultsMap.has(symlinkedProject)) { // Optimization: don't enqueue if will be discarded
                                     queue.push({ project: symlinkedProject, location: { fileName: symlinkedPath as string, pos: originalLocation.pos } });
                                 }
                             }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -329,11 +329,13 @@ namespace ts.server {
         const seen = createDocumentSpanSet();
 
         perProjectResults.forEach((projectResults, project) => {
-            for (const result of projectResults) {
-                // If there's a mapped location, it'll appear in the results for another project
-                if (!seen.has(result) && !getMappedLocationForProject(documentSpanLocation(result), project)) {
-                    results.push(result);
-                    seen.add(result);
+            if (projectResults) {
+                for (const result of projectResults) {
+                    // If there's a mapped location, it'll appear in the results for another project
+                    if (!seen.has(result) && !getMappedLocationForProject(documentSpanLocation(result), project)) {
+                        results.push(result);
+                        seen.add(result);
+                    }
                 }
             }
         });
@@ -383,9 +385,11 @@ namespace ts.server {
         if (defaultProjectResults?.[0].references[0]?.isDefinition === undefined) {
             // Clear all isDefinition properties
             perProjectResults.forEach(projectResults => {
-                for (const referencedSymbol of projectResults) {
-                    for (const ref of referencedSymbol.references) {
-                        delete ref.isDefinition;
+                if (projectResults) {
+                    for (const referencedSymbol of projectResults) {
+                        for (const ref of referencedSymbol.references) {
+                            delete ref.isDefinition;
+                        }
                     }
                 }
             });

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -329,13 +329,11 @@ namespace ts.server {
         const seen = createDocumentSpanSet();
 
         perProjectResults.forEach((projectResults, project) => {
-            if (projectResults) {
-                for (const result of projectResults) {
-                    // If there's a mapped location, it'll appear in the results for another project
-                    if (!seen.has(result) && !getMappedLocationForProject(documentSpanLocation(result), project)) {
-                        results.push(result);
-                        seen.add(result);
-                    }
+            for (const result of projectResults) {
+                // If there's a mapped location, it'll appear in the results for another project
+                if (!seen.has(result) && !getMappedLocationForProject(documentSpanLocation(result), project)) {
+                    results.push(result);
+                    seen.add(result);
                 }
             }
         });
@@ -385,11 +383,9 @@ namespace ts.server {
         if (defaultProjectResults?.[0]?.references[0]?.isDefinition === undefined) {
             // Clear all isDefinition properties
             perProjectResults.forEach(projectResults => {
-                if (projectResults) {
-                    for (const referencedSymbol of projectResults) {
-                        for (const ref of referencedSymbol.references) {
-                            delete ref.isDefinition;
-                        }
+                for (const referencedSymbol of projectResults) {
+                    for (const ref of referencedSymbol.references) {
+                        delete ref.isDefinition;
                     }
                 }
             });
@@ -588,7 +584,8 @@ namespace ts.server {
         // it easier for the caller to skip post-processing.
         if (resultsMap.size === 1) {
             const it = resultsMap.values().next();
-            return it.done ? emptyArray : it.value; // There may not be any results at all
+            Debug.assert(!it.done);
+            return it.value;
         }
 
         return resultsMap;


### PR DESCRIPTION
In making the work queue management more intelligible, we centralized the redundancy check at dequeue time.  As a result, the queue tends to get very large (~1.6M items for `SyntaxKind` in this repo) and dequeuing via `shift` is too slow to do that many times.  This change makes a few tweaks:

1. Use `Project` identity for de-duping and only maintain a set of keys for `loadAncestorProjectTree`
2. Attempt to filter prior to insertion
3. Use `splice` if many consecutive work queue items will be discarded.

On my box, this cuts FAR for `SyntaxKind` in parser.ts from 38 minutes to 20 seconds (vs 26 seconds for 4.6) (we could do better, but effectively decided not to optimize this worst case scenario).