### PR TITLE
Replace all ors with nullish coalescing

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "@types/xml2js": "^0.4.11",
         "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.28.0",
+        "@typescript-eslint/type-utils": "^5.28.0",
         "@typescript-eslint/utils": "^5.28.0",
         "async": "latest",
         "azure-devops-node-api": "^11.1.1",

--- a/scripts/eslint/rules/prefer-nullish-coalescing-truthy.ts
+++ b/scripts/eslint/rules/prefer-nullish-coalescing-truthy.ts
@@ -132,7 +132,12 @@ export = util.createRule<Options, MessageIds>({
                 }
             }
 
-            const possiblyFalsy = (ts.TypeFlags.PossiblyFalsy & ~(ts.TypeFlags.Undefined | ts.TypeFlags.Null)) | ts.TypeFlags.TypeVariable; // TODO: use constraint of type variable?
+            // "Easy" way to check if this thing is potentially falsy if `undefined | null` is removed.
+            // TODO: this is overly conservative, but I'm not sure how to actually check this easily.
+            const possiblyFalsy =
+                (ts.TypeFlags.PossiblyFalsy & ~(ts.TypeFlags.Undefined | ts.TypeFlags.Null))
+                | ts.TypeFlags.EnumLike // For some reason, this is not a part of PossiblyFalsy, even though these can be zero or "".
+                | ts.TypeFlags.TypeParameter; // TODO: if type parameter, check constraint
             if (getTypeFlags(type) & possiblyFalsy) {
                 return;
             }

--- a/scripts/eslint/rules/prefer-nullish-coalescing-truthy.ts
+++ b/scripts/eslint/rules/prefer-nullish-coalescing-truthy.ts
@@ -1,0 +1,244 @@
+/**
+MIT License
+
+Copyright (c) 2019 TypeScript ESLint and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+// Copied from https://github.com/JoshuaKGoldberg/typescript-eslint/blob/5603522f28eee336a4b9a5ddabb79ce356a53517/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+// with modification to ignore boolean/number/string LHS.
+
+/* eslint-disable @typescript-eslint/naming-convention */
+import {
+    AST_NODE_TYPES,
+    AST_TOKEN_TYPES,
+    TSESLint,
+    TSESTree,
+} from "@typescript-eslint/utils";
+import * as util from "./utils";
+import * as ts from "typescript";
+
+type Options = [
+    {
+        ignoreConditionalTests?: boolean;
+        ignoreMixedLogicalExpressions?: boolean;
+    },
+];
+type MessageIds =
+    | "preferNullishAssignment"
+    | "preferNullishLogical"
+    | "suggestNullishAssignment"
+    | "suggestNullishLogical";
+
+export = util.createRule<Options, MessageIds>({
+    name: "prefer-nullish-coalescing",
+    meta: {
+        type: "suggestion",
+        docs: {
+            description:
+                "Enforce using the nullish coalescing operator instead of logical assignments or chaining",
+            recommended: "strict",
+            suggestion: true,
+            requiresTypeChecking: true,
+        },
+        hasSuggestions: true,
+        messages: {
+            preferNullishAssignment:
+                "Prefer using nullish coalescing operator (`??=`) instead of a logical assignment (`||=`), as it is a safer operator.",
+            preferNullishLogical:
+                "Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`), as it is a safer operator.",
+            suggestNullishAssignment: "Fix to nullish coalescing assignment (`??=`).",
+            suggestNullishLogical: "Fix to nullish coalescing operator (`??`).",
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    ignoreConditionalTests: {
+                        type: "boolean",
+                    },
+                    ignoreMixedLogicalExpressions: {
+                        type: "boolean",
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            ignoreConditionalTests: true,
+            ignoreMixedLogicalExpressions: true,
+        },
+    ],
+    create(context, [{ ignoreConditionalTests, ignoreMixedLogicalExpressions }]) {
+        const parserServices = util.getParserServices(context);
+        const sourceCode = context.getSourceCode();
+        const checker = parserServices.program.getTypeChecker();
+
+        function checkNode(
+            node: TSESTree.AssignmentExpression | TSESTree.LogicalExpression,
+            reportMessageId: MessageIds,
+            suggestionMessageId: MessageIds,
+        ): void {
+            const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+            const type = checker.getTypeAtLocation(tsNode.left);
+            const isNullish = util.isNullableType(type, { allowUndefined: true });
+            if (!isNullish) {
+                return;
+            }
+
+            if (util.getTypeFlags(type) & (ts.TypeFlags.BooleanLike | ts.TypeFlags.NumberLike | ts.TypeFlags.StringLike)) {
+                return;
+            }
+
+            if (ignoreConditionalTests === true && isConditionalTest(node)) {
+                return;
+            }
+
+            if (
+                ignoreMixedLogicalExpressions === true &&
+                isMixedLogicalExpression(node)
+            ) {
+                return;
+            }
+
+            const barBarOperator = util.nullThrows(
+                sourceCode.getTokenAfter(
+                    node.left,
+                    token =>
+                        token.type === AST_TOKEN_TYPES.Punctuator &&
+                        token.value === node.operator,
+                ),
+                util.NullThrowsReasons.MissingToken("operator", node.type),
+            );
+
+            function* fix(
+                fixer: TSESLint.RuleFixer,
+            ): IterableIterator<TSESLint.RuleFix> {
+                if (node.parent && util.isLogicalOrOperator(node.parent)) {
+                    // '&&' and '??' operations cannot be mixed without parentheses (e.g. a && b ?? c)
+                    if (
+                        node.left.type === AST_NODE_TYPES.LogicalExpression &&
+                        !util.isLogicalOrOperator(node.left.left)
+                    ) {
+                        yield fixer.insertTextBefore(node.left.right, "(");
+                    }
+                    else {
+                        yield fixer.insertTextBefore(node.left, "(");
+                    }
+                    yield fixer.insertTextAfter(node.right, ")");
+                }
+                yield fixer.replaceText(
+                    barBarOperator,
+                    node.operator.replace("||", "??"),
+                );
+            }
+
+            context.report({
+                node: barBarOperator,
+                messageId: reportMessageId, // 'preferNullish',
+                suggest: [
+                    {
+                        messageId: suggestionMessageId, // 'suggestNullish',
+                        fix,
+                    },
+                ],
+            });
+        }
+
+        return {
+            'AssignmentExpression[operator = "||="]'(
+                node: TSESTree.AssignmentExpression,
+            ): void {
+                checkNode(node, "preferNullishAssignment", "suggestNullishAssignment");
+            },
+            'LogicalExpression[operator = "||"]'(
+                node: TSESTree.LogicalExpression,
+            ): void {
+                checkNode(node, "preferNullishLogical", "suggestNullishLogical");
+            },
+        };
+    },
+});
+
+function isConditionalTest(
+    node: TSESTree.AssignmentExpression | TSESTree.LogicalExpression,
+): boolean {
+    const parents = new Set<TSESTree.Node | null>([node]);
+    let current = node.parent;
+    while (current) {
+        parents.add(current);
+
+        if (
+            (current.type === AST_NODE_TYPES.ConditionalExpression ||
+                current.type === AST_NODE_TYPES.DoWhileStatement ||
+                current.type === AST_NODE_TYPES.IfStatement ||
+                current.type === AST_NODE_TYPES.ForStatement ||
+                current.type === AST_NODE_TYPES.WhileStatement) &&
+            parents.has(current.test)
+        ) {
+            return true;
+        }
+
+        if (
+            [
+                AST_NODE_TYPES.ArrowFunctionExpression,
+                AST_NODE_TYPES.FunctionExpression,
+            ].includes(current.type)
+        ) {
+            /**
+             * This is a weird situation like:
+             * `if (() => a || b) {}`
+             * `if (function () { return a || b }) {}`
+             */
+            return false;
+        }
+
+        current = current.parent;
+    }
+
+    return false;
+}
+
+function isMixedLogicalExpression(
+    node: TSESTree.AssignmentExpression | TSESTree.LogicalExpression,
+): boolean {
+    const seen = new Set<TSESTree.Node | undefined>();
+    const queue = [node.parent, node.left, node.right];
+    for (const current of queue) {
+        if (seen.has(current)) {
+            continue;
+        }
+        seen.add(current);
+
+        if (current && current.type === AST_NODE_TYPES.LogicalExpression) {
+            if (current.operator === "&&") {
+                return true;
+            }
+            else if (current.operator === "||") {
+                // check the pieces of the node to catch cases like `a || b || c && d`
+                queue.push(current.parent, current.left, current.right);
+            }
+        }
+    }
+
+    return false;
+}

--- a/scripts/eslint/rules/prefer-nullish-coalescing-truthy.ts
+++ b/scripts/eslint/rules/prefer-nullish-coalescing-truthy.ts
@@ -61,9 +61,9 @@ export = util.createRule<Options, MessageIds>({
         hasSuggestions: true,
         messages: {
             preferNullishAssignment:
-                "Prefer using nullish coalescing operator (`??=`) instead of a logical assignment (`||=`), as it is a safer operator.",
+                "Prefer using nullish coalescing operator (`??=`) instead of a logical assignment (`||=`).",
             preferNullishLogical:
-                "Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`), as it is a safer operator.",
+                "Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`).",
             suggestNullishAssignment: "Fix to nullish coalescing assignment (`??=`).",
             suggestNullishLogical: "Fix to nullish coalescing operator (`??`).",
         },

--- a/scripts/eslint/rules/utils.ts
+++ b/scripts/eslint/rules/utils.ts
@@ -1,2 +1,31 @@
+// Roughly models: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/util/index.ts
+
 import { ESLintUtils } from "@typescript-eslint/utils";
+
+export * from "@typescript-eslint/utils/dist/ast-utils";
+export * from "@typescript-eslint/type-utils";
+
+const {
+    applyDefault,
+    deepMerge,
+    isObjectNotArray,
+    getParserServices,
+    nullThrows,
+    NullThrowsReasons,
+} = ESLintUtils;
+type InferMessageIdsTypeFromRule<T> =
+    ESLintUtils.InferMessageIdsTypeFromRule<T>;
+type InferOptionsTypeFromRule<T> = ESLintUtils.InferOptionsTypeFromRule<T>;
+
+export {
+    applyDefault,
+    deepMerge,
+    isObjectNotArray,
+    getParserServices,
+    nullThrows,
+    InferMessageIdsTypeFromRule,
+    InferOptionsTypeFromRule,
+    NullThrowsReasons,
+};
+
 export const createRule = ESLintUtils.RuleCreator(() => "");

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -5,6 +5,9 @@
         "project": "./tsconfig-base.json"
     },
     "rules": {
+        "prefer-nullish-coalescing-truthy": "error", // Fork
+        // "@typescript-eslint/prefer-nullish-coalescing": "error",
+        // "@typescript-eslint/prefer-optional-chain": "error",
         "@typescript-eslint/no-unnecessary-qualifier": "error",
         "@typescript-eslint/no-unnecessary-type-assertion": "error"
     },

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -108,7 +108,7 @@ namespace ts {
     }
 
     function getModuleInstanceStateForAliasTarget(specifier: ExportSpecifier, visited: ESMap<number, ModuleInstanceState | undefined>) {
-        const name = specifier.propertyName || specifier.name;
+        const name = specifier.propertyName ?? specifier.name;
         let p: Node | undefined = specifier.parent;
         while (p) {
             if (isBlock(p) || isModuleBlock(p) || isSourceFile(p)) {
@@ -515,9 +515,9 @@ namespace ts {
                             relatedInformation.push(createDiagnosticForNode(node, Diagnostics.Did_you_mean_0, `export type { ${unescapeLeadingUnderscores(node.name.escapedText)} }`));
                         }
 
-                        const declarationName = getNameOfDeclaration(node) || node;
+                        const declarationName = getNameOfDeclaration(node) ?? node;
                         forEach(symbol.declarations, (declaration, index) => {
-                            const decl = getNameOfDeclaration(declaration) || declaration;
+                            const decl = getNameOfDeclaration(declaration) ?? declaration;
                             const diag = createDiagnosticForNode(decl, message, messageNeedsName ? getDisplayName(declaration) : undefined);
                             file.bindDiagnostics.push(
                                 multipleDefaultExports ? addRelatedInfo(diag, createDiagnosticForNode(declarationName, index === 0 ? Diagnostics.Another_export_default_is_here : Diagnostics.and_here)) : diag
@@ -977,7 +977,7 @@ namespace ts {
 
         function addAntecedent(label: FlowLabel, antecedent: FlowNode): void {
             if (!(antecedent.flags & FlowFlags.Unreachable) && !contains(label.antecedents, antecedent)) {
-                (label.antecedents || (label.antecedents = [])).push(antecedent);
+                (label.antecedents ??= []).push(antecedent);
                 setFlowNodeReferenced(antecedent);
             }
         }
@@ -1730,7 +1730,7 @@ namespace ts {
             // of the node as part of the "true" branch, and continue to do so as we ascend back up to the outermost
             // chain node. We then treat the entire node as the right side of the expression.
             const preChainLabel = isOptionalChainRoot(node) ? createBranchLabel() : undefined;
-            bindOptionalExpression(node.expression, preChainLabel || trueTarget, falseTarget);
+            bindOptionalExpression(node.expression, preChainLabel ?? trueTarget, falseTarget);
             if (preChainLabel) {
                 currentFlow = finishFlowLabel(preChainLabel);
             }
@@ -2126,7 +2126,7 @@ namespace ts {
             const saveCurrentFlow = currentFlow;
             for (const typeAlias of delayedTypeAliases) {
                 const host = typeAlias.parent.parent;
-                container = findAncestor(host.parent, n => !!(getContainerFlags(n) & ContainerFlags.IsContainer)) || file;
+                container = findAncestor(host.parent, n => !!(getContainerFlags(n) & ContainerFlags.IsContainer)) ?? file;
                 blockScopeContainer = getEnclosingBlockScopeContainer(host) || file;
                 currentFlow = initFlowNode({ flags: FlowFlags.Start });
                 parent = typeAlias;
@@ -2803,7 +2803,7 @@ namespace ts {
                 file.bindDiagnostics.push(createDiagnosticForNode(node, diag));
             }
             else {
-                file.symbol.globalExports = file.symbol.globalExports || createSymbolTable();
+                file.symbol.globalExports ??= createSymbolTable();
                 declareSymbol(file.symbol.globalExports, file.symbol, node, SymbolFlags.Alias, SymbolFlags.AliasExcludes);
             }
         }
@@ -2933,7 +2933,7 @@ namespace ts {
 
                     if (constructorSymbol && constructorSymbol.valueDeclaration) {
                         // Declare a 'member' if the container is an ES5 class or ES6 constructor
-                        constructorSymbol.members = constructorSymbol.members || createSymbolTable();
+                        constructorSymbol.members ??= createSymbolTable();
                         // It's acceptable for multiple 'this' assignments of the same identifier to occur
                         if (hasDynamicName(node)) {
                             bindDynamicallyNamedThisPropertyAssignment(node, constructorSymbol, constructorSymbol.members);
@@ -2987,7 +2987,7 @@ namespace ts {
 
         function addLateBoundAssignmentDeclarationToSymbol(node: BinaryExpression | DynamicNamedDeclaration, symbol: Symbol | undefined) {
             if (symbol) {
-                (symbol.assignmentDeclarationMembers || (symbol.assignmentDeclarationMembers = new Map())).set(getNodeId(node), node);
+                (symbol.assignmentDeclarationMembers ??= new Map()).set(getNodeId(node), node);
             }
         }
 
@@ -3048,7 +3048,7 @@ namespace ts {
 
         function bindSpecialPropertyAssignment(node: BindablePropertyAssignmentExpression) {
             // Class declarations in Typescript do not allow property declarations
-            const parentSymbol = lookupSymbolForPropertyAccess(node.left.expression, container) || lookupSymbolForPropertyAccess(node.left.expression, blockScopeContainer) ;
+            const parentSymbol = lookupSymbolForPropertyAccess(node.left.expression, container) ?? lookupSymbolForPropertyAccess(node.left.expression, blockScopeContainer) ;
             if (!isInJSFile(node) && !isFunctionSymbol(parentSymbol)) {
                 return;
             }
@@ -3100,7 +3100,7 @@ namespace ts {
                     }
                     else {
                         const table = parent ? parent.exports! :
-                            file.jsGlobalAugmentations || (file.jsGlobalAugmentations = createSymbolTable());
+                            file.jsGlobalAugmentations ??= createSymbolTable();
                         return declareSymbol(table, parent, id, flags, excludeFlags);
                     }
                 });
@@ -3118,8 +3118,8 @@ namespace ts {
 
             // Set up the members collection if it doesn't exist already
             const symbolTable = isPrototypeProperty ?
-                (namespaceSymbol.members || (namespaceSymbol.members = createSymbolTable())) :
-                (namespaceSymbol.exports || (namespaceSymbol.exports = createSymbolTable()));
+                (namespaceSymbol.members ??= createSymbolTable()) :
+                (namespaceSymbol.exports ??= createSymbolTable());
 
             let includes = SymbolFlags.None;
             let excludes = SymbolFlags.None;
@@ -3163,7 +3163,7 @@ namespace ts {
         }
 
         function bindPropertyAssignment(name: BindableStaticNameExpression, propertyAccess: BindableStaticAccessExpression, isPrototypeProperty: boolean, containerIsClass: boolean) {
-            let namespaceSymbol = lookupSymbolForPropertyAccess(name, container) || lookupSymbolForPropertyAccess(name, blockScopeContainer);
+            let namespaceSymbol = lookupSymbolForPropertyAccess(name, container) ?? lookupSymbolForPropertyAccess(name, blockScopeContainer);
             const isToplevel = isTopLevelNamespaceAssignment(propertyAccess);
             namespaceSymbol = bindPotentiallyMissingNamespaces(namespaceSymbol, propertyAccess.expression, isToplevel, isPrototypeProperty, containerIsClass);
             bindPotentiallyNewExpandoMemberToNamespace(propertyAccess, namespaceSymbol, isPrototypeProperty);
@@ -3534,7 +3534,7 @@ namespace ts {
     function lookupSymbolForName(container: Node, name: __String): Symbol | undefined {
         const local = container.locals && container.locals.get(name);
         if (local) {
-            return local.exportSymbol || local;
+            return local.exportSymbol ?? local;
         }
         if (isSourceFile(container) && container.jsGlobalAugmentations && container.jsGlobalAugmentations.has(name)) {
             return container.jsGlobalAugmentations.get(name);

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -230,7 +230,7 @@ namespace ts {
             }
             if (canCopyEmitSignatures) {
                 const oldEmitSignature = oldState.emitSignatures.get(sourceFilePath);
-                if (oldEmitSignature) (state.emitSignatures ||= new Map()).set(sourceFilePath, oldEmitSignature);
+                if (oldEmitSignature) (state.emitSignatures ??= new Map()).set(sourceFilePath, oldEmitSignature);
             }
         });
 
@@ -243,7 +243,7 @@ namespace ts {
             // Add all files to affectedFilesPendingEmit since emit changed
             newProgram.getSourceFiles().forEach(f => addToAffectedFilesPendingEmit(state, f.resolvedPath, BuilderFileEmit.Full));
             Debug.assert(!state.seenAffectedFiles || !state.seenAffectedFiles.size);
-            state.seenAffectedFiles = state.seenAffectedFiles || new Set();
+            state.seenAffectedFiles ??= new Set();
         }
         // Since old states change files set is copied, any additional change means we would need to emit build info
         state.buildInfoEmitPending = !useOldState || state.changedFilesSet.size !== (oldState!.changedFilesSet?.size || 0);
@@ -395,7 +395,7 @@ namespace ts {
     function getNextAffectedFilePendingEmit(state: BuilderProgramState) {
         const { affectedFilesPendingEmit } = state;
         if (affectedFilesPendingEmit) {
-            const seenEmittedFiles = (state.seenEmittedFiles || (state.seenEmittedFiles = new Map()));
+            const seenEmittedFiles = (state.seenEmittedFiles ??= new Map());
             for (let i = state.affectedFilesPendingEmitIndex!; i < affectedFilesPendingEmit.length; i++) {
                 const affectedFile = Debug.checkDefined(state.program).getSourceFileByPath(affectedFilesPendingEmit[i]);
                 if (affectedFile) {
@@ -656,7 +656,7 @@ namespace ts {
             // Change in changeSet/affectedFilesPendingEmit, buildInfo needs to be emitted
             state.buildInfoEmitPending = true;
             if (emitKind !== undefined) {
-                (state.seenEmittedFiles || (state.seenEmittedFiles = new Map())).set((affected as SourceFile).resolvedPath, emitKind);
+                (state.seenEmittedFiles ??= new Map()).set((affected as SourceFile).resolvedPath, emitKind);
             }
             if (isPendingEmit) {
                 state.affectedFilesPendingEmitIndex!++;
@@ -771,7 +771,7 @@ namespace ts {
     export type ProgramBuildInfo = ProgramMultiFileEmitBuildInfo | ProgramBundleEmitBuildInfo;
 
     export function isProgramBundleEmitBuildInfo(info: ProgramBuildInfo): info is ProgramBundleEmitBuildInfo {
-        return !!outFile(info.options || {});
+        return !!outFile(info.options ?? {});
     }
 
     /**
@@ -819,7 +819,7 @@ namespace ts {
                 if (!isJsonSourceFile(file) && sourceFileMayBeEmitted(file, state.program!)) {
                     const emitSignature = state.emitSignatures?.get(key);
                     if (emitSignature !== actualSignature) {
-                        (emitSignatures ||= []).push(emitSignature === undefined ? fileId : [fileId, emitSignature]);
+                        (emitSignatures ??= []).push(emitSignature === undefined ? fileId : [fileId, emitSignature]);
                     }
                 }
             }
@@ -862,7 +862,7 @@ namespace ts {
         if (state.semanticDiagnosticsPerFile) {
             for (const key of arrayFrom(state.semanticDiagnosticsPerFile.keys()).sort(compareStringsCaseSensitive)) {
                 const value = state.semanticDiagnosticsPerFile.get(key)!;
-                (semanticDiagnosticsPerFile ||= []).push(
+                (semanticDiagnosticsPerFile ??= []).push(
                     value.length ?
                         [
                             toFileId(key),
@@ -878,7 +878,7 @@ namespace ts {
             const seenFiles = new Set<Path>();
             for (const path of state.affectedFilesPendingEmit.slice(state.affectedFilesPendingEmitIndex).sort(compareStringsCaseSensitive)) {
                 if (tryAddToSet(seenFiles, path)) {
-                    (affectedFilesPendingEmit ||= []).push([toFileId(path), state.affectedFilesPendingEmitKind!.get(path)!]);
+                    (affectedFilesPendingEmit ??= []).push([toFileId(path), state.affectedFilesPendingEmitKind!.get(path)!]);
                 }
             }
         }
@@ -886,7 +886,7 @@ namespace ts {
         let changeFileSet: ProgramBuildInfoFileId[] | undefined;
         if (state.changedFilesSet.size) {
             for (const path of arrayFrom(state.changedFilesSet.keys()).sort(compareStringsCaseSensitive)) {
-                (changeFileSet ||= []).push(toFileId(path));
+                (changeFileSet ??= []).push(toFileId(path));
             }
         }
 
@@ -927,8 +927,8 @@ namespace ts {
             const key = fileIds.join();
             let fileIdListId = fileNamesToFileIdListId?.get(key);
             if (fileIdListId === undefined) {
-                (fileIdsList ||= []).push(fileIds);
-                (fileNamesToFileIdListId ||= new Map()).set(key, fileIdListId = fileIdsList.length as ProgramBuildInfoFileIdListId);
+                (fileIdsList ??= []).push(fileIds);
+                (fileNamesToFileIdListId ??= new Map()).set(key, fileIdListId = fileIdsList.length as ProgramBuildInfoFileIdListId);
             }
             return fileIdListId;
         }
@@ -942,7 +942,7 @@ namespace ts {
             for (const name of getOwnKeys(options).sort(compareStringsCaseSensitive)) {
                 const optionInfo = optionsNameMap.get(name.toLowerCase());
                 if (optionInfo?.[optionKey]) {
-                    (result ||= {})[name] = convertToReusableCompilerOptionValue(
+                    (result ??= {})[name] = convertToReusableCompilerOptionValue(
                         optionInfo,
                         options[name] as CompilerOptionsValue,
                         relativeToBuildInfoEnsuringAbsolutePath
@@ -1035,7 +1035,7 @@ namespace ts {
             oldProgram = oldProgramOrHost as BuilderProgram;
             configFileParsingDiagnostics = configFileParsingDiagnosticsOrOldProgram as readonly Diagnostic[];
         }
-        return { host, newProgram, oldProgram, configFileParsingDiagnostics: configFileParsingDiagnostics || emptyArray };
+        return { host, newProgram, oldProgram, configFileParsingDiagnostics: configFileParsingDiagnostics ?? emptyArray };
     }
 
     export function computeSignature(text: string, data: WriteFileCallbackData | undefined, computeHash: BuilderState.ComputeHash | undefined) {
@@ -1095,7 +1095,7 @@ namespace ts {
 
         function emitBuildInfo(writeFile?: WriteFileCallback, cancellationToken?: CancellationToken): EmitResult {
             if (state.buildInfoEmitPending) {
-                const result = Debug.checkDefined(state.program).emitBuildInfo(writeFile || maybeBind(host, host.writeFile), cancellationToken);
+                const result = Debug.checkDefined(state.program).emitBuildInfo(writeFile ?? maybeBind(host, host.writeFile), cancellationToken);
                 state.buildInfoEmitPending = false;
                 return result;
             }
@@ -1124,7 +1124,7 @@ namespace ts {
                             state,
                             // When whole program is affected, do emit only once (eg when --out or --outFile is specified)
                             // Otherwise just affected file
-                            affected.emitBuildInfo(writeFile || maybeBind(host, host.writeFile), cancellationToken),
+                            affected.emitBuildInfo(writeFile ?? maybeBind(host, host.writeFile), cancellationToken),
                             affected,
                             /*emitKind*/ BuilderFileEmit.Full,
                             /*isPendingEmitFile*/ false,
@@ -1149,7 +1149,7 @@ namespace ts {
                     affected === state.program ? undefined : affected as SourceFile,
                     getEmitDeclarations(state.compilerOptions) ?
                         getWriteFileCallback(writeFile, customTransformers) :
-                        writeFile || maybeBind(host, host.writeFile),
+                        writeFile ?? maybeBind(host, host.writeFile),
                     cancellationToken,
                     emitOnlyDtsFiles || emitKind === BuilderFileEmit.DtsOnly,
                     customTransformers
@@ -1165,19 +1165,19 @@ namespace ts {
                 if (isDeclarationFileName(fileName)) {
                     if (!outFile(state.compilerOptions)) {
                         Debug.assert(sourceFiles?.length === 1);
-                        let newSignature;
+                        let newSignature: string;
                         if (!customTransformers) {
                             const file = sourceFiles[0];
                             const info = state.fileInfos.get(file.resolvedPath)!;
                             if (info.signature === file.version) {
                                 newSignature = computeSignature(text, data, computeHash);
                                 if (newSignature !== file.version) { // Update it
-                                    if (host.storeFilesChangingSignatureDuringEmit) (state.filesChangingSignature ||= new Set()).add(file.resolvedPath);
+                                    if (host.storeFilesChangingSignatureDuringEmit) (state.filesChangingSignature ??= new Set()).add(file.resolvedPath);
                                     if (state.exportedModulesMap) BuilderState.updateExportedModules(state, file, file.exportedModulesFromDeclarationEmit);
                                     if (state.affectedFiles) {
                                         // Keep old signature so we know what to undo if cancellation happens
                                         const existing = state.oldSignatures?.get(file.resolvedPath);
-                                        if (existing === undefined) (state.oldSignatures ||= new Map()).set(file.resolvedPath, info.signature || false);
+                                        if (existing === undefined) (state.oldSignatures ??= new Map()).set(file.resolvedPath, info.signature || false);
                                         info.signature = newSignature;
                                     }
                                     else {
@@ -1197,7 +1197,7 @@ namespace ts {
                             const oldSignature = state.emitSignatures?.get(filePath);
                             newSignature ||= computeSignature(text, data, computeHash);
                             if (newSignature !== oldSignature) {
-                                (state.emitSignatures ||= new Map()).set(filePath, newSignature);
+                                (state.emitSignatures ??= new Map()).set(filePath, newSignature);
                                 state.hasChangedEmitSignature = true;
                             }
                         }
@@ -1252,7 +1252,7 @@ namespace ts {
                     }
                     return {
                         emitSkipped,
-                        diagnostics: diagnostics || emptyArray,
+                        diagnostics: diagnostics ?? emptyArray,
                         emittedFiles,
                         sourceMaps
                     };
@@ -1274,7 +1274,7 @@ namespace ts {
                 targetSourceFile,
                 getEmitDeclarations(state.compilerOptions) ?
                     getWriteFileCallback(writeFile, customTransformers) :
-                    writeFile || maybeBind(host, host.writeFile),
+                    writeFile ?? maybeBind(host, host.writeFile),
                 cancellationToken,
                 emitOnlyDtsFiles,
                 customTransformers
@@ -1353,7 +1353,7 @@ namespace ts {
             for (const sourceFile of Debug.checkDefined(state.program).getSourceFiles()) {
                 diagnostics = addRange(diagnostics, getSemanticDiagnosticsOfFile(state, sourceFile, cancellationToken));
             }
-            return diagnostics || emptyArray;
+            return diagnostics ?? emptyArray;
         }
     }
 

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -87,7 +87,7 @@ namespace ts {
                     keys: () => forward.keys(),
 
                     deleteKey: k => {
-                        (deleted ||= new Set<Path>()).add(k);
+                        (deleted ??= new Set<Path>()).add(k);
 
                         const set = forward.get(k);
                         if (!set) {
@@ -248,7 +248,7 @@ namespace ts {
             }
 
             function addReferencedFile(referencedPath: Path) {
-                (referencedFiles || (referencedFiles = new Set())).add(referencedPath);
+                (referencedFiles ??= new Set()).add(referencedPath);
             }
         }
 
@@ -343,7 +343,7 @@ namespace ts {
 
         export function updateSignatureOfFile(state: BuilderState, signature: string | undefined, path: Path) {
             state.fileInfos.get(path)!.signature = signature;
-            (state.hasCalledUpdateShapeSignature ||= new Set()).add(path);
+            (state.hasCalledUpdateShapeSignature ??= new Set()).add(path);
         }
 
         /**
@@ -378,7 +378,7 @@ namespace ts {
             if (latestSignature === undefined) {
                 latestSignature = sourceFile.version;
                 if (state.exportedModulesMap && latestSignature !== prevSignature) {
-                    (state.oldExportedModulesMap ||= new Map()).set(sourceFile.resolvedPath, state.exportedModulesMap.getValues(sourceFile.resolvedPath) || false);
+                    (state.oldExportedModulesMap ??= new Map()).set(sourceFile.resolvedPath, state.exportedModulesMap.getValues(sourceFile.resolvedPath) ?? false);
                     // All the references in this file are exported
                     const references = state.referencedMap ? state.referencedMap.getValues(sourceFile.resolvedPath) : undefined;
                     if (references) {
@@ -389,14 +389,14 @@ namespace ts {
                     }
                 }
             }
-            (state.oldSignatures ||= new Map()).set(sourceFile.resolvedPath, prevSignature || false);
-            (state.hasCalledUpdateShapeSignature ||= new Set()).add(sourceFile.resolvedPath);
+            (state.oldSignatures ??= new Map()).set(sourceFile.resolvedPath, prevSignature || false);
+            (state.hasCalledUpdateShapeSignature ??= new Set()).add(sourceFile.resolvedPath);
             info.signature = latestSignature;
             return latestSignature !== prevSignature;
         }
 
         export function computeSignature(text: string, computeHash: ComputeHash | undefined) {
-            return (computeHash || generateDjb2Hash)(text);
+            return (computeHash ?? generateDjb2Hash)(text);
         }
 
         /**
@@ -404,7 +404,7 @@ namespace ts {
          */
         export function updateExportedModules(state: BuilderState, sourceFile: SourceFile, exportedModulesFromDeclarationEmit: ExportedModulesFromDeclarationEmit | undefined) {
             if (!state.exportedModulesMap) return;
-            (state.oldExportedModulesMap ||= new Map()).set(sourceFile.resolvedPath, state.exportedModulesMap.getValues(sourceFile.resolvedPath) || false);
+            (state.oldExportedModulesMap ??= new Map()).set(sourceFile.resolvedPath, state.exportedModulesMap.getValues(sourceFile.resolvedPath) ?? false);
             if (!exportedModulesFromDeclarationEmit) {
                 state.exportedModulesMap.deleteKey(sourceFile.resolvedPath);
                 return;
@@ -530,12 +530,12 @@ namespace ts {
                     addSourceFile(sourceFile);
                 }
             }
-            state.allFilesExcludingDefaultLibraryFile = result || emptyArray;
+            state.allFilesExcludingDefaultLibraryFile = result ?? emptyArray;
             return state.allFilesExcludingDefaultLibraryFile;
 
             function addSourceFile(sourceFile: SourceFile) {
                 if (!programOfThisState.isSourceFileDefaultLibrary(sourceFile)) {
-                    (result || (result = [])).push(sourceFile);
+                    (result ??= []).push(sourceFile);
                 }
             }
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -489,7 +489,7 @@ namespace ts {
                 return node ? getExportSpecifierLocalTargetSymbol(node) : undefined;
             },
             getExportSymbolOfSymbol(symbol) {
-                return getMergedSymbol(symbol.exportSymbol || symbol);
+                return getMergedSymbol(symbol.exportSymbol ?? symbol);
             },
             getTypeAtLocation: nodeIn => {
                 const node = getParseTreeNode(nodeIn);
@@ -681,7 +681,7 @@ namespace ts {
                 return node && getTypeArgumentConstraint(node);
             },
             getSuggestionDiagnostics: (fileIn, ct) => {
-                const file = getParseTreeNode(fileIn, isSourceFile) || Debug.fail("Could not determine parsed source file.");
+                const file = getParseTreeNode(fileIn, isSourceFile) ?? Debug.fail("Could not determine parsed source file.");
                 if (skipTypeChecking(file, compilerOptions, host)) {
                     return emptyArray;
                 }
@@ -700,11 +700,11 @@ namespace ts {
                     diagnostics = addRange(diagnostics, suggestionDiagnostics.getDiagnostics(file.fileName));
                     checkUnusedIdentifiers(getPotentiallyUnusedIdentifiers(file), (containingNode, kind, diag) => {
                         if (!containsParseError(containingNode) && !unusedIsError(kind, !!(containingNode.flags & NodeFlags.Ambient))) {
-                            (diagnostics || (diagnostics = [])).push({ ...diag, category: DiagnosticCategory.Suggestion });
+                            (diagnostics ??= []).push({ ...diag, category: DiagnosticCategory.Suggestion });
                         }
                     });
 
-                    return diagnostics || emptyArray;
+                    return diagnostics ?? emptyArray;
                 }
                 finally {
                     cancellationToken = undefined;
@@ -959,7 +959,7 @@ namespace ts {
         let deferredGlobalESSymbolConstructorSymbol: Symbol | undefined;
         let deferredGlobalESSymbolConstructorTypeSymbol: Symbol | undefined;
         let deferredGlobalESSymbolType: ObjectType | undefined;
-        let deferredGlobalTypedPropertyDescriptorType: GenericType;
+        let deferredGlobalTypedPropertyDescriptorType: GenericType | undefined;
         let deferredGlobalPromiseType: GenericType | undefined;
         let deferredGlobalPromiseLikeType: GenericType | undefined;
         let deferredGlobalPromiseConstructorSymbol: Symbol | undefined;
@@ -975,8 +975,8 @@ namespace ts {
         let deferredGlobalAsyncIterableIteratorType: GenericType | undefined;
         let deferredGlobalAsyncGeneratorType: GenericType | undefined;
         let deferredGlobalTemplateStringsArrayType: ObjectType | undefined;
-        let deferredGlobalImportMetaType: ObjectType;
-        let deferredGlobalImportMetaExpressionType: ObjectType;
+        let deferredGlobalImportMetaType: ObjectType | undefined;
+        let deferredGlobalImportMetaExpressionType: ObjectType | undefined;
         let deferredGlobalImportCallOptionsType: ObjectType | undefined;
         let deferredGlobalExtractSymbol: Symbol | undefined;
         let deferredGlobalOmitSymbol: Symbol | undefined;
@@ -1381,12 +1381,12 @@ namespace ts {
         }
 
         function addDuplicateDeclarationError(node: Declaration, message: DiagnosticMessage, symbolName: string, relatedNodes: readonly Declaration[] | undefined) {
-            const errorNode = (getExpandoInitializer(node, /*isPrototypeAssignment*/ false) ? getNameOfExpando(node) : getNameOfDeclaration(node)) || node;
+            const errorNode = (getExpandoInitializer(node, /*isPrototypeAssignment*/ false) ? getNameOfExpando(node) : getNameOfDeclaration(node)) ?? node;
             const err = lookupOrIssueError(errorNode, message, symbolName);
-            for (const relatedNode of relatedNodes || emptyArray) {
-                const adjustedNode = (getExpandoInitializer(relatedNode, /*isPrototypeAssignment*/ false) ? getNameOfExpando(relatedNode) : getNameOfDeclaration(relatedNode)) || relatedNode;
+            for (const relatedNode of relatedNodes ?? emptyArray) {
+                const adjustedNode = (getExpandoInitializer(relatedNode, /*isPrototypeAssignment*/ false) ? getNameOfExpando(relatedNode) : getNameOfDeclaration(relatedNode)) ?? relatedNode;
                 if (adjustedNode === errorNode) continue;
-                err.relatedInformation = err.relatedInformation || [];
+                err.relatedInformation = err.relatedInformation ?? [];
                 const leadingMessage = createDiagnosticForNode(adjustedNode, Diagnostics._0_was_also_declared_here, symbolName);
                 const followOnMessage = createDiagnosticForNode(adjustedNode, Diagnostics.and_here);
                 if (length(err.relatedInformation) >= 5 || some(err.relatedInformation, r => compareDiagnostics(r, followOnMessage) === Comparison.EqualTo || compareDiagnostics(r, leadingMessage) === Comparison.EqualTo)) continue;
@@ -1910,7 +1910,7 @@ namespace ts {
                         isInExternalModule = true;
                         // falls through
                     case SyntaxKind.ModuleDeclaration:
-                        const moduleExports = getSymbolOfNode(location as SourceFile | ModuleDeclaration)?.exports || emptySymbols;
+                        const moduleExports = getSymbolOfNode(location as SourceFile | ModuleDeclaration)?.exports ?? emptySymbols;
                         if (location.kind === SyntaxKind.SourceFile || (isModuleDeclaration(location) && location.flags & NodeFlags.Ambient && !isGlobalScopeAugmentation(location))) {
 
                             // It's an external module. First see if the module has an export default and if the local
@@ -2134,8 +2134,8 @@ namespace ts {
                     lastSelfReferenceLocation = location;
                 }
                 lastLocation = location;
-                location = isJSDocTemplateTag(location) ? getEffectiveContainerForJSDocTemplateTag(location) || location.parent :
-                    isJSDocParameterTag(location) || isJSDocReturnTag(location) ? getHostSignatureFromJSDoc(location) || location.parent :
+                location = isJSDocTemplateTag(location) ? getEffectiveContainerForJSDocTemplateTag(location) ?? location.parent :
+                    isJSDocParameterTag(location) || isJSDocReturnTag(location) ? getHostSignatureFromJSDoc(location) ?? location.parent :
                     location.parent;
             }
 
@@ -2870,7 +2870,7 @@ namespace ts {
             }
             const result = createSymbol(valueSymbol.flags | typeSymbol.flags, valueSymbol.escapedName);
             result.declarations = deduplicate(concatenate(valueSymbol.declarations, typeSymbol.declarations), equateValues);
-            result.parent = valueSymbol.parent || typeSymbol.parent;
+            result.parent = valueSymbol.parent ?? typeSymbol.parent;
             if (valueSymbol.valueDeclaration) result.valueDeclaration = valueSymbol.valueDeclaration;
             if (typeSymbol.members) result.members = new Map(typeSymbol.members);
             if (valueSymbol.exports) result.exports = new Map(valueSymbol.exports);
@@ -2931,7 +2931,7 @@ namespace ts {
 
                     const symbol = symbolFromModule && symbolFromVariable && symbolFromModule !== symbolFromVariable ?
                         combineValueAndTypeSymbols(symbolFromVariable, symbolFromModule) :
-                        symbolFromModule || symbolFromVariable;
+                        symbolFromModule ?? symbolFromVariable;
                     if (!symbol) {
                         const moduleName = getFullyQualifiedName(moduleSymbol, node);
                         const declarationName = declarationNameToString(name);
@@ -3012,8 +3012,8 @@ namespace ts {
         function getTargetOfImportSpecifier(node: ImportSpecifier | BindingElement, dontResolveAlias: boolean): Symbol | undefined {
             const root = isBindingElement(node) ? getRootDeclaration(node) as VariableDeclaration : node.parent.parent.parent;
             const commonJSPropertyAccess = getCommonJSPropertyAccess(root);
-            const resolved = getExternalModuleMember(root, commonJSPropertyAccess || node, dontResolveAlias);
-            const name = node.propertyName || node.name;
+            const resolved = getExternalModuleMember(root, commonJSPropertyAccess ?? node, dontResolveAlias);
+            const name = node.propertyName ?? node.name;
             if (commonJSPropertyAccess && resolved && isIdentifier(name)) {
                 return resolveSymbol(getPropertyOfType(getTypeOfSymbol(resolved), name.escapedText), dontResolveAlias);
             }
@@ -3036,7 +3036,7 @@ namespace ts {
         function getTargetOfExportSpecifier(node: ExportSpecifier, meaning: SymbolFlags, dontResolveAlias?: boolean) {
             const resolved = node.parent.parent.moduleSpecifier ?
                 getExternalModuleMember(node.parent.parent, node, dontResolveAlias) :
-                resolveEntityName(node.propertyName || node.name, meaning, /*ignoreErrors*/ false, dontResolveAlias);
+                resolveEntityName(node.propertyName ?? node.name, meaning, /*ignoreErrors*/ false, dontResolveAlias);
             markSymbolOfAliasDeclarationIfTypeOnly(node, /*immediateTarget*/ undefined, resolved, /*overwriteEmpty*/ false);
             return resolved;
         }
@@ -3133,7 +3133,7 @@ namespace ts {
                 if (!node) return Debug.fail();
                 const target = getTargetOfAliasDeclaration(node);
                 if (links.aliasTarget === resolvingSymbol) {
-                    links.aliasTarget = target || unknownSymbol;
+                    links.aliasTarget = target ?? unknownSymbol;
                 }
                 else {
                     error(node, Diagnostics.Circular_definition_of_import_alias_0, symbolToString(symbol));
@@ -3322,7 +3322,7 @@ namespace ts {
             if (name.kind === SyntaxKind.Identifier) {
                 const message = meaning === namespaceMeaning || nodeIsSynthesized(name) ? Diagnostics.Cannot_find_namespace_0 : getCannotFindNameDiagnosticForName(getFirstIdentifier(name));
                 const symbolFromJSPrototype = isInJSFile(name) && !nodeIsSynthesized(name) ? resolveEntityNameFromAssignmentDeclaration(name, meaning) : undefined;
-                symbol = getMergedSymbol(resolveName(location || name, name.escapedText, meaning, ignoreErrors || symbolFromJSPrototype ? undefined : message, name, /*isUse*/ true, false));
+                symbol = getMergedSymbol(resolveName(location ?? name, name.escapedText, meaning, ignoreErrors || symbolFromJSPrototype ? undefined : message, name, /*isUse*/ true, false));
                 if (!symbol) {
                     return getMergedSymbol(symbolFromJSPrototype);
                 }
@@ -3466,7 +3466,7 @@ namespace ts {
             const initializer = isAssignmentDeclaration(decl) ? getAssignedExpandoInitializer(decl) :
                 hasOnlyExpressionInitializer(decl) ? getDeclaredExpandoInitializer(decl) :
                 undefined;
-            return initializer || decl;
+            return initializer ?? decl;
         }
 
         /**
@@ -3517,11 +3517,11 @@ namespace ts {
             const currentSourceFile = getSourceFileOfNode(location);
             const contextSpecifier = isStringLiteralLike(location)
                 ? location
-                :   findAncestor(location, isImportCall)?.arguments[0] ||
-                    findAncestor(location, isImportDeclaration)?.moduleSpecifier ||
-                    findAncestor(location, isExternalModuleImportEqualsDeclaration)?.moduleReference.expression ||
-                    findAncestor(location, isExportDeclaration)?.moduleSpecifier ||
-                    (isModuleDeclaration(location) ? location : location.parent && isModuleDeclaration(location.parent) && location.parent.name === location ? location.parent : undefined)?.name ||
+                :   findAncestor(location, isImportCall)?.arguments[0] ??
+                    findAncestor(location, isImportDeclaration)?.moduleSpecifier ??
+                    findAncestor(location, isExternalModuleImportEqualsDeclaration)?.moduleReference.expression ??
+                    findAncestor(location, isExportDeclaration)?.moduleSpecifier ??
+                    (isModuleDeclaration(location) ? location : location.parent && isModuleDeclaration(location.parent) && location.parent.name === location ? location.parent : undefined)?.name ??
                     (isLiteralImportTypeNode(location) ? location : undefined)?.argument.literal;
             const mode = contextSpecifier && isStringLiteralLike(contextSpecifier) ? getModeForUsageLocation(currentSourceFile, contextSpecifier) : currentSourceFile.impliedNodeFormat;
             const resolvedModule = getResolvedModule(currentSourceFile, moduleReference, mode);
@@ -3682,7 +3682,7 @@ namespace ts {
             if (moduleSymbol?.exports) {
                 const exportEquals = resolveSymbol(moduleSymbol.exports.get(InternalSymbolName.ExportEquals), dontResolveAlias);
                 const exported = getCommonJsExportEquals(getMergedSymbol(exportEquals), getMergedSymbol(moduleSymbol));
-                return getMergedSymbol(exported) || moduleSymbol;
+                return getMergedSymbol(exported) ?? moduleSymbol;
             }
             return undefined;
         }
@@ -3847,12 +3847,12 @@ namespace ts {
         function getExportsOfSymbol(symbol: Symbol): SymbolTable {
             return symbol.flags & SymbolFlags.LateBindingContainer ? getResolvedMembersOrExportsOfSymbol(symbol, MembersOrExportsResolutionKind.resolvedExports) :
                 symbol.flags & SymbolFlags.Module ? getExportsOfModule(symbol) :
-                symbol.exports || emptySymbols;
+                symbol.exports ?? emptySymbols;
         }
 
         function getExportsOfModule(moduleSymbol: Symbol): SymbolTable {
             const links = getSymbolLinks(moduleSymbol);
-            return links.resolvedExports || (links.resolvedExports = getExportsOfModuleWorker(moduleSymbol));
+            return links.resolvedExports ??= getExportsOfModuleWorker(moduleSymbol);
         }
 
         interface ExportCollisionTracker {
@@ -3898,7 +3898,7 @@ namespace ts {
             // A module defined by an 'export=' consists of one export that needs to be resolved
             moduleSymbol = resolveExternalModuleSymbol(moduleSymbol);
 
-            return visit(moduleSymbol) || emptySymbols;
+            return visit(moduleSymbol) ?? emptySymbols;
 
             // The ES6 spec permits export * declarations in a module to circularly reference the module itself. For example,
             // module 'a' can 'export * from "b"' and 'b' can 'export * from "a"' without error.
@@ -3980,7 +3980,7 @@ namespace ts {
                     results = append(results, resolvedModule);
                 }
                 if (length(results)) {
-                    (links.extendedContainersByFile || (links.extendedContainersByFile = new Map())).set(id, results!);
+                    (links.extendedContainersByFile ??= new Map()).set(id, results!);
                     return results!;
                 }
             }
@@ -3996,7 +3996,7 @@ namespace ts {
                 if (!ref) continue;
                 results = append(results, sym);
             }
-            return links.extendedContainers = results || emptyArray;
+            return links.extendedContainers = results ?? emptyArray;
         }
 
         /**
@@ -4192,10 +4192,10 @@ namespace ts {
             let result: Symbol[] | undefined;
             members.forEach((symbol, id) => {
                 if (isNamedMember(symbol, id)) {
-                    (result || (result = [])).push(symbol);
+                    (result ??= []).push(symbol);
                 }
             });
-            return result || emptyArray;
+            return result ?? emptyArray;
         }
 
         function isNamedMember(member: Symbol, escapedName: __String) {
@@ -4277,9 +4277,9 @@ namespace ts {
                         // trigger resolving late-bound names, which we may already be in the process of doing while we're here!
                         let table: UnderscoreEscapedMap<Symbol> | undefined;
                         // TODO: Should this filtered table be cached in some way?
-                        (getSymbolOfNode(location as ClassLikeDeclaration | InterfaceDeclaration).members || emptySymbols).forEach((memberSymbol, key) => {
+                        (getSymbolOfNode(location as ClassLikeDeclaration | InterfaceDeclaration).members ?? emptySymbols).forEach((memberSymbol, key) => {
                             if (memberSymbol.flags & (SymbolFlags.Type & ~SymbolFlags.Assignment)) {
-                                (table || (table = createSymbolTable())).set(key, memberSymbol);
+                                (table ??= createSymbolTable()).set(key, memberSymbol);
                             }
                         });
                         if (table && (result = callback(table, /*ignoreQualification*/ undefined, /*isLocalNameLookup*/ false, location))) {
@@ -4302,7 +4302,7 @@ namespace ts {
                 return undefined;
             }
             const links = getSymbolLinks(symbol);
-            const cache = (links.accessibleChainCache ||= new Map());
+            const cache = (links.accessibleChainCache ??= new Map());
             // Go from enclosingDeclaration to the first scope we check, so the cache is keyed off the scope and thus shared more
             const firstRelevantLocation = forEachSymbolTableInScope(enclosingDeclaration, (_, __, ___, node) => node);
             const key = `${useOnlyExternalAliasing ? 0 : 1}|${firstRelevantLocation && getNodeId(firstRelevantLocation)}|${meaning}`;
@@ -4340,7 +4340,7 @@ namespace ts {
             }
 
             function isAccessible(symbolFromSymbolTable: Symbol, resolvedAliasSymbol?: Symbol, ignoreQualification?: boolean) {
-                return (symbol === (resolvedAliasSymbol || symbolFromSymbolTable) || getMergedSymbol(symbol) === getMergedSymbol(resolvedAliasSymbol || symbolFromSymbolTable)) &&
+                return (symbol === (resolvedAliasSymbol ?? symbolFromSymbolTable) || getMergedSymbol(symbol) === getMergedSymbol(resolvedAliasSymbol ?? symbolFromSymbolTable)) &&
                     // if the symbolFromSymbolTable is not external module (it could be if it was determined as ambient external module and would be in globals table)
                     // and if symbolFromSymbolTable or alias resolution matches the symbol,
                     // check the symbol can be qualified, it is only then this symbol is accessible
@@ -4383,7 +4383,7 @@ namespace ts {
                 });
 
                 // If there's no result and we're looking at the global symbol table, treat `globalThis` like an alias and try to lookup thru that
-                return result || (symbols === globals ? getCandidateListForSymbol(globalThisSymbol, globalThisSymbol, ignoreQualification) : undefined);
+                return result ?? (symbols === globals ? getCandidateListForSymbol(globalThisSymbol, globalThisSymbol, ignoreQualification) : undefined);
             }
 
             function getCandidateListForSymbol(symbolFromSymbolTable: Symbol, resolvedImportedSymbol: Symbol, ignoreQualification: boolean | undefined) {
@@ -5124,7 +5124,7 @@ namespace ts {
                         const name = typeParameterToName(newParam, context);
                         const newTypeVariable = factory.createTypeReferenceNode(name);
                         context.approximateLength += 37; // 15 each for two added conditionals, 7 for an added infer type
-                        const newMapper = prependTypeMapping(type.root.checkType, newParam, type.combinedMapper || type.mapper);
+                        const newMapper = prependTypeMapping(type.root.checkType, newParam, type.combinedMapper ?? type.mapper);
                         const saveInferTypeParameters = context.inferTypeParameters;
                         context.inferTypeParameters = type.root.inferTypeParameters;
                         const extendsTypeNode = typeToTypeNodeHelper(instantiateType(type.root.extendsType, newMapper), context);
@@ -5192,7 +5192,7 @@ namespace ts {
                             const name = typeParameterToName(newParam, context);
                             newTypeVariable = factory.createTypeReferenceNode(name);
                         }
-                        appropriateConstraintTypeNode = factory.createTypeOperatorNode(SyntaxKind.KeyOfKeyword, newTypeVariable || typeToTypeNodeHelper(getModifiersTypeFromMappedType(type), context));
+                        appropriateConstraintTypeNode = factory.createTypeOperatorNode(SyntaxKind.KeyOfKeyword, newTypeVariable ?? typeToTypeNodeHelper(getModifiersTypeFromMappedType(type), context));
                     }
                     else {
                         appropriateConstraintTypeNode = typeToTypeNodeHelper(getConstraintTypeFromMappedType(type), context);
@@ -5287,7 +5287,7 @@ namespace ts {
                     const links = context.enclosingDeclaration && getNodeLinks(context.enclosingDeclaration);
                     const key = `${getTypeId(type)}|${context.flags}`;
                     if (links) {
-                        links.serializedTypes ||= new Map();
+                        links.serializedTypes ??= new Map();
                     }
                     const cachedResult = links?.serializedTypes?.get(key);
                     if (cachedResult) {
@@ -5484,7 +5484,7 @@ namespace ts {
                         }
                         let typeArgumentNodes: readonly TypeNode[] | undefined;
                         if (typeArguments.length > 0) {
-                            const typeParameterCount = (type.target.typeParameters || emptyArray).length;
+                            const typeParameterCount = (type.target.typeParameters ?? emptyArray).length;
                             typeArgumentNodes = mapToTypeNodes(typeArguments.slice(i, typeParameterCount), context);
                         }
                         const flags = context.flags;
@@ -5655,7 +5655,7 @@ namespace ts {
                         context.tracker.reportNonSerializableProperty(symbolToString(propertySymbol));
                     }
                 }
-                context.enclosingDeclaration = propertySymbol.valueDeclaration || propertySymbol.declarations?.[0] || saveEnclosingDeclaration;
+                context.enclosingDeclaration = propertySymbol.valueDeclaration ?? propertySymbol.declarations?.[0] ?? saveEnclosingDeclaration;
                 const propertyName = getPropertyNameNodeForSymbol(propertySymbol, context);
                 context.enclosingDeclaration = saveEnclosingDeclaration;
                 context.approximateLength += (symbolName(propertySymbol).length + 1);
@@ -5674,7 +5674,7 @@ namespace ts {
                     }
                     else {
                         if (propertyIsReverseMapped) {
-                            context.reverseMappedStack ||= [];
+                            context.reverseMappedStack ??= [];
                             context.reverseMappedStack.push(propertySymbol as ReverseMappedSymbol);
                         }
                         propertyTypeNode = propertyType ? serializeTypeForDeclaration(context, propertyType, propertySymbol, saveEnclosingDeclaration) : factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
@@ -6040,7 +6040,7 @@ namespace ts {
                                         accessibleSymbolChain = parentChain;
                                         break;
                                     }
-                                    accessibleSymbolChain = parentChain.concat(accessibleSymbolChain || [getAliasForSymbolInContainer(parent, symbol) || symbol]);
+                                    accessibleSymbolChain = parentChain.concat(accessibleSymbolChain ?? [getAliasForSymbolInContainer(parent, symbol) ?? symbol]);
                                     break;
                                 }
                             }
@@ -6099,7 +6099,7 @@ namespace ts {
                 if (context.typeParameterSymbolList?.has(symbolId)) {
                     return undefined;
                 }
-                (context.typeParameterSymbolList || (context.typeParameterSymbolList = new Set())).add(symbolId);
+                (context.typeParameterSymbolList ??= new Set()).add(symbolId);
                 let typeParameterNodes: readonly TypeNode[] | readonly TypeParameterDeclaration[] | undefined;
                 if (context.flags & NodeBuilderFlags.WriteTypeParametersInQualifiedName && index < (chain.length - 1)) {
                     const parentSymbol = symbol;
@@ -6208,7 +6208,7 @@ namespace ts {
                 if (some(chain[0].declarations, hasNonGlobalAugmentationExternalModuleSymbol)) {
                     // module is root, must use `ImportTypeNode`
                     const nonRootParts = chain.length > 1 ? createAccessFromSymbolChain(chain, chain.length - 1, 1) : undefined;
-                    const typeParameterNodes = overrideTypeArguments || lookupTypeParameterNodes(chain, 0, context);
+                    const typeParameterNodes = overrideTypeArguments ?? lookupTypeParameterNodes(chain, 0, context);
                     const contextFile = getSourceFileOfNode(getOriginalNode(context.enclosingDeclaration));
                     const targetFile = getSourceFileOfModule(chain[0]);
                     let specifier: string | undefined;
@@ -6390,9 +6390,9 @@ namespace ts {
                     }
                     // avoiding iterations of the above loop turns out to be worth it when `i` starts to get large, so we cache the max
                     // `i` we've used thus far, to save work later
-                    (context.typeParameterNamesByTextNextNameCount ||= new Map()).set(rawtext, i);
-                    (context.typeParameterNames ||= new Map()).set(getTypeId(type), result);
-                    (context.typeParameterNamesByText ||= new Set()).add(rawtext);
+                    (context.typeParameterNamesByTextNextNameCount ??= new Map()).set(rawtext, i);
+                    (context.typeParameterNames ??= new Map()).set(getTypeId(type), result);
+                    (context.typeParameterNamesByText ??= new Set()).add(rawtext);
                 }
                 return result;
             }
@@ -6715,7 +6715,7 @@ namespace ts {
                                     visitNode(p.type, visitExistingNodeTreeSymbols),
                                     /*initializer*/ undefined
                                 )),
-                                visitNode(newTypeNode || node.type, visitExistingNodeTreeSymbols) || factory.createKeywordTypeNode(SyntaxKind.AnyKeyword)
+                                visitNode(newTypeNode ?? node.type, visitExistingNodeTreeSymbols) ?? factory.createKeywordTypeNode(SyntaxKind.AnyKeyword)
                             );
                         }
                         else {
@@ -6729,7 +6729,7 @@ namespace ts {
                                     visitNode(p.type, visitExistingNodeTreeSymbols),
                                     /*initializer*/ undefined
                                 )),
-                                visitNode(node.type, visitExistingNodeTreeSymbols) || factory.createKeywordTypeNode(SyntaxKind.AnyKeyword)
+                                visitNode(node.type, visitExistingNodeTreeSymbols) ?? factory.createKeywordTypeNode(SyntaxKind.AnyKeyword)
                             );
                         }
                     }
@@ -6774,7 +6774,7 @@ namespace ts {
                     return visitEachChild(node, visitExistingNodeTreeSymbols, nullTransformationContext);
 
                     function getEffectiveDotDotDotForParameter(p: ParameterDeclaration) {
-                        return p.dotDotDotToken || (p.type && isJSDocVariadicType(p.type) ? factory.createToken(SyntaxKind.DotDotDotToken) : undefined);
+                        return p.dotDotDotToken ?? (p.type && isJSDocVariadicType(p.type) ? factory.createToken(SyntaxKind.DotDotDotToken) : undefined);
                     }
 
                     /** Note that `new:T` parameters are not handled, but should be before calling this function. */
@@ -7364,8 +7364,8 @@ namespace ts {
                     const members = getNamespaceMembersForSerialization(symbol);
                     // Split NS members up by declaration - members whose parent symbol is the ns symbol vs those whose is not (but were added in later via merging)
                     const locationMap = arrayToMultiMap(members, m => m.parent && m.parent === symbol ? "real" : "merged");
-                    const realMembers = locationMap.get("real") || emptyArray;
-                    const mergedMembers = locationMap.get("merged") || emptyArray;
+                    const realMembers = locationMap.get("real") ?? emptyArray;
+                    const mergedMembers = locationMap.get("merged") ?? emptyArray;
                     // TODO: `suppressNewPrivateContext` is questionable -we need to simply be emitting privates in whatever scope they were declared in, rather
                     // than whatever scope we traverse to them in. That's a bit of a complex rewrite, since we're not _actually_ tracking privates at all in advance,
                     // so we don't even have placeholders to fill in.
@@ -7388,7 +7388,7 @@ namespace ts {
                                     return undefined;
                                 }
                                 const target = aliasDecl && getTargetOfAliasDeclaration(aliasDecl, /*dontRecursivelyResolve*/ true);
-                                includePrivateSymbol(target || s);
+                                includePrivateSymbol(target ?? s);
                                 const targetName = target ? getInternalSymbolName(target, unescapeLeadingUnderscores(target.escapedName)) : localName;
                                 return factory.createExportSpecifier(/*isTypeOnly*/ false, name === targetName ? undefined : targetName, name);
                             }))
@@ -7453,7 +7453,7 @@ namespace ts {
                                 getSourceFileOfNode(d) === getSourceFileOfNode(context.enclosingDeclaration!)
                             ) ? "local" : "remote"
                         );
-                        const localProps = localVsRemoteMap.get("local") || emptyArray;
+                        const localProps = localVsRemoteMap.get("local") ?? emptyArray;
                         // handle remote props first - we need to make an `import` declaration that points at the module containing each remote
                         // prop in the outermost scope (TODO: a namespace within a namespace would need to be appropriately handled by this)
                         // Example:
@@ -7528,7 +7528,7 @@ namespace ts {
                         return cleanup(factory.createExpressionWithTypeArguments(expr,
                             map(e.typeArguments, a =>
                                 serializeExistingTypeNode(context, a, includePrivateSymbol, bundled)
-                                || typeToTypeNodeHelper(getTypeFromTypeNode(a), context)
+                                ?? typeToTypeNodeHelper(getTypeFromTypeNode(a), context)
                             )
                         ));
 
@@ -7546,7 +7546,7 @@ namespace ts {
                 function serializeAsClass(symbol: Symbol, localName: string, modifierFlags: ModifierFlags) {
                     const originalDecl = symbol.declarations?.find(isClassLike);
                     const oldEnclosing = context.enclosingDeclaration;
-                    context.enclosingDeclaration = originalDecl || oldEnclosing;
+                    context.enclosingDeclaration = originalDecl ?? oldEnclosing;
                     const localParams = getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(symbol);
                     const typeParamDecls = map(localParams, p => typeParameterToDeclaration(p, context));
                     const classType = getDeclaredTypeOfClassOrInterface(symbol);
@@ -7618,7 +7618,7 @@ namespace ts {
                 function getSomeTargetNameFromDeclarations(declarations: Declaration[] | undefined) {
                     return firstDefined(declarations, d => {
                         if (isImportSpecifier(d) || isExportSpecifier(d)) {
-                            return idText(d.propertyName || d.name);
+                            return idText(d.propertyName ?? d.name);
                         }
                         if (isBinaryExpression(d) || isExportAssignment(d)) {
                             const expression = isExportAssignment(d) ? d.expression : d.right;
@@ -7660,7 +7660,7 @@ namespace ts {
                         case SyntaxKind.BindingElement:
                             if (node.parent?.parent?.kind === SyntaxKind.VariableDeclaration) {
                                 // const { SomeClass } = require('./lib');
-                                const specifier = getSpecifierForModuleSymbol(target.parent || target, context); // './lib'
+                                const specifier = getSpecifierForModuleSymbol(target.parent ?? target, context); // './lib'
                                 const { propertyName } = node as BindingElement;
                                 addResult(factory.createImportDeclaration(
                                     /*modifiers*/ undefined,
@@ -7692,7 +7692,7 @@ namespace ts {
                                 // const x = require('y').z
                                 const initializer = (node as VariableDeclaration).initializer! as PropertyAccessExpression; // require('y').z
                                 const uniqueName = factory.createUniqueName(localName); // _x
-                                const specifier = getSpecifierForModuleSymbol(target.parent || target, context); // 'y'
+                                const specifier = getSpecifierForModuleSymbol(target.parent ?? target, context); // 'y'
                                 // import _x = require('y');
                                 addResult(factory.createImportEqualsDeclaration(
                                     /*modifiers*/ undefined,
@@ -7742,7 +7742,7 @@ namespace ts {
                                 // We use `target.parent || target` below as `target.parent` is unset when the target is a module which has been export assigned
                                 // And then made into a default by the `esModuleInterop` or `allowSyntheticDefaultImports` flag
                                 // In such cases, the `target` refers to the module itself already
-                                factory.createStringLiteral(getSpecifierForModuleSymbol(target.parent || target, context)),
+                                factory.createStringLiteral(getSpecifierForModuleSymbol(target.parent ?? target, context)),
                                  /*assertClause*/ undefined
                             ), ModifierFlags.None);
                             break;
@@ -7775,7 +7775,7 @@ namespace ts {
                                             factory.createIdentifier(localName)
                                         )
                                     ])),
-                                factory.createStringLiteral(getSpecifierForModuleSymbol(target.parent || target, context)),
+                                factory.createStringLiteral(getSpecifierForModuleSymbol(target.parent ?? target, context)),
                                  /*assertClause*/ undefined
                             ), ModifierFlags.None);
                             break;
@@ -7847,7 +7847,7 @@ namespace ts {
                         const first = expr && isEntityNameExpression(expr) ? getFirstNonModuleExportsIdentifier(expr) : undefined;
                         const referenced = first && resolveEntityName(first, SymbolFlags.All, /*ignoreErrors*/ true, /*dontResolveAlias*/ true, enclosingDeclaration);
                         if (referenced || target) {
-                            includePrivateSymbol(referenced || target);
+                            includePrivateSymbol(referenced ?? target);
                         }
 
                         // We disable the context's symbol tracker for the duration of this name serialization
@@ -7994,7 +7994,7 @@ namespace ts {
                                         isPrivate ? undefined : serializeTypeForDeclaration(context, getTypeOfSymbol(p), p, enclosingDeclaration, includePrivateSymbol, bundled)
                                     )],
                                     /*body*/ undefined
-                                ), p.declarations?.find(isSetAccessor) || firstPropertyLikeDecl));
+                                ), p.declarations?.find(isSetAccessor) ?? firstPropertyLikeDecl));
                             }
                             if (p.flags & SymbolFlags.GetAccessor) {
                                 const isPrivate = modifierFlags & ModifierFlags.Private;
@@ -8004,7 +8004,7 @@ namespace ts {
                                     [],
                                     isPrivate ? undefined : serializeTypeForDeclaration(context, getTypeOfSymbol(p), p, enclosingDeclaration, includePrivateSymbol, bundled),
                                     /*body*/ undefined
-                                ), p.declarations?.find(isGetAccessor) || firstPropertyLikeDecl));
+                                ), p.declarations?.find(isGetAccessor) ?? firstPropertyLikeDecl));
                             }
                             return result;
                         }
@@ -8019,7 +8019,7 @@ namespace ts {
                                 // TODO: https://github.com/microsoft/TypeScript/pull/32372#discussion_r328386357
                                 // interface members can't have initializers, however class members _can_
                                 /*initializer*/ undefined
-                            ), p.declarations?.find(or(isPropertyDeclaration, isVariableDeclaration)) || firstPropertyLikeDecl);
+                            ), p.declarations?.find(or(isPropertyDeclaration, isVariableDeclaration)) ?? firstPropertyLikeDecl);
                         }
                         if (p.flags & (SymbolFlags.Method | SymbolFlags.Function)) {
                             const type = getTypeOfSymbol(p);
@@ -8514,12 +8514,12 @@ namespace ts {
 
             function buildVisibleNodeList(declarations: Declaration[] | undefined) {
                 forEach(declarations, declaration => {
-                    const resultNode = getAnyImportSyntax(declaration) || declaration;
+                    const resultNode = getAnyImportSyntax(declaration) ?? declaration;
                     if (setVisibility) {
                         getNodeLinks(declaration).isVisible = true;
                     }
                     else {
-                        result = result || [];
+                        result ??= [];
                         pushIfUnique(result, resultNode);
                     }
 
@@ -8644,7 +8644,7 @@ namespace ts {
         }
 
         function getTypeOfPropertyOrIndexSignature(type: Type, name: __String): Type {
-            return getTypeOfPropertyOfType(type, name) || getApplicableIndexInfoForName(type, name)?.type || unknownType;
+            return getTypeOfPropertyOfType(type, name) ?? getApplicableIndexInfoForName(type, name)?.type ?? unknownType;
         }
 
         function isTypeAny(type: Type | undefined) {
@@ -8721,7 +8721,7 @@ namespace ts {
         }
 
         function isGenericTypeWithUndefinedConstraint(type: Type) {
-            return !!(type.flags & TypeFlags.Instantiable) && maybeTypeOfKind(getBaseConstraintOfType(type) || unknownType, TypeFlags.Undefined);
+            return !!(type.flags & TypeFlags.Instantiable) && maybeTypeOfKind(getBaseConstraintOfType(type) ?? unknownType, TypeFlags.Undefined);
         }
 
         function getNonUndefinedType(type: Type) {
@@ -8780,7 +8780,7 @@ namespace ts {
         function getDestructuringPropertyName(node: BindingElement | PropertyAssignment | ShorthandPropertyAssignment | Expression) {
             const parent = node.parent;
             if (node.kind === SyntaxKind.BindingElement && parent.kind === SyntaxKind.ObjectBindingPattern) {
-                return getLiteralPropertyNameText((node as BindingElement).propertyName || (node as BindingElement).name as Identifier);
+                return getLiteralPropertyNameText((node as BindingElement).propertyName ?? (node as BindingElement).name as Identifier);
             }
             if (node.kind === SyntaxKind.PropertyAssignment || node.kind === SyntaxKind.ShorthandPropertyAssignment) {
                 return getLiteralPropertyNameText((node as PropertyAssignment | ShorthandPropertyAssignment).name);
@@ -8826,14 +8826,14 @@ namespace ts {
                     const literalMembers: PropertyName[] = [];
                     for (const element of pattern.elements) {
                         if (!element.dotDotDotToken) {
-                            literalMembers.push(element.propertyName || element.name as Identifier);
+                            literalMembers.push(element.propertyName ?? element.name as Identifier);
                         }
                     }
                     type = getRestType(parentType, literalMembers, declaration.symbol);
                 }
                 else {
                     // Use explicitly specified property name ({ p: xxx } form), or otherwise the implied name ({ p } form)
-                    const name = declaration.propertyName || declaration.name as Identifier;
+                    const name = declaration.propertyName ?? declaration.name as Identifier;
                     const indexType = getLiteralTypeFromPropertyName(name);
                     const declaredType = getIndexedAccessType(parentType, indexType, AccessFlags.ExpressionPosition, name);
                     type = getFlowTypeOfDestructuring(declaration, declaredType);
@@ -8856,7 +8856,7 @@ namespace ts {
                 else if (isArrayLikeType(parentType)) {
                     const indexType = getNumberLiteralType(index);
                     const accessFlags = AccessFlags.ExpressionPosition | (hasDefaultValue(declaration) ? AccessFlags.NoTupleBoundsCheck : 0);
-                    const declaredType = getIndexedAccessTypeOrUndefined(parentType, indexType, accessFlags, declaration.name) || errorType;
+                    const declaredType = getIndexedAccessTypeOrUndefined(parentType, indexType, accessFlags, declaration.name) ?? errorType;
                     type = getFlowTypeOfDestructuring(declaration, declaredType);
                 }
                 else {
@@ -9135,7 +9135,7 @@ namespace ts {
                     return getTypeFromTypeNode(tag.typeExpression);
                 }
                 const containerObjectType = symbol.valueDeclaration && getJSContainerObjectType(symbol.valueDeclaration, symbol, container);
-                return containerObjectType || getWidenedLiteralType(checkExpressionCached(container));
+                return containerObjectType ?? getWidenedLiteralType(checkExpressionCached(container));
             }
             let type;
             let definedInConstructor = false;
@@ -9172,7 +9172,7 @@ namespace ts {
                             jsdocType = getAnnotatedTypeForAssignmentDeclaration(jsdocType, expression, symbol, declaration);
                         }
                         if (!jsdocType) {
-                            (types || (types = [])).push((isBinaryExpression(expression) || isCallExpression(expression)) ? getInitializerTypeFromAssignmentDeclaration(symbol, resolvedSymbol, expression, kind) : neverType);
+                            (types ??= []).push((isBinaryExpression(expression) || isCallExpression(expression)) ? getInitializerTypeFromAssignmentDeclaration(symbol, resolvedSymbol, expression, kind) : neverType);
                         }
                     }
                     type = jsdocType;
@@ -9186,7 +9186,7 @@ namespace ts {
                     if (definedInMethod) {
                         const propType = getTypeOfPropertyInBaseClass(symbol);
                         if (propType) {
-                            (constructorTypes || (constructorTypes = [])).push(propType);
+                            (constructorTypes ??= []).push(propType);
                             definedInConstructor = true;
                         }
                     }
@@ -9291,7 +9291,7 @@ namespace ts {
                 if (resolvedSymbol && !resolvedSymbol.exports) {
                     resolvedSymbol.exports = createSymbolTable();
                 }
-                (resolvedSymbol || symbol).exports!.forEach((s, name) => {
+                (resolvedSymbol ?? symbol).exports!.forEach((s, name) => {
                     const exportedMember = members.get(name)!;
                     if (exportedMember && exportedMember !== s) {
                         if (s.flags & SymbolFlags.Value && exportedMember.flags & SymbolFlags.Value) {
@@ -9307,7 +9307,7 @@ namespace ts {
                             // it's unclear what that's supposed to mean, so it's probably a mistake.
                             if (s.valueDeclaration && exportedMember.valueDeclaration && getSourceFileOfNode(s.valueDeclaration) !== getSourceFileOfNode(exportedMember.valueDeclaration)) {
                                 const unescapedName = unescapeLeadingUnderscores(s.escapedName);
-                                const exportedMemberName = tryCast(exportedMember.valueDeclaration, isNamedDeclaration)?.name || exportedMember.valueDeclaration;
+                                const exportedMemberName = tryCast(exportedMember.valueDeclaration, isNamedDeclaration)?.name ?? exportedMember.valueDeclaration;
                                 addRelatedInfo(
                                     error(s.valueDeclaration, Diagnostics.Duplicate_identifier_0, unescapedName),
                                     createDiagnosticForNode(exportedMemberName, Diagnostics._0_was_also_declared_here, unescapedName));
@@ -9414,7 +9414,7 @@ namespace ts {
             let stringIndexInfo: IndexInfo | undefined;
             let objectFlags = ObjectFlags.ObjectLiteral | ObjectFlags.ContainsObjectOrArrayLiteral;
             forEach(pattern.elements, e => {
-                const name = e.propertyName || e.name as Identifier;
+                const name = e.propertyName ?? e.name as Identifier;
                 if (e.dotDotDotToken) {
                     stringIndexInfo = createIndexInfo(stringType, anyType, /*isReadonly*/ false);
                     return;
@@ -9608,7 +9608,7 @@ namespace ts {
             }
             let type: Type;
             if (declaration.kind === SyntaxKind.ExportAssignment) {
-                type = widenTypeForVariableLikeDeclaration(tryGetTypeFromEffectiveTypeNode(declaration) || checkExpressionCached((declaration as ExportAssignment).expression), declaration);
+                type = widenTypeForVariableLikeDeclaration(tryGetTypeFromEffectiveTypeNode(declaration) ?? checkExpressionCached((declaration as ExportAssignment).expression), declaration);
             }
             else if (
                 isBinaryExpression(declaration) ||
@@ -9632,19 +9632,19 @@ namespace ts {
                 }
                 type = isBinaryExpression(declaration.parent) ?
                     getWidenedTypeForAssignmentDeclaration(symbol) :
-                    tryGetTypeFromEffectiveTypeNode(declaration) || anyType;
+                    tryGetTypeFromEffectiveTypeNode(declaration) ?? anyType;
             }
             else if (isPropertyAssignment(declaration)) {
-                type = tryGetTypeFromEffectiveTypeNode(declaration) || checkPropertyAssignment(declaration);
+                type = tryGetTypeFromEffectiveTypeNode(declaration) ?? checkPropertyAssignment(declaration);
             }
             else if (isJsxAttribute(declaration)) {
-                type = tryGetTypeFromEffectiveTypeNode(declaration) || checkJsxAttribute(declaration);
+                type = tryGetTypeFromEffectiveTypeNode(declaration) ?? checkJsxAttribute(declaration);
             }
             else if (isShorthandPropertyAssignment(declaration)) {
-                type = tryGetTypeFromEffectiveTypeNode(declaration) || checkExpressionForMutableLocation(declaration.name, CheckMode.Normal);
+                type = tryGetTypeFromEffectiveTypeNode(declaration) ?? checkExpressionForMutableLocation(declaration.name, CheckMode.Normal);
             }
             else if (isObjectLiteralMethod(declaration)) {
-                type = tryGetTypeFromEffectiveTypeNode(declaration) || checkObjectLiteralMethod(declaration, CheckMode.Normal);
+                type = tryGetTypeFromEffectiveTypeNode(declaration) ?? checkObjectLiteralMethod(declaration, CheckMode.Normal);
             }
             else if (isParameter(declaration)
                      || isPropertyDeclaration(declaration)
@@ -9759,7 +9759,7 @@ namespace ts {
                     writeType = anyType;
                 }
                 // Absent an explicit setter type annotation we use the read type of the accessor.
-                links.writeType = writeType || getTypeOfAccessors(symbol);
+                links.writeType = writeType ?? getTypeOfAccessors(symbol);
             }
             return links.writeType;
         }
@@ -9824,7 +9824,7 @@ namespace ts {
 
         function getTypeOfEnumMember(symbol: Symbol): Type {
             const links = getSymbolLinks(symbol);
-            return links.type || (links.type = getDeclaredTypeOfEnumMember(symbol));
+            return links.type ??= getDeclaredTypeOfEnumMember(symbol);
         }
 
         function getTypeOfAlias(symbol: Symbol): Type {
@@ -9849,12 +9849,12 @@ namespace ts {
 
         function getTypeOfInstantiatedSymbol(symbol: Symbol): Type {
             const links = getSymbolLinks(symbol);
-            return links.type || (links.type = instantiateType(getTypeOfSymbol(links.target!), links.mapper));
+            return links.type ??= instantiateType(getTypeOfSymbol(links.target!), links.mapper);
         }
 
         function getWriteTypeOfInstantiatedSymbol(symbol: Symbol): Type {
             const links = getSymbolLinks(symbol);
-            return links.writeType || (links.writeType = instantiateType(getWriteTypeOfSymbol(links.target!), links.mapper));
+            return links.writeType ??= instantiateType(getWriteTypeOfSymbol(links.target!), links.mapper);
         }
 
         function reportCircularityError(symbol: Symbol) {
@@ -9906,8 +9906,8 @@ namespace ts {
             if (symbol.flags & SymbolFlags.Property) {
                 return checkFlags & CheckFlags.SyntheticProperty ?
                     checkFlags & CheckFlags.DeferredType ?
-                        getWriteTypeOfSymbolWithDeferredType(symbol) || getTypeOfSymbolWithDeferredType(symbol) :
-                        (symbol as TransientSymbol).writeType || (symbol as TransientSymbol).type! :
+                        getWriteTypeOfSymbolWithDeferredType(symbol) ?? getTypeOfSymbolWithDeferredType(symbol) :
+                        (symbol as TransientSymbol).writeType ?? (symbol as TransientSymbol).type! :
                     getTypeOfSymbol(symbol);
             }
             if (symbol.flags & SymbolFlags.Accessor) {
@@ -10246,7 +10246,7 @@ namespace ts {
 
         function getTupleBaseType(type: TupleType) {
             const elementTypes = sameMap(type.typeParameters, (t, i) => type.elementFlags[i] & ElementFlags.Variadic ? getIndexedAccessType(t, numberType) : t);
-            return createArrayType(getUnionType(elementTypes || emptyArray), type.readonly);
+            return createArrayType(getUnionType(elementTypes ?? emptyArray), type.readonly);
         }
 
         function resolveBaseTypesOfClass(type: InterfaceType) {
@@ -10574,16 +10574,16 @@ namespace ts {
 
         function getDeclaredTypeOfTypeParameter(symbol: Symbol): TypeParameter {
             const links = getSymbolLinks(symbol);
-            return links.declaredType || (links.declaredType = createTypeParameter(symbol));
+            return links.declaredType ??= createTypeParameter(symbol);
         }
 
         function getDeclaredTypeOfAlias(symbol: Symbol): Type {
             const links = getSymbolLinks(symbol);
-            return links.declaredType || (links.declaredType = getDeclaredTypeOfSymbol(resolveAlias(symbol)));
+            return links.declaredType ??= getDeclaredTypeOfSymbol(resolveAlias(symbol));
         }
 
         function getDeclaredTypeOfSymbol(symbol: Symbol): Type {
-            return tryGetDeclaredTypeOfSymbol(symbol) || errorType;
+            return tryGetDeclaredTypeOfSymbol(symbol) ?? errorType;
         }
 
         function tryGetDeclaredTypeOfSymbol(symbol: Symbol): Type | undefined {
@@ -10871,7 +10871,7 @@ namespace ts {
                         // report an error at each declaration.
                         const declarations = earlySymbol ? concatenate(earlySymbol.declarations, lateSymbol.declarations) : lateSymbol.declarations;
                         const name = !(type.flags & TypeFlags.UniqueESSymbol) && unescapeLeadingUnderscores(memberName) || declarationNameToString(declName);
-                        forEach(declarations, declaration => error(getNameOfDeclaration(declaration) || declaration, Diagnostics.Property_0_was_also_declared_here, name));
+                        forEach(declarations, declaration => error(getNameOfDeclaration(declaration) ?? declaration, Diagnostics.Property_0_was_also_declared_here, name));
                         error(declName || decl, Diagnostics.Duplicate_property_0, name);
                         lateSymbol = createSymbol(SymbolFlags.None, memberName, CheckFlags.Late);
                     }
@@ -10900,11 +10900,11 @@ namespace ts {
                 // In the event we recursively resolve the members/exports of the symbol, we
                 // set the initial value of resolvedMembers/resolvedExports to the early-bound
                 // members/exports of the symbol.
-                links[resolutionKind] = earlySymbols || emptySymbols;
+                links[resolutionKind] = earlySymbols ?? emptySymbols;
 
                 // fill in any as-yet-unresolved late-bound members.
                 const lateSymbols = createSymbolTable() as UnderscoreEscapedMap<TransientSymbol>;
-                for (const decl of symbol.declarations || emptyArray) {
+                for (const decl of symbol.declarations ?? emptyArray) {
                     const members = getMembersOfDeclaration(decl);
                     if (members) {
                         for (const member of members) {
@@ -10929,7 +10929,7 @@ namespace ts {
                     }
                 }
 
-                links[resolutionKind] = combineSymbolTables(earlySymbols, lateSymbols) || emptySymbols;
+                links[resolutionKind] = combineSymbolTables(earlySymbols, lateSymbols) ?? emptySymbols;
             }
 
             return links[resolutionKind]!;
@@ -10943,7 +10943,7 @@ namespace ts {
         function getMembersOfSymbol(symbol: Symbol) {
             return symbol.flags & SymbolFlags.LateBindingContainer
                 ? getResolvedMembersOrExportsOfSymbol(symbol, MembersOrExportsResolutionKind.resolvedMembers)
-                : symbol.members || emptySymbols;
+                : symbol.members ?? emptySymbols;
         }
 
         /**
@@ -10965,7 +10965,7 @@ namespace ts {
                         getMembersOfSymbol(parent);
                     }
                 }
-                return links.lateSymbol || (links.lateSymbol = symbol);
+                return links.lateSymbol ??= symbol;
             }
             return symbol;
         }
@@ -10975,7 +10975,7 @@ namespace ts {
                 const target = (type as TypeReference).target;
                 const typeArguments = getTypeArguments(type as TypeReference);
                 if (length(target.typeParameters) === length(typeArguments)) {
-                    const ref = createTypeReference(target, concatenate(typeArguments, [thisArgument || target.thisType!]));
+                    const ref = createTypeReference(target, concatenate(typeArguments, [thisArgument ?? target.thisType!]));
                     return needApparentType ? getApparentType(ref) : ref;
                 }
             }
@@ -11089,8 +11089,7 @@ namespace ts {
                 signature.optionalCallSignatureCache = {};
             }
             const key = callChainFlags === SignatureFlags.IsInnerCallChain ? "inner" : "outer";
-            return signature.optionalCallSignatureCache[key]
-                || (signature.optionalCallSignatureCache[key] = createOptionalCallSignature(signature, callChainFlags));
+            return signature.optionalCallSignatureCache[key] ??= createOptionalCallSignature(signature, callChainFlags);
         }
 
         function createOptionalCallSignature(signature: Signature, callChainFlags: SignatureFlags) {
@@ -11223,7 +11222,7 @@ namespace ts {
                                 s = createUnionSignature(signature, unionSignatures);
                                 s.thisParameter = thisParameter;
                             }
-                            (result || (result = [])).push(s);
+                            (result ??= []).push(s);
                         }
                     }
                 }
@@ -11247,7 +11246,7 @@ namespace ts {
                 }
                 result = results;
             }
-            return result || emptyArray;
+            return result ?? emptyArray;
         }
 
         function compareTypeParametersIdentical(sourceParams: readonly TypeParameter[] | undefined, targetParams: readonly TypeParameter[] | undefined): boolean {
@@ -11276,7 +11275,7 @@ namespace ts {
 
         function combineUnionThisParam(left: Symbol | undefined, right: Symbol | undefined, mapper: TypeMapper | undefined): Symbol | undefined {
             if (!left || !right) {
-                return left || right;
+                return left ?? right;
             }
             // A signature `this` type might be a read or a write position... It's very possible that it should be invariant
             // and we should refuse to merge signatures if there are `this` types and they do not match. However, so as to be
@@ -11299,7 +11298,7 @@ namespace ts {
                 if (longest === right) {
                     longestParamType = instantiateType(longestParamType, mapper);
                 }
-                let shorterParamType = tryGetTypeAtPosition(shorter, i) || unknownType;
+                let shorterParamType = tryGetTypeAtPosition(shorter, i) ?? unknownType;
                 if (shorter === right) {
                     shorterParamType = instantiateType(shorterParamType, mapper);
                 }
@@ -11332,7 +11331,7 @@ namespace ts {
         }
 
         function combineSignaturesOfUnionMembers(left: Signature, right: Signature): Signature {
-            const typeParams = left.typeParameters || right.typeParameters;
+            const typeParams = left.typeParameters ?? right.typeParameters;
             let paramMapper: TypeMapper | undefined;
             if (left.typeParameters && right.typeParameters) {
                 paramMapper = createTypeMapper(right.typeParameters, left.typeParameters);
@@ -11444,7 +11443,7 @@ namespace ts {
                 callSignatures = appendSignatures(callSignatures, getSignaturesOfType(t, SignatureKind.Call));
                 indexInfos = reduceLeft(getIndexInfosOfType(t), (infos, newInfo) => appendIndexInfo(infos, newInfo, /*union*/ false), indexInfos);
             }
-            setStructuredTypeMembers(type, emptySymbols, callSignatures || emptyArray, constructSignatures || emptyArray, indexInfos || emptyArray);
+            setStructuredTypeMembers(type, emptySymbols, callSignatures ?? emptyArray, constructSignatures ?? emptyArray, indexInfos ?? emptyArray);
         }
 
         function appendSignatures(signatures: Signature[] | undefined, newSignatures: readonly Signature[]) {
@@ -11536,7 +11535,7 @@ namespace ts {
                     indexInfos = append(indexInfos, enumNumberIndexInfo);
                 }
             }
-            setStructuredTypeMembers(type, members, emptyArray, emptyArray, indexInfos || emptyArray);
+            setStructuredTypeMembers(type, members, emptyArray, emptyArray, indexInfos ?? emptyArray);
             // We resolve the members before computing the signatures because a signature may use
             // typeof with a qualified name expression that circularly references the type we are
             // in the process of resolving (see issue #6072). The temporarily empty signature list
@@ -11672,7 +11671,7 @@ namespace ts {
             else {
                 forEachType(getLowerBoundOfKeyType(constraintType), addMemberForKeyType);
             }
-            setStructuredTypeMembers(type, members, emptyArray, emptyArray, indexInfos || emptyArray);
+            setStructuredTypeMembers(type, members, emptyArray, emptyArray, indexInfos ?? emptyArray);
 
             function addMemberForKeyType(keyType: Type) {
                 const propNameType = nameType ? instantiateType(nameType, appendTypeMapping(type.mapper, typeParameter, keyType)) : keyType;
@@ -11751,26 +11750,24 @@ namespace ts {
         }
 
         function getTypeParameterFromMappedType(type: MappedType) {
-            return type.typeParameter ||
-                (type.typeParameter = getDeclaredTypeOfTypeParameter(getSymbolOfNode(type.declaration.typeParameter)));
+            return type.typeParameter ??= getDeclaredTypeOfTypeParameter(getSymbolOfNode(type.declaration.typeParameter));
         }
 
         function getConstraintTypeFromMappedType(type: MappedType) {
-            return type.constraintType ||
-                (type.constraintType = getConstraintOfTypeParameter(getTypeParameterFromMappedType(type)) || errorType);
+            return type.constraintType ??= getConstraintOfTypeParameter(getTypeParameterFromMappedType(type)) ?? errorType;
         }
 
         function getNameTypeFromMappedType(type: MappedType) {
             return type.declaration.nameType ?
-                type.nameType || (type.nameType = instantiateType(getTypeFromTypeNode(type.declaration.nameType), type.mapper)) :
+                type.nameType ??= instantiateType(getTypeFromTypeNode(type.declaration.nameType), type.mapper) :
                 undefined;
         }
 
         function getTemplateTypeFromMappedType(type: MappedType) {
-            return type.templateType ||
-                (type.templateType = type.declaration.type ?
+            return type.templateType ??=
+                    type.declaration.type ?
                     instantiateType(addOptionality(getTypeFromTypeNode(type.declaration.type), /*isProperty*/ true, !!(getMappedTypeModifiers(type) & MappedTypeModifiers.IncludeOptional)), type.mapper) :
-                    errorType);
+                    errorType;
         }
 
         function getConstraintDeclarationForMappedType(type: MappedType) {
@@ -12028,7 +12025,7 @@ namespace ts {
         }
 
         function getConstraintFromConditionalType(type: ConditionalType) {
-            return getConstraintOfDistributiveConditionalType(type) || getDefaultConstraintOfConditionalType(type);
+            return getConstraintOfDistributiveConditionalType(type) ?? getDefaultConstraintOfConditionalType(type);
         }
 
         function getConstraintOfConditionalType(type: ConditionalType) {
@@ -12087,7 +12084,7 @@ namespace ts {
          * It also doesn't map indexes to `string`, as where this is used this would be unneeded (and likely undesirable)
          */
         function getBaseConstraintOrType(type: Type) {
-            return getBaseConstraintOfType(type) || type;
+            return getBaseConstraintOfType(type) ?? type;
         }
 
         function hasNonCircularBaseConstraint(type: InstantiableType): boolean {
@@ -12136,7 +12133,7 @@ namespace ts {
                         }
                         result = circularConstraintType;
                     }
-                    t.immediateBaseConstraint = result || noConstraintType;
+                    t.immediateBaseConstraint = result ?? noConstraintType;
                 }
                 return t.immediateBaseConstraint;
             }
@@ -12262,7 +12259,7 @@ namespace ts {
         }
 
         function getApparentTypeOfMappedType(type: MappedType) {
-            return type.resolvedApparentType || (type.resolvedApparentType = getResolvedApparentTypeOfMappedType(type));
+            return type.resolvedApparentType ??= getResolvedApparentTypeOfMappedType(type);
         }
 
         function getResolvedApparentTypeOfMappedType(type: MappedType) {
@@ -12289,7 +12286,7 @@ namespace ts {
          * type itself.
          */
         function getApparentType(type: Type): Type {
-            const t = !(type.flags & TypeFlags.Instantiable) ? type : getBaseConstraintOfType(type) || unknownType;
+            const t = !(type.flags & TypeFlags.Instantiable) ? type : getBaseConstraintOfType(type) ?? unknownType;
             return getObjectFlags(t) & ObjectFlags.Mapped ? getApparentTypeOfMappedType(t as MappedType) :
                 t.flags & TypeFlags.Intersection ? getApparentTypeOfIntersectionType(t as IntersectionType) :
                 t.flags & TypeFlags.StringLike ? globalStringType :
@@ -12376,7 +12373,7 @@ namespace ts {
                         const indexInfo = !isLateBoundName(name) && getApplicableIndexInfoForName(type, name);
                         if (indexInfo) {
                             checkFlags |= CheckFlags.WritePartial | (indexInfo.isReadonly ? CheckFlags.Readonly : 0);
-                            indexTypes = append(indexTypes, isTupleType(type) ? getRestTypeOfTupleType(type) || undefinedType : indexInfo.type);
+                            indexTypes = append(indexTypes, isTupleType(type) ? getRestTypeOfTupleType(type) ?? undefinedType : indexInfo.type);
                         }
                         else if (isObjectLiteralType(type) && !(getObjectFlags(type) & ObjectFlags.ContainsSpread)) {
                             checkFlags |= CheckFlags.WritePartial;
@@ -12486,8 +12483,8 @@ namespace ts {
                 property = createUnionOrIntersectionProperty(type, name, skipObjectFunctionPropertyAugment);
                 if (property) {
                     const properties = skipObjectFunctionPropertyAugment ?
-                        type.propertyCacheWithoutObjectFunctionPropertyAugment ||= createSymbolTable() :
-                        type.propertyCache ||= createSymbolTable();
+                        type.propertyCacheWithoutObjectFunctionPropertyAugment ??= createSymbolTable() :
+                        type.propertyCache ??= createSymbolTable();
                     properties.set(name, property);
                 }
             }
@@ -12508,7 +12505,7 @@ namespace ts {
          */
         function getReducedType(type: Type): Type {
             if (type.flags & TypeFlags.Union && (type as UnionType).objectFlags & ObjectFlags.ContainsIntersections) {
-                return (type as UnionType).resolvedReducedType || ((type as UnionType).resolvedReducedType = getReducedUnionType(type as UnionType));
+                return (type as UnionType).resolvedReducedType ??= getReducedUnionType(type as UnionType);
             }
             else if (type.flags & TypeFlags.Intersection) {
                 if (!((type as IntersectionType).objectFlags & ObjectFlags.IsNeverIntersectionComputed)) {
@@ -12634,7 +12631,7 @@ namespace ts {
                         applicableInfo = info;
                     }
                     else {
-                        (applicableInfos || (applicableInfos = [applicableInfo])).push(info);
+                        (applicableInfos ??= [applicableInfo]).push(info);
                     }
                 }
             }
@@ -13043,7 +13040,7 @@ namespace ts {
                     signature.resolvedTypePredicate = targetTypePredicate ? instantiateTypePredicate(targetTypePredicate, signature.mapper!) : noTypePredicate;
                 }
                 else if (signature.compositeSignatures) {
-                    signature.resolvedTypePredicate = getUnionOrIntersectionTypePredicate(signature.compositeSignatures, signature.compositeKind) || noTypePredicate;
+                    signature.resolvedTypePredicate = getUnionOrIntersectionTypePredicate(signature.compositeSignatures, signature.compositeKind) ?? noTypePredicate;
                 }
                 else {
                     const type = signature.declaration && getEffectiveReturnTypeNode(signature.declaration);
@@ -13056,7 +13053,7 @@ namespace ts {
                     }
                     signature.resolvedTypePredicate = type && isTypePredicateNode(type) ?
                         createTypePredicateFromTypePredicateNode(type, signature) :
-                        jsdocPredicate || noTypePredicate;
+                        jsdocPredicate ?? noTypePredicate;
                 }
                 Debug.assert(!!signature.resolvedTypePredicate);
             }
@@ -13083,7 +13080,7 @@ namespace ts {
                 }
                 let type = signature.target ? instantiateType(getReturnTypeOfSignature(signature.target), signature.mapper) :
                     signature.compositeSignatures ? instantiateType(getUnionOrIntersectionType(map(signature.compositeSignatures, getReturnTypeOfSignature), signature.compositeKind, UnionReduction.Subtype), signature.mapper) :
-                    getReturnTypeFromAnnotation(signature.declaration!) ||
+                    getReturnTypeFromAnnotation(signature.declaration!) ??
                     (nodeIsMissing((signature.declaration as FunctionLikeDeclaration).body) ? anyType : getReturnTypeFromBody(signature.declaration as FunctionLikeDeclaration));
                 if (signature.flags & SignatureFlags.IsInnerCallChain) {
                     type = addOptionalTypeMarker(type);
@@ -13145,7 +13142,7 @@ namespace ts {
         }
 
         function getRestTypeOfSignature(signature: Signature): Type {
-            return tryGetRestTypeOfSignature(signature) || anyType;
+            return tryGetRestTypeOfSignature(signature) ?? anyType;
         }
 
         function tryGetRestTypeOfSignature(signature: Signature): Type | undefined {
@@ -13173,7 +13170,7 @@ namespace ts {
         }
 
         function getSignatureInstantiationWithoutFillingInTypeArguments(signature: Signature, typeArguments: readonly Type[] | undefined): Signature {
-            const instantiations = signature.instantiations || (signature.instantiations = new Map<string, Signature>());
+            const instantiations = signature.instantiations ??= new Map<string, Signature>();
             const id = getTypeListId(typeArguments);
             let instantiation = instantiations.get(id);
             if (!instantiation) {
@@ -13192,7 +13189,7 @@ namespace ts {
 
         function getErasedSignature(signature: Signature): Signature {
             return signature.typeParameters ?
-                signature.erasedSignatureCache || (signature.erasedSignatureCache = createErasedSignature(signature)) :
+                signature.erasedSignatureCache ??= createErasedSignature(signature) :
                 signature;
         }
 
@@ -13203,7 +13200,7 @@ namespace ts {
 
         function getCanonicalSignature(signature: Signature): Signature {
             return signature.typeParameters ?
-                signature.canonicalSignatureCache || (signature.canonicalSignatureCache = createCanonicalSignature(signature)) :
+                signature.canonicalSignatureCache ??= createCanonicalSignature(signature) :
                 signature;
         }
 
@@ -13227,7 +13224,7 @@ namespace ts {
                     return signature.baseSignatureCache;
                 }
                 const typeEraser = createTypeEraser(typeParameters);
-                const baseConstraintMapper = createTypeMapper(typeParameters, map(typeParameters, tp => getConstraintOfTypeParameter(tp) || unknownType));
+                const baseConstraintMapper = createTypeMapper(typeParameters, map(typeParameters, tp => getConstraintOfTypeParameter(tp) ?? unknownType));
                 let baseConstraints: readonly Type[] = map(typeParameters, tp => instantiateType(tp, baseConstraintMapper) || unknownType);
                 // Run N type params thru the immediate constraint mapper up to N times
                 // This way any noncircular interdependent type parameters are definitely resolved to their external dependencies
@@ -13390,7 +13387,7 @@ namespace ts {
                 else {
                     const constraintDeclaration = getConstraintDeclaration(typeParameter);
                     if (!constraintDeclaration) {
-                        typeParameter.constraint = getInferredTypeParameterConstraint(typeParameter) || noConstraintType;
+                        typeParameter.constraint = getInferredTypeParameterConstraint(typeParameter) ?? noConstraintType;
                     }
                     else {
                         let type = getTypeFromTypeNode(constraintDeclaration);
@@ -13494,7 +13491,7 @@ namespace ts {
         function getTypeArguments(type: TypeReference): readonly Type[] {
             if (!type.resolvedTypeArguments) {
                 if (!pushTypeResolution(type, TypeSystemPropertyName.ResolvedTypeArguments)) {
-                    return type.target.localTypeParameters?.map(() => errorType) || emptyArray;
+                    return type.target.localTypeParameters?.map(() => errorType) ?? emptyArray;
                 }
                 const node = type.node;
                 const typeArguments = !node ? emptyArray :
@@ -13505,9 +13502,9 @@ namespace ts {
                     type.resolvedTypeArguments = type.mapper ? instantiateTypes(typeArguments, type.mapper) : typeArguments;
                 }
                 else {
-                    type.resolvedTypeArguments = type.target.localTypeParameters?.map(() => errorType) || emptyArray;
+                    type.resolvedTypeArguments = type.target.localTypeParameters?.map(() => errorType) ?? emptyArray;
                     error(
-                        type.node || currentNode,
+                        type.node ?? currentNode,
                         type.target.symbol ? Diagnostics.Type_arguments_for_0_circularly_reference_themselves : Diagnostics.Tuple_type_arguments_circularly_reference_themselves,
                         type.target.symbol && symbolToString(type.target.symbol)
                     );
@@ -13683,7 +13680,7 @@ namespace ts {
             if (symbol === unknownSymbol) {
                 return errorType;
             }
-            symbol = getExpandoSymbol(symbol) || symbol;
+            symbol = getExpandoSymbol(symbol) ?? symbol;
             if (symbol.flags & (SymbolFlags.Class | SymbolFlags.Interface)) {
                 return getTypeFromClassOrInterfaceReference(node, symbol);
             }
@@ -13979,17 +13976,17 @@ namespace ts {
 
         function getGlobalTypedPropertyDescriptorType() {
             // We always report an error, so store a result in the event we could not resolve the symbol to prevent reporting it multiple times
-            return deferredGlobalTypedPropertyDescriptorType ||= getGlobalType("TypedPropertyDescriptor" as __String, /*arity*/ 1, /*reportErrors*/ true) || emptyGenericType;
+            return deferredGlobalTypedPropertyDescriptorType ??= getGlobalType("TypedPropertyDescriptor" as __String, /*arity*/ 1, /*reportErrors*/ true) || emptyGenericType;
         }
 
         function getGlobalTemplateStringsArrayType() {
             // We always report an error, so store a result in the event we could not resolve the symbol to prevent reporting it multiple times
-            return deferredGlobalTemplateStringsArrayType ||= getGlobalType("TemplateStringsArray" as __String, /*arity*/ 0, /*reportErrors*/ true) || emptyObjectType;
+            return deferredGlobalTemplateStringsArrayType ??= getGlobalType("TemplateStringsArray" as __String, /*arity*/ 0, /*reportErrors*/ true) || emptyObjectType;
         }
 
         function getGlobalImportMetaType() {
             // We always report an error, so store a result in the event we could not resolve the symbol to prevent reporting it multiple times
-            return deferredGlobalImportMetaType ||= getGlobalType("ImportMeta" as __String, /*arity*/ 0, /*reportErrors*/ true) || emptyObjectType;
+            return deferredGlobalImportMetaType ??= getGlobalType("ImportMeta" as __String, /*arity*/ 0, /*reportErrors*/ true) || emptyObjectType;
         }
 
         function getGlobalImportMetaExpressionType() {
@@ -14011,75 +14008,75 @@ namespace ts {
         }
 
         function getGlobalImportCallOptionsType(reportErrors: boolean) {
-            return (deferredGlobalImportCallOptionsType ||= getGlobalType("ImportCallOptions" as __String, /*arity*/ 0, reportErrors)) || emptyObjectType;
+            return (deferredGlobalImportCallOptionsType ??= getGlobalType("ImportCallOptions" as __String, /*arity*/ 0, reportErrors)) ?? emptyObjectType;
         }
 
         function getGlobalESSymbolConstructorSymbol(reportErrors: boolean): Symbol | undefined {
-            return deferredGlobalESSymbolConstructorSymbol ||= getGlobalValueSymbol("Symbol" as __String, reportErrors);
+            return deferredGlobalESSymbolConstructorSymbol ??= getGlobalValueSymbol("Symbol" as __String, reportErrors);
         }
 
         function getGlobalESSymbolConstructorTypeSymbol(reportErrors: boolean): Symbol | undefined {
-            return deferredGlobalESSymbolConstructorTypeSymbol ||= getGlobalTypeSymbol("SymbolConstructor" as __String, reportErrors);
+            return deferredGlobalESSymbolConstructorTypeSymbol ??= getGlobalTypeSymbol("SymbolConstructor" as __String, reportErrors);
         }
 
         function getGlobalESSymbolType() {
-            return (deferredGlobalESSymbolType ||= getGlobalType("Symbol" as __String, /*arity*/ 0, /*reportErrors*/ false)) || emptyObjectType;
+            return (deferredGlobalESSymbolType ??= getGlobalType("Symbol" as __String, /*arity*/ 0, /*reportErrors*/ false)) ?? emptyObjectType;
         }
 
         function getGlobalPromiseType(reportErrors: boolean) {
-            return (deferredGlobalPromiseType ||= getGlobalType("Promise" as __String, /*arity*/ 1, reportErrors)) || emptyGenericType;
+            return (deferredGlobalPromiseType ??= getGlobalType("Promise" as __String, /*arity*/ 1, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalPromiseLikeType(reportErrors: boolean) {
-            return (deferredGlobalPromiseLikeType ||= getGlobalType("PromiseLike" as __String, /*arity*/ 1, reportErrors)) || emptyGenericType;
+            return (deferredGlobalPromiseLikeType ??= getGlobalType("PromiseLike" as __String, /*arity*/ 1, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalPromiseConstructorSymbol(reportErrors: boolean): Symbol | undefined {
-            return deferredGlobalPromiseConstructorSymbol ||= getGlobalValueSymbol("Promise" as __String, reportErrors);
+            return deferredGlobalPromiseConstructorSymbol ??= getGlobalValueSymbol("Promise" as __String, reportErrors);
         }
 
         function getGlobalPromiseConstructorLikeType(reportErrors: boolean) {
-            return (deferredGlobalPromiseConstructorLikeType ||= getGlobalType("PromiseConstructorLike" as __String, /*arity*/ 0, reportErrors)) || emptyObjectType;
+            return (deferredGlobalPromiseConstructorLikeType ??= getGlobalType("PromiseConstructorLike" as __String, /*arity*/ 0, reportErrors)) ?? emptyObjectType;
         }
 
         function getGlobalAsyncIterableType(reportErrors: boolean) {
-            return (deferredGlobalAsyncIterableType ||= getGlobalType("AsyncIterable" as __String, /*arity*/ 1, reportErrors)) || emptyGenericType;
+            return (deferredGlobalAsyncIterableType ??= getGlobalType("AsyncIterable" as __String, /*arity*/ 1, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalAsyncIteratorType(reportErrors: boolean) {
-            return (deferredGlobalAsyncIteratorType ||= getGlobalType("AsyncIterator" as __String, /*arity*/ 3, reportErrors)) || emptyGenericType;
+            return (deferredGlobalAsyncIteratorType ??= getGlobalType("AsyncIterator" as __String, /*arity*/ 3, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalAsyncIterableIteratorType(reportErrors: boolean) {
-            return (deferredGlobalAsyncIterableIteratorType ||= getGlobalType("AsyncIterableIterator" as __String, /*arity*/ 1, reportErrors)) || emptyGenericType;
+            return (deferredGlobalAsyncIterableIteratorType ??= getGlobalType("AsyncIterableIterator" as __String, /*arity*/ 1, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalAsyncGeneratorType(reportErrors: boolean) {
-            return (deferredGlobalAsyncGeneratorType ||= getGlobalType("AsyncGenerator" as __String, /*arity*/ 3, reportErrors)) || emptyGenericType;
+            return (deferredGlobalAsyncGeneratorType ??= getGlobalType("AsyncGenerator" as __String, /*arity*/ 3, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalIterableType(reportErrors: boolean) {
-            return (deferredGlobalIterableType ||= getGlobalType("Iterable" as __String, /*arity*/ 1, reportErrors)) || emptyGenericType;
+            return (deferredGlobalIterableType ??= getGlobalType("Iterable" as __String, /*arity*/ 1, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalIteratorType(reportErrors: boolean) {
-            return (deferredGlobalIteratorType ||= getGlobalType("Iterator" as __String, /*arity*/ 3, reportErrors)) || emptyGenericType;
+            return (deferredGlobalIteratorType ??= getGlobalType("Iterator" as __String, /*arity*/ 3, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalIterableIteratorType(reportErrors: boolean) {
-            return (deferredGlobalIterableIteratorType ||= getGlobalType("IterableIterator" as __String, /*arity*/ 1, reportErrors)) || emptyGenericType;
+            return (deferredGlobalIterableIteratorType ??= getGlobalType("IterableIterator" as __String, /*arity*/ 1, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalGeneratorType(reportErrors: boolean) {
-            return (deferredGlobalGeneratorType ||= getGlobalType("Generator" as __String, /*arity*/ 3, reportErrors)) || emptyGenericType;
+            return (deferredGlobalGeneratorType ??= getGlobalType("Generator" as __String, /*arity*/ 3, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalIteratorYieldResultType(reportErrors: boolean) {
-            return (deferredGlobalIteratorYieldResultType ||= getGlobalType("IteratorYieldResult" as __String, /*arity*/ 1, reportErrors)) || emptyGenericType;
+            return (deferredGlobalIteratorYieldResultType ??= getGlobalType("IteratorYieldResult" as __String, /*arity*/ 1, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalIteratorReturnResultType(reportErrors: boolean) {
-            return (deferredGlobalIteratorReturnResultType ||= getGlobalType("IteratorReturnResult" as __String, /*arity*/ 1, reportErrors)) || emptyGenericType;
+            return (deferredGlobalIteratorReturnResultType ??= getGlobalType("IteratorReturnResult" as __String, /*arity*/ 1, reportErrors)) ?? emptyGenericType;
         }
 
         function getGlobalTypeOrUndefined(name: __String, arity = 0): ObjectType | undefined {
@@ -14089,24 +14086,24 @@ namespace ts {
 
         function getGlobalExtractSymbol(): Symbol | undefined {
             // We always report an error, so cache a result in the event we could not resolve the symbol to prevent reporting it multiple times
-            deferredGlobalExtractSymbol ||= getGlobalTypeAliasSymbol("Extract" as __String, /*arity*/ 2, /*reportErrors*/ true) || unknownSymbol;
+            deferredGlobalExtractSymbol ??= getGlobalTypeAliasSymbol("Extract" as __String, /*arity*/ 2, /*reportErrors*/ true) ?? unknownSymbol;
             return deferredGlobalExtractSymbol === unknownSymbol ? undefined : deferredGlobalExtractSymbol;
         }
 
         function getGlobalOmitSymbol(): Symbol | undefined {
             // We always report an error, so cache a result in the event we could not resolve the symbol to prevent reporting it multiple times
-            deferredGlobalOmitSymbol ||= getGlobalTypeAliasSymbol("Omit" as __String, /*arity*/ 2, /*reportErrors*/ true) || unknownSymbol;
+            deferredGlobalOmitSymbol ??= getGlobalTypeAliasSymbol("Omit" as __String, /*arity*/ 2, /*reportErrors*/ true) ?? unknownSymbol;
             return deferredGlobalOmitSymbol === unknownSymbol ? undefined : deferredGlobalOmitSymbol;
         }
 
         function getGlobalAwaitedSymbol(reportErrors: boolean): Symbol | undefined {
             // Only cache `unknownSymbol` if we are reporting errors so that we don't report the error more than once.
-            deferredGlobalAwaitedSymbol ||= getGlobalTypeAliasSymbol("Awaited" as __String, /*arity*/ 1, reportErrors) || (reportErrors ? unknownSymbol : undefined);
+            deferredGlobalAwaitedSymbol ??= getGlobalTypeAliasSymbol("Awaited" as __String, /*arity*/ 1, reportErrors) ?? (reportErrors ? unknownSymbol : undefined);
             return deferredGlobalAwaitedSymbol === unknownSymbol ? undefined : deferredGlobalAwaitedSymbol;
         }
 
         function getGlobalBigIntType() {
-            return (deferredGlobalBigIntType ||= getGlobalType("BigInt" as __String, /*arity*/ 0, /*reportErrors*/ false)) || emptyObjectType;
+            return deferredGlobalBigIntType ??= getGlobalType("BigInt" as __String, /*arity*/ 0, /*reportErrors*/ false) ?? emptyObjectType;
         }
 
         /**
@@ -14246,7 +14243,7 @@ namespace ts {
         }
 
         function createTupleType(elementTypes: readonly Type[], elementFlags?: readonly ElementFlags[], readonly = false, namedMemberDeclarations?: readonly (NamedTupleMember | ParameterDeclaration)[]) {
-            const tupleTarget = getTupleTargetType(elementFlags || map(elementTypes, _ => ElementFlags.Required), readonly, namedMemberDeclarations);
+            const tupleTarget = getTupleTargetType(elementFlags ?? map(elementTypes, _ => ElementFlags.Required), readonly, namedMemberDeclarations);
             return tupleTarget === emptyGenericType ? emptyObjectType :
                 elementTypes.length ? createNormalizedTypeReference(tupleTarget, elementTypes) :
                 tupleTarget;
@@ -14430,7 +14427,7 @@ namespace ts {
         function sliceTupleType(type: TupleTypeReference, index: number, endSkipCount = 0) {
             const target = type.target;
             const endIndex = getTypeReferenceArity(type) - endSkipCount;
-            return index > target.fixedLength ? getRestArrayTypeOfTupleType(type) || createTupleType(emptyArray) :
+            return index > target.fixedLength ? getRestArrayTypeOfTupleType(type) ?? createTupleType(emptyArray) :
                 createTupleType(getTypeArguments(type).slice(index, endIndex), target.elementFlags.slice(index, endIndex),
                     /*readonly*/ false, target.labeledElementDeclarations && target.labeledElementDeclarations.slice(index, endIndex));
         }
@@ -14907,7 +14904,7 @@ namespace ts {
             while (i < types.length) {
                 const t = types[i];
                 if (getObjectFlags(t) & ObjectFlags.PrimitiveUnion) {
-                    (unionTypes || (unionTypes = [types[index] as UnionType])).push(t as UnionType);
+                    (unionTypes ??= [types[index] as UnionType]).push(t as UnionType);
                     orderedRemoveItemAt(types, i);
                 }
                 else {
@@ -15119,8 +15116,8 @@ namespace ts {
 
         function getIndexTypeForGenericType(type: InstantiableType | UnionOrIntersectionType, stringsOnly: boolean) {
             return stringsOnly ?
-                type.resolvedStringIndexType || (type.resolvedStringIndexType = createIndexType(type, /*stringsOnly*/ true)) :
-                type.resolvedIndexType || (type.resolvedIndexType = createIndexType(type, /*stringsOnly*/ false));
+                type.resolvedStringIndexType ??= createIndexType(type, /*stringsOnly*/ true) :
+                type.resolvedIndexType ??= createIndexType(type, /*stringsOnly*/ false);
         }
 
         /**
@@ -15184,7 +15181,7 @@ namespace ts {
         // they're the same type regardless of what's being distributed over.
         function hasDistributiveNameType(mappedType: MappedType) {
             const typeVariable = getTypeParameterFromMappedType(mappedType);
-            return isDistributive(getNameTypeFromMappedType(mappedType) || typeVariable);
+            return isDistributive(getNameTypeFromMappedType(mappedType) ?? typeVariable);
             function isDistributive(type: Type): boolean {
                 return type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Primitive | TypeFlags.Never | TypeFlags.TypeParameter | TypeFlags.Object | TypeFlags.NonPrimitive) ? true :
                     type.flags & TypeFlags.Conditional ? (type as ConditionalType).root.isDistributive && (type as ConditionalType).checkType === typeVariable :
@@ -15479,7 +15476,7 @@ namespace ts {
 
         function isUncalledFunctionReference(node: Node, symbol: Symbol) {
             if (symbol.flags & (SymbolFlags.Function | SymbolFlags.Method)) {
-                const parent = findAncestor(node.parent, n => !isAccessExpression(n)) || node.parent;
+                const parent = findAncestor(node.parent, n => !isAccessExpression(n)) ?? node.parent;
                 if (isCallLikeExpression(parent)) {
                     return isCallOrNewExpression(parent) && isIdentifier(node) && hasMatchingArgument(parent, node);
                 }
@@ -15494,7 +15491,7 @@ namespace ts {
 
             if (propName !== undefined) {
                 if (accessFlags & AccessFlags.Contextual) {
-                    return getTypeOfPropertyOfContextualType(objectType, propName) || anyType;
+                    return getTypeOfPropertyOfContextualType(objectType, propName) ?? anyType;
                 }
                 const prop = getPropertyOfType(objectType, propName);
                 if (prop) {
@@ -15533,7 +15530,7 @@ namespace ts {
                     }
                     errorIfWritingToReadonlyIndex(getIndexInfoOfType(objectType, numberType));
                     return mapType(objectType, t => {
-                        const restType = getRestTypeOfTupleType(t as TupleTypeReference) || undefinedType;
+                        const restType = getRestTypeOfTupleType(t as TupleTypeReference) ?? undefinedType;
                         return accessFlags & AccessFlags.IncludeUndefined ? getUnionType([restType, undefinedType]) : restType;
                     });
                 }
@@ -15544,7 +15541,7 @@ namespace ts {
                 }
                 // If no index signature is applicable, we default to the string index signature. In effect, this means the string
                 // index signature applies even when accessing with a symbol-like type.
-                const indexInfo = getApplicableIndexInfo(objectType, indexType) || getIndexInfoOfType(objectType, stringType);
+                const indexInfo = getApplicableIndexInfo(objectType, indexType) ?? getIndexInfoOfType(objectType, stringType);
                 if (indexInfo) {
                     if (accessFlags & AccessFlags.NoIndexSignatures && indexInfo.keyType !== numberType) {
                         if (accessExpression) {
@@ -15824,7 +15821,7 @@ namespace ts {
         }
 
         function getIndexedAccessType(objectType: Type, indexType: Type, accessFlags = AccessFlags.None, accessNode?: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression, aliasSymbol?: Symbol, aliasTypeArguments?: readonly Type[]): Type {
-            return getIndexedAccessTypeOrUndefined(objectType, indexType, accessFlags, accessNode, aliasSymbol, aliasTypeArguments) || (accessNode ? errorType : unknownType);
+            return getIndexedAccessTypeOrUndefined(objectType, indexType, accessFlags, accessNode, aliasSymbol, aliasTypeArguments) ?? (accessNode ? errorType : unknownType);
         }
 
         function indexTypeLessThan(indexType: Type, limit: number) {
@@ -16052,7 +16049,7 @@ namespace ts {
                     if (!(inferredExtendsType.flags & TypeFlags.AnyOrUnknown) && ((checkType.flags & TypeFlags.Any && !isUnwrapped) || !isTypeAssignableTo(getPermissiveInstantiation(checkType), getPermissiveInstantiation(inferredExtendsType)))) {
                         // Return union of trueType and falseType for 'any' since it matches anything
                         if (checkType.flags & TypeFlags.Any && !isUnwrapped) {
-                            (extraTypes || (extraTypes = [])).push(instantiateType(getTypeFromTypeNode(root.node.trueType), combinedMapper || mapper));
+                            (extraTypes ??= []).push(instantiateType(getTypeFromTypeNode(root.node.trueType), combinedMapper ?? mapper));
                         }
                         // If falseType is an immediately nested conditional type that isn't distributive or has an
                         // identical checkType, switch to that type and loop.
@@ -16077,7 +16074,7 @@ namespace ts {
                     // doesn't immediately resolve to 'string' instead of being deferred.
                     if (inferredExtendsType.flags & TypeFlags.AnyOrUnknown || isTypeAssignableTo(getRestrictiveInstantiation(checkType), getRestrictiveInstantiation(inferredExtendsType))) {
                         const trueType = getTypeFromTypeNode(root.node.trueType);
-                        const trueMapper = combinedMapper || mapper;
+                        const trueMapper = combinedMapper ?? mapper;
                         if (canTailRecurse(trueType, trueMapper)) {
                             continue;
                         }
@@ -16092,7 +16089,7 @@ namespace ts {
                 result.extendsType = instantiateType(root.extendsType, mapper);
                 result.mapper = mapper;
                 result.combinedMapper = combinedMapper;
-                result.aliasSymbol = aliasSymbol || root.aliasSymbol;
+                result.aliasSymbol = aliasSymbol ?? root.aliasSymbol;
                 result.aliasTypeArguments = aliasSymbol ? aliasTypeArguments : instantiateTypes(root.aliasTypeArguments, mapper!); // TODO: GH#18217
                 break;
             }
@@ -16126,15 +16123,15 @@ namespace ts {
         }
 
         function getTrueTypeFromConditionalType(type: ConditionalType) {
-            return type.resolvedTrueType || (type.resolvedTrueType = instantiateType(getTypeFromTypeNode(type.root.node.trueType), type.mapper));
+            return type.resolvedTrueType ??= instantiateType(getTypeFromTypeNode(type.root.node.trueType), type.mapper);
         }
 
         function getFalseTypeFromConditionalType(type: ConditionalType) {
-            return type.resolvedFalseType || (type.resolvedFalseType = instantiateType(getTypeFromTypeNode(type.root.node.falseType), type.mapper));
+            return type.resolvedFalseType ??= instantiateType(getTypeFromTypeNode(type.root.node.falseType), type.mapper);
         }
 
         function getInferredTrueTypeFromConditionalType(type: ConditionalType) {
-            return type.resolvedInferredTrueType || (type.resolvedInferredTrueType = type.combinedMapper ? instantiateType(getTypeFromTypeNode(type.root.node.trueType), type.combinedMapper) : getTrueTypeFromConditionalType(type));
+            return type.resolvedInferredTrueType ?? type.combinedMapper ? instantiateType(getTypeFromTypeNode(type.root.node.trueType), type.combinedMapper) : getTrueTypeFromConditionalType(type);
         }
 
         function getInferTypeParameters(node: ConditionalTypeNode): TypeParameter[] | undefined {
@@ -16320,7 +16317,7 @@ namespace ts {
                 return type;
             }
             if (every((type as UnionType).types, isEmptyObjectTypeOrSpreadsIntoEmptyObject)) {
-                return find((type as UnionType).types, isEmptyObjectType) || emptyObjectType;
+                return find((type as UnionType).types, isEmptyObjectType) ?? emptyObjectType;
             }
             const firstType = find((type as UnionType).types, t => !isEmptyObjectTypeOrSpreadsIntoEmptyObject(t));
             if (!firstType) {
@@ -16478,7 +16475,7 @@ namespace ts {
             const type = createType(flags) as LiteralType;
             type.symbol = symbol!;
             type.value = value;
-            type.regularType = regularType || type;
+            type.regularType = regularType ?? type;
             return type;
         }
 
@@ -16496,7 +16493,7 @@ namespace ts {
 
         function getRegularTypeOfLiteralType(type: Type): Type {
             return type.flags & TypeFlags.Literal ? (type as LiteralType).regularType :
-                type.flags & TypeFlags.Union ? ((type as UnionType).regularType || ((type as UnionType).regularType = mapType(type, getRegularTypeOfLiteralType) as UnionType)) :
+                type.flags & TypeFlags.Union ? ((type as UnionType).regularType ??= mapType(type, getRegularTypeOfLiteralType) as UnionType) :
                 type;
         }
 
@@ -16506,20 +16503,20 @@ namespace ts {
 
         function getStringLiteralType(value: string): StringLiteralType {
             let type;
-            return stringLiteralTypes.get(value) ||
+            return stringLiteralTypes.get(value) ??
                 (stringLiteralTypes.set(value, type = createLiteralType(TypeFlags.StringLiteral, value) as StringLiteralType), type);
         }
 
         function getNumberLiteralType(value: number): NumberLiteralType {
             let type;
-            return numberLiteralTypes.get(value) ||
+            return numberLiteralTypes.get(value) ??
                 (numberLiteralTypes.set(value, type = createLiteralType(TypeFlags.NumberLiteral, value) as NumberLiteralType), type);
         }
 
         function getBigIntLiteralType(value: PseudoBigInt): BigIntLiteralType {
             let type;
             const key = pseudoBigIntToString(value);
-            return bigIntLiteralTypes.get(key) ||
+            return bigIntLiteralTypes.get(key) ??
                 (bigIntLiteralTypes.set(key, type = createLiteralType(TypeFlags.BigIntLiteral, value) as BigIntLiteralType), type);
         }
 
@@ -16528,7 +16525,7 @@ namespace ts {
             const qualifier = typeof value === "string" ? "@" : "#";
             const key = enumId + qualifier + value;
             const flags = TypeFlags.EnumLiteral | (typeof value === "string" ? TypeFlags.StringLiteral : TypeFlags.NumberLiteral);
-            return enumLiteralTypes.get(key) ||
+            return enumLiteralTypes.get(key) ??
                 (enumLiteralTypes.set(key, type = createLiteralType(flags, value, symbol)), type);
         }
 
@@ -16555,7 +16552,7 @@ namespace ts {
                 const symbol = isCommonJsExportPropertyAssignment(node) ? getSymbolOfNode((node as BinaryExpression).left) : getSymbolOfNode(node);
                 if (symbol) {
                     const links = getSymbolLinks(symbol);
-                    return links.uniqueESSymbolType || (links.uniqueESSymbolType = createUniqueESSymbolType(symbol));
+                    return links.uniqueESSymbolType ??= createUniqueESSymbolType(symbol);
                 }
             }
             return esSymbolType;
@@ -16598,7 +16595,7 @@ namespace ts {
         }
 
         function getTypeFromRestTypeNode(node: RestTypeNode | NamedTupleMember) {
-            return getTypeFromTypeNode(getArrayElementTypeNode(node.type) || node.type);
+            return getTypeFromTypeNode(getArrayElementTypeNode(node.type) ?? node.type);
         }
 
         function getArrayElementTypeNode(node: TypeNode): TypeNode | undefined {
@@ -16621,9 +16618,9 @@ namespace ts {
 
         function getTypeFromNamedTupleTypeNode(node: NamedTupleMember): Type {
             const links = getNodeLinks(node);
-            return links.resolvedType || (links.resolvedType =
+            return links.resolvedType ??=
                     node.dotDotDotToken ? getTypeFromRestTypeNode(node) :
-                    addOptionality(getTypeFromTypeNode(node.type), /*isProperty*/ true, !!node.questionToken));
+                    addOptionality(getTypeFromTypeNode(node.type), /*isProperty*/ true, !!node.questionToken);
         }
 
         function getTypeFromTypeNode(node: TypeNode): Type {
@@ -16837,7 +16834,7 @@ namespace ts {
         }
 
         function getRestrictiveTypeParameter(tp: TypeParameter) {
-            return tp.constraint === unknownType ? tp : tp.restrictiveInstantiation || (
+            return tp.constraint === unknownType ? tp : tp.restrictiveInstantiation ?? (
                 tp.restrictiveInstantiation = createTypeParameter(tp.symbol),
                 (tp.restrictiveInstantiation as TypeParameter).constraint = unknownType,
                 tp.restrictiveInstantiation
@@ -16929,7 +16926,7 @@ namespace ts {
                     const templateTagParameters = getTypeParametersFromDeclaration(declaration as DeclarationWithTypeParameters);
                     outerTypeParameters = addRange(outerTypeParameters, templateTagParameters);
                 }
-                typeParameters = outerTypeParameters || emptyArray;
+                typeParameters = outerTypeParameters ?? emptyArray;
                 const allDeclarations = type.objectFlags & (ObjectFlags.Reference | ObjectFlags.InstantiationExpressionType) ? [declaration] : type.symbol.declarations!;
                 typeParameters = (target.objectFlags & (ObjectFlags.Reference | ObjectFlags.InstantiationExpressionType) || target.symbol.flags & SymbolFlags.Method || target.symbol.flags & SymbolFlags.TypeLiteral) && !target.aliasTypeArguments ?
                     filter(typeParameters, tp => some(allDeclarations, d => isTypeParameterPossiblyReferenced(tp, d))) :
@@ -16942,7 +16939,7 @@ namespace ts {
                 // instantiation cache key from the type IDs of the type arguments.
                 const combinedMapper = combineTypeMappers(type.mapper, mapper);
                 const typeArguments = map(typeParameters, t => getMappedType(t, combinedMapper));
-                const newAliasSymbol = aliasSymbol || type.aliasSymbol;
+                const newAliasSymbol = aliasSymbol ?? type.aliasSymbol;
                 const newAliasTypeArguments = aliasSymbol ? aliasTypeArguments : instantiateTypes(type.aliasTypeArguments, mapper);
                 const id = getTypeListId(typeArguments) + getAliasId(newAliasSymbol, newAliasTypeArguments);
                 if (!target.instantiations) {
@@ -17117,7 +17114,7 @@ namespace ts {
             }
             result.target = type;
             result.mapper = mapper;
-            result.aliasSymbol = aliasSymbol || type.aliasSymbol;
+            result.aliasSymbol = aliasSymbol ?? type.aliasSymbol;
             result.aliasTypeArguments = aliasSymbol ? aliasTypeArguments : instantiateTypes(type.aliasTypeArguments, mapper);
             return result;
         }
@@ -17201,7 +17198,7 @@ namespace ts {
                 if (newTypes === types && aliasSymbol === type.aliasSymbol) {
                     return type;
                 }
-                const newAliasSymbol = aliasSymbol || type.aliasSymbol;
+                const newAliasSymbol = aliasSymbol ?? type.aliasSymbol;
                 const newAliasTypeArguments = aliasSymbol ? aliasTypeArguments : instantiateTypes(type.aliasTypeArguments, mapper);
                 return flags & TypeFlags.Intersection || origin && origin.flags & TypeFlags.Intersection ?
                     getIntersectionType(newTypes, newAliasSymbol, newAliasTypeArguments) :
@@ -17217,7 +17214,7 @@ namespace ts {
                 return getStringMappingType((type as StringMappingType).symbol, instantiateType((type as StringMappingType).type, mapper));
             }
             if (flags & TypeFlags.IndexedAccess) {
-                const newAliasSymbol = aliasSymbol || type.aliasSymbol;
+                const newAliasSymbol = aliasSymbol ?? type.aliasSymbol;
                 const newAliasTypeArguments = aliasSymbol ? aliasTypeArguments : instantiateTypes(type.aliasTypeArguments, mapper);
                 return getIndexedAccessType(instantiateType((type as IndexedAccessType).objectType, mapper), instantiateType((type as IndexedAccessType).indexType, mapper), (type as IndexedAccessType).accessFlags, /*accessNode*/ undefined, newAliasSymbol, newAliasTypeArguments);
             }
@@ -17262,12 +17259,12 @@ namespace ts {
 
         function getUniqueLiteralFilledInstantiation(type: Type) {
             return type.flags & (TypeFlags.Primitive | TypeFlags.AnyOrUnknown | TypeFlags.Never) ? type :
-                type.uniqueLiteralFilledInstantiation || (type.uniqueLiteralFilledInstantiation = instantiateType(type, uniqueLiteralMapper));
+                type.uniqueLiteralFilledInstantiation ??= instantiateType(type, uniqueLiteralMapper);
         }
 
         function getPermissiveInstantiation(type: Type) {
             return type.flags & (TypeFlags.Primitive | TypeFlags.AnyOrUnknown | TypeFlags.Never) ? type :
-                type.permissiveInstantiation || (type.permissiveInstantiation = instantiateType(type, permissiveMapper));
+                type.permissiveInstantiation ??= instantiateType(type, permissiveMapper);
         }
 
         function getRestrictiveInstantiation(type: Type) {
@@ -17403,7 +17400,7 @@ namespace ts {
         function isTypeDerivedFrom(source: Type, target: Type): boolean {
             return source.flags & TypeFlags.Union ? every((source as UnionType).types, t => isTypeDerivedFrom(t, target)) :
                 target.flags & TypeFlags.Union ? some((target as UnionType).types, t => isTypeDerivedFrom(source, t)) :
-                source.flags & TypeFlags.InstantiableNonPrimitive ? isTypeDerivedFrom(getBaseConstraintOfType(source) || unknownType, target) :
+                source.flags & TypeFlags.InstantiableNonPrimitive ? isTypeDerivedFrom(getBaseConstraintOfType(source) ?? unknownType, target) :
                 target === globalObjectType ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) :
                 target === globalFunctionType ? !!(source.flags & TypeFlags.Object) && isFunctionObjectType(source as ObjectType) :
                 hasBaseType(source, getTargetType(target)) || (isArrayType(target) && !isReadonlyArrayType(target) && isTypeDerivedFrom(source, globalReadonlyArrayType));
@@ -17513,7 +17510,7 @@ namespace ts {
                     const returnType = getReturnTypeOfSignature(s);
                     return !(returnType.flags & (TypeFlags.Any | TypeFlags.Never)) && checkTypeRelatedTo(returnType, target, relation, /*errorNode*/ undefined);
                 })) {
-                    const resultObj: { errors?: Diagnostic[] } = errorOutputContainer || {};
+                    const resultObj: { errors?: Diagnostic[] } = errorOutputContainer ?? {};
                     checkTypeAssignableTo(source, target, node, headMessage, containingMessageChain, resultObj);
                     const diagnostic = resultObj.errors![resultObj.errors!.length - 1];
                     addRelatedInfo(diagnostic, createDiagnosticForNode(
@@ -17558,7 +17555,7 @@ namespace ts {
                 if (elaborated) {
                     return elaborated;
                 }
-                const resultObj: { errors?: Diagnostic[] } = errorOutputContainer || {};
+                const resultObj: { errors?: Diagnostic[] } = errorOutputContainer ?? {};
                 checkTypeRelatedTo(sourceReturn, targetReturn, relation, returnExpression, /*message*/ undefined, containingMessageChain, resultObj);
                 if (resultObj.errors) {
                     if (target.symbol && length(target.symbol.declarations)) {
@@ -17635,7 +17632,7 @@ namespace ts {
                     reportedError = true;
                     if (!elaborated) {
                         // Issue error on the prop itself, since the prop couldn't elaborate the error
-                        const resultObj: { errors?: Diagnostic[] } = errorOutputContainer || {};
+                        const resultObj: { errors?: Diagnostic[] } = errorOutputContainer ?? {};
                         // Use the expression type, if available
                         const specificSource = next ? checkExpressionForMutableLocationWithContextualType(next, sourcePropType) : sourcePropType;
                         if (exactOptionalPropertyTypes && isExactOptionalPropertyMismatch(specificSource, targetPropType)) {
@@ -17644,8 +17641,8 @@ namespace ts {
                             resultObj.errors = [diag];
                         }
                         else {
-                            const targetIsOptional = !!(propName && (getPropertyOfType(target, propName) || unknownSymbol).flags & SymbolFlags.Optional);
-                            const sourceIsOptional = !!(propName && (getPropertyOfType(source, propName) || unknownSymbol).flags & SymbolFlags.Optional);
+                            const targetIsOptional = !!(propName && (getPropertyOfType(target, propName) ?? unknownSymbol).flags & SymbolFlags.Optional);
+                            const sourceIsOptional = !!(propName && (getPropertyOfType(source, propName) ?? unknownSymbol).flags & SymbolFlags.Optional);
                             targetPropType = removeMissingType(targetPropType, targetIsOptional);
                             sourcePropType = removeMissingType(sourcePropType, targetIsOptional && sourceIsOptional);
                             const result = checkTypeRelatedTo(specificSource, targetPropType, relation, prop, errorMessage, containingMessageChain, resultObj);
@@ -17770,7 +17767,7 @@ namespace ts {
                             typeToString(childrenTargetType)
                         );
                         if (errorOutputContainer && errorOutputContainer.skipLogging) {
-                            (errorOutputContainer.errors || (errorOutputContainer.errors = [])).push(diag);
+                            (errorOutputContainer.errors ??= []).push(diag);
                         }
                     }
                 }
@@ -17799,7 +17796,7 @@ namespace ts {
                             typeToString(childrenTargetType)
                         );
                         if (errorOutputContainer && errorOutputContainer.skipLogging) {
-                            (errorOutputContainer.errors || (errorOutputContainer.errors = [])).push(diag);
+                            (errorOutputContainer.errors ??= []).push(diag);
                         }
                     }
                 }
@@ -17959,7 +17956,7 @@ namespace ts {
             const sourceRestType = getNonArrayRestType(source);
             const targetRestType = getNonArrayRestType(target);
             if (sourceRestType || targetRestType) {
-                void instantiateType(sourceRestType || targetRestType, reportUnreliableMarkers);
+                void instantiateType(sourceRestType ?? targetRestType, reportUnreliableMarkers);
             }
 
             const kind = target.declaration ? target.declaration.kind : SyntaxKind.Unknown;
@@ -18273,7 +18270,7 @@ namespace ts {
         function getNormalizedType(type: Type, writing: boolean): Type {
             while (true) {
                 const t = isFreshLiteralType(type) ? (type as FreshableType).regularType :
-                    getObjectFlags(type) & ObjectFlags.Reference ? (type as TypeReference).node ? createTypeReference((type as TypeReference).target, getTypeArguments(type as TypeReference)) : getSingleBaseForNonAugmentingSubtype(type) || type :
+                    getObjectFlags(type) & ObjectFlags.Reference ? (type as TypeReference).node ? createTypeReference((type as TypeReference).target, getTypeArguments(type as TypeReference)) : getSingleBaseForNonAugmentingSubtype(type) ?? type :
                     type.flags & TypeFlags.UnionOrIntersection ? getNormalizedUnionOrIntersectionType(type as UnionOrIntersectionType, writing) :
                     type.flags & TypeFlags.Substitution ? writing ? (type as SubstitutionType).baseType : (type as SubstitutionType).substitute :
                     type.flags & TypeFlags.Simplifiable ? getSimplifiedType(type, writing) :
@@ -18341,9 +18338,9 @@ namespace ts {
             }
             if (overflow) {
                 tracing?.instant(tracing.Phase.CheckTypes, "checkTypeRelatedTo_DepthLimit", { sourceId: source.id, targetId: target.id, depth: sourceDepth, targetDepth });
-                const diag = error(errorNode || currentNode, Diagnostics.Excessive_stack_depth_comparing_types_0_and_1, typeToString(source), typeToString(target));
+                const diag = error(errorNode ?? currentNode, Diagnostics.Excessive_stack_depth_comparing_types_0_and_1, typeToString(source), typeToString(target));
                 if (errorOutputContainer) {
-                    (errorOutputContainer.errors || (errorOutputContainer.errors = [])).push(diag);
+                    (errorOutputContainer.errors ??= []).push(diag);
                 }
             }
             else if (errorInfo) {
@@ -18373,7 +18370,7 @@ namespace ts {
                     addRelatedInfo(diag, ...relatedInfo);
                 }
                 if (errorOutputContainer) {
-                    (errorOutputContainer.errors || (errorOutputContainer.errors = [])).push(diag);
+                    (errorOutputContainer.errors ??= []).push(diag);
                 }
                 if (!errorOutputContainer || !errorOutputContainer.skipLogging) {
                     diagnostics.add(diag);
@@ -18407,11 +18404,11 @@ namespace ts {
             function reportIncompatibleError(message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number, arg3?: string | number) {
                 overrideNextErrorInfo++; // Suppress the next relation error
                 lastSkippedInfo = undefined; // Reset skipped info cache
-                (incompatibleStack ||= []).push([message, arg0, arg1, arg2, arg3]);
+                (incompatibleStack ??= []).push([message, arg0, arg1, arg2, arg3]);
             }
 
             function reportIncompatibleStack() {
-                const stack = incompatibleStack || [];
+                const stack = incompatibleStack ?? [];
                 incompatibleStack = undefined;
                 const info = lastSkippedInfo;
                 lastSkippedInfo = undefined;
@@ -18869,7 +18866,7 @@ namespace ts {
                     const propType = prop && getTypeOfSymbol(prop) || getApplicableIndexInfoForName(type, name)?.type || undefinedType;
                     return append(propTypes, propType);
                 };
-                return getUnionType(reduceLeft(types, appendPropType, /*initial*/ undefined) || emptyArray);
+                return getUnionType(reduceLeft(types, appendPropType, /*initial*/ undefined) ?? emptyArray);
             }
 
             function hasExcessProperties(source: FreshObjectLiteralType, target: Type, reportErrors: boolean): boolean {
@@ -18884,7 +18881,7 @@ namespace ts {
                 let reducedTarget = target;
                 let checkTypes: Type[] | undefined;
                 if (target.flags & TypeFlags.Union) {
-                    reducedTarget = findMatchingDiscriminantType(source, target as UnionType, isRelatedTo) || filterPrimitivesIfContainsNonPrimitive(target as UnionType);
+                    reducedTarget = findMatchingDiscriminantType(source, target as UnionType, isRelatedTo) ?? filterPrimitivesIfContainsNonPrimitive(target as UnionType);
                     checkTypes = reducedTarget.flags & TypeFlags.Union ? (reducedTarget as UnionType).types : [reducedTarget];
                 }
                 for (const prop of getPropertiesOfType(source)) {
@@ -19475,7 +19472,7 @@ namespace ts {
                                 targetKeys = getUnionType([...mappedKeys, nameType]);
                             }
                             else {
-                                targetKeys = nameType || constraintType;
+                                targetKeys = nameType ?? constraintType;
                             }
                             if (isRelatedTo(source, targetKeys, RecursionFlags.Target, reportErrors) === Ternary.True) {
                                 return Ternary.True;
@@ -19503,8 +19500,8 @@ namespace ts {
                     if (relation === assignableRelation || relation === comparableRelation) {
                         const objectType = (target as IndexedAccessType).objectType;
                         const indexType = (target as IndexedAccessType).indexType;
-                        const baseObjectType = getBaseConstraintOfType(objectType) || objectType;
-                        const baseIndexType = getBaseConstraintOfType(indexType) || indexType;
+                        const baseObjectType = getBaseConstraintOfType(objectType) ?? objectType;
+                        const baseIndexType = getBaseConstraintOfType(indexType) ?? indexType;
                         if (!isGenericObjectType(baseObjectType) && !isGenericIndexType(baseIndexType)) {
                             const accessFlags = AccessFlags.Writing | (baseObjectType !== objectType ? AccessFlags.NoIndexSignatures : 0);
                             const constraint = getIndexedAccessTypeOrUndefined(baseObjectType, baseIndexType, accessFlags);
@@ -19576,7 +19573,7 @@ namespace ts {
                                     // If the target type has shape `{ [P in Q as R]?: T }`, then a property of the target has type `R`,
                                     // but the property is optional, so we only want to compare properties `R` that are common between `keyof S` and `R`.
                                     const indexingType = keysRemapped
-                                        ? (filteredByApplicability || targetKeys)
+                                        ? (filteredByApplicability ?? targetKeys)
                                         : filteredByApplicability
                                             ? getIntersectionType([filteredByApplicability, typeParameter])
                                             : typeParameter;
@@ -19641,7 +19638,7 @@ namespace ts {
                 if (sourceFlags & TypeFlags.TypeVariable) {
                     // IndexedAccess comparisons are handled above in the `targetFlags & TypeFlage.IndexedAccess` branch
                     if (!(sourceFlags & TypeFlags.IndexedAccess && targetFlags & TypeFlags.IndexedAccess)) {
-                        const constraint = getConstraintOfType(source as TypeVariable) || unknownType;
+                        const constraint = getConstraintOfType(source as TypeVariable) ?? unknownType;
                         // hi-speed no-this-instantiation check (less accurate, but avoids costly `this`-instantiation when the constraint will suffice), see #28231 for report on why this is needed
                         if (result = isRelatedTo(constraint, target, RecursionFlags.Source, /*reportErrors*/ false, /*headMessage*/ undefined, intersectionState)) {
                             resetErrorInfo(saveErrorInfo);
@@ -19798,7 +19795,7 @@ namespace ts {
                     }
                     else if (isReadonlyArrayType(target) ? isArrayOrTupleType(source) : isArrayType(target) && isTupleType(source) && !source.target.readonly) {
                         if (relation !== identityRelation) {
-                            return isRelatedTo(getIndexTypeOfType(source, numberType) || anyType, getIndexTypeOfType(target, numberType) || anyType, RecursionFlags.Both, reportErrors);
+                            return isRelatedTo(getIndexTypeOfType(source, numberType) ?? anyType, getIndexTypeOfType(target, numberType) ?? anyType, RecursionFlags.Both, reportErrors);
                         }
                         else {
                             // By flags alone, we know that the `target` is a readonly array while the source is a normal array or tuple
@@ -19830,7 +19827,7 @@ namespace ts {
                             }
                         }
                         if (varianceCheckFailed && result) {
-                            errorInfo = originalErrorInfo || errorInfo || saveErrorInfo.errorInfo; // Use variance error (there is no structural one) and return false
+                            errorInfo = originalErrorInfo ?? errorInfo ?? saveErrorInfo.errorInfo; // Use variance error (there is no structural one) and return false
                         }
                         else if (result) {
                             return result;
@@ -20042,7 +20039,7 @@ namespace ts {
                         result = properties.slice(0, i);
                     }
                 }
-                return result || properties;
+                return result ?? properties;
             }
 
             function isPropertySymbolTypeRelated(sourceProp: Symbol, targetProp: Symbol, getTypeOfSourceProperty: (sym: Symbol) => Type, reportErrors: boolean, intersectionState: IntersectionState): Ternary {
@@ -20074,7 +20071,7 @@ namespace ts {
                     if (!isValidOverrideOf(sourceProp, targetProp)) {
                         if (reportErrors) {
                             reportError(Diagnostics.Property_0_is_protected_but_type_1_is_not_a_class_derived_from_2, symbolToString(targetProp),
-                                typeToString(getDeclaringClass(sourceProp) || source), typeToString(getDeclaringClass(targetProp) || target));
+                                typeToString(getDeclaringClass(sourceProp) ?? source), typeToString(getDeclaringClass(targetProp) ?? target));
                         }
                         return Ternary.False;
                     }
@@ -20252,7 +20249,7 @@ namespace ts {
                             }
                             const sourceType = !isTupleType(source) ? sourceTypeArguments[0] :
                                 i < startCount || i >= targetArity - endCount ? removeMissingType(sourceTypeArguments[sourceIndex], !!(sourceFlags & targetFlags & ElementFlags.Optional)) :
-                                getElementTypeOfSliceOfTupleType(source, startCount, endCount) || neverType;
+                                getElementTypeOfSliceOfTupleType(source, startCount, endCount) ?? neverType;
                             const targetType = targetTypeArguments[i];
                             const targetCheckType = sourceFlags & ElementFlags.Variadic && targetFlags & ElementFlags.Rest ? createArrayType(targetType) :
                                 removeMissingType(targetType, !!(targetFlags & ElementFlags.Optional));
@@ -20656,10 +20653,10 @@ namespace ts {
         }
 
         function getBestMatchingType(source: Type, target: UnionOrIntersectionType, isRelatedTo = compareTypesAssignable) {
-            return findMatchingDiscriminantType(source, target, isRelatedTo, /*skipPartial*/ true) ||
-                findMatchingTypeReferenceOrTypeAliasReference(source, target) ||
-                findBestTypeForObjectLiteral(source, target) ||
-                findBestTypeForInvokable(source, target) ||
+            return findMatchingDiscriminantType(source, target, isRelatedTo, /*skipPartial*/ true) ??
+                findMatchingTypeReferenceOrTypeAliasReference(source, target) ??
+                findBestTypeForObjectLiteral(source, target) ??
+                findBestTypeForInvokable(source, target) ??
                 findMostOverlappyType(source, target);
         }
 
@@ -21261,7 +21258,7 @@ namespace ts {
                 return propType;
             }
             if (everyType(type, isTupleType)) {
-                return mapType(type, t => getRestTypeOfTupleType(t as TupleTypeReference) || undefinedType);
+                return mapType(type, t => getRestTypeOfTupleType(t as TupleTypeReference) ?? undefinedType);
             }
             return undefined;
         }
@@ -21280,7 +21277,7 @@ namespace ts {
         }
 
         function extractUnitType(type: Type) {
-            return type.flags & TypeFlags.Intersection ? find((type as IntersectionType).types, isUnitType) || type : type;
+            return type.flags & TypeFlags.Intersection ? find((type as IntersectionType).types, isUnitType) ?? type : type;
         }
 
         function isLiteralType(type: Type): boolean {
@@ -21429,9 +21426,7 @@ namespace ts {
         }
 
         function getGlobalNonNullableTypeInstantiation(type: Type) {
-            if (!deferredGlobalNonNullableTypeAlias) {
-                deferredGlobalNonNullableTypeAlias = getGlobalSymbol("NonNullable" as __String, SymbolFlags.TypeAlias, /*diagnostic*/ undefined) || unknownSymbol;
-            }
+            deferredGlobalNonNullableTypeAlias ??= getGlobalSymbol("NonNullable" as __String, SymbolFlags.TypeAlias, /*diagnostic*/ undefined) ?? unknownSymbol;
             return deferredGlobalNonNullableTypeAlias !== unknownSymbol ?
                 getTypeAliasInstantiation(deferredGlobalNonNullableTypeAlias, [type]) :
                 getIntersectionType([type, emptyObjectType]);
@@ -21658,7 +21653,7 @@ namespace ts {
                     result = getWidenedTypeOfObjectLiteral(type, context);
                 }
                 else if (type.flags & TypeFlags.Union) {
-                    const unionContext = context || createWideningContext(/*parent*/ undefined, /*propertyName*/ undefined, (type as UnionType).types);
+                    const unionContext = context ?? createWideningContext(/*parent*/ undefined, /*propertyName*/ undefined, (type as UnionType).types);
                     const widenedTypes = sameMap((type as UnionType).types, t => t.flags & TypeFlags.Nullable ? t : getWidenedTypeWithContext(t, unionContext));
                     // Widening an empty object literal transitions from a highly restrictive type to
                     // a highly inclusive one. For that reason we perform subtype reduction here if the
@@ -21674,7 +21669,7 @@ namespace ts {
                 if (result && context === undefined) {
                     type.widened = result;
                 }
-                return result || type;
+                return result ?? type;
             }
             return type;
         }
@@ -21842,7 +21837,7 @@ namespace ts {
         }
 
         function createInferenceContext(typeParameters: readonly TypeParameter[], signature: Signature | undefined, flags: InferenceFlags, compareTypes?: TypeComparer): InferenceContext {
-            return createInferenceContextWorker(typeParameters.map(createInferenceInfo), signature, flags, compareTypes || compareTypesAssignable);
+            return createInferenceContextWorker(typeParameters.map(createInferenceInfo), signature, flags, compareTypes ?? compareTypesAssignable);
         }
 
         function cloneInferenceContext<T extends InferenceContext | undefined>(context: T, extraFlags: InferenceFlags = 0): InferenceContext | T & undefined {
@@ -22080,7 +22075,7 @@ namespace ts {
             const templateType = getTemplateTypeFromMappedType(target);
             const inference = createInferenceInfo(typeParameter);
             inferTypes([inference], sourceType, templateType);
-            return getTypeFromInference(inference) || unknownType;
+            return getTypeFromInference(inference) ?? unknownType;
         }
 
         function* getUnmatchedProperties(source: Type, target: Type, requireOptionalProperties: boolean, matchDiscriminantProperties: boolean): IterableIterator<Symbol> {
@@ -22397,7 +22392,7 @@ namespace ts {
                     source = getUnionType(sources);
                 }
                 else if (target.flags & TypeFlags.Intersection && some((target as IntersectionType).types,
-                    t => !!getInferenceInfoForType(t) || (isGenericMappedType(t) && !!getInferenceInfoForType(getHomomorphicTypeVariable(t) || neverType)))) {
+                    t => !!getInferenceInfoForType(t) || (isGenericMappedType(t) && !!getInferenceInfoForType(getHomomorphicTypeVariable(t) ?? neverType)))) {
                     // We reduce intersection types only when they contain naked type parameters. For example, when
                     // inferring from 'string[] & { extra: any }' to 'string[] & T' we want to remove string[] and
                     // infer { extra: any } for T. But when inferring to 'string[] & Iterable<T>' we want to keep the
@@ -23128,7 +23123,7 @@ namespace ts {
                     inferredType = getTypeFromInference(inference);
                 }
 
-                inference.inferredType = inferredType || getDefaultTypeArgumentType(!!(context.flags & InferenceFlags.AnyDefault));
+                inference.inferredType = inferredType ?? getDefaultTypeArgumentType(!!(context.flags & InferenceFlags.AnyDefault));
 
                 const constraint = getConstraintOfTypeParameter(inference.typeParameter);
                 if (constraint) {
@@ -23560,7 +23555,7 @@ namespace ts {
 
         function getTypeFacts(type: Type): TypeFacts {
             if (type.flags & (TypeFlags.Intersection | TypeFlags.Instantiable)) {
-                type = getBaseConstraintOfType(type) || unknownType;
+                type = getBaseConstraintOfType(type) ?? unknownType;
             }
             const flags = type.flags;
             if (flags & (TypeFlags.String | TypeFlags.StringMapping)) {
@@ -23687,7 +23682,7 @@ namespace ts {
             const nameType = getLiteralTypeFromPropertyName(name);
             if (!isTypeUsableAsPropertyName(nameType)) return errorType;
             const text = getPropertyNameFromType(nameType);
-            return getTypeOfPropertyOfType(type, text) || includeUndefinedInIndexSignature(getApplicableIndexInfoForName(type, text)?.type) || errorType;
+            return getTypeOfPropertyOfType(type, text) ?? includeUndefinedInIndexSignature(getApplicableIndexInfoForName(type, text)?.type) ?? errorType;
         }
 
         function getTypeOfDestructuredArrayElement(type: Type, index: number) {
@@ -23764,7 +23759,7 @@ namespace ts {
             const pattern = node.parent;
             const parentType = getInitialType(pattern.parent as VariableDeclaration | BindingElement);
             const type = pattern.kind === SyntaxKind.ObjectBindingPattern ?
-                getTypeOfDestructuredProperty(parentType, node.propertyName || node.name as Identifier) :
+                getTypeOfDestructuredProperty(parentType, node.propertyName ?? node.name as Identifier) :
                 !node.dotDotDotToken ?
                     getTypeOfDestructuredArrayElement(parentType, pattern.elements.indexOf(node)) :
                     getTypeOfDestructuredSpreadExpression(parentType);
@@ -23776,7 +23771,7 @@ namespace ts {
             // from its initializer, we'll already have cached the type. Otherwise we compute it now
             // without caching such that transient types are reflected.
             const links = getNodeLinks(node);
-            return links.resolvedType || getTypeOfExpression(node);
+            return links.resolvedType ?? getTypeOfExpression(node);
         }
 
         function getInitialTypeOfVariableDeclaration(node: VariableDeclaration) {
@@ -24041,7 +24036,7 @@ namespace ts {
 
         // We perform subtype reduction upon obtaining the final array type from an evolving array type.
         function getFinalArrayType(evolvingArrayType: EvolvingArrayType): Type {
-            return evolvingArrayType.finalArrayType || (evolvingArrayType.finalArrayType = createFinalArrayType(evolvingArrayType.elementType));
+            return evolvingArrayType.finalArrayType ??= createFinalArrayType(evolvingArrayType.elementType);
         }
 
         function finalizeEvolvingArrayType(type: Type): Type {
@@ -24194,7 +24189,7 @@ namespace ts {
 
         function hasTypePredicateOrNeverReturnType(signature: Signature) {
             return !!(getTypePredicateOfSignature(signature) ||
-                signature.declaration && (getReturnTypeFromAnnotation(signature.declaration) || unknownType).flags & TypeFlags.Never);
+                signature.declaration && (getReturnTypeFromAnnotation(signature.declaration) ?? unknownType).flags & TypeFlags.Never);
         }
 
         function getTypePredicateArgument(predicate: TypePredicate, callExpression: CallExpression) {
@@ -24349,7 +24344,7 @@ namespace ts {
                 case SyntaxKind.PropertyAccessExpression:
                 case SyntaxKind.ElementAccessExpression:
                     // The resolvedSymbol property is initialized by checkPropertyAccess or checkElementAccess before we get here.
-                    return isConstantReference((node as AccessExpression).expression) && isReadonlySymbol(getNodeLinks(node).resolvedSymbol || unknownSymbol);
+                    return isConstantReference((node as AccessExpression).expression) && isReadonlySymbol(getNodeLinks(node).resolvedSymbol ?? unknownSymbol);
             }
             return false;
         }
@@ -24901,7 +24896,7 @@ namespace ts {
             function narrowTypeBySwitchOnDiscriminantProperty(type: Type, access: AccessExpression | BindingElement | ParameterDeclaration, switchStatement: SwitchStatement, clauseStart: number, clauseEnd: number) {
                 if (clauseStart < clauseEnd && type.flags & TypeFlags.Union && getKeyPropertyName(type as UnionType) === getAccessedPropertyName(access)) {
                     const clauseTypes = getSwitchClauseTypes(switchStatement).slice(clauseStart, clauseEnd);
-                    const candidate = getUnionType(map(clauseTypes, t => getConstituentTypeForKeyType(type as UnionType, t) || unknownType));
+                    const candidate = getUnionType(map(clauseTypes, t => getConstituentTypeForKeyType(type as UnionType, t) ?? unknownType));
                     if (candidate !== unknownType) {
                         return candidate;
                     }
@@ -25443,7 +25438,7 @@ namespace ts {
         }
 
         function getTypeOfSymbolAtLocation(symbol: Symbol, location: Node) {
-            symbol = symbol.exportSymbol || symbol;
+            symbol = symbol.exportSymbol ?? symbol;
 
             // If we have an identifier or a property access at the given location, if the location is
             // an dotted name expression, and if the location is not an assignment target, obtain the type
@@ -25934,7 +25929,7 @@ namespace ts {
                                 const links = getNodeLinks(part);
                                 links.flags |= NodeCheckFlags.ContainsCapturedBlockScopeBinding;
 
-                                const capturedBindings = links.capturedBlockScopeBindings || (links.capturedBlockScopeBindings = []);
+                                const capturedBindings = links.capturedBlockScopeBindings ??= [];
                                 pushIfUnique(capturedBindings, symbol);
 
                                 if (part === container.initializer) {
@@ -26107,7 +26102,7 @@ namespace ts {
                     }
                 }
             }
-            return type || anyType;
+            return type ?? anyType;
         }
 
         function tryGetThisTypeAt(node: Node, includeGlobalThis = true, container = getThisContainer(node, /*includeArrowFunctions*/ false)): Type | undefined {
@@ -26591,7 +26586,7 @@ namespace ts {
 
         function getContextualTypeForBindingElement(declaration: BindingElement): Type | undefined {
             const parent = declaration.parent.parent;
-            const name = declaration.propertyName || declaration.name;
+            const name = declaration.propertyName ?? declaration.name;
             const parentType = getContextualTypeForVariableLikeDeclaration(parent) ||
                 parent.kind !== SyntaxKind.BindingElement && parent.initializer && checkDeclarationInitializer(parent, declaration.dotDotDotToken ? CheckMode.RestBindingElement : CheckMode.Normal);
             if (!parentType || isBindingPattern(name) || isComputedNonLiteralName(name)) return undefined;
@@ -26707,8 +26702,7 @@ namespace ts {
             const isAsync = !!(getFunctionFlags(functionDecl) & FunctionFlags.Async);
             const contextualReturnType = getContextualReturnType(functionDecl);
             if (contextualReturnType) {
-                return getIterationTypeOfGeneratorFunctionReturnType(kind, contextualReturnType, isAsync)
-                    || undefined;
+                return getIterationTypeOfGeneratorFunctionReturnType(kind, contextualReturnType, isAsync);
             }
 
             return undefined;
@@ -26880,7 +26874,7 @@ namespace ts {
                     let valueDeclaration = binaryExpression.left.symbol?.valueDeclaration;
                     // falls through
                 case AssignmentDeclarationKind.ModuleExports:
-                    valueDeclaration ||= binaryExpression.symbol?.valueDeclaration;
+                    valueDeclaration ??= binaryExpression.symbol?.valueDeclaration;
                     const annotated = valueDeclaration && getEffectiveTypeAnnotationNode(valueDeclaration);
                     return annotated ? getTypeFromTypeNode(annotated) : undefined;
                 case AssignmentDeclarationKind.ObjectDefinePropertyValue:
@@ -26953,8 +26947,8 @@ namespace ts {
             function getTypeOfConcretePropertyOfContextualType(t: Type) {
                 if (isGenericMappedType(t) && !t.declaration.nameType) {
                     const constraint = getConstraintTypeFromMappedType(t);
-                    const constraintOfConstraint = getBaseConstraintOfType(constraint) || constraint;
-                    const propertyNameType = nameType || getStringLiteralType(unescapeLeadingUnderscores(name));
+                    const constraintOfConstraint = getBaseConstraintOfType(constraint) ?? constraint;
+                    const propertyNameType = nameType ?? getStringLiteralType(unescapeLeadingUnderscores(name));
                     if (isTypeAssignableTo(propertyNameType, constraintOfConstraint)) {
                         return substituteIndexedMappedType(t, propertyNameType);
                     }
@@ -26978,7 +26972,7 @@ namespace ts {
                 if (!(t.flags & TypeFlags.StructuredType)) {
                     return undefined;
                 }
-                return findApplicableIndexInfo(getIndexInfosOfStructuredType(t), nameType || getStringLiteralType(unescapeLeadingUnderscores(name)))?.type;
+                return findApplicableIndexInfo(getIndexInfosOfStructuredType(t), nameType ?? getStringLiteralType(unescapeLeadingUnderscores(name)))?.type;
             }
         }
 
@@ -27107,7 +27101,7 @@ namespace ts {
         }
 
         function discriminateContextualTypeByObjectMembers(node: ObjectLiteralExpression, contextualType: UnionType) {
-            return getMatchingUnionConstituentForObjectLiteral(contextualType, node) || discriminateTypeByDiscriminableItems(contextualType,
+            return getMatchingUnionConstituentForObjectLiteral(contextualType, node) ?? discriminateTypeByDiscriminableItems(contextualType,
                 concatenate(
                     map(
                         filter(node.properties, p => !!p.symbol && p.kind === SyntaxKind.PropertyAssignment && isPossiblyDiscriminantValue(p.initializer) && isDiscriminantProperty(contextualType, p.symbol.escapedName)),
@@ -27444,7 +27438,7 @@ namespace ts {
 
         function combineIntersectionThisParam(left: Symbol | undefined, right: Symbol | undefined, mapper: TypeMapper | undefined): Symbol | undefined {
             if (!left || !right) {
-                return left || right;
+                return left ?? right;
             }
             // A signature `this` type might be a read or a write position... It's very possible that it should be invariant
             // and we should refuse to merge signatures if there are `this` types and they do not match. However, so as to be
@@ -27467,7 +27461,7 @@ namespace ts {
                 if (longest === right) {
                     longestParamType = instantiateType(longestParamType, mapper);
                 }
-                let shorterParamType = tryGetTypeAtPosition(shorter, i) || unknownType;
+                let shorterParamType = tryGetTypeAtPosition(shorter, i) ?? unknownType;
                 if (shorter === right) {
                     shorterParamType = instantiateType(shorterParamType, mapper);
                 }
@@ -27500,7 +27494,7 @@ namespace ts {
         }
 
         function combineSignaturesOfIntersectionMembers(left: Signature, right: Signature): Signature {
-            const typeParams = left.typeParameters || right.typeParameters;
+            const typeParams = left.typeParameters ?? right.typeParameters;
             let paramMapper: TypeMapper | undefined;
             if (left.typeParameters && right.typeParameters) {
                 paramMapper = createTypeMapper(right.typeParameters, left.typeParameters);
@@ -27652,8 +27646,8 @@ namespace ts {
                         // get the contextual element type from it. So we do something similar to
                         // getContextualTypeForElementExpression, which will crucially not error
                         // if there is no index type / iterated type.
-                        const restElementType = getIndexTypeOfType(spreadType, numberType) ||
-                            getIteratedTypeOrElementType(IterationUse.Destructuring, spreadType, undefinedType, /*errorNode*/ undefined, /*checkAssignability*/ false) ||
+                        const restElementType = getIndexTypeOfType(spreadType, numberType) ??
+                            getIteratedTypeOrElementType(IterationUse.Destructuring, spreadType, undefinedType, /*errorNode*/ undefined, /*checkAssignability*/ false) ??
                             unknownType;
                         elementTypes.push(restElementType);
                         elementFlags.push(ElementFlags.Rest);
@@ -27687,7 +27681,7 @@ namespace ts {
                 return createArrayLiteralType(createTupleType(elementTypes, elementFlags, /*readonly*/ inConstContext));
             }
             return createArrayLiteralType(createArrayType(elementTypes.length ?
-                getUnionType(sameMap(elementTypes, (t, i) => elementFlags[i] & ElementFlags.Variadic ? getIndexedAccessTypeOrUndefined(t, numberType) || anyType : t), UnionReduction.Subtype) :
+                getUnionType(sameMap(elementTypes, (t, i) => elementFlags[i] & ElementFlags.Variadic ? getIndexedAccessTypeOrUndefined(t, numberType) ?? anyType : t), UnionReduction.Subtype) :
                 strictNullChecks ? implicitNeverType : undefinedWideningType, inConstContext));
         }
 
@@ -27974,7 +27968,7 @@ namespace ts {
                 for (const prop of getPropertiesOfType(contextualType)) {
                     if (!propertiesTable.get(prop.escapedName) && !getPropertyOfType(spread, prop.escapedName)) {
                         if (!(prop.flags & SymbolFlags.Optional)) {
-                            error(prop.valueDeclaration || (prop as TransientSymbol).bindingElement,
+                            error(prop.valueDeclaration ?? (prop as TransientSymbol).bindingElement,
                                 Diagnostics.Initializer_provides_no_value_for_this_binding_element_and_the_binding_element_has_no_default_value);
                         }
                         propertiesTable.set(prop.escapedName, prop);
@@ -28199,7 +28193,7 @@ namespace ts {
             if (typeToIntersect && spread !== emptyJsxObjectType) {
                 return getIntersectionType([typeToIntersect, spread]);
             }
-            return typeToIntersect || (spread === emptyJsxObjectType ? createJsxAttributesType() : spread);
+            return typeToIntersect ?? (spread === emptyJsxObjectType ? createJsxAttributesType() : spread);
 
             /**
              * Create anonymous type from given attributes symbol table.
@@ -28322,7 +28316,7 @@ namespace ts {
             const mod = resolveExternalModule(location!, runtimeImportSpecifier, errorMessage, location!);
             const result = mod && mod !== unknownSymbol ? getMergedSymbol(resolveSymbol(mod)) : undefined;
             if (links) {
-                links.jsxImplicitImportContainer = result || false;
+                links.jsxImplicitImportContainer = result ?? false;
             }
             return result;
         }
@@ -28507,7 +28501,7 @@ namespace ts {
                 }
                 else if (links.jsxFlags & JsxFlags.IntrinsicIndexedElement) {
                     return links.resolvedJsxElementAttributesType =
-                        getIndexTypeOfType(getJsxType(JsxNames.IntrinsicElements, node), stringType) || errorType;
+                        getIndexTypeOfType(getJsxType(JsxNames.IntrinsicElements, node), stringType) ?? errorType;
                 }
                 else {
                     return links.resolvedJsxElementAttributesType = errorType;
@@ -28809,7 +28803,7 @@ namespace ts {
                         error(errorNode,
                             Diagnostics.Property_0_is_protected_and_only_accessible_within_class_1_and_its_subclasses,
                             symbolToString(prop),
-                            typeToString(getDeclaringClass(prop) || containingType));
+                            typeToString(getDeclaringClass(prop) ?? containingType));
                     }
                     return false;
                 }
@@ -29045,7 +29039,7 @@ namespace ts {
                     right,
                     Diagnostics.Property_0_is_not_accessible_outside_class_1_because_it_has_a_private_identifier,
                     diagName,
-                    diagnosticName(typeClass.name || anon)
+                    diagnosticName(typeClass.name ?? anon)
                 );
                 return true;
             }
@@ -29753,7 +29747,7 @@ namespace ts {
             const accessFlags = isAssignmentTarget(node) ?
                 AccessFlags.Writing | (isGenericObjectType(objectType) && !isThisTypeParameter(objectType) ? AccessFlags.NoIndexSignatures : 0) :
                 AccessFlags.ExpressionPosition;
-            const indexedAccessType = getIndexedAccessTypeOrUndefined(objectType, effectiveIndexType, accessFlags, node) || errorType;
+            const indexedAccessType = getIndexedAccessTypeOrUndefined(objectType, effectiveIndexType, accessFlags, node) ?? errorType;
             return checkIndexedAccessIndexType(getFlowTypeOfAccessExpression(node, getNodeLinks(node).resolvedSymbol, indexedAccessType, indexExpression, checkMode), node);
         }
 
@@ -29944,7 +29938,7 @@ namespace ts {
         }
 
         function getSingleCallOrConstructSignature(type: Type): Signature | undefined {
-            return getSingleSignature(type, SignatureKind.Call, /*allowMembers*/ false) ||
+            return getSingleSignature(type, SignatureKind.Call, /*allowMembers*/ false) ??
                 getSingleSignature(type, SignatureKind.Construct, /*allowMembers*/ false);
         }
 
@@ -30151,7 +30145,7 @@ namespace ts {
                 const constraint = getConstraintOfTypeParameter(typeParameters[i]);
                 if (constraint) {
                     const errorInfo = reportErrors && headMessage ? (() => chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Type_0_does_not_satisfy_the_constraint_1)) : undefined;
-                    const typeArgumentHeadMessage = headMessage || Diagnostics.Type_0_does_not_satisfy_the_constraint_1;
+                    const typeArgumentHeadMessage = headMessage ?? Diagnostics.Type_0_does_not_satisfy_the_constraint_1;
                     if (!mapper) {
                         mapper = createTypeMapper(typeParameters, typeArgumentTypes);
                     }
@@ -30281,7 +30275,7 @@ namespace ts {
                         addRelatedInfo(diag, createDiagnosticForNode(tagNameDeclaration, Diagnostics._0_is_declared_here, entityNameToString(node.tagName)));
                     }
                     if (errorOutputContainer && errorOutputContainer.skipLogging) {
-                        (errorOutputContainer.errors || (errorOutputContainer.errors = [])).push(diag);
+                        (errorOutputContainer.errors ??= []).push(diag);
                     }
                     if (!errorOutputContainer.skipLogging) {
                         diagnostics.add(diag);
@@ -30305,7 +30299,7 @@ namespace ts {
             if (isJsxOpeningLikeElement(node)) {
                 if (!checkApplicableSignatureForJsxOpeningLikeElement(node, signature, relation, checkMode, reportErrors, containingMessageChain, errorOutputContainer)) {
                     Debug.assert(!reportErrors || !!errorOutputContainer.errors, "jsx should have errors when reporting errors");
-                    return errorOutputContainer.errors || emptyArray;
+                    return errorOutputContainer.errors ?? emptyArray;
                 }
                 return undefined;
             }
@@ -30316,11 +30310,11 @@ namespace ts {
                 // If the expression is a new expression, then the check is skipped.
                 const thisArgumentNode = getThisArgumentOfCall(node);
                 const thisArgumentType = getThisArgumentType(thisArgumentNode);
-                const errorNode = reportErrors ? (thisArgumentNode || node) : undefined;
+                const errorNode = reportErrors ? (thisArgumentNode ?? node) : undefined;
                 const headMessage = Diagnostics.The_this_context_of_type_0_is_not_assignable_to_method_s_this_of_type_1;
                 if (!checkTypeRelatedTo(thisArgumentType, thisType, relation, errorNode, headMessage, containingMessageChain, errorOutputContainer)) {
                     Debug.assert(!reportErrors || !!errorOutputContainer.errors, "this parameter should have errors when reporting errors");
-                    return errorOutputContainer.errors || emptyArray;
+                    return errorOutputContainer.errors ?? emptyArray;
                 }
             }
             const headMessage = Diagnostics.Argument_of_type_0_is_not_assignable_to_parameter_of_type_1;
@@ -30338,7 +30332,7 @@ namespace ts {
                     if (!checkTypeRelatedToAndOptionallyElaborate(checkArgType, paramType, relation, reportErrors ? arg : undefined, arg, headMessage, containingMessageChain, errorOutputContainer)) {
                         Debug.assert(!reportErrors || !!errorOutputContainer.errors, "parameter should have errors when reporting errors");
                         maybeAddMissingAwaitInfo(arg, checkArgType, paramType);
-                        return errorOutputContainer.errors || emptyArray;
+                        return errorOutputContainer.errors ?? emptyArray;
                     }
                 }
             }
@@ -30352,7 +30346,7 @@ namespace ts {
                 if (!checkTypeRelatedTo(spreadType, restType, relation, errorNode, headMessage, /*containingMessageChain*/ undefined, errorOutputContainer)) {
                     Debug.assert(!reportErrors || !!errorOutputContainer.errors, "rest parameter should have errors when reporting errors");
                     maybeAddMissingAwaitInfo(errorNode, spreadType, restType);
-                    return errorOutputContainer.errors || emptyArray;
+                    return errorOutputContainer.errors ?? emptyArray;
                 }
             }
             return undefined;
@@ -30412,7 +30406,7 @@ namespace ts {
             if (isJsxOpeningLikeElement(node)) {
                 return node.attributes.properties.length > 0 || (isJsxOpeningElement(node) && node.parent.children.length > 0) ? [node.attributes] : emptyArray;
             }
-            const args = node.arguments || emptyArray;
+            const args = node.arguments ?? emptyArray;
             const spreadIndex = getSpreadArgumentIndex(args);
             if (spreadIndex >= 0) {
                 // Create synthetic arguments from spreads of tuple types.
@@ -30657,7 +30651,7 @@ namespace ts {
                 }
             }
 
-            const candidates = candidatesOutArray || [];
+            const candidates = candidatesOutArray ?? [];
             // reorderCandidates fills up the candidates array directly
             reorderCandidates(signatures, candidates, callChainFlags);
             if (!candidates.length) {
@@ -30843,7 +30837,7 @@ namespace ts {
                 const oldCandidateForArgumentArityError = candidateForArgumentArityError;
                 const oldCandidateForTypeArgumentError = candidateForTypeArgumentError;
 
-                const failedSignatureDeclarations = failed.declaration?.symbol?.declarations || emptyArray;
+                const failedSignatureDeclarations = failed.declaration?.symbol?.declarations ?? emptyArray;
                 const isOverload = failedSignatureDeclarations.length > 1;
                 const implDecl = isOverload ? find(failedSignatureDeclarations, d => isFunctionLikeDeclaration(d) && nodeIsPresent(d.body)) : undefined;
                 if (implDecl) {
@@ -30912,7 +30906,7 @@ namespace ts {
                     }
                     if (getSignatureApplicabilityError(node, args, checkCandidate, relation, argCheckMode, /*reportErrors*/ false, /*containingMessageChain*/ undefined)) {
                         // Give preference to error candidates that have no rest parameters (as they are more specific)
-                        (candidatesForArgumentError || (candidatesForArgumentError = [])).push(checkCandidate);
+                        (candidatesForArgumentError ??= []).push(checkCandidate);
                         continue;
                     }
                     if (argCheckMode) {
@@ -30932,7 +30926,7 @@ namespace ts {
                         }
                         if (getSignatureApplicabilityError(node, args, checkCandidate, relation, argCheckMode, /*reportErrors*/ false, /*containingMessageChain*/ undefined)) {
                             // Give preference to error candidates that have no rest parameters (as they are more specific)
-                            (candidatesForArgumentError || (candidatesForArgumentError = [])).push(checkCandidate);
+                            (candidatesForArgumentError ??= []).push(checkCandidate);
                             continue;
                         }
                     }
@@ -31040,7 +31034,7 @@ namespace ts {
                 typeArguments.pop();
             }
             while (typeArguments.length < typeParameters.length) {
-                typeArguments.push(getDefaultFromTypeParameter(typeParameters[typeArguments.length]) || getConstraintOfTypeParameter(typeParameters[typeArguments.length]) || getDefaultTypeArgumentType(isJs));
+                typeArguments.push(getDefaultFromTypeParameter(typeParameters[typeArguments.length]) ?? getConstraintOfTypeParameter(typeParameters[typeArguments.length]) ?? getDefaultTypeArgumentType(isJs));
             }
             return typeArguments;
         }
@@ -31707,8 +31701,8 @@ namespace ts {
                 const links = getSymbolLinks(source);
                 if (!links.inferredClassSymbol || !links.inferredClassSymbol.has(getSymbolId(target))) {
                     const inferred = isTransientSymbol(target) ? target : cloneSymbol(target) as TransientSymbol;
-                    inferred.exports = inferred.exports || createSymbolTable();
-                    inferred.members = inferred.members || createSymbolTable();
+                    inferred.exports ??= createSymbolTable();
+                    inferred.members ??= createSymbolTable();
                     inferred.flags |= source.flags & SymbolFlags.Class;
                     if (source.exports?.size) {
                         mergeSymbolTable(inferred.exports, source.exports);
@@ -31716,7 +31710,7 @@ namespace ts {
                     if (source.members?.size) {
                         mergeSymbolTable(inferred.members, source.members);
                     }
-                    (links.inferredClassSymbol || (links.inferredClassSymbol = new Map())).set(getSymbolId(inferred), inferred);
+                    (links.inferredClassSymbol ??= new Map()).set(getSymbolId(inferred), inferred);
                     return inferred;
                 }
                 return links.inferredClassSymbol.get(getSymbolId(target));
@@ -31948,7 +31942,7 @@ namespace ts {
                 const esModuleSymbol = resolveESModuleSymbol(moduleSymbol, specifier, /*dontRecursivelyResolve*/ true, /*suppressUsageError*/ false);
                 if (esModuleSymbol) {
                     return createPromiseReturnType(node,
-                        getTypeWithSyntheticDefaultOnly(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier) ||
+                        getTypeWithSyntheticDefaultOnly(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier) ??
                             getTypeWithSyntheticDefaultImportType(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier)
                     );
                 }
@@ -32262,7 +32256,7 @@ namespace ts {
                 return signature.parameters[pos].escapedName;
             }
             const restParameter = signature.parameters[paramCount] || unknownSymbol;
-            const restType = overrideRestType || getTypeOfSymbol(restParameter);
+            const restType = overrideRestType ?? getTypeOfSymbol(restParameter);
             if (isTupleType(restType)) {
                 const associatedNames = ((restType as TypeReference).target as TupleType).labeledElementDeclarations;
                 const index = pos - paramCount;
@@ -32328,7 +32322,7 @@ namespace ts {
         }
 
         function getTypeAtPosition(signature: Signature, pos: number): Type {
-            return tryGetTypeAtPosition(signature, pos) || anyType;
+            return tryGetTypeAtPosition(signature, pos) ?? anyType;
         }
 
         function tryGetTypeAtPosition(signature: Signature, pos: number): Type | undefined {
@@ -32539,7 +32533,7 @@ namespace ts {
             const links = getSymbolLinks(parameter);
             if (!links.type) {
                 const declaration = parameter.valueDeclaration as ParameterDeclaration | undefined;
-                links.type = type || (declaration ? getWidenedTypeForVariableLikeDeclaration(declaration, /*reportErrors*/ true) : getTypeOfSymbol(parameter));
+                links.type = type ?? (declaration ? getWidenedTypeForVariableLikeDeclaration(declaration, /*reportErrors*/ true) : getTypeOfSymbol(parameter));
                 if (declaration && declaration.name.kind !== SyntaxKind.Identifier) {
                     // if inference didn't come up with anything but unknown, fall back to the binding pattern if present.
                     if (links.type === unknownType) {
@@ -32575,7 +32569,7 @@ namespace ts {
             if (globalPromiseType !== emptyGenericType) {
                 // if the promised type is itself a promise, get the underlying type; otherwise, fallback to the promised type
                 // Unwrap an `Awaited<T>` to `T` to improve inference.
-                promisedType = getAwaitedTypeNoAlias(unwrapAwaitedType(promisedType)) || unknownType;
+                promisedType = getAwaitedTypeNoAlias(unwrapAwaitedType(promisedType)) ?? unknownType;
                 return createTypeReference(globalPromiseType, [promisedType]);
             }
 
@@ -32588,7 +32582,7 @@ namespace ts {
             if (globalPromiseLikeType !== emptyGenericType) {
                 // if the promised type is itself a promise, get the underlying type; otherwise, fallback to the promised type
                 // Unwrap an `Awaited<T>` to `T` to improve inference.
-                promisedType = getAwaitedTypeNoAlias(unwrapAwaitedType(promisedType)) || unknownType;
+                promisedType = getAwaitedTypeNoAlias(unwrapAwaitedType(promisedType)) ?? unknownType;
                 return createTypeReference(globalPromiseLikeType, [promisedType]);
             }
 
@@ -32707,9 +32701,9 @@ namespace ts {
 
             if (isGenerator) {
                 return createGeneratorReturnType(
-                    yieldType || neverType,
-                    returnType || fallbackReturnType,
-                    nextType || getContextualIterationType(IterationTypeKind.Next, func) || unknownType,
+                    yieldType ?? neverType,
+                    returnType ?? fallbackReturnType,
+                    nextType ?? getContextualIterationType(IterationTypeKind.Next, func) ?? unknownType,
                     isAsync);
             }
             else {
@@ -32717,17 +32711,17 @@ namespace ts {
                 // Promise/A+ compatible implementation will always assimilate any foreign promise, so the
                 // return type of the body is awaited type of the body, wrapped in a native Promise<T> type.
                 return isAsync
-                    ? createPromiseType(returnType || fallbackReturnType)
-                    : returnType || fallbackReturnType;
+                    ? createPromiseType(returnType ?? fallbackReturnType)
+                    : returnType ?? fallbackReturnType;
             }
         }
 
         function createGeneratorReturnType(yieldType: Type, returnType: Type, nextType: Type, isAsyncGenerator: boolean) {
             const resolver = isAsyncGenerator ? asyncIterationTypesResolver : syncIterationTypesResolver;
             const globalGeneratorType = resolver.getGlobalGeneratorType(/*reportErrors*/ false);
-            yieldType = resolver.resolveIterationType(yieldType, /*errorNode*/ undefined) || unknownType;
-            returnType = resolver.resolveIterationType(returnType, /*errorNode*/ undefined) || unknownType;
-            nextType = resolver.resolveIterationType(nextType, /*errorNode*/ undefined) || unknownType;
+            yieldType = resolver.resolveIterationType(yieldType, /*errorNode*/ undefined) ?? unknownType;
+            returnType = resolver.resolveIterationType(returnType, /*errorNode*/ undefined) ?? unknownType;
+            nextType = resolver.resolveIterationType(nextType, /*errorNode*/ undefined) ?? unknownType;
             if (globalGeneratorType === emptyGenericType) {
                 // Fall back to the global IterableIterator if returnType is assignable to the expected return iteration
                 // type of IterableIterator, and the expected next iteration type of IterableIterator is assignable to
@@ -32779,7 +32773,7 @@ namespace ts {
         }
 
         function getYieldedTypeOfYieldExpression(node: YieldExpression, expressionType: Type, sentType: Type, isAsync: boolean): Type | undefined {
-            const errorNode = node.expression || node;
+            const errorNode = node.expression ?? node;
             // A `yield*` expression effectively yields everything that its operand yields
             const yieldedType = node.asteriskToken ? checkIteratedTypeOrElementType(isAsync ? IterationUse.AsyncYieldStar : IterationUse.YieldStar, expressionType, sentType, errorNode) : expressionType;
             return !isAsync ? yieldedType : getAwaitedType(yieldedType, errorNode, node.asteriskToken
@@ -32910,7 +32904,7 @@ namespace ts {
                 }
 
                 const hasExplicitReturn = func.flags & NodeFlags.HasExplicitReturn;
-                const errorNode = getEffectiveReturnTypeNode(func) || func;
+                const errorNode = getEffectiveReturnTypeNode(func) ?? func;
 
                 if (type && type.flags & TypeFlags.Never) {
                     error(errorNode, Diagnostics.A_function_returning_never_cannot_have_a_reachable_end_point);
@@ -33608,7 +33602,7 @@ namespace ts {
                         // We create a synthetic expression so that getIndexedAccessType doesn't get confused
                         // when the element is a SyntaxKind.ElementAccessExpression.
                         const accessFlags = AccessFlags.ExpressionPosition | (hasDefaultValue(element) ? AccessFlags.NoTupleBoundsCheck : 0);
-                        const elementType = getIndexedAccessTypeOrUndefined(sourceType, indexType, accessFlags, createSyntheticExpression(element, indexType)) || errorType;
+                        const elementType = getIndexedAccessTypeOrUndefined(sourceType, indexType, accessFlags, createSyntheticExpression(element, indexType)) ?? errorType;
                         const assignedType = hasDefaultValue(element) ? getTypeWithFacts(elementType, TypeFacts.NEUndefined) : elementType;
                         const type = getFlowTypeOfDestructuring(element, assignedType);
                         return checkDestructuringAssignment(element, type, checkMode);
@@ -33974,7 +33968,7 @@ namespace ts {
                     if ((leftType.flags & TypeFlags.BooleanLike) &&
                         (rightType.flags & TypeFlags.BooleanLike) &&
                         (suggestedOperator = getSuggestedBooleanOperator(operatorToken.kind)) !== undefined) {
-                        error(errorNode || operatorToken, Diagnostics.The_0_operator_is_not_allowed_for_boolean_types_Consider_using_1_instead, tokenToString(operatorToken.kind), tokenToString(suggestedOperator));
+                        error(errorNode ?? operatorToken, Diagnostics.The_0_operator_is_not_allowed_for_boolean_types_Consider_using_1_instead, tokenToString(operatorToken.kind), tokenToString(suggestedOperator));
                         return numberType;
                     }
                     else {
@@ -34276,7 +34270,7 @@ namespace ts {
 
             function reportOperatorError(isRelated?: (left: Type, right: Type) => boolean) {
                 let wouldWorkWithAwait = false;
-                const errNode = errorNode || operatorToken;
+                const errNode = errorNode ?? operatorToken;
                 if (isRelated) {
                     const awaitedLeftType = getAwaitedTypeNoAlias(leftType);
                     const awaitedRightType = getAwaitedTypeNoAlias(rightType);
@@ -34372,21 +34366,21 @@ namespace ts {
             const iterationTypes = returnType && getIterationTypesOfGeneratorFunctionReturnType(returnType, isAsync);
             const signatureYieldType = iterationTypes && iterationTypes.yieldType || anyType;
             const signatureNextType = iterationTypes && iterationTypes.nextType || anyType;
-            const resolvedSignatureNextType = isAsync ? getAwaitedType(signatureNextType) || anyType : signatureNextType;
+            const resolvedSignatureNextType = isAsync ? getAwaitedType(signatureNextType) ?? anyType : signatureNextType;
             const yieldExpressionType = node.expression ? checkExpression(node.expression) : undefinedWideningType;
             const yieldedType = getYieldedTypeOfYieldExpression(node, yieldExpressionType, resolvedSignatureNextType, isAsync);
             if (returnType && yieldedType) {
-                checkTypeAssignableToAndOptionallyElaborate(yieldedType, signatureYieldType, node.expression || node, node.expression);
+                checkTypeAssignableToAndOptionallyElaborate(yieldedType, signatureYieldType, node.expression ?? node, node.expression);
             }
 
             if (node.asteriskToken) {
                 const use = isAsync ? IterationUse.AsyncYieldStar : IterationUse.YieldStar;
                 return getIterationTypeOfIterable(use, IterationTypeKind.Return, yieldExpressionType, node.expression)
-                    || anyType;
+                    ?? anyType;
             }
             else if (returnType) {
                 return getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Next, returnType, isAsync)
-                    || anyType;
+                    ?? anyType;
             }
             let type = getContextualIterationType(IterationTypeKind.Next, func);
             if (!type) {
@@ -34443,7 +34437,7 @@ namespace ts {
 
         function isTemplateLiteralContextualType(type: Type): boolean {
             return !!(type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral) ||
-                type.flags & TypeFlags.InstantiableNonPrimitive && maybeTypeOfKind(getBaseConstraintOfType(type) || unknownType, TypeFlags.StringLike));
+                type.flags & TypeFlags.InstantiableNonPrimitive && maybeTypeOfKind(getBaseConstraintOfType(type) ?? unknownType, TypeFlags.StringLike));
         }
 
         function getContextNode(node: Expression): Node {
@@ -34515,7 +34509,7 @@ namespace ts {
             contextualType?: Type | undefined
         ) {
             const initializer = getEffectiveInitializer(declaration)!;
-            const type = getQuickTypeOfExpression(initializer) ||
+            const type = getQuickTypeOfExpression(initializer) ??
                 (contextualType ?
                     checkExpressionWithContextualType(initializer, contextualType, /*inferenceContext*/ undefined, checkMode || CheckMode.Normal)
                     : checkExpressionCached(initializer, checkMode));
@@ -34566,7 +34560,7 @@ namespace ts {
                     // If the contextual type is a type variable constrained to a primitive type, consider
                     // this a literal context for literals of that primitive type. For example, given a
                     // type parameter 'T extends string', infer string literal types for T.
-                    const constraint = getBaseConstraintOfType(contextualType) || unknownType;
+                    const constraint = getBaseConstraintOfType(contextualType) ?? unknownType;
                     return maybeTypeOfKind(constraint, TypeFlags.String) && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral) ||
                         maybeTypeOfKind(constraint, TypeFlags.Number) && maybeTypeOfKind(candidateType, TypeFlags.NumberLiteral) ||
                         maybeTypeOfKind(constraint, TypeFlags.BigInt) && maybeTypeOfKind(candidateType, TypeFlags.BigIntLiteral) ||
@@ -34629,7 +34623,7 @@ namespace ts {
             if (checkMode && checkMode & (CheckMode.Inferential | CheckMode.SkipGenericFunctions)) {
                 const callSignature = getSingleSignature(type, SignatureKind.Call, /*allowMembers*/ true);
                 const constructSignature = getSingleSignature(type, SignatureKind.Construct, /*allowMembers*/ true);
-                const signature = callSignature || constructSignature;
+                const signature = callSignature ?? constructSignature;
                 if (signature && signature.typeParameters) {
                     const contextualType = getApparentTypeOfContextualType(node as Expression, ContextFlags.NoConstraints);
                     if (contextualType) {
@@ -34693,7 +34687,7 @@ namespace ts {
         }
 
         function hasInferenceCandidates(info: InferenceInfo) {
-            return !!(info.candidates || info.contraCandidates);
+            return !!(info.candidates ?? info.contraCandidates);
         }
 
         function hasOverlappingInferences(a: InferenceInfo[], b: InferenceInfo[]) {
@@ -34792,7 +34786,7 @@ namespace ts {
             const type = checkExpression(node);
             // If control flow analysis was required to determine the type, it is worth caching.
             if (flowInvocationCount !== startInvocationCount) {
-                const cache = flowTypeCache || (flowTypeCache = []);
+                const cache = flowTypeCache ??= [];
                 cache[getNodeId(node)] = type;
                 setNodeFlags(node, node.flags | NodeFlags.TypeCached);
             }
@@ -35274,9 +35268,9 @@ namespace ts {
                             //    interface BadGenerator extends Iterable<number>, Iterator<string> { }
                             //    function* g(): BadGenerator { } // Iterable and Iterator have different types!
                             //
-                            const generatorYieldType = getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Yield, returnType, (functionFlags & FunctionFlags.Async) !== 0) || anyType;
-                            const generatorReturnType = getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Return, returnType, (functionFlags & FunctionFlags.Async) !== 0) || generatorYieldType;
-                            const generatorNextType = getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Next, returnType, (functionFlags & FunctionFlags.Async) !== 0) || unknownType;
+                            const generatorYieldType = getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Yield, returnType, (functionFlags & FunctionFlags.Async) !== 0) ?? anyType;
+                            const generatorReturnType = getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Return, returnType, (functionFlags & FunctionFlags.Async) !== 0) ?? generatorYieldType;
+                            const generatorNextType = getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Next, returnType, (functionFlags & FunctionFlags.Async) !== 0) ?? unknownType;
                             const generatorInstantiation = createGeneratorReturnType(generatorYieldType, generatorReturnType, generatorNextType, !!(functionFlags & FunctionFlags.Async));
                             checkTypeAssignableTo(generatorInstantiation, returnType, returnTypeNode);
                         }
@@ -36061,7 +36055,7 @@ namespace ts {
                             error(getNameOfDeclaration(o), Diagnostics.Overload_signatures_must_all_be_ambient_or_non_ambient);
                         }
                         else if (deviation & (ModifierFlags.Private | ModifierFlags.Protected)) {
-                            error(getNameOfDeclaration(o) || o, Diagnostics.Overload_signatures_must_all_be_public_private_or_protected);
+                            error(getNameOfDeclaration(o) ?? o, Diagnostics.Overload_signatures_must_all_be_public_private_or_protected);
                         }
                         else if (deviation & ModifierFlags.Abstract) {
                             error(getNameOfDeclaration(o), Diagnostics.Overload_signatures_must_all_be_abstract_or_non_abstract);
@@ -36113,7 +36107,7 @@ namespace ts {
                 // In this case the subsequent node is not really consecutive (.pos !== node.end), and we must ignore it here.
                 if (subsequentNode && subsequentNode.pos === node.end) {
                     if (subsequentNode.kind === node.kind) {
-                        const errorNode: Node = (subsequentNode as FunctionLikeDeclaration).name || subsequentNode;
+                        const errorNode: Node = (subsequentNode as FunctionLikeDeclaration).name ?? subsequentNode;
                         const subsequentName = (subsequentNode as FunctionLikeDeclaration).name;
                         if (node.name && subsequentName && (
                             // both are private identifiers
@@ -36144,7 +36138,7 @@ namespace ts {
                         }
                     }
                 }
-                const errorNode: Node = node.name || node;
+                const errorNode: Node = node.name ?? node;
                 if (isConstructor) {
                     error(errorNode, Diagnostics.Constructor_implementation_is_missing);
                 }
@@ -36231,7 +36225,7 @@ namespace ts {
 
             if (duplicateFunctionDeclaration) {
                 forEach(functionDeclarations, declaration => {
-                    error(getNameOfDeclaration(declaration) || declaration, Diagnostics.Duplicate_function_implementation);
+                    error(getNameOfDeclaration(declaration) ?? declaration, Diagnostics.Duplicate_function_implementation);
                 });
             }
 
@@ -36247,7 +36241,7 @@ namespace ts {
                                 : undefined;
                     if (diagnostic) {
                         addRelatedInfo(
-                            error(getNameOfDeclaration(declaration) || declaration, diagnostic, symbolName(symbol)),
+                            error(getNameOfDeclaration(declaration) ?? declaration, diagnostic, symbolName(symbol)),
                             ...relatedDiagnostics
                         );
                     }
@@ -36510,7 +36504,7 @@ namespace ts {
             const awaitedType = withAlias ?
                 getAwaitedType(type, errorNode, diagnosticMessage, arg0) :
                 getAwaitedTypeNoAlias(type, errorNode, diagnosticMessage, arg0);
-            return awaitedType || errorType;
+            return awaitedType ?? errorType;
         }
 
         /**
@@ -36763,7 +36757,7 @@ namespace ts {
                 if (globalPromiseType !== emptyGenericType && !isReferenceToType(returnType, globalPromiseType)) {
                     // The promise type was not a valid type reference to the global promise type, so we
                     // report an error and return the unknown type.
-                    error(returnTypeNode, Diagnostics.The_return_type_of_an_async_function_or_method_must_be_the_global_Promise_T_type_Did_you_mean_to_write_Promise_0, typeToString(getAwaitedTypeNoAlias(returnType) || voidType));
+                    error(returnTypeNode, Diagnostics.The_return_type_of_an_async_function_or_method_must_be_the_global_Promise_T_type_Did_you_mean_to_write_Promise_0, typeToString(getAwaitedTypeNoAlias(returnType) ?? voidType));
                     return;
                 }
             }
@@ -36890,7 +36884,7 @@ namespace ts {
                     && !symbolIsValue(rootSymbol)
                     && !some(rootSymbol.declarations, isTypeOnlyImportOrExportDeclaration)) {
                     const diag = error(typeName, Diagnostics.A_type_referenced_in_a_decorated_signature_must_be_imported_with_import_type_or_a_namespace_import_when_isolatedModules_and_emitDecoratorMetadata_are_enabled);
-                    const aliasDeclaration = find(rootSymbol.declarations || emptyArray, isAliasSymbolDeclaration);
+                    const aliasDeclaration = find(rootSymbol.declarations ?? emptyArray, isAliasSymbolDeclaration);
                     if (aliasDeclaration) {
                         addRelatedInfo(diag, createDiagnosticForNode(aliasDeclaration, Diagnostics._0_was_imported_here, idText(rootName)));
                     }
@@ -37173,7 +37167,7 @@ namespace ts {
                 // - if node.localSymbol !== undefined - this is current declaration is exported and localSymbol points to the local symbol
                 // - if node.localSymbol === undefined - this node is non-exported so we can just pick the result of getSymbolOfNode
                 const symbol = getSymbolOfNode(node);
-                const localSymbol = node.localSymbol || symbol;
+                const localSymbol = node.localSymbol ?? symbol;
 
                 // Since the javascript won't do semantic analysis like typescript,
                 // if the javascript file comes before the typescript file and both contain same name functions,
@@ -37296,7 +37290,7 @@ namespace ts {
         }
 
         function errorUnusedLocal(declaration: Declaration, name: string, addDiagnostic: AddUnusedDiagnostic) {
-            const node = getNameOfDeclaration(declaration) || declaration;
+            const node = getNameOfDeclaration(declaration) ?? declaration;
             const message = isTypeDeclaration(declaration) ? Diagnostics._0_is_declared_but_never_used : Diagnostics._0_is_declared_but_its_value_is_never_read;
             addDiagnostic(declaration, UnusedKind.Local, createDiagnosticForNode(node, message, name));
         }
@@ -37899,7 +37893,7 @@ namespace ts {
                 const parent = node.parent.parent;
                 const parentCheckMode = node.dotDotDotToken ? CheckMode.RestBindingElement : CheckMode.Normal;
                 const parentType = getTypeForBindingElementParent(parent, parentCheckMode);
-                const name = node.propertyName || node.name;
+                const name = node.propertyName ?? node.name;
                 if (parentType && !isBindingPattern(name)) {
                     const exprType = getLiteralTypeFromPropertyName(name);
                     if (isTypeUsableAsPropertyName(exprType)) {
@@ -38385,7 +38379,7 @@ namespace ts {
             if (isTypeAny(inputType)) {
                 return inputType;
             }
-            return getIteratedTypeOrElementType(use, inputType, sentType, errorNode, /*checkAssignability*/ true) || anyType;
+            return getIteratedTypeOrElementType(use, inputType, sentType, errorNode, /*checkAssignability*/ true) ?? anyType;
         }
 
         /**
@@ -38680,8 +38674,8 @@ namespace ts {
                 getGlobalAwaitedSymbol(/*reportErrors*/ true);
             }
             return createIterationTypes(
-                getAwaitedType(yieldType, errorNode) || anyType,
-                getAwaitedType(returnType, errorNode) || anyType,
+                getAwaitedType(yieldType, errorNode) ?? anyType,
+                getAwaitedType(returnType, errorNode) ?? anyType,
                 nextType);
         }
 
@@ -38702,7 +38696,7 @@ namespace ts {
 
             if (use & IterationUse.AllowsAsyncIterablesFlag) {
                 const iterationTypes =
-                    getIterationTypesOfIterableCached(type, asyncIterationTypesResolver) ||
+                    getIterationTypesOfIterableCached(type, asyncIterationTypesResolver) ??
                     getIterationTypesOfIterableFast(type, asyncIterationTypesResolver);
                 if (iterationTypes) {
                     return use & IterationUse.ForOfFlag ?
@@ -38713,7 +38707,7 @@ namespace ts {
 
             if (use & IterationUse.AllowsSyncIterablesFlag) {
                 const iterationTypes =
-                    getIterationTypesOfIterableCached(type, syncIterationTypesResolver) ||
+                    getIterationTypesOfIterableCached(type, syncIterationTypesResolver) ??
                     getIterationTypesOfIterableFast(type, syncIterationTypesResolver);
                 if (iterationTypes) {
                     if (use & IterationUse.AllowsAsyncIterablesFlag) {
@@ -38765,7 +38759,7 @@ namespace ts {
 
         function getIterationTypesOfGlobalIterableType(globalType: Type, resolver: IterationTypesResolver) {
             const globalIterationTypes =
-                getIterationTypesOfIterableCached(globalType, resolver) ||
+                getIterationTypesOfIterableCached(globalType, resolver) ??
                 getIterationTypesOfIterableSlow(globalType, resolver, /*errorNode*/ undefined);
             return globalIterationTypes === noIterationTypes ? defaultIterationTypes : globalIterationTypes;
         }
@@ -38796,7 +38790,7 @@ namespace ts {
                 // While we define these as `any` and `undefined` in our libs by default, a custom lib *could* use
                 // different definitions.
                 const { returnType, nextType } = getIterationTypesOfGlobalIterableType(globalType, resolver);
-                return setCachedIterationTypes(type, resolver.iterableCacheKey, createIterationTypes(resolver.resolveIterationType(yieldType, /*errorNode*/ undefined) || yieldType, resolver.resolveIterationType(returnType, /*errorNode*/ undefined) || returnType, nextType));
+                return setCachedIterationTypes(type, resolver.iterableCacheKey, createIterationTypes(resolver.resolveIterationType(yieldType, /*errorNode*/ undefined) ?? yieldType, resolver.resolveIterationType(returnType, /*errorNode*/ undefined) ?? returnType, nextType));
             }
 
             // As an optimization, if the type is an instantiation of the following global type, then
@@ -38804,7 +38798,7 @@ namespace ts {
             // - `Generator<T, TReturn, TNext>` or `AsyncGenerator<T, TReturn, TNext>`
             if (isReferenceToType(type, resolver.getGlobalGeneratorType(/*reportErrors*/ false))) {
                 const [yieldType, returnType, nextType] = getTypeArguments(type as GenericType);
-                return setCachedIterationTypes(type, resolver.iterableCacheKey, createIterationTypes(resolver.resolveIterationType(yieldType, /*errorNode*/ undefined) || yieldType, resolver.resolveIterationType(returnType, /*errorNode*/ undefined) || returnType, nextType));
+                return setCachedIterationTypes(type, resolver.iterableCacheKey, createIterationTypes(resolver.resolveIterationType(yieldType, /*errorNode*/ undefined) ?? yieldType, resolver.resolveIterationType(returnType, /*errorNode*/ undefined) ?? returnType, nextType));
             }
         }
 
@@ -38860,8 +38854,8 @@ namespace ts {
             }
 
             const iterationTypes =
-                getIterationTypesOfIteratorCached(type, resolver) ||
-                getIterationTypesOfIteratorFast(type, resolver) ||
+                getIterationTypesOfIteratorCached(type, resolver) ??
+                getIterationTypesOfIteratorFast(type, resolver) ??
                 getIterationTypesOfIteratorSlow(type, resolver, errorNode);
             return iterationTypes === noIterationTypes ? undefined : iterationTypes;
         }
@@ -38902,7 +38896,7 @@ namespace ts {
                 // iteration types of their `next`, `return`, and `throw` methods. While we define these as `any`
                 // and `undefined` in our libs by default, a custom lib *could* use different definitions.
                 const globalIterationTypes =
-                    getIterationTypesOfIteratorCached(globalType, resolver) ||
+                    getIterationTypesOfIteratorCached(globalType, resolver) ??
                     getIterationTypesOfIteratorSlow(globalType, resolver, /*errorNode*/ undefined);
                 const { returnType, nextType } = globalIterationTypes === noIterationTypes ? defaultIterationTypes : globalIterationTypes;
                 return setCachedIterationTypes(type, resolver.iteratorCacheKey, createIterationTypes(yieldType, returnType, nextType));
@@ -38919,7 +38913,7 @@ namespace ts {
             // > [done] is the result status of an iterator `next` method call. If the end of the iterator was reached `done` is `true`.
             // > If the end was not reached `done` is `false` and a value is available.
             // > If a `done` property (either own or inherited) does not exist, it is consider to have the value `false`.
-            const doneType = getTypeOfPropertyOfType(type, "done" as __String) || falseType;
+            const doneType = getTypeOfPropertyOfType(type, "done" as __String) ?? falseType;
             return isTypeAssignableTo(kind === IterationTypeKind.Yield ? falseType : trueType, doneType);
         }
 
@@ -38974,7 +38968,7 @@ namespace ts {
             // > ... If the iterator does not have a return value, `value` is `undefined`. In that case, the
             // > `value` property may be absent from the conforming object if it does not inherit an explicit
             // > `value` property.
-            return setCachedIterationTypes(type, "iterationTypesOfIteratorResult", createIterationTypes(yieldType, returnType || voidType, /*nextType*/ undefined));
+            return setCachedIterationTypes(type, "iterationTypesOfIteratorResult", createIterationTypes(yieldType, returnType ?? voidType, /*nextType*/ undefined));
         }
 
         /**
@@ -39057,7 +39051,7 @@ namespace ts {
                 }
                 else if (methodName === "return") {
                     // The value of `return(value)` *is* awaited by async generators
-                    const resolvedMethodParameterType = resolver.resolveIterationType(methodParameterType, errorNode) || anyType;
+                    const resolvedMethodParameterType = resolver.resolveIterationType(methodParameterType, errorNode) ?? anyType;
                     returnTypes = append(returnTypes, resolvedMethodParameterType);
                 }
             }
@@ -39065,7 +39059,7 @@ namespace ts {
             // Resolve the *yield* and *return* types from the return type of the method (i.e. `IteratorResult`)
             let yieldType: Type;
             const methodReturnType = methodReturnTypes ? getIntersectionType(methodReturnTypes) : neverType;
-            const resolvedMethodReturnType = resolver.resolveIterationType(methodReturnType, errorNode) || anyType;
+            const resolvedMethodReturnType = resolver.resolveIterationType(methodReturnType, errorNode) ?? anyType;
             const iterationTypes = getIterationTypesOfIteratorResult(resolvedMethodReturnType);
             if (iterationTypes === noIterationTypes) {
                 if (errorNode) {
@@ -39122,7 +39116,7 @@ namespace ts {
 
             const use = isAsyncGenerator ? IterationUse.AsyncGeneratorReturnType : IterationUse.GeneratorReturnType;
             const resolver = isAsyncGenerator ? asyncIterationTypesResolver : syncIterationTypesResolver;
-            return getIterationTypesOfIterable(type, use, /*errorNode*/ undefined) ||
+            return getIterationTypesOfIterable(type, use, /*errorNode*/ undefined) ??
                 getIterationTypesOfIterator(type, resolver, /*errorNode*/ undefined);
         }
 
@@ -39136,8 +39130,8 @@ namespace ts {
         function unwrapReturnType(returnType: Type, functionFlags: FunctionFlags) {
             const isGenerator = !!(functionFlags & FunctionFlags.Generator);
             const isAsync = !!(functionFlags & FunctionFlags.Async);
-            return isGenerator ? getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Return, returnType, isAsync) || errorType :
-                isAsync ? getAwaitedTypeNoAlias(returnType) || errorType :
+            return isGenerator ? getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Return, returnType, isAsync) ?? errorType :
+                isAsync ? getAwaitedTypeNoAlias(returnType) ?? errorType :
                 returnType;
         }
 
@@ -39384,7 +39378,7 @@ namespace ts {
                 // We check only when (a) the property is declared in the containing type, or (b) the applicable index signature is declared
                 // in the containing type, or (c) the containing type is an interface and no base interface contains both the property and
                 // the index signature (i.e. property and index signature are declared in separate inherited interfaces).
-                const errorNode = localPropDeclaration || localIndexDeclaration ||
+                const errorNode = localPropDeclaration ?? localIndexDeclaration ??
                     (interfaceDeclaration && !some(getBaseTypes(type as InterfaceType), base => !!getPropertyOfObjectType(base, prop.escapedName) && !!getIndexTypeOfType(base, info.keyType)) ? interfaceDeclaration : undefined);
                 if (errorNode && !isTypeAssignableTo(propType, info.type)) {
                     error(errorNode, Diagnostics.Property_0_of_type_1_is_not_assignable_to_2_index_type_3,
@@ -39404,7 +39398,7 @@ namespace ts {
                 // We check only when (a) the check index signature is declared in the containing type, or (b) the applicable index
                 // signature is declared in the containing type, or (c) the containing type is an interface and no base interface contains
                 // both index signatures (i.e. the index signatures are declared in separate inherited interfaces).
-                const errorNode = localCheckDeclaration || localIndexDeclaration ||
+                const errorNode = localCheckDeclaration ?? localIndexDeclaration ??
                     (interfaceDeclaration && !some(getBaseTypes(type as InterfaceType), base => !!getIndexInfoOfType(base, checkInfo.keyType) && !!getIndexTypeOfType(base, info.keyType)) ? interfaceDeclaration : undefined);
                 if (errorNode && !isTypeAssignableTo(checkInfo.type, info.type)) {
                     error(errorNode, Diagnostics._0_index_type_1_is_not_assignable_to_2_index_type_3,
@@ -39682,17 +39676,17 @@ namespace ts {
                         }
                         else {
                             // Report static side error only when instance type is assignable
-                            checkTypeAssignableTo(staticType, getTypeWithoutSignatures(staticBaseType), node.name || node,
+                            checkTypeAssignableTo(staticType, getTypeWithoutSignatures(staticBaseType), node.name ?? node,
                                 Diagnostics.Class_static_side_0_incorrectly_extends_base_class_static_side_1);
                         }
                         if (baseConstructorType.flags & TypeFlags.TypeVariable) {
                             if (!isMixinConstructorType(staticType)) {
-                                error(node.name || node, Diagnostics.A_mixin_class_must_have_a_constructor_with_a_single_rest_parameter_of_type_any);
+                                error(node.name ?? node, Diagnostics.A_mixin_class_must_have_a_constructor_with_a_single_rest_parameter_of_type_any);
                             }
                             else {
                                 const constructSignatures = getSignaturesOfType(baseConstructorType, SignatureKind.Construct);
                                 if (constructSignatures.some(signature => signature.flags & SignatureFlags.Abstract) && !hasSyntacticModifier(node, ModifierFlags.Abstract)) {
-                                    error(node.name || node, Diagnostics.A_mixin_class_that_extends_from_a_type_variable_containing_an_abstract_construct_signature_must_also_be_declared_abstract);
+                                    error(node.name ?? node, Diagnostics.A_mixin_class_that_extends_from_a_type_variable_containing_an_abstract_construct_signature_must_also_be_declared_abstract);
                                 }
                             }
                         }
@@ -39951,7 +39945,7 @@ namespace ts {
             }
             if (!issuedMemberError) {
                 // check again with diagnostics to generate a less-specific error
-                checkTypeAssignableTo(typeWithThis, baseWithThis, node.name || node, broadDiag);
+                checkTypeAssignableTo(typeWithThis, baseWithThis, node.name ?? node, broadDiag);
             }
         }
 
@@ -40116,7 +40110,7 @@ namespace ts {
                             const errorMessage = overriddenInstanceProperty ?
                                 Diagnostics._0_is_defined_as_an_accessor_in_class_1_but_is_overridden_here_in_2_as_an_instance_property :
                                 Diagnostics._0_is_defined_as_a_property_in_class_1_but_is_overridden_here_in_2_as_an_accessor;
-                            error(getNameOfDeclaration(derived.valueDeclaration) || derived.valueDeclaration, errorMessage, symbolToString(base), typeToString(baseType), typeToString(type));
+                            error(getNameOfDeclaration(derived.valueDeclaration) ?? derived.valueDeclaration, errorMessage, symbolToString(base), typeToString(baseType), typeToString(type));
                         }
                         else if (useDefineForClassFields) {
                             const uninitialized = derived.declarations?.find(d => d.kind === SyntaxKind.PropertyDeclaration && !(d as PropertyDeclaration).initializer);
@@ -40133,7 +40127,7 @@ namespace ts {
                                     || !strictNullChecks
                                     || !isPropertyInitializedInConstructor(propName, type, constructor)) {
                                     const errorMessage = Diagnostics.Property_0_will_overwrite_the_base_property_in_1_If_this_is_intentional_add_an_initializer_Otherwise_add_a_declare_modifier_or_remove_the_redundant_declaration;
-                                    error(getNameOfDeclaration(derived.valueDeclaration) || derived.valueDeclaration, errorMessage, symbolToString(base), typeToString(baseType));
+                                    error(getNameOfDeclaration(derived.valueDeclaration) ?? derived.valueDeclaration, errorMessage, symbolToString(base), typeToString(baseType));
                                 }
                             }
                         }
@@ -40158,7 +40152,7 @@ namespace ts {
                         errorMessage = Diagnostics.Class_0_defines_instance_member_property_1_but_extended_class_2_defines_it_as_instance_member_function;
                     }
 
-                    error(getNameOfDeclaration(derived.valueDeclaration) || derived.valueDeclaration, errorMessage, typeToString(baseType), symbolToString(base), typeToString(type));
+                    error(getNameOfDeclaration(derived.valueDeclaration) ?? derived.valueDeclaration, errorMessage, typeToString(baseType), symbolToString(base), typeToString(type));
                 }
             }
         }
@@ -40841,19 +40835,19 @@ namespace ts {
                 // Based on symbol.flags we can compute a set of excluded meanings (meaning that resolved alias should not have,
                 // otherwise it will conflict with some local declaration). Note that in addition to normal flags we include matching SymbolFlags.Export*
                 // in order to prevent collisions with declarations that were exported from the current module (they still contribute to local names).
-                symbol = getMergedSymbol(symbol.exportSymbol || symbol);
+                symbol = getMergedSymbol(symbol.exportSymbol ?? symbol);
 
                 // A type-only import/export will already have a grammar error in a JS file, so no need to issue more errors within
                 if (isInJSFile(node) && !(target.flags & SymbolFlags.Value) && !isTypeOnlyImportOrExportDeclaration(node)) {
                     const errorNode =
-                        isImportOrExportSpecifier(node) ? node.propertyName || node.name :
+                        isImportOrExportSpecifier(node) ? node.propertyName ?? node.name :
                         isNamedDeclaration(node) ? node.name :
                         node;
 
                     Debug.assert(node.kind !== SyntaxKind.NamespaceExport);
                     if (node.kind === SyntaxKind.ExportSpecifier) {
                         const diag = error(errorNode, Diagnostics.Types_cannot_appear_in_export_declarations_in_JavaScript_files);
-                        const alreadyExportedSymbol = getSourceFileOfNode(node).symbol?.exports?.get((node.propertyName || node.name).escapedText);
+                        const alreadyExportedSymbol = getSourceFileOfNode(node).symbol?.exports?.get((node.propertyName ?? node.name).escapedText);
                         if (alreadyExportedSymbol === target) {
                             const exportingDeclaration = alreadyExportedSymbol.declarations?.find(isJSDocNode);
                             if (exportingDeclaration) {
@@ -40904,7 +40898,7 @@ namespace ts {
                                     const message = isType
                                         ? Diagnostics._0_is_a_type_and_must_be_imported_using_a_type_only_import_when_preserveValueImports_and_isolatedModules_are_both_enabled
                                         : Diagnostics._0_resolves_to_a_type_only_declaration_and_must_be_imported_using_a_type_only_import_when_preserveValueImports_and_isolatedModules_are_both_enabled;
-                                    const name = idText(node.kind === SyntaxKind.ImportSpecifier ? node.propertyName || node.name : node.name);
+                                    const name = idText(node.kind === SyntaxKind.ImportSpecifier ? node.propertyName ?? node.name : node.name);
                                     addTypeOnlyDeclarationRelatedInfo(
                                         error(node, message, name),
                                         isType ? undefined : typeOnlyAlias,
@@ -40924,7 +40918,7 @@ namespace ts {
                                     const message = isType
                                         ? Diagnostics.Re_exporting_a_type_when_the_isolatedModules_flag_is_provided_requires_using_export_type
                                         : Diagnostics._0_resolves_to_a_type_only_declaration_and_must_be_re_exported_using_a_type_only_re_export_when_isolatedModules_is_enabled;
-                                    const name = idText(node.propertyName || node.name);
+                                    const name = idText(node.propertyName ?? node.name);
                                     addTypeOnlyDeclarationRelatedInfo(
                                         error(node, message, name),
                                         isType ? undefined : typeOnlyAlias,
@@ -41214,10 +41208,10 @@ namespace ts {
         function checkExportSpecifier(node: ExportSpecifier) {
             checkAliasSymbol(node);
             if (getEmitDeclarations(compilerOptions)) {
-                collectLinkedAliases(node.propertyName || node.name, /*setVisibility*/ true);
+                collectLinkedAliases(node.propertyName ?? node.name, /*setVisibility*/ true);
             }
             if (!node.parent.parent.moduleSpecifier) {
-                const exportedName = node.propertyName || node.name;
+                const exportedName = node.propertyName ?? node.name;
                 // find immediate value referenced by exported name (SymbolFlags.Alias is set so we don't chase down aliases)
                 const symbol = resolveName(exportedName, exportedName.escapedText, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias,
                     /*nameNotFoundMessage*/ undefined, /*nameArg*/ undefined, /*isUse*/ true);
@@ -41228,7 +41222,7 @@ namespace ts {
                     markExportAsReferenced(node);
                     const target = symbol && (symbol.flags & SymbolFlags.Alias ? resolveAlias(symbol) : symbol);
                     if (!target || target === unknownSymbol || target.flags & SymbolFlags.Value) {
-                        checkExpressionCached(node.propertyName || node.name);
+                        checkExpressionCached(node.propertyName ?? node.name);
                     }
                 }
             }
@@ -41324,7 +41318,7 @@ namespace ts {
             if (!links.exportsChecked) {
                 const exportEqualsSymbol = moduleSymbol.exports!.get("export=" as __String);
                 if (exportEqualsSymbol && hasExportedMembers(moduleSymbol)) {
-                    const declaration = getDeclarationOfAliasSymbol(exportEqualsSymbol) || exportEqualsSymbol.valueDeclaration;
+                    const declaration = getDeclarationOfAliasSymbol(exportEqualsSymbol) ?? exportEqualsSymbol.valueDeclaration;
                     if (declaration && !isTopLevelInExternalModuleAugmentation(declaration) && !isInJSFile(declaration)) {
                         error(declaration, Diagnostics.An_export_assignment_cannot_be_used_in_a_module_with_other_exported_elements);
                     }
@@ -41670,7 +41664,7 @@ namespace ts {
             const enclosingFile = getSourceFileOfNode(node);
             const links = getNodeLinks(enclosingFile);
             if (!(links.flags & NodeCheckFlags.TypeChecked)) {
-                links.deferredNodes ||= new Set();
+                links.deferredNodes ??= new Set();
                 links.deferredNodes.add(node);
             }
         }
@@ -41749,7 +41743,7 @@ namespace ts {
         }
 
         function getPotentiallyUnusedIdentifiers(sourceFile: SourceFile): readonly PotentiallyUnusedIdentifier[] {
-            return allPotentiallyUnusedIdentifiers.get(sourceFile.path) || emptyArray;
+            return allPotentiallyUnusedIdentifiers.get(sourceFile.path) ?? emptyArray;
         }
 
         // Fully type check a source file and collect the relevant diagnostics.
@@ -42453,7 +42447,7 @@ namespace ts {
             if (isExportSpecifier(node)) {
                 return node.parent.parent.moduleSpecifier ?
                     getExternalModuleMember(node.parent.parent, node) :
-                    resolveEntityName(node.propertyName || node.name, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias);
+                    resolveEntityName(node.propertyName ?? node.name, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias);
             }
             else {
                 return resolveEntityName(node, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias);
@@ -42514,7 +42508,7 @@ namespace ts {
             }
 
             if (isBindingPattern(node)) {
-                return getTypeForVariableLikeDeclaration(node.parent, /*includeOptionality*/ true, CheckMode.Normal) || errorType;
+                return getTypeForVariableLikeDeclaration(node.parent, /*includeOptionality*/ true, CheckMode.Normal) ?? errorType;
             }
 
             if (isInRightSideOfImportOrExportAssignment(node as Identifier)) {
@@ -42557,14 +42551,14 @@ namespace ts {
             //     for ({ skills: { primary, secondary } } = multiRobot, i = 0; i < 1; i++) {
             if (expr.parent.kind === SyntaxKind.PropertyAssignment) {
                 const node = cast(expr.parent.parent, isObjectLiteralExpression);
-                const typeOfParentObjectLiteral = getTypeOfAssignmentPattern(node) || errorType;
+                const typeOfParentObjectLiteral = getTypeOfAssignmentPattern(node) ?? errorType;
                 const propertyIndex = indexOfNode(node.properties, expr.parent);
                 return checkObjectLiteralDestructuringPropertyAssignment(node, typeOfParentObjectLiteral, propertyIndex);
             }
             // Array literal assignment - array destructuring pattern
             const node = cast(expr.parent, isArrayLiteralExpression);
             //    [{ property1: p1, property2 }] = elems;
-            const typeOfArrayLiteral = getTypeOfAssignmentPattern(node) || errorType;
+            const typeOfArrayLiteral = getTypeOfAssignmentPattern(node) ?? errorType;
             const elementType = checkIteratedTypeOrElementType(IterationUse.Destructuring, typeOfArrayLiteral, undefinedType, expr.parent) || errorType;
             return checkArrayLiteralDestructuringElementAssignment(node, typeOfArrayLiteral, node.elements.indexOf(expr), elementType);
         }
@@ -43195,7 +43189,7 @@ namespace ts {
         }
 
         function getJsxFactoryEntity(location: Node): EntityName | undefined {
-            return location ? (getJsxNamespace(location), (getSourceFileOfNode(location).localJsxFactory || _jsxFactoryEntity)) : _jsxFactoryEntity;
+            return location ? (getJsxNamespace(location), (getSourceFileOfNode(location).localJsxFactory ?? _jsxFactoryEntity)) : _jsxFactoryEntity;
         }
 
         function getJsxFragmentFactoryEntity(location: Node): EntityName | undefined {
@@ -43389,7 +43383,7 @@ namespace ts {
                         const file = getSourceFileOfNode(decl);
                         const typeReferenceDirective = fileToDirective.get(file.path);
                         if (typeReferenceDirective) {
-                            (typeReferenceDirectives || (typeReferenceDirectives = [])).push(typeReferenceDirective);
+                            (typeReferenceDirectives ??= []).push(typeReferenceDirective);
                         }
                         else {
                             // found at least one entry that does not originate from type reference directive
@@ -43487,7 +43481,7 @@ namespace ts {
                     patternAmbientModules = concatenate(patternAmbientModules, file.patternAmbientModules);
                 }
                 if (file.moduleAugmentations.length) {
-                    (augmentations || (augmentations = [])).push(file.moduleAugmentations);
+                    (augmentations ??= []).push(file.moduleAugmentations);
                 }
                 if (file.symbol && file.symbol.globalExports) {
                     // Merge in UMD exports with first-in-wins semantics (see #9771)
@@ -43655,7 +43649,7 @@ namespace ts {
 
         function resolveHelpersModule(node: SourceFile, errorNode: Node) {
             if (!externalHelpersModule) {
-                externalHelpersModule = resolveExternalModule(node, externalHelpersModuleNameText, Diagnostics.This_syntax_requires_an_imported_helper_but_module_0_cannot_be_found, errorNode) || unknownSymbol;
+                externalHelpersModule = resolveExternalModule(node, externalHelpersModuleNameText, Diagnostics.This_syntax_requires_an_imported_helper_but_module_0_cannot_be_found, errorNode) ?? unknownSymbol;
             }
             return externalHelpersModule;
         }
@@ -44661,7 +44655,7 @@ namespace ts {
          * A set accessor has one parameter or a `this` parameter and one more parameter.
          */
         function doesAccessorHaveCorrectParameterCount(accessor: AccessorDeclaration) {
-            return getAccessorThisParameter(accessor) || accessor.parameters.length === (accessor.kind === SyntaxKind.GetAccessor ? 0 : 1);
+            return getAccessorThisParameter(accessor) ?? accessor.parameters.length === (accessor.kind === SyntaxKind.GetAccessor ? 0 : 1);
         }
 
         function getAccessorThisParameter(accessor: AccessorDeclaration): ParameterDeclaration | undefined {
@@ -44679,7 +44673,7 @@ namespace ts {
                 if (isInJSFile(parent) && isJSDocTypeExpression(parent)) {
                     const host = getJSDocHost(parent);
                     if (host) {
-                        parent = getSingleVariableOfVariableStatement(host) || host;
+                        parent = getSingleVariableOfVariableStatement(host) ?? host;
                     }
                 }
                 switch (parent.kind) {
@@ -45074,7 +45068,7 @@ namespace ts {
         }
 
         function checkGrammarConstructorTypeAnnotation(node: ConstructorDeclaration) {
-            const type = node.type || getEffectiveReturnTypeNode(node);
+            const type = node.type ?? getEffectiveReturnTypeNode(node);
             if (type) {
                 return grammarErrorOnNode(type, Diagnostics.Type_annotation_cannot_appear_on_a_constructor_declaration);
             }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1516,8 +1516,8 @@ namespace ts {
         if (typeAcquisition && typeAcquisition.enableAutoDiscovery !== undefined && typeAcquisition.enable === undefined) {
             return {
                 enable: typeAcquisition.enableAutoDiscovery,
-                include: typeAcquisition.include || [],
-                exclude: typeAcquisition.exclude || []
+                include: typeAcquisition.include ?? [],
+                exclude: typeAcquisition.exclude ?? []
             };
         }
         return typeAcquisition;
@@ -1624,7 +1624,7 @@ namespace ts {
                     else {
                         const watchOpt = getOptionDeclarationFromName(watchOptionsDidYouMeanDiagnostics.getOptionsNameMap, inputOptionName, /*allowShort*/ true);
                         if (watchOpt) {
-                            i = parseOptionValue(args, i, watchOptionsDidYouMeanDiagnostics, watchOpt, watchOptions || (watchOptions = {}), errors);
+                            i = parseOptionValue(args, i, watchOptionsDidYouMeanDiagnostics, watchOpt, watchOptions ??= {}, errors);
                         }
                         else {
                             errors.push(createUnknownOptionError(inputOptionName, diagnostics, createCompilerDiagnostic, s));
@@ -1638,7 +1638,7 @@ namespace ts {
         }
 
         function parseResponseFile(fileName: string) {
-            const text = tryReadFile(fileName, readFile || (fileName => sys.readFile(fileName)));
+            const text = tryReadFile(fileName, readFile ?? (fileName => sys.readFile(fileName)));
             if (!isString(text)) {
                 errors.push(text);
                 return;
@@ -1726,7 +1726,7 @@ namespace ts {
                         break;
                     case "list":
                         const result = parseListTypeOption(opt, args[i], errors);
-                        options[opt.name] = result || [];
+                        options[opt.name] = result ?? [];
                         if (result) {
                             i++;
                         }
@@ -2747,10 +2747,10 @@ namespace ts {
 
         const parsedConfig = parseConfig(json, sourceFile, host, basePath, configFileName, resolutionStack, errors, extendedConfigCache);
         const { raw } = parsedConfig;
-        const options = extend(existingOptions, parsedConfig.options || {});
+        const options = extend(existingOptions, parsedConfig.options ?? {});
         const watchOptions = existingWatchOptions && parsedConfig.watchOptions ?
             extend(existingWatchOptions, parsedConfig.watchOptions) :
-            parsedConfig.watchOptions || existingWatchOptions;
+            parsedConfig.watchOptions ?? existingWatchOptions;
 
         options.configFilePath = configFileName && normalizeSlashes(configFileName);
         const configFileSpecs = getConfigFileSpecs();
@@ -2763,7 +2763,7 @@ namespace ts {
             watchOptions,
             fileNames: getFileNames(basePathForFileNames),
             projectReferences: getProjectReferences(basePathForFileNames),
-            typeAcquisition: parsedConfig.typeAcquisition || getDefaultTypeAcquisition(),
+            typeAcquisition: parsedConfig.typeAcquisition ?? getDefaultTypeAcquisition(),
             raw,
             errors,
             // Wildcard directories (provided as part of a wildcard path) are stored in a
@@ -2857,7 +2857,7 @@ namespace ts {
                         createCompilerDiagnosticOnlyIfJson(Diagnostics.Compiler_option_0_requires_a_value_of_type_1, "reference.path", "string");
                     }
                     else {
-                        (projectReferences || (projectReferences = [])).push({
+                        (projectReferences ??= []).push({
                             path: getNormalizedAbsolutePath(ref.path, basePath),
                             originalPath: ref.path,
                             prepend: ref.prepend,
@@ -2910,8 +2910,8 @@ namespace ts {
         return createCompilerDiagnostic(
             Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2,
             configFileName || "tsconfig.json",
-            JSON.stringify(includeSpecs || []),
-            JSON.stringify(excludeSpecs || []));
+            JSON.stringify(includeSpecs ?? []),
+            JSON.stringify(excludeSpecs ?? []));
     }
 
     function shouldReportNoInputFiles(fileNames: string[], canJsonReportNoInutFiles: boolean, resolutionStack?: Path[]) {
@@ -3008,7 +3008,7 @@ namespace ts {
                 ownConfig.options = assign({}, extendedConfig.options, ownConfig.options);
                 ownConfig.watchOptions = ownConfig.watchOptions && extendedConfig.watchOptions ?
                     assign({}, extendedConfig.watchOptions, ownConfig.watchOptions) :
-                    ownConfig.watchOptions || extendedConfig.watchOptions;
+                    ownConfig.watchOptions ?? extendedConfig.watchOptions;
                 // TODO extend type typeAcquisition
             }
         }
@@ -3068,13 +3068,13 @@ namespace ts {
                         currentOption = options;
                         break;
                     case "watchOptions":
-                        currentOption = (watchOptions || (watchOptions = {}));
+                        currentOption = (watchOptions ??= {});
                         break;
                     case "typeAcquisition":
-                        currentOption = (typeAcquisition || (typeAcquisition = getDefaultTypeAcquisition(configFileName)));
+                        currentOption = (typeAcquisition ??= getDefaultTypeAcquisition(configFileName));
                         break;
                     case "typingOptions":
-                        currentOption = (typingOptionstypeAcquisition || (typingOptionstypeAcquisition = getDefaultTypeAcquisition(configFileName)));
+                        currentOption = (typingOptionstypeAcquisition ??= getDefaultTypeAcquisition(configFileName));
                         break;
                     default:
                         Debug.fail("Unknown option");
@@ -3270,7 +3270,7 @@ namespace ts {
         for (const id in jsonOptions) {
             const opt = optionsNameMap.get(id);
             if (opt) {
-                (defaultOptions || (defaultOptions = {}))[opt.name] = convertJsonOption(opt, jsonOptions[id], basePath, errors);
+                (defaultOptions ??= {})[opt.name] = convertJsonOption(opt, jsonOptions[id], basePath, errors);
             }
             else {
                 errors.push(createUnknownOptionError(id, diagnostics, createCompilerDiagnostic));

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -396,7 +396,7 @@ namespace ts {
                 }
             }
         }
-        return result || emptyArray;
+        return result ?? emptyArray;
     }
 
     export function flatMapToMutable<T, U>(array: readonly T[] | undefined, mapfn: (x: T, i: number) => U | readonly U[] | undefined): U[] {
@@ -473,7 +473,7 @@ namespace ts {
                 }
             }
         }
-        return result || array;
+        return result ?? array;
     }
 
     export function mapAllOrFail<T, U>(array: readonly T[], mapFn: (x: T, i: number) => U | undefined): U[] | undefined {
@@ -796,7 +796,7 @@ namespace ts {
     export function sortAndDeduplicate<T>(array: readonly string[]): SortedReadonlyArray<string>;
     export function sortAndDeduplicate<T>(array: readonly T[], comparer: Comparer<T>, equalityComparer?: EqualityComparer<T>): SortedReadonlyArray<T>;
     export function sortAndDeduplicate<T>(array: readonly T[], comparer?: Comparer<T>, equalityComparer?: EqualityComparer<T>): SortedReadonlyArray<T> {
-        return deduplicateSorted(sort(array, comparer), equalityComparer || comparer || compareStringsCaseSensitive as any as Comparer<T>);
+        return deduplicateSorted(sort(array, comparer), equalityComparer ?? comparer ?? compareStringsCaseSensitive as any as Comparer<T>);
     }
 
     export function arrayIsSorted<T>(array: readonly T[], comparer: Comparer<T>) {
@@ -852,7 +852,7 @@ namespace ts {
                 }
             }
         }
-        return result || array;
+        return result ?? array;
     }
 
     /**
@@ -1999,10 +1999,10 @@ namespace ts {
             // Hold onto common string comparers. This avoids constantly reallocating comparers during
             // tests.
             if (locale === undefined) {
-                return defaultComparer || (defaultComparer = stringComparerFactory(locale));
+                return defaultComparer ??= stringComparerFactory(locale);
             }
             else if (locale === "en-US") {
-                return enUSComparer || (enUSComparer = stringComparerFactory(locale));
+                return enUSComparer ??= stringComparerFactory(locale);
             }
             else {
                 return stringComparerFactory(locale);
@@ -2035,7 +2035,7 @@ namespace ts {
      * accents/diacritic marks, or case as unequal.
      */
     export function compareStringsCaseSensitiveUI(a: string, b: string) {
-        const comparer = uiComparerCaseSensitive || (uiComparerCaseSensitive = createUIStringComparer(uiLocale));
+        const comparer = uiComparerCaseSensitive ??= createUIStringComparer(uiLocale);
         return comparer(a, b);
     }
 
@@ -2337,7 +2337,7 @@ namespace ts {
     }
 
     export function enumerateInsertsAndDeletes<T, U>(newItems: readonly T[], oldItems: readonly U[], comparer: (a: T, b: U) => Comparison, inserted: (newItem: T) => void, deleted: (oldItem: U) => void, unchanged?: (oldItem: U, newItem: T) => void) {
-        unchanged = unchanged || noop;
+        unchanged ??= noop;
         let newIndex = 0;
         let oldIndex = 0;
         const newLen = newItems.length;

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -114,7 +114,7 @@ namespace ts {
             debugger;
             const e = new Error(message ? `Debug Failure. ${message}` : "Debug Failure.");
             if ((Error as any).captureStackTrace) {
-                (Error as any).captureStackTrace(e, stackCrawlMark || fail);
+                (Error as any).captureStackTrace(e, stackCrawlMark ?? fail);
             }
             throw e;
         }
@@ -122,7 +122,7 @@ namespace ts {
         export function failBadSyntaxKind(node: Node, message?: string, stackCrawlMark?: AnyFunction): never {
             return fail(
                 `${message || "Unexpected node."}\r\nNode ${formatSyntaxKind(node.kind)} was unexpected.`,
-                stackCrawlMark || failBadSyntaxKind);
+                stackCrawlMark ?? failBadSyntaxKind);
         }
 
         export function assert(expression: unknown, message?: string, verboseDebugInfo?: string | (() => string), stackCrawlMark?: AnyFunction): asserts expression {
@@ -131,44 +131,44 @@ namespace ts {
                 if (verboseDebugInfo) {
                     message += "\r\nVerbose Debug Information: " + (typeof verboseDebugInfo === "string" ? verboseDebugInfo : verboseDebugInfo());
                 }
-                fail(message, stackCrawlMark || assert);
+                fail(message, stackCrawlMark ?? assert);
             }
         }
 
         export function assertEqual<T>(a: T, b: T, msg?: string, msg2?: string, stackCrawlMark?: AnyFunction): void {
             if (a !== b) {
                 const message = msg ? msg2 ? `${msg} ${msg2}` : msg : "";
-                fail(`Expected ${a} === ${b}. ${message}`, stackCrawlMark || assertEqual);
+                fail(`Expected ${a} === ${b}. ${message}`, stackCrawlMark ?? assertEqual);
             }
         }
 
         export function assertLessThan(a: number, b: number, msg?: string, stackCrawlMark?: AnyFunction): void {
             if (a >= b) {
-                fail(`Expected ${a} < ${b}. ${msg || ""}`, stackCrawlMark || assertLessThan);
+                fail(`Expected ${a} < ${b}. ${msg || ""}`, stackCrawlMark ?? assertLessThan);
             }
         }
 
         export function assertLessThanOrEqual(a: number, b: number, stackCrawlMark?: AnyFunction): void {
             if (a > b) {
-                fail(`Expected ${a} <= ${b}`, stackCrawlMark || assertLessThanOrEqual);
+                fail(`Expected ${a} <= ${b}`, stackCrawlMark ?? assertLessThanOrEqual);
             }
         }
 
         export function assertGreaterThanOrEqual(a: number, b: number, stackCrawlMark?: AnyFunction): void {
             if (a < b) {
-                fail(`Expected ${a} >= ${b}`, stackCrawlMark || assertGreaterThanOrEqual);
+                fail(`Expected ${a} >= ${b}`, stackCrawlMark ?? assertGreaterThanOrEqual);
             }
         }
 
         export function assertIsDefined<T>(value: T, message?: string, stackCrawlMark?: AnyFunction): asserts value is NonNullable<T> {
             // eslint-disable-next-line no-null/no-null
             if (value === undefined || value === null) {
-                fail(message, stackCrawlMark || assertIsDefined);
+                fail(message, stackCrawlMark ?? assertIsDefined);
             }
         }
 
         export function checkDefined<T>(value: T | null | undefined, message?: string, stackCrawlMark?: AnyFunction): T {
-            assertIsDefined(value, message, stackCrawlMark || checkDefined);
+            assertIsDefined(value, message, stackCrawlMark ?? checkDefined);
             return value;
         }
 
@@ -176,18 +176,18 @@ namespace ts {
         export function assertEachIsDefined<T>(value: readonly T[], message?: string, stackCrawlMark?: AnyFunction): asserts value is readonly NonNullable<T>[];
         export function assertEachIsDefined<T>(value: readonly T[], message?: string, stackCrawlMark?: AnyFunction) {
             for (const v of value) {
-                assertIsDefined(v, message, stackCrawlMark || assertEachIsDefined);
+                assertIsDefined(v, message, stackCrawlMark ?? assertEachIsDefined);
             }
         }
 
         export function checkEachDefined<T, A extends readonly T[]>(value: A, message?: string, stackCrawlMark?: AnyFunction): A {
-            assertEachIsDefined(value, message, stackCrawlMark || checkEachDefined);
+            assertEachIsDefined(value, message, stackCrawlMark ?? checkEachDefined);
             return value;
         }
 
         export function assertNever(member: never, message = "Illegal value:", stackCrawlMark?: AnyFunction): never {
             const detail = typeof member === "object" && hasProperty(member, "kind") && hasProperty(member, "pos") ? "SyntaxKind: " + formatSyntaxKind((member as Node).kind) : JSON.stringify(member);
-            return fail(`${message} ${detail}`, stackCrawlMark || assertNever);
+            return fail(`${message} ${detail}`, stackCrawlMark ?? assertNever);
         }
 
         export function assertEachNode<T extends Node, U extends T>(nodes: NodeArray<T>, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts nodes is NodeArray<U>;
@@ -201,7 +201,7 @@ namespace ts {
                     test === undefined || every(nodes, test),
                     message || "Unexpected node.",
                     () => `Node array did not pass test '${getFunctionName(test)}'.`,
-                    stackCrawlMark || assertEachNode);
+                    stackCrawlMark ?? assertEachNode);
             }
         }
 
@@ -213,7 +213,7 @@ namespace ts {
                     node !== undefined && (test === undefined || test(node)),
                     message || "Unexpected node.",
                     () => `Node ${formatSyntaxKind(node?.kind)} did not pass test '${getFunctionName(test!)}'.`,
-                    stackCrawlMark || assertNode);
+                    stackCrawlMark ?? assertNode);
             }
         }
 
@@ -225,7 +225,7 @@ namespace ts {
                     node === undefined || test === undefined || !test(node),
                     message || "Unexpected node.",
                     () => `Node ${formatSyntaxKind(node!.kind)} should not have passed test '${getFunctionName(test!)}'.`,
-                    stackCrawlMark || assertNotNode);
+                    stackCrawlMark ?? assertNotNode);
             }
         }
 
@@ -238,7 +238,7 @@ namespace ts {
                     test === undefined || node === undefined || test(node),
                     message || "Unexpected node.",
                     () => `Node ${formatSyntaxKind(node?.kind)} did not pass test '${getFunctionName(test!)}'.`,
-                    stackCrawlMark || assertOptionalNode);
+                    stackCrawlMark ?? assertOptionalNode);
             }
         }
 
@@ -251,7 +251,7 @@ namespace ts {
                     kind === undefined || node === undefined || node.kind === kind,
                     message || "Unexpected node.",
                     () => `Node ${formatSyntaxKind(node?.kind)} was not a '${formatSyntaxKind(kind)}' token.`,
-                    stackCrawlMark || assertOptionalToken);
+                    stackCrawlMark ?? assertOptionalToken);
             }
         }
 
@@ -262,7 +262,7 @@ namespace ts {
                     node === undefined,
                     message || "Unexpected node.",
                     () => `Node ${formatSyntaxKind(node!.kind)} was unexpected'.`,
-                    stackCrawlMark || assertMissingNode);
+                    stackCrawlMark ?? assertMissingNode);
             }
         }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -149,11 +149,11 @@ namespace ts {
         return { addOutput, getOutputs };
         function addOutput(path: string | undefined) {
             if (path) {
-                (outputs || (outputs = [])).push(path);
+                (outputs ??= []).push(path);
             }
         }
         function getOutputs(): readonly string[] {
-            return outputs || emptyArray;
+            return outputs ?? emptyArray;
         }
     }
 
@@ -505,7 +505,7 @@ namespace ts {
                 return;
             }
             else if (isExportSpecifier(node)) {
-                resolver.collectLinkedAliases(node.propertyName || node.name, /*setVisibility*/ true);
+                resolver.collectLinkedAliases(node.propertyName ?? node.name, /*setVisibility*/ true);
                 return;
             }
             forEachChild(node, collectLinkedAliases);
@@ -1209,7 +1209,7 @@ namespace ts {
         }
 
         function getCurrentLineMap() {
-            return currentLineMap || (currentLineMap = getLineStarts(Debug.checkDefined(currentSourceFile)));
+            return currentLineMap ??= getLineStarts(Debug.checkDefined(currentSourceFile));
         }
 
         function emit(node: Node, parenthesizerRule?: (node: Node) => Node): void;
@@ -1836,7 +1836,7 @@ namespace ts {
                 for (const helper of helpers) {
                     if (!helper.scoped && !shouldSkip && !bundledHelpers.get(helper.name)) {
                         bundledHelpers.set(helper.name, true);
-                        (result || (result = [])).push(helper.name);
+                        (result ??= []).push(helper.name);
                     }
                 }
             }
@@ -2501,7 +2501,7 @@ namespace ts {
 
         function emitPropertyAccessExpression(node: PropertyAccessExpression) {
             emitExpression(node.expression, parenthesizer.parenthesizeLeftSideOfAccess);
-            const token = node.questionDotToken || setTextRangePosEnd(factory.createToken(SyntaxKind.DotToken) as DotToken, node.expression.end, node.name.pos);
+            const token = node.questionDotToken ?? setTextRangePosEnd(factory.createToken(SyntaxKind.DotToken) as DotToken, node.expression.end, node.name.pos);
             const linesBeforeDot = getLinesBetweenNodes(node, node.expression, token);
             const linesAfterDot = getLinesBetweenNodes(node, token, node.name);
 
@@ -3132,8 +3132,8 @@ namespace ts {
                 emit(node.catchClause);
             }
             if (node.finallyBlock) {
-                writeLineOrSpace(node, node.catchClause || node.tryBlock, node.finallyBlock);
-                emitTokenWithComment(SyntaxKind.FinallyKeyword, (node.catchClause || node.tryBlock).end, writeKeyword, node);
+                writeLineOrSpace(node, node.catchClause ?? node.tryBlock, node.finallyBlock);
+                emitTokenWithComment(SyntaxKind.FinallyKeyword, (node.catchClause ?? node.tryBlock).end, writeKeyword, node);
                 writeSpace();
                 emit(node.finallyBlock);
             }
@@ -3988,7 +3988,7 @@ namespace ts {
         }
 
         function emitSyntheticTripleSlashReferencesIfNeeded(node: Bundle) {
-            emitTripleSlashDirectives(!!node.hasNoDefaultLib, node.syntheticFileReferences || [], node.syntheticTypeReferences || [], node.syntheticLibReferences || []);
+            emitTripleSlashDirectives(!!node.hasNoDefaultLib, node.syntheticFileReferences ?? [], node.syntheticTypeReferences ?? [], node.syntheticLibReferences ?? []);
             for (const prepend of node.prepends) {
                 if (isUnparsedSource(prepend) && prepend.syntheticReferences) {
                     for (const ref of prepend.syntheticReferences) {
@@ -4150,7 +4150,7 @@ namespace ts {
                     if (!isPrologueDirective(statement)) break;
                     if (seenPrologueDirectives.has(statement.expression.text)) continue;
                     seenPrologueDirectives.add(statement.expression.text);
-                    (directives || (directives = [])).push({
+                    (directives ??= []).push({
                         pos: statement.pos,
                         end: statement.end,
                         expression: {
@@ -4161,7 +4161,7 @@ namespace ts {
                     });
                     end = end < statement.end ? statement.end : end;
                 }
-                if (directives) (prologues || (prologues = [])).push({ file: index, text: sourceFile.text.substring(0, end), directives });
+                if (directives) (prologues ??= []).push({ file: index, text: sourceFile.text.substring(0, end), directives });
             }
             return prologues;
         }
@@ -5105,7 +5105,7 @@ namespace ts {
                     forEach((node as NamedImports).elements, generateNames);
                     break;
                 case SyntaxKind.ImportSpecifier:
-                    generateNameIfNeeded((node as ImportSpecifier).propertyName || (node as ImportSpecifier).name);
+                    generateNameIfNeeded((node as ImportSpecifier).propertyName ?? (node as ImportSpecifier).name);
                     break;
             }
         }
@@ -5770,7 +5770,7 @@ namespace ts {
 
         function getParsedSourceMap(node: UnparsedSource) {
             if (node.parsedSourceMap === undefined && node.sourceMapText !== undefined) {
-                node.parsedSourceMap = tryParseRawSourceMap(node.sourceMapText) || false;
+                node.parsedSourceMap = tryParseRawSourceMap(node.sourceMapText) ?? false;
             }
             return node.parsedSourceMap || undefined;
         }
@@ -5802,11 +5802,11 @@ namespace ts {
                 }
             }
             else {
-                const source = sourceMapRange.source || sourceMapSource;
+                const source = sourceMapRange.source ?? sourceMapSource;
                 if (node.kind !== SyntaxKind.NotEmittedStatement
                     && (emitFlags & EmitFlags.NoLeadingSourceMap) === 0
                     && sourceMapRange.pos >= 0) {
-                    emitSourcePos(sourceMapRange.source || sourceMapSource, skipSourceTrivia(source, sourceMapRange.pos));
+                    emitSourcePos(source, skipSourceTrivia(source, sourceMapRange.pos));
                 }
                 if (emitFlags & EmitFlags.NoNestedSourceMaps) {
                     sourceMapsDisabled = true;
@@ -5826,7 +5826,7 @@ namespace ts {
                 if (node.kind !== SyntaxKind.NotEmittedStatement
                     && (emitFlags & EmitFlags.NoTrailingSourceMap) === 0
                     && sourceMapRange.end >= 0) {
-                    emitSourcePos(sourceMapRange.source || sourceMapSource, sourceMapRange.end);
+                    emitSourcePos(sourceMapRange.source ?? sourceMapSource, sourceMapRange.end);
                 }
             }
         }

--- a/src/compiler/factory/emitHelpers.ts
+++ b/src/compiler/factory/emitHelpers.ts
@@ -161,7 +161,7 @@ namespace ts {
             context.requestEmitHelper(asyncGeneratorHelper);
 
             // Mark this node as originally an async function
-            (generatorFunc.emitNode || (generatorFunc.emitNode = {} as EmitNode)).flags |= EmitFlags.AsyncFunctionBody | EmitFlags.ReuseTempVariableScope;
+            (generatorFunc.emitNode ??= {} as EmitNode).flags |= EmitFlags.AsyncFunctionBody | EmitFlags.ReuseTempVariableScope;
 
             return factory.createCallExpression(
                 getUnscopedHelperName("__asyncGenerator"),
@@ -253,7 +253,7 @@ namespace ts {
             );
 
             // Mark this node as originally an async function
-            (generatorFunc.emitNode || (generatorFunc.emitNode = {} as EmitNode)).flags |= EmitFlags.AsyncFunctionBody | EmitFlags.ReuseTempVariableScope;
+            (generatorFunc.emitNode ??= {} as EmitNode).flags |= EmitFlags.AsyncFunctionBody | EmitFlags.ReuseTempVariableScope;
 
             return factory.createCallExpression(
                 getUnscopedHelperName("__awaiter"),
@@ -997,7 +997,7 @@ namespace ts {
     let allUnscopedEmitHelpers: ReadonlyESMap<string, UnscopedEmitHelper> | undefined;
 
     export function getAllUnscopedEmitHelpers() {
-        return allUnscopedEmitHelpers || (allUnscopedEmitHelpers = arrayToMap([
+        return allUnscopedEmitHelpers ??= arrayToMap([
             decorateHelper,
             metadataHelper,
             paramHelper,
@@ -1022,7 +1022,7 @@ namespace ts {
             classPrivateFieldInHelper,
             createBindingHelper,
             setModuleDefaultHelper
-        ], helper => helper.name));
+        ], helper => helper.name);
     }
 
     export const asyncSuperHelper: EmitHelper = {

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -6620,9 +6620,9 @@ namespace ts {
         setEachParent(prependChildren, node);
         node.hasNoDefaultLib = hasNoDefaultLib;
         node.helpers = helpers;
-        node.referencedFiles = referencedFiles || emptyArray;
+        node.referencedFiles = referencedFiles ?? emptyArray;
         node.typeReferenceDirectives = typeReferenceDirectives;
-        node.libReferenceDirectives = libReferenceDirectives || emptyArray;
+        node.libReferenceDirectives = libReferenceDirectives ?? emptyArray;
         return node;
     }
 

--- a/src/compiler/factory/parenthesizerRules.ts
+++ b/src/compiler/factory/parenthesizerRules.ts
@@ -42,7 +42,7 @@ namespace ts {
         };
 
         function getParenthesizeLeftSideOfBinaryForOperator(operatorKind: BinaryOperator) {
-            binaryLeftOperandParenthesizerCache ||= new Map();
+            binaryLeftOperandParenthesizerCache ??= new Map();
             let parenthesizerRule = binaryLeftOperandParenthesizerCache.get(operatorKind);
             if (!parenthesizerRule) {
                 parenthesizerRule = node => parenthesizeLeftSideOfBinary(operatorKind, node);
@@ -52,7 +52,7 @@ namespace ts {
         }
 
         function getParenthesizeRightSideOfBinaryForOperator(operatorKind: BinaryOperator) {
-            binaryRightOperandParenthesizerCache ||= new Map();
+            binaryRightOperandParenthesizerCache ??= new Map();
             let parenthesizerRule = binaryRightOperandParenthesizerCache.get(operatorKind);
             if (!parenthesizerRule) {
                 parenthesizerRule = node => parenthesizeRightSideOfBinary(operatorKind, /*leftSide*/ undefined, node);

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -556,7 +556,7 @@ namespace ts {
             if (create) {
                 const parseNode = getOriginalNode(node, isSourceFile);
                 const emitNode = getOrCreateEmitNode(parseNode);
-                return emitNode.externalHelpersModuleName || (emitNode.externalHelpersModuleName = factory.createUniqueName(externalHelpersModuleNameText));
+                return emitNode.externalHelpersModuleName ??= factory.createUniqueName(externalHelpersModuleNameText);
             }
         }
     }
@@ -591,8 +591,8 @@ namespace ts {
         const moduleName = getExternalModuleName(importNode);
         if (moduleName && isStringLiteral(moduleName)) {
             return tryGetModuleNameFromDeclaration(importNode, host, factory, resolver, compilerOptions)
-                || tryRenameExternalModule(factory, moduleName, sourceFile)
-                || factory.cloneNode(moduleName);
+                ?? tryRenameExternalModule(factory, moduleName, sourceFile)
+                ?? factory.cloneNode(moduleName);
         }
 
         return undefined;

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -293,7 +293,7 @@ namespace ts {
         forEachAncestorDirectory(normalizePath(currentDirectory), directory => {
             const atTypes = combinePaths(directory, nodeModulesAtTypes);
             if (host.directoryExists!(atTypes)) {
-                (typeRoots || (typeRoots = [])).push(atTypes);
+                (typeRoots ??= []).push(atTypes);
             }
             return undefined;
         });
@@ -665,7 +665,7 @@ namespace ts {
             return cache?.get(toPath(packageJsonPath, currentDirectory, getCanonicalFileName));
         }
         function setPackageJsonInfo(packageJsonPath: string, info: PackageJsonInfo | boolean) {
-            (cache ||= new Map()).set(toPath(packageJsonPath, currentDirectory, getCanonicalFileName), info);
+            (cache ??= new Map()).set(toPath(packageJsonPath, currentDirectory, getCanonicalFileName), info);
         }
         function clear() {
             cache = undefined;
@@ -808,8 +808,8 @@ namespace ts {
         directoryToModuleNameMap?: CacheWithRedirects<ModeAwareCache<ResolvedModuleWithFailedLookupLocations>>,
         moduleNameToDirectoryMap?: CacheWithRedirects<PerModuleNameCache>,
     ): ModuleResolutionCache {
-        const preDirectoryResolutionCache = createPerDirectoryResolutionCache(currentDirectory, getCanonicalFileName, directoryToModuleNameMap ||= createCacheWithRedirects(options));
-        moduleNameToDirectoryMap ||= createCacheWithRedirects(options);
+        const preDirectoryResolutionCache = createPerDirectoryResolutionCache(currentDirectory, getCanonicalFileName, directoryToModuleNameMap ??= createCacheWithRedirects(options));
+        moduleNameToDirectoryMap ??= createCacheWithRedirects(options);
         const packageJsonInfoCache = createPackageJsonInfoCache(currentDirectory, getCanonicalFileName);
 
         return {
@@ -930,8 +930,8 @@ namespace ts {
         packageJsonInfoCache?: PackageJsonInfoCache | undefined,
         directoryToModuleNameMap?: CacheWithRedirects<ModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>>,
     ): TypeReferenceDirectiveResolutionCache {
-        const preDirectoryResolutionCache = createPerDirectoryResolutionCache(currentDirectory, getCanonicalFileName, directoryToModuleNameMap ||= createCacheWithRedirects(options));
-        packageJsonInfoCache ||= createPackageJsonInfoCache(currentDirectory, getCanonicalFileName);
+        const preDirectoryResolutionCache = createPerDirectoryResolutionCache(currentDirectory, getCanonicalFileName, directoryToModuleNameMap ??= createCacheWithRedirects(options));
+        packageJsonInfoCache ??= createPackageJsonInfoCache(currentDirectory, getCanonicalFileName);
 
         return {
             ...packageJsonInfoCache,
@@ -1139,7 +1139,7 @@ namespace ts {
                 trace(state.host, Diagnostics.paths_option_is_specified_looking_for_a_pattern_to_match_module_name_0, moduleName);
             }
             const baseDirectory = getPathsBasePath(state.compilerOptions, state.host)!; // Always defined when 'paths' is defined
-            const pathPatterns = configFile?.configFileSpecs ? configFile.configFileSpecs.pathPatterns ||= tryParsePatterns(paths) : undefined;
+            const pathPatterns = configFile?.configFileSpecs ? configFile.configFileSpecs.pathPatterns ??= tryParsePatterns(paths) : undefined;
             return tryLoadModuleUsingPaths(extensions, moduleName, baseDirectory, paths, pathPatterns, loader, /*onlyRecordFailures*/ false, state);
         }
     }
@@ -1602,16 +1602,16 @@ namespace ts {
                     case Extension.Mjs:
                     case Extension.Mts:
                     case Extension.Dmts:
-                        return tryExtension(Extension.Mts) || (useDts ? tryExtension(Extension.Dmts) : undefined);
+                        return tryExtension(Extension.Mts) ?? (useDts ? tryExtension(Extension.Dmts) : undefined);
                     case Extension.Cjs:
                     case Extension.Cts:
                     case Extension.Dcts:
-                        return tryExtension(Extension.Cts) || (useDts ? tryExtension(Extension.Dcts) : undefined);
+                        return tryExtension(Extension.Cts) ?? (useDts ? tryExtension(Extension.Dcts) : undefined);
                     case Extension.Json:
                         candidate += Extension.Json;
                         return useDts ? tryExtension(Extension.Dts) : undefined;
                     default:
-                        return tryExtension(Extension.Ts) || tryExtension(Extension.Tsx) || (useDts ? tryExtension(Extension.Dts) : undefined);
+                        return tryExtension(Extension.Ts) ?? tryExtension(Extension.Tsx) ?? (useDts ? tryExtension(Extension.Dts) : undefined);
                 }
             case Extensions.JavaScript:
                 switch (originalExtension) {
@@ -1626,7 +1626,7 @@ namespace ts {
                     case Extension.Json:
                         return tryExtension(Extension.Json);
                     default:
-                        return tryExtension(Extension.Js) || tryExtension(Extension.Jsx);
+                        return tryExtension(Extension.Js) ?? tryExtension(Extension.Jsx);
                 }
             case Extensions.TSConfig:
             case Extensions.Json:
@@ -1729,7 +1729,7 @@ namespace ts {
             }
         }
 
-        return packageJsonInfo.resolvedEntrypoints = entrypoints || false;
+        return packageJsonInfo.resolvedEntrypoints = entrypoints ?? false;
     }
 
     function loadEntrypointsFromExportMap(
@@ -2447,7 +2447,7 @@ namespace ts {
                 return loadModuleFromExports(packageInfo, extensions, combinePaths(".", rest), state, cache, redirectedReference)?.value;
             }
             let pathAndExtension =
-                loadModuleFromFile(extensions, candidate, onlyRecordFailures, state) ||
+                loadModuleFromFile(extensions, candidate, onlyRecordFailures, state) ??
                 loadNodeModuleFromDirectoryWorker(
                     extensions,
                     candidate,
@@ -2490,7 +2490,7 @@ namespace ts {
     }
 
     function tryLoadModuleUsingPaths(extensions: Extensions, moduleName: string, baseDirectory: string, paths: MapLike<string[]>, pathPatterns: readonly (string | Pattern)[] | undefined, loader: ResolutionKindSpecificLoader, onlyRecordFailures: boolean, state: ModuleResolutionState): SearchResult<Resolved> {
-        pathPatterns ||= tryParsePatterns(paths);
+        pathPatterns ??= tryParsePatterns(paths);
         const matchedPattern = matchPatternOrExact(pathPatterns, moduleName);
         if (matchedPattern) {
             const matchedStar = isString(matchedPattern) ? undefined : matchedText(matchedPattern, moduleName);
@@ -2592,7 +2592,7 @@ namespace ts {
             reportDiagnostic: diag => void diagnostics.push(diag),
         };
 
-        const resolved = tryResolve(Extensions.TypeScript) || tryResolve(Extensions.JavaScript);
+        const resolved = tryResolve(Extensions.TypeScript) ?? tryResolve(Extensions.JavaScript);
         // No originalPath because classic resolution doesn't resolve realPath
         return createResolvedModuleWithFailedLookupLocations(
             resolved && resolved.value,

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -202,7 +202,7 @@ namespace ts.moduleSpecifiers {
         if (!moduleSourceFile) return { moduleSpecifiers: emptyArray, computedWithoutCache };
 
         computedWithoutCache = true;
-        modulePaths ||= getAllModulePathsWorker(importingSourceFile.path, moduleSourceFile.originalFileName, host);
+        modulePaths ??= getAllModulePathsWorker(importingSourceFile.path, moduleSourceFile.originalFileName, host);
         const result = computeModuleSpecifiers(modulePaths, compilerOptions, importingSourceFile, host, userPreferences, options);
         cache?.set(importingSourceFile.path, moduleSourceFile.path, userPreferences, options, modulePaths, result);
         return { moduleSpecifiers: result, computedWithoutCache };
@@ -398,7 +398,7 @@ namespace ts.moduleSpecifiers {
         const cwd = host.getCurrentDirectory();
         const referenceRedirect = host.isSourceOfProjectReferenceRedirect(importedFileName) ? host.getProjectReferenceRedirect(importedFileName) : undefined;
         const importedPath = toPath(importedFileName, cwd, getCanonicalFileName);
-        const redirects = host.redirectTargetsMap.get(importedPath) || emptyArray;
+        const redirects = host.redirectTargetsMap.get(importedPath) ?? emptyArray;
         const importedFileNames = [...(referenceRedirect ? [referenceRedirect] : emptyArray), importedFileName, ...redirects];
         const targets = importedFileNames.map(f => getNormalizedAbsolutePath(f, cwd));
         let shouldFilterIgnoredPaths = !every(targets, containsIgnoredPath);
@@ -491,7 +491,7 @@ namespace ts.moduleSpecifiers {
             let pathsInDirectory: ModulePath[] | undefined;
             allFileNames.forEach(({ path, isRedirect, isInNodeModules }, fileName) => {
                 if (startsWith(path, directoryStart)) {
-                    (pathsInDirectory ||= []).push({ path: fileName, isRedirect, isInNodeModules });
+                    (pathsInDirectory ??= []).push({ path: fileName, isRedirect, isInNodeModules });
                     allFileNames.delete(fileName);
                 }
             });
@@ -734,7 +734,7 @@ namespace ts.moduleSpecifiers {
             let moduleFileToTry = path;
             const cachedPackageJson = host.getPackageJsonInfoCache?.()?.getPackageJsonInfo(packageJsonPath);
             if (typeof cachedPackageJson === "object" || cachedPackageJson === undefined && host.fileExists(packageJsonPath)) {
-                const packageJsonContent = cachedPackageJson?.packageJsonContent || JSON.parse(host.readFile!(packageJsonPath)!);
+                const packageJsonContent = cachedPackageJson?.packageJsonContent ?? JSON.parse(host.readFile!(packageJsonPath)!);
                 if (getEmitModuleResolutionKind(options) === ModuleResolutionKind.Node16 || getEmitModuleResolutionKind(options) === ModuleResolutionKind.NodeNext) {
                     // `conditions` *could* be made to go against `importingSourceFile.impliedNodeFormat` if something wanted to generate
                     // an ImportEqualsDeclaration in an ESM-implied file or an ImportCall in a CJS-implied file. But since this function is

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -64,7 +64,7 @@ namespace ts {
     export function isFileProbablyExternalModule(sourceFile: SourceFile) {
         // Try to use the first top-level import/export when available, then
         // fall back to looking for an 'import.meta' somewhere in the tree if necessary.
-        return forEach(sourceFile.statements, isAnExternalModuleIndicatorNode) ||
+        return forEach(sourceFile.statements, isAnExternalModuleIndicatorNode) ??
             getImportMetaIfNecessary(sourceFile);
     }
 
@@ -769,7 +769,7 @@ namespace ts {
         else {
             const setIndicator = format === undefined ? overrideSetExternalModuleIndicator : (file: SourceFile) => {
                 file.impliedNodeFormat = format;
-                return (overrideSetExternalModuleIndicator || setExternalModuleIndicator)(file);
+                return (overrideSetExternalModuleIndicator ?? setExternalModuleIndicator)(file);
             };
             result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind, setIndicator);
         }
@@ -986,7 +986,7 @@ namespace ts {
 
             initializeState(fileName, sourceText, languageVersion, syntaxCursor, scriptKind);
 
-            const result = parseSourceFileWorker(languageVersion, setParentNodes, scriptKind, setExternalModuleIndicatorOverride || setExternalModuleIndicator);
+            const result = parseSourceFileWorker(languageVersion, setParentNodes, scriptKind, setExternalModuleIndicatorOverride ?? setExternalModuleIndicator);
 
             clearState();
 
@@ -1893,7 +1893,7 @@ namespace ts {
         function parseExpectedToken<TKind extends SyntaxKind>(t: TKind, diagnosticMessage?: DiagnosticMessage, arg0?: any): Token<TKind>;
         function parseExpectedToken(t: SyntaxKind, diagnosticMessage?: DiagnosticMessage, arg0?: any): Node {
             return parseOptionalToken(t) ||
-                createMissingNode(t, /*reportAtCurrentPosition*/ false, diagnosticMessage || Diagnostics._0_expected, arg0 || tokenToString(t));
+                createMissingNode(t, /*reportAtCurrentPosition*/ false, diagnosticMessage ?? Diagnostics._0_expected, arg0 || tokenToString(t));
         }
 
         function parseExpectedTokenJSDoc<TKind extends JSDocSyntaxKind>(t: TKind): Token<TKind>;
@@ -2010,7 +2010,7 @@ namespace ts {
             }
 
             if (token() === SyntaxKind.PrivateIdentifier) {
-                parseErrorAtCurrentToken(privateIdentifierDiagnosticMessage || Diagnostics.Private_identifiers_are_not_allowed_outside_class_bodies);
+                parseErrorAtCurrentToken(privateIdentifierDiagnosticMessage ?? Diagnostics.Private_identifiers_are_not_allowed_outside_class_bodies);
                 return createIdentifier(/*isIdentifier*/ true);
             }
 
@@ -2030,7 +2030,7 @@ namespace ts {
                 Diagnostics.Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here :
                 Diagnostics.Identifier_expected;
 
-            return createMissingNode<Identifier>(SyntaxKind.Identifier, reportAtCurrentPosition, diagnosticMessage || defaultMessage, msgArg);
+            return createMissingNode<Identifier>(SyntaxKind.Identifier, reportAtCurrentPosition, diagnosticMessage ?? defaultMessage, msgArg);
         }
 
         function parseBindingIdentifier(privateIdentifierDiagnosticMessage?: DiagnosticMessage) {
@@ -3893,7 +3893,7 @@ namespace ts {
                 case SyntaxKind.NeverKeyword:
                 case SyntaxKind.ObjectKeyword:
                     // If these are followed by a dot, then parse these out as a dotted type reference instead.
-                    return tryParse(parseKeywordAndNoDot) || parseTypeReference();
+                    return tryParse(parseKeywordAndNoDot) ?? parseTypeReference();
                 case SyntaxKind.AsteriskEqualsToken:
                     // If there is '*=', treat it as * followed by postfix =
                     scanner.reScanAsteriskEqualsToken();
@@ -4124,7 +4124,7 @@ namespace ts {
             if (token() === operator || hasLeadingOperator) {
                 const types = [type];
                 while (parseOptional(operator)) {
-                    types.push(parseFunctionOrConstructorTypeToError(isUnionType) || parseConstituentType());
+                    types.push(parseFunctionOrConstructorTypeToError(isUnionType) ?? parseConstituentType());
                 }
                 type = finishNode(createTypeNode(createNodeArray(types, pos)), pos);
             }
@@ -4387,7 +4387,7 @@ namespace ts {
             // If we do successfully parse arrow-function, we must *not* recurse for productions 1, 2 or 3. An ArrowFunction is
             // not a LeftHandSideExpression, nor does it start a ConditionalExpression.  So we are done
             // with AssignmentExpression if we see one.
-            const arrowExpression = tryParseParenthesizedArrowFunctionExpression(allowReturnTypeInArrowFunction) || tryParseAsyncSimpleArrowFunctionExpression(allowReturnTypeInArrowFunction);
+            const arrowExpression = tryParseParenthesizedArrowFunctionExpression(allowReturnTypeInArrowFunction) ?? tryParseAsyncSimpleArrowFunctionExpression(allowReturnTypeInArrowFunction);
             if (arrowExpression) {
                 return arrowExpression;
             }
@@ -4674,7 +4674,7 @@ namespace ts {
 
             const result = parseParenthesizedArrowFunctionExpression(/*allowAmbiguity*/ false, allowReturnTypeInArrowFunction);
             if (!result) {
-                (notParenthesizedArrow || (notParenthesizedArrow = new Set())).add(tokenPos);
+                (notParenthesizedArrow ??= new Set()).add(tokenPos);
             }
 
             return result;
@@ -5639,7 +5639,7 @@ namespace ts {
 
         function parsePropertyAccessExpressionRest(pos: number, expression: LeftHandSideExpression, questionDotToken: QuestionDotToken | undefined) {
             const name = parseRightSideOfDot(/*allowIdentifierNames*/ true, /*allowPrivateIdentifiers*/ true);
-            const isOptionalChain = questionDotToken || tryReparseOptionalChain(expression);
+            const isOptionalChain = questionDotToken ?? tryReparseOptionalChain(expression);
             const propertyAccess = isOptionalChain ?
                 factory.createPropertyAccessChain(expression, questionDotToken, name) :
                 factory.createPropertyAccessExpression(expression, name);
@@ -6949,7 +6949,7 @@ namespace ts {
             const node = factory.createPropertyDeclaration(
                 combineDecoratorsAndModifiers(decorators, modifiers),
                 name,
-                questionToken || exclamationToken,
+                questionToken ?? exclamationToken,
                 type,
                 initializer);
             return withJSDoc(finishNode(node, pos), hasJSDoc);
@@ -8672,7 +8672,7 @@ namespace ts {
                     while (child = tryParse(() => parseChildParameterOrPropertyTag(PropertyLikeParse.CallbackParameter, indent) as JSDocParameterTag)) {
                         parameters = append(parameters, child);
                     }
-                    return createNodeArray(parameters || [], pos);
+                    return createNodeArray(parameters ?? [], pos);
                 }
 
                 function parseCallbackTag(start: number, tagName: Identifier, indent: number, indentText: string): JSDocCallbackTag {
@@ -8859,7 +8859,7 @@ namespace ts {
 
                 function parseJSDocIdentifierName(message?: DiagnosticMessage): Identifier {
                     if (!tokenIsIdentifierOrKeyword(token())) {
-                        return createMissingNode<Identifier>(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ !message, message || Diagnostics.Identifier_expected);
+                        return createMissingNode<Identifier>(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ !message, message ?? Diagnostics.Identifier_expected);
                     }
 
                     identifierCount++;
@@ -9538,7 +9538,7 @@ namespace ts {
     export function processCommentPragmas(context: PragmaContext, sourceText: string): void {
         const pragmas: PragmaPseudoMapEntry[] = [];
 
-        for (const range of getLeadingCommentRanges(sourceText, 0) || emptyArray) {
+        for (const range of getLeadingCommentRanges(sourceText, 0) ?? emptyArray) {
             const comment = sourceText.substring(range.pos, range.end);
             extractPragmas(pragmas, range, comment);
         }

--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -118,7 +118,7 @@ namespace ts.performance {
     export function enable(system: System = sys) {
         if (!enabled) {
             enabled = true;
-            perfHooks ||= tryGetNativePerformanceHooks();
+            perfHooks ??= tryGetNativePerformanceHooks();
             if (perfHooks) {
                 timeorigin = perfHooks.performance.timeOrigin;
                 // NodeJS's Web Performance API is currently slower than expected, but we'd still like

--- a/src/compiler/performanceCore.ts
+++ b/src/compiler/performanceCore.ts
@@ -114,7 +114,7 @@ namespace ts {
 
     // Unlike with the native Map/Set 'tryGet' functions in corePublic.ts, we eagerly evaluate these
     // since we will need them for `timestamp`, below.
-    const nativePerformanceHooks = tryGetWebPerformanceHooks() || tryGetNodePerformanceHooks();
+    const nativePerformanceHooks = tryGetWebPerformanceHooks() ?? tryGetNodePerformanceHooks();
     const nativePerformance = nativePerformanceHooks?.performance;
 
     export function tryGetNativePerformanceHooks() {

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -426,7 +426,7 @@ namespace ts {
 
     /* @internal */
     export function getLineStarts(sourceFile: SourceFileLike): readonly number[] {
-        return sourceFile.lineMap || (sourceFile.lineMap = computeLineStarts(sourceFile.text));
+        return sourceFile.lineMap ??= computeLineStarts(sourceFile.text);
     }
 
     /* @internal */

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -59,7 +59,7 @@ namespace ts {
 
     /* @internal */
     export function getModifiedTime(host: { getModifiedTime: NonNullable<System["getModifiedTime"]>; }, fileName: string) {
-        return host.getModifiedTime(fileName) || missingFileModifiedTime;
+        return host.getModifiedTime(fileName) ?? missingFileModifiedTime;
     }
 
     interface Levels {
@@ -87,8 +87,8 @@ namespace ts {
             return;
         }
         const pollingIntervalChanged = setCustomLevels("TSC_WATCH_POLLINGINTERVAL", PollingInterval);
-        pollingChunkSize = getCustomPollingBasedLevels("TSC_WATCH_POLLINGCHUNKSIZE", defaultChunkLevels) || pollingChunkSize;
-        unchangedPollThresholds = getCustomPollingBasedLevels("TSC_WATCH_UNCHANGEDPOLLTHRESHOLDS", defaultChunkLevels) || unchangedPollThresholds;
+        pollingChunkSize = getCustomPollingBasedLevels("TSC_WATCH_POLLINGCHUNKSIZE", defaultChunkLevels) ?? pollingChunkSize;
+        unchangedPollThresholds = getCustomPollingBasedLevels("TSC_WATCH_UNCHANGEDPOLLTHRESHOLDS", defaultChunkLevels) ?? unchangedPollThresholds;
 
         function getLevel(envVar: string, level: keyof Levels) {
             return system.getEnvironmentVariable(`${envVar}_${level.toUpperCase()}`);
@@ -104,7 +104,7 @@ namespace ts {
             function setCustomLevel(level: keyof Levels) {
                 const customLevel = getLevel(baseVariable, level);
                 if (customLevel) {
-                    (customLevels || (customLevels = {}))[level] = Number(customLevel);
+                    (customLevels ??= {})[level] = Number(customLevel);
                 }
             }
         }
@@ -343,7 +343,7 @@ namespace ts {
             const filePath = toCanonicalName(fileName);
             fileWatcherCallbacks.add(filePath, callback);
             const dirPath = getDirectoryPath(filePath) || ".";
-            const watcher = dirWatchers.get(dirPath) ||
+            const watcher = dirWatchers.get(dirPath) ??
                 createDirectoryWatcher(getDirectoryPath(fileName) || ".", dirPath, fallbackOptions);
             watcher.referenceCount++;
             return {
@@ -745,7 +745,7 @@ namespace ts {
                 closeFileWatcher,
                 addChildDirectoryWatcher
             );
-            parentWatcher.childWatches = newChildWatches || emptyArray;
+            parentWatcher.childWatches = newChildWatches ?? emptyArray;
             return hasChanges;
 
             /**
@@ -760,7 +760,7 @@ namespace ts {
              * Add child directory watcher to the new ChildDirectoryWatcher list
              */
             function addChildDirectoryWatcher(childWatcher: ChildDirectoryWatcher) {
-                (newChildWatches || (newChildWatches = [])).push(childWatcher);
+                (newChildWatches ??= []).push(childWatcher);
             }
         }
 
@@ -805,7 +805,7 @@ namespace ts {
         return (eventName, _relativeFileName, modifiedTime) => {
             if (eventName === "rename") {
                 // Check time stamps rather than file system entry checks
-                modifiedTime ||= getModifiedTime(fileName) || missingFileModifiedTime;
+                modifiedTime ??= getModifiedTime(fileName) ?? missingFileModifiedTime;
                 callback(fileName, modifiedTime !== missingFileModifiedTime ? FileWatcherEventKind.Created : FileWatcherEventKind.Deleted, modifiedTime);
             }
             else {
@@ -938,11 +938,11 @@ namespace ts {
         }
 
         function ensureDynamicPollingWatchFile() {
-            return dynamicPollingWatchFile ||= createDynamicPriorityPollingWatchFile({ getModifiedTime, setTimeout });
+            return dynamicPollingWatchFile ??= createDynamicPriorityPollingWatchFile({ getModifiedTime, setTimeout });
         }
 
         function ensureFixedChunkSizePollingWatchFile() {
-            return fixedChunkSizePollingWatchFile ||= createFixedChunkSizePollingWatchFile({ getModifiedTime, setTimeout });
+            return fixedChunkSizePollingWatchFile ??= createFixedChunkSizePollingWatchFile({ getModifiedTime, setTimeout });
         }
 
         function updateOptionsForWatchFile(options: WatchOptions | undefined, useNonPollingWatchers?: boolean): WatchOptions {
@@ -1159,7 +1159,7 @@ namespace ts {
                     (!relativeName ||
                         relativeName === lastDirectoryPart ||
                         endsWith(relativeName, lastDirectoryPartWithDirectorySeparator!))) {
-                    const modifiedTime = getModifiedTime(fileOrDirectory) || missingFileModifiedTime;
+                    const modifiedTime = getModifiedTime(fileOrDirectory) ?? missingFileModifiedTime;
                     if (originalRelativeName) callback(event, originalRelativeName, modifiedTime);
                     callback(event, relativeName, modifiedTime);
                     if (inodeWatching) {
@@ -1198,7 +1198,7 @@ namespace ts {
                     fileOrDirectory,
                     (_fileName, eventKind, modifiedTime) => {
                         if (eventKind === FileWatcherEventKind.Created) {
-                            modifiedTime ||= getModifiedTime(fileOrDirectory) || missingFileModifiedTime;
+                            modifiedTime ??= getModifiedTime(fileOrDirectory) ?? missingFileModifiedTime;
                             if (modifiedTime !== missingFileModifiedTime) {
                                 callback("rename", "", modifiedTime);
                                 // Call the callback for current file or directory

--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -587,7 +587,7 @@ namespace ts {
                         expression = expandPreOrPostfixIncrementOrDecrementExpression(factory, node, expression, hoistVariableDeclaration, temp);
                         expression = createPrivateIdentifierAssignment(
                             info,
-                            initializeExpression || readExpression,
+                            initializeExpression ?? readExpression,
                             expression,
                             SyntaxKind.EqualsToken
                         );
@@ -895,7 +895,7 @@ namespace ts {
 
             if (isCompoundAssignment(operator)) {
                 const { readExpression, initializeExpression } = createCopiableReceiverExpr(receiver);
-                receiver = initializeExpression || readExpression;
+                receiver = initializeExpression ?? readExpression;
                 right = factory.createBinaryExpression(
                     createPrivateIdentifierAccessHelper(info, readExpression),
                     getNonAssignmentOperatorForCompoundAssignment(operator),
@@ -1146,7 +1146,7 @@ namespace ts {
                 }
                 else {
                     const expressions: Expression[] = [];
-                    temp ||= createClassTempVar();
+                    temp ??= createClassTempVar();
                     if (isClassWithConstructorReference) {
                         // record an alias as the class name is not in scope for statics.
                         enableSubstitutionForClassAliases();
@@ -1262,7 +1262,7 @@ namespace ts {
                             parameters ?? [],
                             body
                         ),
-                        constructor || node
+                        constructor ?? node
                     ),
                     constructor
                 )
@@ -1728,7 +1728,7 @@ namespace ts {
         }
 
         function substituteExpressionIdentifier(node: Identifier): Expression {
-            return trySubstituteClassAlias(node) || node;
+            return trySubstituteClassAlias(node) ?? node;
         }
 
         function trySubstituteClassAlias(node: Identifier): Expression | undefined {
@@ -1790,7 +1790,7 @@ namespace ts {
         }
 
         function getClassLexicalEnvironment() {
-            return currentClassLexicalEnvironment ||= {
+            return currentClassLexicalEnvironment ??= {
                 facts: ClassFacts.None,
                 classConstructor: undefined,
                 superClassReference: undefined,
@@ -1800,7 +1800,7 @@ namespace ts {
 
         function getPrivateIdentifierEnvironment() {
             const lex = getClassLexicalEnvironment();
-            lex.privateIdentifierEnvironment ||= {
+            lex.privateIdentifierEnvironment ??= {
                 className: "",
                 identifiers: new Map()
             };
@@ -1808,7 +1808,7 @@ namespace ts {
         }
 
         function getPendingExpressions() {
-            return pendingExpressions || (pendingExpressions = []);
+            return pendingExpressions ??= [];
         }
 
         function addPrivateIdentifierToEnvironment(node: PrivateClassElementDeclaration) {
@@ -2124,7 +2124,7 @@ namespace ts {
                 if (isSpreadAssignment(node)) {
                     return factory.updateSpreadAssignment(
                         node,
-                        wrapped || visitNode(node.expression, visitorDestructuringTarget, isExpression)
+                        wrapped ?? visitNode(node.expression, visitorDestructuringTarget, isExpression)
                     );
                 }
                 Debug.assert(wrapped === undefined, "Should not have generated a wrapped target");
@@ -2168,7 +2168,7 @@ namespace ts {
         return factory.createAssignment(
             variableName,
             factory.createObjectLiteralExpression([
-                factory.createPropertyAssignment("value", initializer || factory.createVoidZero())
+                factory.createPropertyAssignment("value", initializer ?? factory.createVoidZero())
             ])
         );
     }
@@ -2177,7 +2177,7 @@ namespace ts {
         return factory.createCallExpression(
             factory.createPropertyAccessExpression(weakMapName, "set"),
             /*typeArguments*/ undefined,
-            [receiver, initializer || factory.createVoidZero()]
+            [receiver, initializer ?? factory.createVoidZero()]
         );
     }
 

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -97,7 +97,7 @@ namespace ts {
             if (!typeReferenceDirectives) {
                 return;
             }
-            necessaryTypeReferences = necessaryTypeReferences || new Set();
+            necessaryTypeReferences ??= new Set();
             for (const ref of typeReferenceDirectives) {
                 necessaryTypeReferences.add(ref);
             }
@@ -135,14 +135,14 @@ namespace ts {
                 const errorInfo = getSymbolAccessibilityDiagnostic(symbolAccessibilityResult);
                 if (errorInfo) {
                     if (errorInfo.typeName) {
-                        context.addDiagnostic(createDiagnosticForNode(symbolAccessibilityResult.errorNode || errorInfo.errorNode,
+                        context.addDiagnostic(createDiagnosticForNode(symbolAccessibilityResult.errorNode ?? errorInfo.errorNode,
                             errorInfo.diagnosticMessage,
                             getTextOfNode(errorInfo.typeName),
                             symbolAccessibilityResult.errorSymbolName,
                             symbolAccessibilityResult.errorModuleName));
                     }
                     else {
-                        context.addDiagnostic(createDiagnosticForNode(symbolAccessibilityResult.errorNode || errorInfo.errorNode,
+                        context.addDiagnostic(createDiagnosticForNode(symbolAccessibilityResult.errorNode ?? errorInfo.errorNode,
                             errorInfo.diagnosticMessage,
                             symbolAccessibilityResult.errorSymbolName,
                             symbolAccessibilityResult.errorModuleName));
@@ -155,7 +155,7 @@ namespace ts {
 
         function trackExternalModuleSymbolOfImportTypeNode(symbol: Symbol) {
             if (!isBundledEmit) {
-                (exportedModulesFromDeclarationEmit || (exportedModulesFromDeclarationEmit = [])).push(symbol);
+                (exportedModulesFromDeclarationEmit ??= []).push(symbol);
             }
         }
 
@@ -169,7 +169,7 @@ namespace ts {
         function reportPrivateInBaseOfClassExpression(propertyName: string) {
             if (errorNameNode || errorFallbackNode) {
                 context.addDiagnostic(
-                    createDiagnosticForNode((errorNameNode || errorFallbackNode)!, Diagnostics.Property_0_of_exported_class_expression_may_not_be_private_or_protected, propertyName));
+                    createDiagnosticForNode((errorNameNode ?? errorFallbackNode)!, Diagnostics.Property_0_of_exported_class_expression_may_not_be_private_or_protected, propertyName));
             }
         }
 
@@ -182,7 +182,7 @@ namespace ts {
 
         function reportInaccessibleUniqueSymbolError() {
             if (errorNameNode || errorFallbackNode) {
-                context.addDiagnostic(createDiagnosticForNode((errorNameNode || errorFallbackNode)!, Diagnostics.The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary,
+                context.addDiagnostic(createDiagnosticForNode((errorNameNode ?? errorFallbackNode)!, Diagnostics.The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary,
                     errorDeclarationNameWithFallback(),
                     "unique symbol"));
             }
@@ -190,14 +190,14 @@ namespace ts {
 
         function reportCyclicStructureError() {
             if (errorNameNode || errorFallbackNode) {
-                context.addDiagnostic(createDiagnosticForNode((errorNameNode || errorFallbackNode)!, Diagnostics.The_inferred_type_of_0_references_a_type_with_a_cyclic_structure_which_cannot_be_trivially_serialized_A_type_annotation_is_necessary,
+                context.addDiagnostic(createDiagnosticForNode((errorNameNode ?? errorFallbackNode)!, Diagnostics.The_inferred_type_of_0_references_a_type_with_a_cyclic_structure_which_cannot_be_trivially_serialized_A_type_annotation_is_necessary,
                     errorDeclarationNameWithFallback()));
             }
         }
 
         function reportInaccessibleThisError() {
             if (errorNameNode || errorFallbackNode) {
-                context.addDiagnostic(createDiagnosticForNode((errorNameNode || errorFallbackNode)!, Diagnostics.The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary,
+                context.addDiagnostic(createDiagnosticForNode((errorNameNode ?? errorFallbackNode)!, Diagnostics.The_inferred_type_of_0_references_an_inaccessible_1_type_A_type_annotation_is_necessary,
                     errorDeclarationNameWithFallback(),
                     "this"));
             }
@@ -205,7 +205,7 @@ namespace ts {
 
         function reportLikelyUnsafeImportRequiredError(specifier: string) {
             if (errorNameNode || errorFallbackNode) {
-                context.addDiagnostic(createDiagnosticForNode((errorNameNode || errorFallbackNode)!, Diagnostics.The_inferred_type_of_0_cannot_be_named_without_a_reference_to_1_This_is_likely_not_portable_A_type_annotation_is_necessary,
+                context.addDiagnostic(createDiagnosticForNode((errorNameNode ?? errorFallbackNode)!, Diagnostics.The_inferred_type_of_0_cannot_be_named_without_a_reference_to_1_This_is_likely_not_portable_A_type_annotation_is_necessary,
                     errorDeclarationNameWithFallback(),
                     specifier));
             }
@@ -213,7 +213,7 @@ namespace ts {
 
         function reportTruncationError() {
             if (errorNameNode || errorFallbackNode) {
-                context.addDiagnostic(createDiagnosticForNode((errorNameNode || errorFallbackNode)!, Diagnostics.The_inferred_type_of_this_node_exceeds_the_maximum_length_the_compiler_will_serialize_An_explicit_type_annotation_is_needed));
+                context.addDiagnostic(createDiagnosticForNode((errorNameNode ?? errorFallbackNode)!, Diagnostics.The_inferred_type_of_this_node_exceeds_the_maximum_length_the_compiler_will_serialize_An_explicit_type_annotation_is_needed));
             }
         }
 
@@ -232,13 +232,13 @@ namespace ts {
 
         function reportNonSerializableProperty(propertyName: string) {
             if (errorNameNode || errorFallbackNode) {
-                context.addDiagnostic(createDiagnosticForNode((errorNameNode || errorFallbackNode)!, Diagnostics.The_type_of_this_node_cannot_be_serialized_because_its_property_0_cannot_be_serialized, propertyName));
+                context.addDiagnostic(createDiagnosticForNode((errorNameNode ?? errorFallbackNode)!, Diagnostics.The_type_of_this_node_cannot_be_serialized_because_its_property_0_cannot_be_serialized, propertyName));
             }
         }
 
         function reportImportTypeNodeResolutionModeOverride() {
             if (!isNightly() && (errorNameNode || errorFallbackNode)) {
-                context.addDiagnostic(createDiagnosticForNode((errorNameNode || errorFallbackNode)!, Diagnostics.The_type_of_this_expression_cannot_be_named_without_a_resolution_mode_assertion_which_is_an_unstable_feature_Use_nightly_TypeScript_to_silence_this_error_Try_updating_with_npm_install_D_typescript_next));
+                context.addDiagnostic(createDiagnosticForNode((errorNameNode ?? errorFallbackNode)!, Diagnostics.The_type_of_this_expression_cannot_be_named_without_a_resolution_mode_assertion_which_is_an_unstable_feature_Use_nightly_TypeScript_to_silence_this_error_Try_updating_with_npm_install_D_typescript_next));
             }
         }
 
@@ -248,7 +248,7 @@ namespace ts {
                 diagnosticMessage: s.errorModuleName
                     ? Diagnostics.Declaration_emit_for_this_file_requires_using_private_name_0_from_module_1_An_explicit_type_annotation_may_unblock_declaration_emit
                     : Diagnostics.Declaration_emit_for_this_file_requires_using_private_name_0_An_explicit_type_annotation_may_unblock_declaration_emit,
-                errorNode: s.errorNode || sourceFile
+                errorNode: s.errorNode ?? sourceFile
             }));
             const result = resolver.getDeclarationStatementsForSourceFile(sourceFile, declarationEmitNodeBuilderFlags, symbolTracker, bundled);
             getSymbolAccessibilityDiagnostic = oldDiag;
@@ -502,8 +502,8 @@ namespace ts {
                 maskModifiers(p, modifierMask),
                 p.dotDotDotToken,
                 filterBindingPatternInitializersAndRenamings(p.name),
-                resolver.isOptionalParameter(p) ? (p.questionToken || factory.createToken(SyntaxKind.QuestionToken)) : undefined,
-                ensureType(p, type || p.type, /*ignorePrivate*/ true), // Ignore private param props, since this type is going straight back into a param
+                resolver.isOptionalParameter(p) ? (p.questionToken ?? factory.createToken(SyntaxKind.QuestionToken)) : undefined,
+                ensureType(p, type ?? p.type, /*ignorePrivate*/ true), // Ignore private param props, since this type is going straight back into a param
                 ensureNoInitializer(p)
             );
             if (!suppressNewDiagnosticContexts) {
@@ -573,7 +573,7 @@ namespace ts {
                 || node.kind === SyntaxKind.PropertyDeclaration
                 || node.kind === SyntaxKind.PropertySignature) {
                 if (isPropertySignature(node) || !node.initializer) return cleanup(resolver.createTypeOfDeclaration(node, enclosingDeclaration, declarationEmitNodeBuilderFlags, symbolTracker, shouldUseResolverType));
-                return cleanup(resolver.createTypeOfDeclaration(node, enclosingDeclaration, declarationEmitNodeBuilderFlags, symbolTracker, shouldUseResolverType) || resolver.createTypeOfExpression(node.initializer, enclosingDeclaration, declarationEmitNodeBuilderFlags, symbolTracker));
+                return cleanup(resolver.createTypeOfDeclaration(node, enclosingDeclaration, declarationEmitNodeBuilderFlags, symbolTracker, shouldUseResolverType) ?? resolver.createTypeOfExpression(node.initializer, enclosingDeclaration, declarationEmitNodeBuilderFlags, symbolTracker));
             }
             return cleanup(resolver.createReturnTypeOfSignatureDeclaration(node, enclosingDeclaration, declarationEmitNodeBuilderFlags, symbolTracker));
 
@@ -582,7 +582,7 @@ namespace ts {
                 if (!suppressNewDiagnosticContexts) {
                     getSymbolAccessibilityDiagnostic = oldDiag;
                 }
-                return returnValue || factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
+                return returnValue ?? factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
             }
         }
 
@@ -670,7 +670,7 @@ namespace ts {
                 }
                 newParams = append(newParams, newValueParameter);
             }
-            return factory.createNodeArray(newParams || emptyArray);
+            return factory.createNodeArray(newParams ?? emptyArray);
         }
 
         function ensureTypeParams(node: Node, params: NodeArray<TypeParameterDeclaration> | undefined) {
@@ -714,7 +714,7 @@ namespace ts {
                 else {
                     const symbol = resolver.getSymbolOfExternalModuleSpecifier(input);
                     if (symbol) {
-                        (exportedModulesFromDeclarationEmit || (exportedModulesFromDeclarationEmit = [])).push(symbol);
+                        (exportedModulesFromDeclarationEmit ??= []).push(symbol);
                     }
                 }
             }
@@ -1250,7 +1250,7 @@ namespace ts {
                     if (clean && resolver.isExpandoFunctionDeclaration(input) && shouldEmitFunctionProperties(input)) {
                         const props = resolver.getPropertiesOfContainerFunction(input);
                         // Use parseNodeFactory so it is usable as an enclosing declaration
-                        const fakespace = parseNodeFactory.createModuleDeclaration(/*modifiers*/ undefined, clean.name || factory.createIdentifier("_default"), factory.createModuleBlock([]), NodeFlags.Namespace);
+                        const fakespace = parseNodeFactory.createModuleDeclaration(/*modifiers*/ undefined, clean.name ?? factory.createIdentifier("_default"), factory.createModuleBlock([]), NodeFlags.Namespace);
                         setParent(fakespace, enclosingDeclaration as SourceFile | NamespaceDeclaration);
                         fakespace.locals = createSymbolTable(props);
                         fakespace.symbol = props[0].parent!;
@@ -1410,7 +1410,7 @@ namespace ts {
                                     if (isBindingPattern(elem.name)) {
                                         elems = concatenate(elems, walkBindingPattern(elem.name));
                                     }
-                                    elems = elems || [];
+                                    elems ??= [];
                                     elems.push(factory.createPropertyDeclaration(
                                         ensureModifiers(param),
                                         elem.name as Identifier,

--- a/src/compiler/transformers/declarations/diagnostics.ts
+++ b/src/compiler/transformers/declarations/diagnostics.ts
@@ -306,7 +306,7 @@ namespace ts {
 
             return {
                 diagnosticMessage,
-                errorNode: (node as NamedDeclaration).name || node
+                errorNode: (node as NamedDeclaration).name ?? node
             };
         }
 

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -633,7 +633,7 @@ namespace ts {
                     convertedLoopState.containsLexicalThis = true;
                     return node;
                 }
-                return convertedLoopState.thisName || (convertedLoopState.thisName = factory.createUniqueName("this"));
+                return convertedLoopState.thisName ??= factory.createUniqueName("this");
             }
             return node;
         }
@@ -647,7 +647,7 @@ namespace ts {
                 return node;
             }
             if (resolver.isArgumentsLocalBinding(node)) {
-                return convertedLoopState.argumentsName || (convertedLoopState.argumentsName = factory.createUniqueName("arguments"));
+                return convertedLoopState.argumentsName ??= factory.createUniqueName("arguments");
             }
             return node;
         }
@@ -931,7 +931,7 @@ namespace ts {
                 transformConstructorBody(constructor, node, extendsClauseElement, hasSynthesizedSuper)
             );
 
-            setTextRange(constructorFunction, constructor || node);
+            setTextRange(constructorFunction, constructor ?? node);
             if (extendsClauseElement) {
                 setEmitFlags(constructorFunction, EmitFlags.CapturesThis);
             }
@@ -955,7 +955,7 @@ namespace ts {
             // If this is the case, we do not include the synthetic `...args` parameter and
             // will instead use the `arguments` object in ES5/3.
             return visitParameterList(constructor && !hasSynthesizedSuper ? constructor.parameters : undefined, visitor, context)
-                || [] as ParameterDeclaration[];
+                ?? [] as ParameterDeclaration[];
         }
 
         function createDefaultConstructorBody(node: ClassDeclaration | ClassExpression, isDerivedClass: boolean) {
@@ -1104,7 +1104,7 @@ namespace ts {
 
                     // If the super() call is the first statement, we can directly create and assign its result to `_this`
                     if (superStatementIndex <= existingPrologue.length) {
-                        insertCaptureThisForNode(statements, constructor, superCallExpression || createActualThis());
+                        insertCaptureThisForNode(statements, constructor, superCallExpression ?? createActualThis());
                     }
                     // Since the `super()` call isn't the first statement, it's split across 1-2 statements:
                     // * A prologue `var _this = this;`, in case the constructor accesses this before super()
@@ -2124,7 +2124,7 @@ namespace ts {
                 const element = node.elements[i];
                 const visited = visitNode(element, i < node.elements.length - 1 ? visitorWithUnusedExpressionResult : visitor, isExpression);
                 if (result || visited !== element) {
-                    result ||= node.elements.slice(0, i);
+                    result ??= node.elements.slice(0, i);
                     result.push(visited);
                 }
             }
@@ -2992,7 +2992,7 @@ namespace ts {
                 }
                 else {
                     // this is top level converted loop and we need to create an alias for 'arguments' object
-                    (extraVariableDeclarations || (extraVariableDeclarations = [])).push(
+                    (extraVariableDeclarations ??= []).push(
                         factory.createVariableDeclaration(
                             state.argumentsName,
                             /*exclamationToken*/ undefined,
@@ -3014,7 +3014,7 @@ namespace ts {
                     // NOTE:
                     // if converted loops were all nested in arrow function then we'll always emit '_this' so convertedLoopState.thisName will not be set.
                     // If it is set this means that all nested loops are not nested in arrow function and it is safe to capture 'this'.
-                    (extraVariableDeclarations || (extraVariableDeclarations = [])).push(
+                    (extraVariableDeclarations ??= []).push(
                         factory.createVariableDeclaration(
                             state.thisName,
                             /*exclamationToken*/ undefined,

--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -498,7 +498,7 @@ namespace ts {
                 const element = node.elements[i];
                 const visited = visitNode(element, i < node.elements.length - 1 ? visitorWithUnusedExpressionResult : visitor, isExpression);
                 if (result || visited !== element) {
-                    result ||= node.elements.slice(0, i);
+                    result ??= node.elements.slice(0, i);
                     result.push(visited);
                 }
             }

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -2821,7 +2821,7 @@ namespace ts {
             clauses.push(
                 factory.createCaseClause(
                     factory.createNumericLiteral(labelNumber),
-                    statements || []
+                    statements ?? []
                 )
             );
 

--- a/src/compiler/transformers/jsx.ts
+++ b/src/compiler/transformers/jsx.ts
@@ -225,7 +225,7 @@ namespace ts {
                 tagName,
                 objectProperties,
                 keyAttr,
-                children || emptyArray,
+                children ?? emptyArray,
                 isChild,
                 location
             );
@@ -322,7 +322,7 @@ namespace ts {
             }
             return visitJsxOpeningLikeElementOrFragmentJSX(
                 getImplicitJsxFragmentReference(),
-                childrenProps || factory.createObjectLiteralExpression([]),
+                childrenProps ?? factory.createObjectLiteralExpression([]),
                 /*keyAttr*/ undefined,
                 children,
                 isChild,
@@ -387,7 +387,7 @@ namespace ts {
                 expressions.push(factory.createObjectLiteralExpression([children]));
             }
 
-            return singleOrUndefined(expressions) || emitHelpers().createAssignHelper(expressions);
+            return singleOrUndefined(expressions) ?? emitHelpers().createAssignHelper(expressions);
         }
 
         function transformJsxSpreadAttributeToExpression(node: JsxSpreadAttribute) {

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -780,7 +780,7 @@ namespace ts {
                     factory.createCallExpression(
                         factory.createIdentifier("require"),
                         /*typeArguments*/ undefined,
-                        [factory.createArrayLiteralExpression([arg || factory.createOmittedExpression()]), resolve, reject]
+                        [factory.createArrayLiteralExpression([arg ?? factory.createOmittedExpression()]), resolve, reject]
                     )
                 )
             ]);
@@ -1125,7 +1125,7 @@ namespace ts {
                             setOriginalNode(
                                 setTextRange(
                                     factory.createExpressionStatement(
-                                        emitHelpers().createCreateBindingHelper(generatedName, factory.createStringLiteralFromNode(specifier.propertyName || specifier.name), specifier.propertyName ? factory.createStringLiteralFromNode(specifier.name) : undefined)
+                                        emitHelpers().createCreateBindingHelper(generatedName, factory.createStringLiteralFromNode(specifier.propertyName ?? specifier.name), specifier.propertyName ? factory.createStringLiteralFromNode(specifier.name) : undefined)
                                     ),
                                     specifier),
                                 specifier
@@ -1136,10 +1136,10 @@ namespace ts {
                         const exportNeedsImportDefault =
                             !!getESModuleInterop(compilerOptions) &&
                             !(getEmitFlags(node) & EmitFlags.NeverApplyImportHelper) &&
-                            idText(specifier.propertyName || specifier.name) === "default";
+                            idText(specifier.propertyName ?? specifier.name) === "default";
                         const exportedValue = factory.createPropertyAccessExpression(
                             exportNeedsImportDefault ? emitHelpers().createImportDefaultHelper(generatedName) : generatedName,
-                            specifier.propertyName || specifier.name);
+                            specifier.propertyName ?? specifier.name);
                         statements.push(
                             setOriginalNode(
                                 setTextRange(
@@ -1921,7 +1921,7 @@ namespace ts {
                         );
                     }
                     else if (isImportSpecifier(importDeclaration)) {
-                        const name = importDeclaration.propertyName || importDeclaration.name;
+                        const name = importDeclaration.propertyName ?? importDeclaration.name;
                         return setTextRange(
                             factory.createPropertyAccessExpression(
                                 factory.getGeneratedNameForNode(importDeclaration.parent?.parent?.parent || importDeclaration),
@@ -1979,7 +1979,7 @@ namespace ts {
         function getExports(name: Identifier): Identifier[] | undefined {
             if (!isGeneratedIdentifier(name)) {
                 const valueDeclaration = resolver.getReferencedImportDeclaration(name)
-                    || resolver.getReferencedValueDeclaration(name);
+                    ?? resolver.getReferencedValueDeclaration(name);
                 if (valueDeclaration) {
                     return currentModuleInfo
                         && currentModuleInfo.exportedBindings[getOriginalNodeId(valueDeclaration)];

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -487,7 +487,7 @@ namespace ts {
                                                 factory.createStringLiteral(idText(e.name)),
                                                 factory.createElementAccessExpression(
                                                     parameterName,
-                                                    factory.createStringLiteral(idText(e.propertyName || e.name))
+                                                    factory.createStringLiteral(idText(e.propertyName ?? e.name))
                                                 )
                                             )
                                         );
@@ -1766,7 +1766,7 @@ namespace ts {
                                 factory.cloneNode(name),
                                 factory.createPropertyAccessExpression(
                                     factory.getGeneratedNameForNode(importDeclaration.parent?.parent?.parent || importDeclaration),
-                                    factory.cloneNode(importDeclaration.propertyName || importDeclaration.name)
+                                    factory.cloneNode(importDeclaration.propertyName ?? importDeclaration.name)
                                 ),
                             ),
                             /*location*/ node
@@ -1832,7 +1832,7 @@ namespace ts {
                         return setTextRange(
                             factory.createPropertyAccessExpression(
                                 factory.getGeneratedNameForNode(importDeclaration.parent?.parent?.parent || importDeclaration),
-                                factory.cloneNode(importDeclaration.propertyName || importDeclaration.name)
+                                factory.cloneNode(importDeclaration.propertyName ?? importDeclaration.name)
                             ),
                             /*location*/ node
                         );
@@ -1893,7 +1893,7 @@ namespace ts {
             let exportedNames: Identifier[] | undefined;
             if (!isGeneratedIdentifier(name)) {
                 const valueDeclaration = resolver.getReferencedImportDeclaration(name)
-                    || resolver.getReferencedValueDeclaration(name);
+                    ?? resolver.getReferencedValueDeclaration(name);
 
                 if (valueDeclaration) {
                     const exportContainer = resolver.getReferencedExportContainer(name, /*prefixLocals*/ false);

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -634,7 +634,7 @@ namespace ts {
                 context.startLexicalEnvironment();
             }
 
-            const name = node.name || (facts & ClassFacts.NeedsName ? factory.getGeneratedNameForNode(node) : undefined);
+            const name = node.name ?? (facts & ClassFacts.NeedsName ? factory.getGeneratedNameForNode(node) : undefined);
             const allDecorators = getAllDecoratorsOfClass(node);
             const decorators = transformAllDecoratorsOfDeclaration(node, node, allDecorators);
 
@@ -1219,7 +1219,7 @@ namespace ts {
                 visitPropertyNameOfClassElement(node),
                 visitParameterList(node.parameters, visitor, context),
                 /*type*/ undefined,
-                visitFunctionBody(node.body, visitor, context) || factory.createBlock([])
+                visitFunctionBody(node.body, visitor, context) ?? factory.createBlock([])
             );
         }
 
@@ -1241,7 +1241,7 @@ namespace ts {
                 concatenate(decorators, visitNodes(node.modifiers, modifierVisitor, isModifierLike)),
                 visitPropertyNameOfClassElement(node),
                 visitParameterList(node.parameters, visitor, context),
-                visitFunctionBody(node.body, visitor, context) || factory.createBlock([])
+                visitFunctionBody(node.body, visitor, context) ?? factory.createBlock([])
             );
         }
 
@@ -1949,7 +1949,7 @@ namespace ts {
         function getInnerMostModuleDeclarationFromDottedModule(moduleDeclaration: ModuleDeclaration): ModuleDeclaration | undefined {
             if (moduleDeclaration.body!.kind === SyntaxKind.ModuleDeclaration) {
                 const recursiveInnerModule = getInnerMostModuleDeclarationFromDottedModule(moduleDeclaration.body as ModuleDeclaration);
-                return recursiveInnerModule || moduleDeclaration.body as ModuleDeclaration;
+                return recursiveInnerModule ?? moduleDeclaration.body as ModuleDeclaration;
             }
         }
 
@@ -2390,7 +2390,7 @@ namespace ts {
 
         function substituteExpressionIdentifier(node: Identifier): Expression {
             return trySubstituteNamespaceExportedName(node)
-                || node;
+            ?? node;
         }
 
         function trySubstituteNamespaceExportedName(node: Identifier): Expression | undefined {

--- a/src/compiler/transformers/utilities.ts
+++ b/src/compiler/transformers/utilities.ts
@@ -202,13 +202,13 @@ namespace ts {
         function addExportedNamesForExportDeclaration(node: ExportDeclaration) {
             for (const specifier of cast(node.exportClause, isNamedExports).elements) {
                 if (!uniqueExports.get(idText(specifier.name))) {
-                    const name = specifier.propertyName || specifier.name;
+                    const name = specifier.propertyName ?? specifier.name;
                     if (!node.moduleSpecifier) {
                         exportSpecifiers.add(idText(name), specifier);
                     }
 
                     const decl = resolver.getReferencedImportDeclaration(name)
-                        || resolver.getReferencedValueDeclaration(name);
+                    ?? resolver.getReferencedValueDeclaration(name);
 
                     if (decl) {
                         multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(decl), specifier.name);

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -21,7 +21,7 @@ namespace ts {
     }
 
     export function getDeclarationsOfKind<T extends Declaration>(symbol: Symbol, kind: T["kind"]): T[] {
-        return filter(symbol.declarations || emptyArray, d => d.kind === kind) as T[];
+        return filter(symbol.declarations ?? emptyArray, d => d.kind === kind) as T[];
     }
 
     export function createSymbolTable(symbols?: readonly Symbol[]): SymbolTable {
@@ -272,7 +272,7 @@ namespace ts {
     }
 
     export function getSourceFileOfModule(module: Symbol) {
-        return getSourceFileOfNode(module.valueDeclaration || getNonAugmentationDeclaration(module));
+        return getSourceFileOfNode(module.valueDeclaration ?? getNonAugmentationDeclaration(module));
     }
 
     export function isPlainJsFile(file: SourceFile | undefined, checkJs: boolean | undefined): boolean {
@@ -478,7 +478,7 @@ namespace ts {
 
         if (isJSDocNode(node) || node.kind === SyntaxKind.JsxText) {
             // JsxText cannot actually contain comments, even though the scanner will think it sees comments
-            return skipTrivia((sourceFile || getSourceFileOfNode(node)).text, node.pos, /*stopAfterLineBreak*/ false, /*stopAtComments*/ true);
+            return skipTrivia((sourceFile ?? getSourceFileOfNode(node)).text, node.pos, /*stopAfterLineBreak*/ false, /*stopAtComments*/ true);
         }
 
         if (includeJsDoc && hasJSDocNodes(node)) {
@@ -494,7 +494,7 @@ namespace ts {
         }
 
         return skipTrivia(
-            (sourceFile || getSourceFileOfNode(node)).text,
+            (sourceFile ?? getSourceFileOfNode(node)).text,
             node.pos,
             /*stopAfterLineBreak*/ false,
             /*stopAtComments*/ false,
@@ -507,7 +507,7 @@ namespace ts {
             return getTokenPosOfNode(node, sourceFile);
         }
 
-        return skipTrivia((sourceFile || getSourceFileOfNode(node)).text, lastDecorator.end);
+        return skipTrivia((sourceFile ?? getSourceFileOfNode(node)).text, lastDecorator.end);
     }
 
     export function getSourceTextOfNodeFromSourceFile(sourceFile: SourceFile, node: Node, includeTrivia = false): string {
@@ -2256,7 +2256,7 @@ namespace ts {
     export function getAssignedExpandoInitializer(node: Node | undefined): Expression | undefined {
         if (node && node.parent && isBinaryExpression(node.parent) && node.parent.operatorToken.kind === SyntaxKind.EqualsToken) {
             const isPrototypeAssignment = isPrototypeAccess(node.parent.left);
-            return getExpandoInitializer(node.parent.right, isPrototypeAssignment) ||
+            return getExpandoInitializer(node.parent.right, isPrototypeAssignment) ??
                 getDefaultedExpandoInitializer(node.parent.left, node.parent.right, isPrototypeAssignment);
         }
         if (node && isCallExpression(node) && isBindableObjectDefinePropertyCall(node)) {
@@ -2576,7 +2576,7 @@ namespace ts {
     }
 
     export function importFromModuleSpecifier(node: StringLiteralLike): AnyValidImportOrReExport {
-        return tryGetImportFromModuleSpecifier(node) || Debug.failBadSyntaxKind(node.parent);
+        return tryGetImportFromModuleSpecifier(node) ?? Debug.failBadSyntaxKind(node.parent);
     }
 
     export function tryGetImportFromModuleSpecifier(node: StringLiteralLike): AnyValidImportOrReExport | undefined {
@@ -2740,7 +2740,7 @@ namespace ts {
             }
             node = getNextJSDocCommentLocation(node);
         }
-        return result || emptyArray;
+        return result ?? emptyArray;
     }
 
     function filterOwnedJSDocTags(hostNode: Node, jsDoc: JSDoc | JSDocTag) {
@@ -2835,11 +2835,11 @@ namespace ts {
         const host = getJSDocHost(node);
         if (host) {
             return getSourceOfDefaultedAssignment(host)
-                || getSourceOfAssignment(host)
-                || getSingleInitializerOfVariableStatementOrPropertyDeclaration(host)
-                || getSingleVariableOfVariableStatement(host)
-                || getNestedModuleDeclaration(host)
-                || host;
+                ?? getSourceOfAssignment(host)
+                ?? getSingleInitializerOfVariableStatementOrPropertyDeclaration(host)
+                ?? getSingleVariableOfVariableStatement(host)
+                ?? getNestedModuleDeclaration(host)
+                ?? host;
         }
     }
 
@@ -3222,7 +3222,7 @@ namespace ts {
 
     /** Returns the node in an `extends` or `implements` clause of a class or interface. */
     export function getAllSuperTypeNodes(node: Node): readonly TypeNode[] {
-        return isInterfaceDeclaration(node) ? getInterfaceBaseTypeNodes(node) || emptyArray :
+        return isInterfaceDeclaration(node) ? getInterfaceBaseTypeNodes(node) ?? emptyArray :
             isClassLike(node) ? concatenate(singleElementArray(getEffectiveBaseTypeNode(node)), getEffectiveImplementsTypeNodes(node)) || emptyArray :
             emptyArray;
     }
@@ -3470,7 +3470,7 @@ namespace ts {
     }
 
     export function getOriginalSourceFile(sourceFile: SourceFile) {
-        return getParseTreeNode(sourceFile, isSourceFile) || sourceFile;
+        return getParseTreeNode(sourceFile, isSourceFile) ?? sourceFile;
     }
 
     export const enum Associativity {
@@ -3956,7 +3956,7 @@ namespace ts {
         function getDiagnostics(): Diagnostic[];
         function getDiagnostics(fileName?: string): Diagnostic[] {
             if (fileName) {
-                return fileDiagnostics.get(fileName) || [];
+                return fileDiagnostics.get(fileName) ?? [];
             }
 
             const fileDiags: Diagnostic[] = flatMapToMutable(filesWithDiagnostics, f => fileDiagnostics.get(f));
@@ -4638,7 +4638,7 @@ namespace ts {
     export function getEffectiveReturnTypeNode(node: SignatureDeclaration | JSDocSignature): TypeNode | undefined {
         return isJSDocSignature(node) ?
             node.type && node.type.typeExpression && node.type.typeExpression.type :
-            node.type || (isInJSFile(node) ? getJSDocReturnType(node) : undefined);
+            node.type ?? (isInJSFile(node) ? getJSDocReturnType(node) : undefined);
     }
 
     export function getJSDocTypeParameterDeclarations(node: DeclarationWithTypeParameters): readonly TypeParameterDeclaration[] {
@@ -6014,7 +6014,7 @@ namespace ts {
     function SourceMapSource(this: SourceMapSource, fileName: string, text: string, skipTrivia?: (pos: number) => number) {
         this.fileName = fileName;
         this.text = text;
-        this.skipTrivia = skipTrivia || (pos => pos);
+        this.skipTrivia = skipTrivia ?? (pos => pos);
     }
 
     // eslint-disable-next-line prefer-const
@@ -6328,7 +6328,7 @@ namespace ts {
             case ModuleDetectionKind.Force:
                 // All non-declaration files are modules, declaration files still do the usual isFileProbablyExternalModule
                 return (file: SourceFile) => {
-                    file.externalModuleIndicator = isFileProbablyExternalModule(file) || !file.isDeclarationFile || undefined;
+                    file.externalModuleIndicator = (isFileProbablyExternalModule(file) ?? !file.isDeclarationFile) || undefined;
                 };
             case ModuleDetectionKind.Legacy:
                 // Files are modules if they have imports, exports, or import.meta
@@ -6566,7 +6566,7 @@ namespace ts {
             getSymlinkedFiles: () => symlinkedFiles,
             getSymlinkedDirectories: () => symlinkedDirectories,
             getSymlinkedDirectoriesByRealpath: () => symlinkedDirectoriesByRealpath,
-            setSymlinkedFile: (path, real) => (symlinkedFiles || (symlinkedFiles = new Map())).set(path, real),
+            setSymlinkedFile: (path, real) => (symlinkedFiles ??= new Map()).set(path, real),
             setSymlinkedDirectory: (symlink, real) => {
                 // Large, interconnected dependency graphs in pnpm will have a huge number of symlinks
                 // where both the realpath and the symlink path are inside node_modules/.pnpm. Since
@@ -6575,9 +6575,9 @@ namespace ts {
                 if (!containsIgnoredPath(symlinkPath)) {
                     symlinkPath = ensureTrailingDirectorySeparator(symlinkPath);
                     if (real !== false && !symlinkedDirectories?.has(symlinkPath)) {
-                        (symlinkedDirectoriesByRealpath ||= createMultiMap()).add(ensureTrailingDirectorySeparator(real.realPath), symlink);
+                        (symlinkedDirectoriesByRealpath ??= createMultiMap()).add(ensureTrailingDirectorySeparator(real.realPath), symlink);
                     }
-                    (symlinkedDirectories || (symlinkedDirectories = new Map())).set(symlinkPath, real);
+                    (symlinkedDirectories ??= new Map()).set(symlinkPath, real);
                 }
             },
             setSymlinksFromResolutions(files, typeReferenceDirectives) {
@@ -6595,7 +6595,7 @@ namespace ts {
             if (!resolution || !resolution.originalPath || !resolution.resolvedFileName) return;
             const { resolvedFileName, originalPath } = resolution;
             cache.setSymlinkedFile(toPath(originalPath, cwd, getCanonicalFileName), resolvedFileName);
-            const [commonResolved, commonOriginal] = guessDirectorySymlink(resolvedFileName, originalPath, cwd, getCanonicalFileName) || emptyArray;
+            const [commonResolved, commonOriginal] = guessDirectorySymlink(resolvedFileName, originalPath, cwd, getCanonicalFileName) ?? emptyArray;
             if (commonResolved && commonOriginal) {
                 cache.setSymlinkedDirectory(
                     commonOriginal,

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -563,7 +563,7 @@ namespace ts {
     }
 
     export function getNameOfJSDocTypedef(declaration: JSDocTypedefTag): Identifier | PrivateIdentifier | undefined {
-        return declaration.name || nameForNamelessJSDocTypedef(declaration);
+        return declaration.name ?? nameForNamelessJSDocTypedef(declaration);
     }
 
     /** @internal */
@@ -620,7 +620,7 @@ namespace ts {
 
     export function getNameOfDeclaration(declaration: Declaration | Expression | undefined): DeclarationName | undefined {
         if (declaration === undefined) return undefined;
-        return getNonAssignedNameOfDeclaration(declaration) ||
+        return getNonAssignedNameOfDeclaration(declaration) ??
             (isFunctionExpression(declaration) || isArrowFunction(declaration) || isClassExpression(declaration) ? getAssignedName(declaration) : undefined);
     }
 

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -34,7 +34,7 @@ namespace ts {
             return undefined;
         }
         else if (isArray(visited)) {
-            visitedNode = (lift || extractSingleNode)(visited);
+            visitedNode = (lift ?? extractSingleNode)(visited);
         }
         else {
             visitedNode = visited;
@@ -449,7 +449,7 @@ namespace ts {
                     nodesVisitor(node.modifiers, visitor, isModifierLike),
                     nodeVisitor(node.name, visitor, isPropertyName),
                     // QuestionToken and ExclamationToken is uniqued in Property Declaration and the signature of 'updateProperty' is that too
-                    nodeVisitor(node.questionToken || node.exclamationToken, tokenVisitor, isQuestionOrExclamationToken),
+                    nodeVisitor(node.questionToken ?? node.exclamationToken, tokenVisitor, isQuestionOrExclamationToken),
                     nodeVisitor(node.type, visitor, isTypeNode),
                     nodeVisitor(node.initializer, visitor, isExpression));
 

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -48,8 +48,8 @@ namespace ts {
     export function createIncrementalProgram<T extends BuilderProgram = EmitAndSemanticDiagnosticsBuilderProgram>({
         rootNames, options, configFileParsingDiagnostics, projectReferences, host, createProgram
     }: IncrementalProgramOptions<T>): T {
-        host = host || createIncrementalCompilerHost(options);
-        createProgram = createProgram || createEmitAndSemanticDiagnosticsBuilderProgram as any as CreateProgram<T>;
+        host ??= createIncrementalCompilerHost(options);
+        createProgram ??= createEmitAndSemanticDiagnosticsBuilderProgram as any as CreateProgram<T>;
         const oldProgram = readBuilderProgram(options, host) as any as T;
         return createProgram(rootNames, options, host, oldProgram, configFileParsingDiagnostics, projectReferences);
     }
@@ -301,7 +301,7 @@ namespace ts {
         let hasChangedConfigFileParsingErrors = false;
 
         const cachedDirectoryStructureHost = configFileName === undefined ? undefined : createCachedDirectoryStructureHost(host, currentDirectory, useCaseSensitiveFileNames);
-        const directoryStructureHost: DirectoryStructureHost = cachedDirectoryStructureHost || host;
+        const directoryStructureHost: DirectoryStructureHost = cachedDirectoryStructureHost ?? host;
         const parseConfigFileHost = parseConfigHostFromCompilerHostLike(host, directoryStructureHost);
 
         // From tsc we want to get already parsed result and hence check for rootFileNames
@@ -609,7 +609,7 @@ namespace ts {
             if (hostSourceFileInfo !== undefined) {
                 // record the missing file paths so they can be removed later if watchers arent tracking them
                 if (isFileMissingOnHost(hostSourceFileInfo)) {
-                    (missingFilePathsRequestedForRelease || (missingFilePathsRequestedForRelease = [])).push(oldSourceFile.path);
+                    (missingFilePathsRequestedForRelease ??= []).push(oldSourceFile.path);
                 }
                 else if ((hostSourceFileInfo as FilePresentOnHost).sourceFile === oldSourceFile) {
                     if (hostSourceFileInfo.fileWatcher) {
@@ -737,7 +737,7 @@ namespace ts {
                 configFileName,
                 optionsToExtendForConfigFile,
                 parseConfigFileHost,
-                extendedConfigCache ||= new Map(),
+                extendedConfigCache ??= new Map(),
                 watchOptionsToExtend,
                 extraFileExtensions
             )!); // TODO: GH#18217
@@ -783,7 +783,7 @@ namespace ts {
                 config.reloadLevel = undefined;
             }
             else {
-                (parsedConfigs ||= new Map()).set(configPath, config = { parsedCommandLine });
+                (parsedConfigs ??= new Map()).set(configPath, config = { parsedCommandLine });
             }
             watchReferencedProject(configFileName, configPath, config);
             return parsedCommandLine;
@@ -797,7 +797,7 @@ namespace ts {
                 configFileName,
                 /*optionsToExtend*/ undefined,
                 parseConfigFileHost,
-                extendedConfigCache ||= new Map(),
+                extendedConfigCache ??= new Map(),
                 watchOptionsToExtend
             );
             parseConfigFileHost.onUnRecoverableConfigFileDiagnostic = onUnRecoverableConfigFileDiagnostic;
@@ -961,7 +961,7 @@ namespace ts {
 
         function watchReferencedProject(configFileName: string, configPath: Path, commandLine: ParsedConfig) {
             // Watch file
-            commandLine.watcher ||= watchFile(
+            commandLine.watcher ??= watchFile(
                 configFileName,
                 (_fileName, eventKind) => {
                     updateCachedSystemWithFile(configFileName, configPath, eventKind);
@@ -971,13 +971,13 @@ namespace ts {
                     scheduleProgramUpdate();
                 },
                 PollingInterval.High,
-                commandLine.parsedCommandLine?.watchOptions || watchOptions,
+                commandLine.parsedCommandLine?.watchOptions ?? watchOptions,
                 WatchType.ConfigFileOfReferencedProject
             );
             // Watch Wild card
             if (commandLine.parsedCommandLine?.wildcardDirectories) {
                 updateWatchingWildcardDirectories(
-                    commandLine.watchedDirectories ||= new Map(),
+                    commandLine.watchedDirectories ??= new Map(),
                     new Map(getEntries(commandLine.parsedCommandLine?.wildcardDirectories)),
                     (directory, flags) => watchDirectory(
                         directory,
@@ -1013,7 +1013,7 @@ namespace ts {
                             }
                         },
                         flags,
-                        commandLine.parsedCommandLine?.watchOptions || watchOptions,
+                        commandLine.parsedCommandLine?.watchOptions ?? watchOptions,
                         WatchType.WildcardDirectoryOfReferencedProject
                     )
                 );
@@ -1026,7 +1026,7 @@ namespace ts {
             updateExtendedConfigFilesWatches(
                 configPath,
                 commandLine.parsedCommandLine?.options,
-                commandLine.parsedCommandLine?.watchOptions || watchOptions,
+                commandLine.parsedCommandLine?.watchOptions ?? watchOptions,
                 WatchType.ExtendedConfigOfReferencedProject
             );
         }

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -297,7 +297,7 @@ namespace ts {
         createExtendedConfigFileWatch: (extendedConfigPath: string, extendedConfigFilePath: Path) => FileWatcher,
         toPath: (fileName: string) => Path,
     ) {
-        const extendedConfigs = arrayToMap(options?.configFile?.extendedSourceFiles || emptyArray, toPath);
+        const extendedConfigs = arrayToMap(options?.configFile?.extendedSourceFiles ?? emptyArray, toPath);
         // remove project from all unrelated watchers
         extendedConfigFilesMap.forEach((watcher, extendedConfigFilePath) => {
             if (!extendedConfigs.has(extendedConfigFilePath)) {
@@ -571,7 +571,7 @@ namespace ts {
                 watchFile: createFileWatcherWithLogging,
                 watchDirectory: createDirectoryWatcherWithLogging
             } :
-            triggerInvokingFactory || plainInvokeFactory;
+            triggerInvokingFactory ?? plainInvokeFactory;
         const excludeWatcherFactory = watchLogLevel === WatchLogLevel.Verbose ?
             createExcludeWatcherWithLogging :
             returnNoopFileWatcher;

--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -61,7 +61,7 @@ namespace ts.server {
         }
 
         private lineOffsetToPosition(fileName: string, lineOffset: protocol.Location, lineMap?: number[]): number {
-            lineMap = lineMap || this.getLineMap(fileName);
+            lineMap ??= this.getLineMap(fileName);
             return computePositionOfLineAndCharacter(lineMap, lineOffset.line - 1, lineOffset.offset - 1);
         }
 
@@ -565,7 +565,7 @@ namespace ts.server {
                 return { start: 0, length: 0 };
             }
             fileName = fileName || span.file;
-            lineMap = lineMap || this.getLineMap(fileName);
+            lineMap ??= this.getLineMap(fileName);
             return createTextSpanFromBounds(
                 this.lineOffsetToPosition(fileName, span.start, lineMap),
                 this.lineOffsetToPosition(fileName, span.end, lineMap));

--- a/src/harness/compilerImpl.ts
+++ b/src/harness/compilerImpl.ts
@@ -258,10 +258,10 @@ namespace compiler {
         // and if the test is running `skipLibCheck` - an indicator that we want the tets to run quickly - skip the before/after error comparison, too
         const skipErrorComparison = ts.length(rootFiles) >= 100 || (!!compilerOptions.skipLibCheck && !!compilerOptions.declaration);
 
-        const preProgram = !skipErrorComparison ? ts.createProgram(rootFiles || [], { ...compilerOptions, configFile: compilerOptions.configFile, traceResolution: false }, host) : undefined;
+        const preProgram = !skipErrorComparison ? ts.createProgram(rootFiles ?? [], { ...compilerOptions, configFile: compilerOptions.configFile, traceResolution: false }, host) : undefined;
         const preErrors = preProgram && ts.getPreEmitDiagnostics(preProgram);
 
-        const program = ts.createProgram(rootFiles || [], compilerOptions, host);
+        const program = ts.createProgram(rootFiles ?? [], compilerOptions, host);
         const emitResult = program.emit();
         const postErrors = ts.getPreEmitDiagnostics(program);
         const longerErrors = ts.length(preErrors) > postErrors.length ? preErrors : postErrors;

--- a/src/harness/documentsUtil.ts
+++ b/src/harness/documentsUtil.ts
@@ -13,11 +13,11 @@ namespace documents {
         constructor(file: string, text: string, meta?: Map<string, string>) {
             this.file = file;
             this.text = text;
-            this.meta = meta || new Map<string, string>();
+            this.meta = meta ?? new Map<string, string>();
         }
 
         public get lineStarts(): readonly number[] {
-            return this._lineStarts || (this._lineStarts = ts.computeLineStarts(this.text));
+            return this._lineStarts ??= ts.computeLineStarts(this.text);
         }
 
         public static fromTestFile(file: Harness.Compiler.TestFile) {
@@ -29,12 +29,12 @@ namespace documents {
         }
 
         public asTestFile() {
-            return this._testFile || (this._testFile = {
+            return this._testFile ??= {
                 unitName: this.file,
                 content: this.text,
                 fileOptions: Array.from(this.meta)
                     .reduce((obj, [key, value]) => (obj[key] = value, obj), {} as Record<string, string>)
-            });
+            };
         }
     }
 

--- a/src/harness/evaluatorImpl.ts
+++ b/src/harness/evaluatorImpl.ts
@@ -347,7 +347,7 @@ namespace evaluator {
                             // Set state so that re-entry while adding dependencies does nothing.
                             module.state = SystemModuleState.AddingDependencies;
                             const base = vpath.dirname(module.file);
-                            const dependencies = module.requestedDependencies || [];
+                            const dependencies = module.requestedDependencies ?? [];
 
                             for (const dependencyId of dependencies) {
                                 const dependency = this.load(this.resolve(dependencyId, base));

--- a/src/harness/fakesHosts.ts
+++ b/src/harness/fakesHosts.ts
@@ -245,7 +245,7 @@ namespace fakes {
         }
 
         public get parseConfigHost() {
-            return this._parseConfigHost || (this._parseConfigHost = new ParseConfigHost(this.sys));
+            return this._parseConfigHost ??= new ParseConfigHost(this.sys);
         }
 
         public getCurrentDirectory(): string {
@@ -532,7 +532,7 @@ ${indentText}${text}`;
 
         private constructor(sys: System | vfs.FileSystem, options?: ts.CompilerOptions, setParentNodes?: boolean, createProgram?: ts.CreateProgram<ts.BuilderProgram>) {
             super(sys, options, setParentNodes);
-            this.createProgram = createProgram || ts.createEmitAndSemanticDiagnosticsBuilderProgram;
+            this.createProgram = createProgram ?? ts.createEmitAndSemanticDiagnosticsBuilderProgram;
         }
 
         static create(sys: System | vfs.FileSystem, options?: ts.CompilerOptions, setParentNodes?: boolean, createProgram?: ts.CreateProgram<ts.BuilderProgram>) {

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -1083,10 +1083,10 @@ namespace Harness {
                 return option.type;
             }
             if (option.type === "boolean") {
-                return booleanVaryByStarSettingValues || (booleanVaryByStarSettingValues = new ts.Map(ts.getEntries({
+                return booleanVaryByStarSettingValues ??= new ts.Map(ts.getEntries({
                     true: 1,
                     false: 0
-                })));
+                }));
             }
         }
     }
@@ -1443,7 +1443,7 @@ namespace Harness {
             }
 
             const referenceDir = referencePath(relativeFileBase, opts && opts.Baselinefolder, opts && opts.Subfolder);
-            let existing = IO.readDirectory(referenceDir, referencedExtensions || [extension]);
+            let existing = IO.readDirectory(referenceDir, referencedExtensions ?? [extension]);
             if (extension === ".ts" || referencedExtensions && referencedExtensions.indexOf(".ts") > -1 && referencedExtensions.indexOf(".d.ts") === -1) {
                 // special-case and filter .d.ts out of .ts results
                 existing = existing.filter(f => !ts.endsWith(f, ".d.ts"));

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -27,7 +27,7 @@ namespace Harness.LanguageService {
         }
 
         public getLineMap(): number[] {
-            return this.lineMap || (this.lineMap = ts.computeLineStarts(this.content));
+            return this.lineMap ??= ts.computeLineStarts(this.content);
         }
 
         public updateContent(content: string): void {
@@ -763,7 +763,7 @@ namespace Harness.LanguageService {
             }
 
             // System FS would follow symlinks, even though snapshots are stored by original file name
-            const snapshot = this.host.getScriptSnapshot(fileName) || this.host.getScriptSnapshot(this.realpath(fileName));
+            const snapshot = this.host.getScriptSnapshot(fileName) ?? this.host.getScriptSnapshot(this.realpath(fileName));
             return snapshot && ts.getSnapshotText(snapshot);
         }
 

--- a/src/harness/vfsUtil.ts
+++ b/src/harness/vfsUtil.ts
@@ -959,7 +959,7 @@ namespace vfs {
         private _getShadow(root: DirectoryInode): DirectoryInode;
         private _getShadow(root: Inode): Inode;
         private _getShadow(root: Inode) {
-            const shadows = this._lazy.shadows || (this._lazy.shadows = new Map<number, Inode>());
+            const shadows = this._lazy.shadows ?? (this._lazy.shadows = new Map<number, Inode>());
 
             let shadow = shadows.get(root.ino);
             if (!shadow) {

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -166,7 +166,7 @@ interface Array<T> { length: number; [n: number]: T; }`
         if (!isNumber(eachKeyCountOrValueTester)) {
             valueTester = eachKeyCountOrValueTester;
         }
-        const [expectedValues, valueMapper] = valueTester || [undefined, undefined!];
+        const [expectedValues, valueMapper] = valueTester ?? [undefined, undefined!];
         expectedKeys.forEach((count, name) => {
             assert.isTrue(actual.has(name), `${caption}: expected to contain ${name}, actual keys: ${arrayFrom(actual.keys())}`);
             // Check key information only if eachKeyCount is provided
@@ -1171,7 +1171,7 @@ interface Array<T> { length: number; [n: number]: T; }`
     function baselineOutputs(baseline: string[], output: readonly string[], start: number, end = output.length) {
         let baselinedOutput: string[] | undefined;
         for (let i = start; i < end; i++) {
-            (baselinedOutput ||= []).push(output[i].replace(/Elapsed::\s[0-9]+(?:\.\d+)?ms/g, "Elapsed:: *ms"));
+            (baselinedOutput ??= []).push(output[i].replace(/Elapsed::\s[0-9]+(?:\.\d+)?ms/g, "Elapsed:: *ms"));
         }
         if (baselinedOutput) baseline.push(baselinedOutput.join(""));
     }

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -146,7 +146,7 @@ namespace ts.JsTyping {
         const filesToWatch: string[] = [];
 
         if (typeAcquisition.include) addInferredTypings(typeAcquisition.include, "Explicitly included types");
-        const exclude = typeAcquisition.exclude || [];
+        const exclude = typeAcquisition.exclude ?? [];
 
         // Directories to search for package.json, bower.json and other typing information
         if (!compilerOptions.types) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -258,9 +258,9 @@ namespace ts.server {
             const propertyValue = protocolOptions[option.name];
             if (propertyValue === undefined) return;
             const mappedValues = watchOptionsConverters.get(option.name);
-            (watchOptions || (watchOptions = {}))[option.name] = mappedValues ?
+            (watchOptions ??= {})[option.name] = mappedValues ?
                 isString(propertyValue) ? mappedValues.get(propertyValue.toLowerCase()) : propertyValue :
-                convertJsonOption(option, propertyValue, currentDirectory || "", errors || (errors = []));
+                convertJsonOption(option, propertyValue, currentDirectory || "", errors ??= []);
         });
         return watchOptions && { watchOptions, errors };
     }
@@ -270,7 +270,7 @@ namespace ts.server {
         typeAcquisitionDeclarations.forEach((option) => {
             const propertyValue = protocolOptions[option.name];
             if (propertyValue === undefined) return;
-            (result || (result = {}))[option.name] = propertyValue;
+            (result ??= {})[option.name] = propertyValue;
         });
         return result;
     }
@@ -505,7 +505,7 @@ namespace ts.server {
 
         function callback(ref: ResolvedProjectReference, loadKind: ProjectReferenceProjectLoadKind) {
             const configFileName = toNormalizedPath(ref.sourceFile.fileName);
-            const child = project.projectService.findConfiguredProjectByProjectName(configFileName) || (
+            const child = project.projectService.findConfiguredProjectByProjectName(configFileName) ?? (
                 loadKind === ProjectReferenceProjectLoadKind.Find ?
                     undefined :
                     loadKind === ProjectReferenceProjectLoadKind.FindCreate ?
@@ -542,7 +542,7 @@ namespace ts.server {
                 return result;
             }
 
-            (seenResolvedRefs || (seenResolvedRefs = new Map())).set(canonicalPath, loadKind);
+            (seenResolvedRefs ??= new Map()).set(canonicalPath, loadKind);
             return ref.references && forEachResolvedProjectReferenceProjectWorker(ref.references, ref.commandLine.options, cb, loadKind, projectService, seenResolvedRefs);
         });
     }
@@ -817,8 +817,8 @@ namespace ts.server {
             this.throttleWaitMilliseconds = opts.throttleWaitMilliseconds;
             this.eventHandler = opts.eventHandler;
             this.suppressDiagnosticEvents = opts.suppressDiagnosticEvents;
-            this.globalPlugins = opts.globalPlugins || emptyArray;
-            this.pluginProbeLocations = opts.pluginProbeLocations || emptyArray;
+            this.globalPlugins = opts.globalPlugins ?? emptyArray;
+            this.pluginProbeLocations = opts.pluginProbeLocations ?? emptyArray;
             this.allowLocalPluginLoads = !!opts.allowLocalPluginLoads;
             this.typesMapLocation = (opts.typesMapLocation === undefined) ? combinePaths(getDirectoryPath(this.getExecutingFilePath()), "typesMap.json") : opts.typesMapLocation;
             this.session = opts.session;
@@ -1102,7 +1102,7 @@ namespace ts.server {
             const canonicalProjectRootPath = projectRootPath && this.toCanonicalFileName(projectRootPath);
             if (canonicalProjectRootPath) {
                 this.compilerOptionsForInferredProjectsPerProjectRoot.set(canonicalProjectRootPath, compilerOptions);
-                this.watchOptionsForInferredProjectsPerProjectRoot.set(canonicalProjectRootPath, watchOptions || false);
+                this.watchOptionsForInferredProjectsPerProjectRoot.set(canonicalProjectRootPath, watchOptions ?? false);
                 this.typeAcquisitionForInferredProjectsPerProjectRoot.set(canonicalProjectRootPath, typeAcquisition);
             }
             else {
@@ -1143,7 +1143,7 @@ namespace ts.server {
             if (isInferredProjectName(projectName)) {
                 return findProjectByName(projectName, this.inferredProjects);
             }
-            return this.findExternalProjectByProjectName(projectName) || this.findConfiguredProjectByProjectName(toNormalizedPath(projectName));
+            return this.findExternalProjectByProjectName(projectName) ?? this.findConfiguredProjectByProjectName(toNormalizedPath(projectName));
         }
 
         /* @internal */
@@ -1174,7 +1174,7 @@ namespace ts.server {
 
         /* @internal */
         ensureDefaultProjectForFile(fileName: NormalizedPath): Project {
-            return this.tryGetDefaultProjectForFile(fileName) || this.doEnsureDefaultProjectForFile(fileName);
+            return this.tryGetDefaultProjectForFile(fileName) ?? this.doEnsureDefaultProjectForFile(fileName);
         }
 
         private doEnsureDefaultProjectForFile(fileName: NormalizedPath): Project {
@@ -1484,8 +1484,8 @@ namespace ts.server {
         assignOrphanScriptInfoToInferredProject(info: ScriptInfo, projectRootPath: NormalizedPath | undefined) {
             Debug.assert(info.isOrphan());
 
-            const project = this.getOrCreateInferredProjectForProjectRootPathIfEnabled(info, projectRootPath) ||
-                this.getOrCreateSingleInferredProjectIfEnabled() ||
+            const project = this.getOrCreateInferredProjectForProjectRootPathIfEnabled(info, projectRootPath) ??
+                this.getOrCreateSingleInferredProjectIfEnabled() ??
                 this.getOrCreateSingleInferredWithoutProjectRoot(
                     info.isDynamic ?
                         projectRootPath || this.currentDirectory :
@@ -1641,7 +1641,7 @@ namespace ts.server {
                 // By default the info would get impacted by presence of config file since its in the detection path
                 // Only adding the info as a root to inferred project will need the existence to be watched by file watcher
                 if (isOpenScriptInfo(info) && !configFileExistenceInfo.openFilesImpactedByConfigFile?.has(info.path)) {
-                    (configFileExistenceInfo.openFilesImpactedByConfigFile ||= new Map()).set(info.path, false);
+                    (configFileExistenceInfo.openFilesImpactedByConfigFile ??= new Map()).set(info.path, false);
                 }
                 return configFileExistenceInfo.exists;
             }
@@ -1659,7 +1659,7 @@ namespace ts.server {
             const exists = this.host.fileExists(configFileName);
             let openFilesImpactedByConfigFile: ESMap<Path, boolean> | undefined;
             if (isOpenScriptInfo(info)) {
-                (openFilesImpactedByConfigFile ||= new Map()).set(info.path, false);
+                (openFilesImpactedByConfigFile ??= new Map()).set(info.path, false);
             }
             configFileExistenceInfo = { exists, openFilesImpactedByConfigFile };
             this.configFileExistenceInfoCache.set(canonicalConfigFilePath, configFileExistenceInfo);
@@ -1791,10 +1791,10 @@ namespace ts.server {
                 }
 
                 // Set this file as the root of inferred project
-                (configFileExistenceInfo.openFilesImpactedByConfigFile ||= new Map()).set(info.path, true);
+                (configFileExistenceInfo.openFilesImpactedByConfigFile ??= new Map()).set(info.path, true);
 
                 // If there is no configured project for this config file, add the file watcher
-                configFileExistenceInfo.watcher ||= canWatchDirectory(getDirectoryPath(canonicalConfigFilePath) as Path) ?
+                configFileExistenceInfo.watcher ??= canWatchDirectory(getDirectoryPath(canonicalConfigFilePath) as Path) ?
                     this.watchFactory.watchFile(
                         configFileName,
                         (_filename, eventKind) => this.onConfigFileChanged(canonicalConfigFilePath, eventKind),
@@ -2183,7 +2183,7 @@ namespace ts.server {
             }
 
             // Parse the config file and ensure its cached
-            const cachedDirectoryStructureHost = configFileExistenceInfo.config?.cachedDirectoryStructureHost ||
+            const cachedDirectoryStructureHost = configFileExistenceInfo.config?.cachedDirectoryStructureHost ??
                 createCachedDirectoryStructureHost(this.host, this.host.getCurrentDirectory(), this.host.useCaseSensitiveFileNames)!;
 
             // Read updated contents from disk
@@ -2271,7 +2271,7 @@ namespace ts.server {
                 if (config!.watchedDirectories && !config!.watchedDirectoriesStale) return;
                 config!.watchedDirectoriesStale = false;
                 updateWatchingWildcardDirectories(
-                    config!.watchedDirectories ||= new Map(),
+                    config!.watchedDirectories ??= new Map(),
                     new Map(getEntries(config!.parsedCommandLine!.wildcardDirectories!)),
                     // Create new directory watcher
                     (directory, flags) => this.watchWildcardDirectory(directory as Path, flags, configFileName, config!),
@@ -2704,8 +2704,8 @@ namespace ts.server {
 
         /*@internal*/
         watchPackageJsonsInNodeModules(dir: Path, project: Project): FileWatcher {
-            const watcher = this.nodeModulesWatchers.get(dir) || this.createNodeModulesWatcher(dir);
-            (watcher.affectedModuleSpecifierCacheProjects ||= new Set()).add(project.getProjectName());
+            const watcher = this.nodeModulesWatchers.get(dir) ?? this.createNodeModulesWatcher(dir);
+            (watcher.affectedModuleSpecifierCacheProjects ??= new Set()).add(project.getProjectName());
 
             return {
                 close: () => {
@@ -2717,7 +2717,7 @@ namespace ts.server {
 
         private watchClosedScriptInfoInNodeModules(dir: Path): FileWatcher {
             const watchDir = dir + "/node_modules" as Path;
-            const watcher = this.nodeModulesWatchers.get(watchDir) || this.createNodeModulesWatcher(watchDir);
+            const watcher = this.nodeModulesWatchers.get(watchDir) ?? this.createNodeModulesWatcher(watchDir);
             watcher.refreshScriptInfoRefCount++;
 
             return {
@@ -2729,7 +2729,7 @@ namespace ts.server {
         }
 
         private getModifiedTime(info: ScriptInfo) {
-            return (this.host.getModifiedTime!(info.path) || missingFileModifiedTime).getTime();
+            return (this.host.getModifiedTime!(info.path) ?? missingFileModifiedTime).getTime();
         }
 
         private refreshScriptInfo(info: ScriptInfo) {
@@ -2891,7 +2891,7 @@ namespace ts.server {
             if (sourceMapFileInfo) {
                 declarationInfo.sourceMapFilePath = sourceMapFileInfo.path;
                 sourceMapFileInfo.declarationInfoPath = declarationInfo.path;
-                sourceMapFileInfo.documentPositionMapper = documentPositionMapper || false;
+                sourceMapFileInfo.documentPositionMapper = documentPositionMapper ?? false;
                 sourceMapFileInfo.sourceInfos = this.addSourceInfoToSourceMap(sourceFileName, project, sourceMapFileInfo.sourceInfos);
             }
             else if (mapFileNameFromDeclarationInfo) {
@@ -2915,7 +2915,7 @@ namespace ts.server {
             if (sourceFileName) {
                 // Attach as source
                 const sourceInfo = this.getOrCreateScriptInfoNotOpenedByClient(sourceFileName, project.currentDirectory, project.directoryStructureHost)!;
-                (sourceInfos || (sourceInfos = new Set())).add(sourceInfo.path);
+                (sourceInfos ??= new Set()).add(sourceInfo.path);
             }
             return sourceInfos;
         }
@@ -2949,14 +2949,14 @@ namespace ts.server {
             }
 
             // Need to look for other files.
-            const info = this.getOrCreateScriptInfoNotOpenedByClient(fileName, (project || this).currentDirectory, project ? project.directoryStructureHost : this.host);
+            const info = this.getOrCreateScriptInfoNotOpenedByClient(fileName, (project ?? this).currentDirectory, project ? project.directoryStructureHost : this.host);
             if (!info) return undefined;
 
             // Attach as source
             if (declarationInfo && isString(declarationInfo.sourceMapFilePath) && info !== declarationInfo) {
                 const sourceMapInfo = this.getScriptInfoForPath(declarationInfo.sourceMapFilePath);
                 if (sourceMapInfo) {
-                    (sourceMapInfo.sourceInfos || (sourceMapInfo.sourceInfos = new Set())).add(info.path);
+                    (sourceMapInfo.sourceInfos ??= new Set()).add(info.path);
                 }
             }
 
@@ -3047,7 +3047,7 @@ namespace ts.server {
         private getWatchOptionsFromProjectWatchOptions(projectOptions: WatchOptions | undefined) {
             return projectOptions && this.hostConfiguration.watchOptions ?
                 { ...this.hostConfiguration.watchOptions, ...projectOptions } :
-                projectOptions || this.hostConfiguration.watchOptions;
+                projectOptions ?? this.hostConfiguration.watchOptions;
         }
 
         closeLog() {
@@ -3127,7 +3127,7 @@ namespace ts.server {
                 // otherwise we create a new one.
                 const configFileName = this.getConfigFileNameForFile(info);
                 if (configFileName) {
-                    const project = this.findConfiguredProjectByProjectName(configFileName) || this.createConfiguredProject(configFileName);
+                    const project = this.findConfiguredProjectByProjectName(configFileName) ?? this.createConfiguredProject(configFileName);
                     if (!updatedProjects.has(project.canonicalConfigFilePath)) {
                         updatedProjects.set(project.canonicalConfigFilePath, true);
                         if (delayReload) {
@@ -3454,7 +3454,7 @@ namespace ts.server {
                 if (!configFileName) return;
 
                 // find or delay load the project
-                const ancestor = this.findConfiguredProjectByProjectName(configFileName) ||
+                const ancestor = this.findConfiguredProjectByProjectName(configFileName) ??
                     this.createConfiguredProjectWithDelayLoad(configFileName, `Creating project possibly referencing default composite project ${project.getProjectName()} of open file ${info.fileName}`);
                 if (ancestor.isInitialLoadPending()) {
                     // Set a potential project reference
@@ -3466,7 +3466,7 @@ namespace ts.server {
 
         /*@internal*/
         loadAncestorProjectTree(forProjects?: ReadonlyCollection<string>) {
-            forProjects = forProjects || mapDefinedEntries(
+            forProjects ??= mapDefinedEntries(
                 this.configuredProjects,
                 (key, project) => !project.isInitialLoadPending() ? [key, true] : undefined
             );
@@ -3499,7 +3499,7 @@ namespace ts.server {
 
                 // Load this project,
                 const configFileName = toNormalizedPath(child.sourceFile.fileName);
-                const childProject = project.projectService.findConfiguredProjectByProjectName(configFileName) ||
+                const childProject = project.projectService.findConfiguredProjectByProjectName(configFileName) ??
                     project.projectService.createAndLoadConfiguredProject(configFileName, `Creating project referenced by : ${project.projectName} as it references project ${referencedProject.sourceFile.fileName}`);
                 updateProjectIfDirty(childProject);
 
@@ -3712,7 +3712,7 @@ namespace ts.server {
                         file.hasMixedContent,
                         file.projectRootPath ? toNormalizedPath(file.projectRootPath) : undefined
                     );
-                    (openScriptInfos || (openScriptInfos = [])).push(info);
+                    (openScriptInfos ??= []).push(info);
                 }
             }
 
@@ -3835,7 +3835,7 @@ namespace ts.server {
                 return [];
             }
 
-            const typeAcqInclude = typeAcquisition.include || (typeAcquisition.include = []);
+            const typeAcqInclude = typeAcquisition.include ??= [];
             const excludeRules: string[] = [];
 
             const normalizedNames = rootFiles.map(f => normalizeSlashes(f.fileName)) as NormalizedPath[];
@@ -3942,9 +3942,9 @@ namespace ts.server {
                 const typeAcquisition = convertEnableAutoDiscoveryToEnable(proj.typingOptions);
                 proj.typeAcquisition = typeAcquisition;
             }
-            proj.typeAcquisition = proj.typeAcquisition || {};
-            proj.typeAcquisition.include = proj.typeAcquisition.include || [];
-            proj.typeAcquisition.exclude = proj.typeAcquisition.exclude || [];
+            proj.typeAcquisition ??= {};
+            proj.typeAcquisition.include ??= [];
+            proj.typeAcquisition.exclude ??= [];
             if (proj.typeAcquisition.enable === undefined) {
                 proj.typeAcquisition.enable = hasNoTypeScriptSource(proj.rootFiles.map(f => f.fileName));
             }
@@ -3957,7 +3957,7 @@ namespace ts.server {
                 const normalized = toNormalizedPath(file.fileName);
                 if (getBaseConfigFileName(normalized)) {
                     if (this.serverMode === LanguageServiceMode.Semantic && this.host.fileExists(normalized)) {
-                        (tsConfigFiles || (tsConfigFiles = [])).push(normalized);
+                        (tsConfigFiles ??= []).push(normalized);
                     }
                 }
                 else {
@@ -4018,7 +4018,7 @@ namespace ts.server {
                         }
                         else {
                             // record existing config files so avoid extra add-refs
-                            (exisingConfigFiles || (exisingConfigFiles = [])).push(oldConfig);
+                            (exisingConfigFiles ??= []).push(oldConfig);
                             iOld++;
                             iNew++;
                         }
@@ -4180,7 +4180,7 @@ namespace ts.server {
 
             // Also save the current configuration to pass on to any projects that are yet to be loaded.
             // If a plugin is configured twice, only the latest configuration will be remembered.
-            this.currentPluginConfigOverrides = this.currentPluginConfigOverrides || new Map();
+            this.currentPluginConfigOverrides ??= new Map();
             this.currentPluginConfigOverrides.set(args.pluginName, args.configuration);
         }
 
@@ -4228,7 +4228,7 @@ namespace ts.server {
 
         /*@internal*/
         private watchPackageJsonFile(path: Path) {
-            const watchers = this.packageJsonFilesMap || (this.packageJsonFilesMap = new Map());
+            const watchers = this.packageJsonFilesMap ??= new Map();
             if (!watchers.has(path)) {
                 this.invalidateProjectPackageJson(path);
                 watchers.set(path, this.watchFactory.watchFile(
@@ -4288,7 +4288,7 @@ namespace ts.server {
 
         /*@internal*/
         getIncompleteCompletionsCache() {
-            return this.incompleteCompletionsCache ||= createIncompleteCompletionsCache();
+            return this.incompleteCompletionsCache ??= createIncompleteCompletionsCache();
         }
     }
 

--- a/src/server/moduleSpecifierCache.ts
+++ b/src/server/moduleSpecifierCache.ts
@@ -27,7 +27,7 @@ namespace ts.server {
                             // No trailing slash
                             const nodeModulesPath = p.path.substring(0, p.path.indexOf(nodeModulesPathPart) + nodeModulesPathPart.length - 1);
                             if (!containedNodeModulesWatchers?.has(nodeModulesPath)) {
-                                (containedNodeModulesWatchers ||= new Map()).set(
+                                (containedNodeModulesWatchers ??= new Map()).set(
                                     nodeModulesPath,
                                     host.watchNodeModulesForPackageJsonChanges(nodeModulesPath),
                                 );
@@ -77,7 +77,7 @@ namespace ts.server {
                 result.clear();
             }
             currentKey = newKey;
-            return cache ||= new Map();
+            return cache ??= new Map();
         }
 
         function key(fromFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions) {

--- a/src/server/packageJsonCache.ts
+++ b/src/server/packageJsonCache.ts
@@ -22,7 +22,7 @@ namespace ts.server {
                 directoriesWithoutPackageJson.set(getDirectoryPath(fileName), true);
             },
             getInDirectory: directory => {
-                return packageJsons.get(combinePaths(directory, "package.json")) || undefined;
+                return packageJsons.get(combinePaths(directory, "package.json")) ?? undefined;
             },
             directoryHasPackageJson,
             searchDirectoryAndAncestors: directory => {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -248,7 +248,7 @@ namespace ts.server {
             const result = host.require!(resolvedPath, moduleName); // TODO: GH#18217
             if (result.error) {
                 const err = result.error.stack || result.error.message || JSON.stringify(result.error);
-                (logErrors || log)(`Failed to load module '${moduleName}' from ${resolvedPath}: ${err}`);
+                (logErrors ?? log)(`Failed to load module '${moduleName}' from ${resolvedPath}: ${err}`);
                 return undefined;
             }
             return result.module;
@@ -268,7 +268,7 @@ namespace ts.server {
             }
             if (result.error) {
                 const err = result.error.stack || result.error.message || JSON.stringify(result.error);
-                (logErrors || log)(`Failed to dynamically import module '${moduleName}' from ${resolvedPath}: ${err}`);
+                (logErrors ?? log)(`Failed to dynamically import module '${moduleName}' from ${resolvedPath}: ${err}`);
                 return undefined;
             }
             return result.module;
@@ -429,11 +429,11 @@ namespace ts.server {
             this.rootFilesMap.forEach(value => {
                 if (this.languageServiceEnabled || (value.info && value.info.isScriptOpen())) {
                     // if language service is disabled - process only files that are open
-                    (result || (result = [])).push(value.fileName);
+                    (result ??= []).push(value.fileName);
                 }
             });
 
-            return addRange(result, this.typingFiles) || ts.emptyArray;
+            return addRange(result, this.typingFiles) ?? ts.emptyArray;
         }
 
         private getOrCreateScriptInfoAndAttachToProject(fileName: string) {
@@ -649,14 +649,14 @@ namespace ts.server {
          * Get the errors that dont have any file name associated
          */
         getGlobalProjectErrors(): readonly Diagnostic[] {
-            return filter(this.projectErrors, diagnostic => !diagnostic.file) || emptyArray;
+            return filter(this.projectErrors, diagnostic => !diagnostic.file) ?? emptyArray;
         }
 
         /**
          * Get all the project errors
          */
         getAllProjectErrors(): readonly Diagnostic[] {
-            return this.projectErrors || emptyArray;
+            return this.projectErrors ?? emptyArray;
         }
 
         setProjectErrors(projectErrors: Diagnostic[] | undefined) {
@@ -1038,14 +1038,14 @@ namespace ts.server {
         }
 
         registerFileUpdate(fileName: string) {
-            (this.updatedFileNames || (this.updatedFileNames = new Set<string>())).add(fileName);
+            (this.updatedFileNames ??= new Set<string>()).add(fileName);
         }
 
         /*@internal*/
         markFileAsDirty(changedFile: Path) {
             this.markAsDirty();
             if (this.exportMapCache && !this.exportMapCache.isEmpty()) {
-                (this.changedFilesForExportMapCache ||= new Set()).add(changedFile);
+                (this.changedFilesForExportMapCache ??= new Set()).add(changedFile);
             }
         }
 
@@ -1103,7 +1103,7 @@ namespace ts.server {
             this.hasAddedorRemovedFiles = false;
             this.hasAddedOrRemovedSymlinks = false;
 
-            const changedFiles: readonly Path[] = this.resolutionCache.finishRecordingFilesWithChangedResolutions() || emptyArray;
+            const changedFiles: readonly Path[] = this.resolutionCache.finishRecordingFilesWithChangedResolutions() ?? emptyArray;
 
             for (const file of changedFiles) {
                 // delete cached information for changed files
@@ -1211,7 +1211,7 @@ namespace ts.server {
                 // Update the missing file paths watcher
                 updateMissingFilePathsWatch(
                     this.program,
-                    this.missingFilesMap || (this.missingFilesMap = new Map()),
+                    this.missingFilesMap ??= new Map(),
                     // Watch the missing files
                     missingFilePath => this.addMissingFileWatcher(missingFilePath)
                 );
@@ -1282,7 +1282,7 @@ namespace ts.server {
                 this.moduleSpecifierCache.clear();
             }
 
-            const oldExternalFiles = this.externalFiles || emptyArray as SortedReadonlyArray<string>;
+            const oldExternalFiles = this.externalFiles ?? emptyArray as SortedReadonlyArray<string>;
             this.externalFiles = this.getExternalFiles();
             enumerateInsertsAndDeletes<string, string>(this.externalFiles, oldExternalFiles, getStringComparer(!this.useCaseSensitiveFileNames()),
                 // Ensure a ScriptInfo is created for new external files. This is performed indirectly
@@ -1484,7 +1484,7 @@ namespace ts.server {
         }
 
         getTypeAcquisition() {
-            return this.typeAcquisition || {};
+            return this.typeAcquisition ?? {};
         }
 
         /* @internal */
@@ -1774,7 +1774,7 @@ namespace ts.server {
 
         /*@internal*/
         getCachedExportInfoMap() {
-            return this.exportMapCache ||= createCacheableExportInfoMap(this);
+            return this.exportMapCache ??= createCacheableExportInfoMap(this);
         }
 
         /*@internal*/
@@ -1804,7 +1804,7 @@ namespace ts.server {
                 return {
                     fileExists: this.program.fileExists,
                     directoryExists: this.program.directoryExists,
-                    realpath: this.program.realpath || this.projectService.host.realpath?.bind(this.projectService.host),
+                    realpath: this.program.realpath ?? this.projectService.host.realpath?.bind(this.projectService.host),
                     getCurrentDirectory: this.getCurrentDirectory.bind(this),
                     readFile: this.projectService.host.readFile.bind(this.projectService.host),
                     getDirectories: this.projectService.host.getDirectories.bind(this.projectService.host),
@@ -1936,7 +1936,7 @@ namespace ts.server {
                     unresolvedImports = append(unresolvedImports, parsePackageName(name).packageName);
                 }
             });
-            return unresolvedImports || emptyArray;
+            return unresolvedImports ?? emptyArray;
         });
     }
 
@@ -1959,7 +1959,7 @@ namespace ts.server {
             if (!options && !this.getCompilationSettings()) {
                 return;
             }
-            const newOptions = cloneCompilerOptions(options || this.getCompilationSettings());
+            const newOptions = cloneCompilerOptions(options ?? this.getCompilationSettings());
             if (this._isJsInferredProject && typeof newOptions.maxNodeModuleJsDepth !== "number") {
                 newOptions.maxNodeModuleJsDepth = 2;
             }
@@ -2045,7 +2045,7 @@ namespace ts.server {
         }
 
         getTypeAcquisition(): TypeAcquisition {
-            return this.typeAcquisition || {
+            return this.typeAcquisition ?? {
                 enable: allRootFilesAreJsOrDts(this),
                 include: ts.emptyArray,
                 exclude: ts.emptyArray
@@ -2168,11 +2168,11 @@ namespace ts.server {
             if (rootNames?.length) {
                 hostProject.log(`AutoImportProviderProject: found ${rootNames.length} root files in ${dependenciesAdded} dependencies in ${timestamp() - start} ms`);
             }
-            return rootNames || ts.emptyArray;
+            return rootNames ?? ts.emptyArray;
 
             function addDependency(dependency: string) {
                 if (!startsWith(dependency, "@types/")) {
-                    (dependencyNames || (dependencyNames = new Set())).add(dependency);
+                    (dependencyNames ??= new Set()).add(dependency);
                 }
             }
 
@@ -2304,7 +2304,7 @@ namespace ts.server {
         }
 
         getScriptFileNames() {
-            return this.rootFileNames || ts.emptyArray;
+            return this.rootFileNames ?? ts.emptyArray;
         }
 
         getLanguageService(): never {
@@ -2503,7 +2503,7 @@ namespace ts.server {
         /*@internal*/
         setPotentialProjectReference(canonicalConfigPath: NormalizedPath) {
             Debug.assert(this.isInitialLoadPending());
-            (this.potentialProjectReferences || (this.potentialProjectReferences = new Set())).add(canonicalConfigPath);
+            (this.potentialProjectReferences ??= new Set()).add(canonicalConfigPath);
         }
 
         /*@internal*/
@@ -2552,14 +2552,14 @@ namespace ts.server {
          * Get the errors that dont have any file name associated
          */
         getGlobalProjectErrors(): readonly Diagnostic[] {
-            return filter(this.projectErrors, diagnostic => !diagnostic.file) || emptyArray;
+            return filter(this.projectErrors, diagnostic => !diagnostic.file) ?? emptyArray;
         }
 
         /**
          * Get all the project errors
          */
         getAllProjectErrors(): readonly Diagnostic[] {
-            return this.projectErrors || emptyArray;
+            return this.projectErrors ?? emptyArray;
         }
 
         setProjectErrors(projectErrors: Diagnostic[]) {
@@ -2648,7 +2648,7 @@ namespace ts.server {
         }
 
         getEffectiveTypeRoots() {
-            return getEffectiveTypeRoots(this.getCompilationSettings(), this.directoryStructureHost) || [];
+            return getEffectiveTypeRoots(this.getCompilationSettings(), this.directoryStructureHost) ?? [];
         }
 
         /*@internal*/

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -47,7 +47,7 @@ namespace ts.server {
         private pendingReloadFromDisk = false;
 
         constructor(private readonly host: ServerHost, private readonly info: ScriptInfo, initialVersion?: ScriptInfoVersion) {
-            this.version = initialVersion || { svc: 0, text: 0 };
+            this.version = initialVersion ?? { svc: 0, text: 0 };
         }
 
         public getVersion() {
@@ -255,7 +255,7 @@ namespace ts.server {
 
         private getLineMap() {
             Debug.assert(!this.svc, "ScriptVersionCache should not be set");
-            return this.lineMap || (this.lineMap = computeLineStarts(this.getOrLoadText()));
+            return this.lineMap ??= computeLineStarts(this.getOrLoadText());
         }
 
         getLineInfo(): LineInfo {
@@ -522,7 +522,7 @@ namespace ts.server {
                                 // its not the last one, find it and use that one if there
                                 if (defaultConfiguredProject === undefined &&
                                     index !== this.containingProjects.length - 1) {
-                                    defaultConfiguredProject = project.projectService.findDefaultConfiguredProject(this) || false;
+                                    defaultConfiguredProject = project.projectService.findDefaultConfiguredProject(this) ?? false;
                                 }
                                 if (defaultConfiguredProject === project) return project;
                                 if (!firstNonSourceOfProjectReferenceRedirect) firstNonSourceOfProjectReferenceRedirect = project;
@@ -537,8 +537,11 @@ namespace ts.server {
                         }
                     }
                     return ensurePrimaryProjectKind(defaultConfiguredProject ||
+                        // eslint-disable-next-line prefer-nullish-coalescing-truthy
                         firstNonSourceOfProjectReferenceRedirect ||
+                        // eslint-disable-next-line prefer-nullish-coalescing-truthy
                         firstConfiguredProject ||
+                        // eslint-disable-next-line prefer-nullish-coalescing-truthy
                         firstExternalProject ||
                         firstInferredProject);
             }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -805,7 +805,7 @@ namespace ts.server {
             const { throttleWaitMilliseconds } = opts;
 
             this.eventHandler = this.canUseEvents
-                ? opts.eventHandler || (event => this.defaultEventHandler(event))
+                ? opts.eventHandler ?? (event => this.defaultEventHandler(event))
                 : undefined;
             const multistepOperationHost: MultistepOperationHost = {
                 executeWithRequestId: (requestId, action) => this.executeWithRequestId(requestId, action),
@@ -1282,7 +1282,7 @@ namespace ts.server {
         private getDefinition(args: protocol.FileLocationRequestArgs, simplifiedResult: boolean): readonly protocol.FileSpanWithContext[] | readonly DefinitionInfo[] {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
-            const definitions = this.mapDefinitionInfoLocations(project.getLanguageService().getDefinitionAtPosition(file, position) || emptyArray, project);
+            const definitions = this.mapDefinitionInfoLocations(project.getLanguageService().getDefinitionAtPosition(file, position) ?? emptyArray, project);
             return simplifiedResult ? this.mapDefinitionInfo(definitions, project) : definitions.map(Session.mapToOriginalLocation);
         }
 
@@ -1335,7 +1335,7 @@ namespace ts.server {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
             const unmappedDefinitions = project.getLanguageService().getDefinitionAtPosition(file, position);
-            let definitions: readonly DefinitionInfo[] = this.mapDefinitionInfoLocations(unmappedDefinitions || emptyArray, project).slice();
+            let definitions: readonly DefinitionInfo[] = this.mapDefinitionInfoLocations(unmappedDefinitions ?? emptyArray, project).slice();
             const needsJsResolution = this.projectService.serverMode === LanguageServiceMode.Semantic && (
                 !some(definitions, d => toNormalizedPath(d.fileName) !== file && !d.isAmbient) ||
                 some(definitions, d => !!d.failedAliasResolution));
@@ -1441,7 +1441,7 @@ namespace ts.server {
                         if (some(candidates)) {
                             return candidates;
                         }
-                    }) || emptyArray;
+                    }) ?? emptyArray;
                 }
                 return emptyArray;
             }
@@ -1577,7 +1577,7 @@ namespace ts.server {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
 
-            const definitions = this.mapDefinitionInfoLocations(project.getLanguageService().getTypeDefinitionAtPosition(file, position) || emptyArray, project);
+            const definitions = this.mapDefinitionInfoLocations(project.getLanguageService().getTypeDefinitionAtPosition(file, position) ?? emptyArray, project);
             return this.mapDefinitionInfo(definitions, project);
         }
 
@@ -1595,7 +1595,7 @@ namespace ts.server {
         private getImplementation(args: protocol.FileLocationRequestArgs, simplifiedResult: boolean): readonly protocol.FileSpanWithContext[] | readonly ImplementationLocation[] {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
-            const implementations = this.mapImplementationLocations(project.getLanguageService().getImplementationAtPosition(file, position) || emptyArray, project);
+            const implementations = this.mapImplementationLocations(project.getLanguageService().getImplementationAtPosition(file, position) ?? emptyArray, project);
             return simplifiedResult ?
                 implementations.map(({ fileName, textSpan, contextSpan }) => this.toFileSpanWithContext(fileName, textSpan, contextSpan, project)) :
                 implementations.map(Session.mapToOriginalLocation);
@@ -1880,7 +1880,7 @@ namespace ts.server {
             // Since this is syntactic operation, there should always be project for the file
             // we wouldnt have to ensure project but rather throw if we dont get project
             const file = toNormalizedPath(args.file);
-            const project = this.getProject(args.projectFileName) || this.projectService.tryGetDefaultProjectForFile(file);
+            const project = this.getProject(args.projectFileName) ?? this.projectService.tryGetDefaultProjectForFile(file);
             if (!project) {
                 return Errors.ThrowNoProject();
             }
@@ -1892,7 +1892,7 @@ namespace ts.server {
 
         private getFileAndProjectWorker(uncheckedFileName: string, projectFileName: string | undefined): { file: NormalizedPath, project: Project } {
             const file = toNormalizedPath(uncheckedFileName);
-            const project = this.getProject(projectFileName) || this.projectService.ensureDefaultProjectForFile(file);
+            const project = this.getProject(projectFileName) ?? this.projectService.ensureDefaultProjectForFile(file);
             return { file, project };
         }
 

--- a/src/services/breakpoints.ts
+++ b/src/services/breakpoints.ts
@@ -39,7 +39,7 @@ namespace ts.BreakpointResolver {
             const start = lastDecorator ?
                 skipTrivia(sourceFile.text, lastDecorator.end) :
                 startNode.getStart(sourceFile);
-            return createTextSpanFromBounds(start, (endNode || startNode).getEnd());
+            return createTextSpanFromBounds(start, (endNode ?? startNode).getEnd());
         }
 
         function textSpanEndingAtNextToken(startNode: Node, previousTokenToFindNextEndToken: Node): TextSpan {
@@ -618,14 +618,14 @@ namespace ts.BreakpointResolver {
                     case SyntaxKind.ObjectBindingPattern:
                         // Breakpoint in last binding element or binding pattern if it contains no elements
                         const bindingPattern = node.parent as BindingPattern;
-                        return spanInNode(lastOrUndefined(bindingPattern.elements) || bindingPattern);
+                        return spanInNode(lastOrUndefined(bindingPattern.elements) ?? bindingPattern);
 
                     // Default to parent node
                     default:
                         if (isArrayLiteralOrObjectLiteralDestructuringPattern(node.parent)) {
                             // Breakpoint in last binding element or binding pattern if it contains no elements
                             const objectLiteral = node.parent as ObjectLiteralExpression;
-                            return textSpan(lastOrUndefined(objectLiteral.properties) || objectLiteral);
+                            return textSpan(lastOrUndefined(objectLiteral.properties) ?? objectLiteral);
                         }
                         return spanInNode(node.parent);
                 }
@@ -636,13 +636,13 @@ namespace ts.BreakpointResolver {
                     case SyntaxKind.ArrayBindingPattern:
                         // Breakpoint in last binding element or binding pattern if it contains no elements
                         const bindingPattern = node.parent as BindingPattern;
-                        return textSpan(lastOrUndefined(bindingPattern.elements) || bindingPattern);
+                        return textSpan(lastOrUndefined(bindingPattern.elements) ?? bindingPattern);
 
                     default:
                         if (isArrayLiteralOrObjectLiteralDestructuringPattern(node.parent)) {
                             // Breakpoint in last binding element or binding pattern if it contains no elements
                             const arrayLiteral = node.parent as ArrayLiteralExpression;
-                            return textSpan(lastOrUndefined(arrayLiteral.elements) || arrayLiteral);
+                            return textSpan(lastOrUndefined(arrayLiteral.elements) ?? arrayLiteral);
                         }
 
                         // Default to parent node

--- a/src/services/callHierarchy.ts
+++ b/src/services/callHierarchy.ts
@@ -322,7 +322,7 @@ namespace ts.CallHierarchy {
                 || isRightSideOfPropertyAccess(node)
                 || isArgumentExpressionOfElementAccess(node)) {
                 const sourceFile = node.getSourceFile();
-                const ancestor = findAncestor(node, isValidCallHierarchyDeclaration) || sourceFile;
+                const ancestor = findAncestor(node, isValidCallHierarchyDeclaration) ?? sourceFile;
                 return { declaration: ancestor, range: createTextRangeFromNode(node, sourceFile) };
             }
         }

--- a/src/services/codefixes/addMissingAwait.ts
+++ b/src/services/codefixes/addMissingAwait.ts
@@ -54,7 +54,7 @@ namespace ts.codefix {
                 }
                 const trackChanges: ContextualTrackChangesFunction = cb => (cb(t), []);
                 return getDeclarationSiteFix(context, expression, diagnostic.code, checker, trackChanges, fixedDeclarations)
-                    || getUseSiteFix(context, expression, diagnostic.code, checker, trackChanges, fixedDeclarations);
+                ?? getUseSiteFix(context, expression, diagnostic.code, checker, trackChanges, fixedDeclarations);
             });
         },
     });
@@ -156,7 +156,7 @@ namespace ts.codefix {
                 continue;
             }
 
-            (initializers || (initializers = [])).push({
+            (initializers ??= []).push({
                 expression: declaration.initializer,
                 declarationSymbol: symbol,
             });
@@ -189,7 +189,7 @@ namespace ts.codefix {
                         isCompleteFix = false;
                         continue;
                     }
-                    (sides || (sides = [])).push(side);
+                    (sides ??= []).push(side);
                 }
             }
             return sides && { identifiers: sides, isCompleteFix };

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -257,7 +257,7 @@ namespace ts.codefix {
                 if (renameInfo && renameInfo.text !== (original.name || original.propertyName).getText()) {
                     return factory.createBindingElement(
                         original.dotDotDotToken,
-                        original.propertyName || original.name,
+                        original.propertyName ?? original.name,
                         renameInfo,
                         original.initializer);
                 }
@@ -273,7 +273,7 @@ namespace ts.codefix {
     }
 
     function getNewNameIfConflict(name: Identifier, originalNames: ReadonlyESMap<string, Symbol[]>): SynthIdentifier {
-        const numVarsSameName = (originalNames.get(name.text) || emptyArray).length;
+        const numVarsSameName = (originalNames.get(name.text) ?? emptyArray).length;
         const identifier = numVarsSameName === 0 ? name : factory.createIdentifier(name.text + "_" + numVarsSameName);
         return createSynthIdentifier(identifier);
     }
@@ -561,7 +561,7 @@ namespace ts.codefix {
                 const returnType = callSignatures[0].getReturnType();
                 const varDeclOrAssignment = createVariableOrAssignmentOrExpressionStatement(continuationArgName, factory.createAwaitExpression(synthCall), getExplicitPromisedTypeOfPromiseReturningCallExpression(parent, func, transformer.checker));
                 if (continuationArgName) {
-                    continuationArgName.types.push(transformer.checker.getAwaitedType(returnType) || returnType);
+                    continuationArgName.types.push(transformer.checker.getAwaitedType(returnType) ?? returnType);
                 }
                 return varDeclOrAssignment;
 
@@ -653,7 +653,7 @@ namespace ts.codefix {
                         if (!shouldReturn(parent, transformer)) {
                             const transformedStatement = createVariableOrAssignmentOrExpressionStatement(continuationArgName, possiblyAwaitedRightHandSide, /*typeAnnotation*/ undefined);
                             if (continuationArgName) {
-                                continuationArgName.types.push(transformer.checker.getAwaitedType(returnType) || returnType);
+                                continuationArgName.types.push(transformer.checker.getAwaitedType(returnType) ?? returnType);
                             }
                             return transformedStatement;
                         }
@@ -780,7 +780,7 @@ namespace ts.codefix {
             }
 
             const mapEntry = transformer.synthNamesMap.get(getSymbolId(symbol).toString());
-            return mapEntry || createSynthIdentifier(identifier, types);
+            return mapEntry ?? createSynthIdentifier(identifier, types);
         }
 
         function getSymbol(node: Node): Symbol | undefined {

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -220,7 +220,7 @@ namespace ts.codefix {
         if (!classDeclaration && isPrivateIdentifier(token)) return undefined;
 
         // Prefer to change the class instead of the interface if they are merged
-        const declaration = classDeclaration || find(symbol.declarations, d => isInterfaceDeclaration(d) || isTypeLiteralNode(d)) as InterfaceDeclaration | TypeLiteralNode | undefined;
+        const declaration = classDeclaration ?? find(symbol.declarations, d => isInterfaceDeclaration(d) || isTypeLiteralNode(d)) as InterfaceDeclaration | TypeLiteralNode | undefined;
         if (declaration && !isSourceFileFromLibrary(program, declaration.getSourceFile())) {
             const makeStatic = !isTypeLiteralNode(declaration) && ((leftExpressionType as TypeReference).target || leftExpressionType) !== checker.getDeclaredTypeOfSymbol(symbol);
             if (makeStatic && (isPrivateIdentifier(token) || isInterfaceDeclaration(declaration))) return undefined;
@@ -337,7 +337,7 @@ namespace ts.codefix {
             const contextualType = checker.getContextualType(token.parent as Expression);
             typeNode = contextualType ? checker.typeToTypeNode(contextualType, /*enclosingDeclaration*/ undefined, NodeBuilderFlags.NoTruncation) : undefined;
         }
-        return typeNode || factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
+        return typeNode ?? factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
     }
 
     function addPropertyDeclaration(changeTracker: textChanges.ChangeTracker, sourceFile: SourceFile, node: ClassLikeDeclaration | InterfaceDeclaration | TypeLiteralNode, tokenName: string, typeNode: TypeNode, modifierFlags: ModifierFlags): void {
@@ -547,7 +547,7 @@ namespace ts.codefix {
             return factory.createObjectLiteralExpression(props, /*multiLine*/ true);
         }
         if (getObjectFlags(type) & ObjectFlags.Anonymous) {
-            const decl = find(type.symbol.declarations || emptyArray, or(isFunctionTypeNode, isMethodSignature, isMethodDeclaration));
+            const decl = find(type.symbol.declarations ?? emptyArray, or(isFunctionTypeNode, isMethodSignature, isMethodDeclaration));
             if (decl === undefined) return createUndefined();
 
             const signature = checker.getSignaturesOfType(type, SignatureKind.Call);

--- a/src/services/codefixes/fixAwaitInSyncFunction.ts
+++ b/src/services/codefixes/fixAwaitInSyncFunction.ts
@@ -55,7 +55,7 @@ namespace ts.codefix {
                 break;
             case SyntaxKind.ArrowFunction:
                 const kind = containingFunction.typeParameters ? SyntaxKind.LessThanToken : SyntaxKind.OpenParenToken;
-                insertBefore = findChildOfKind(containingFunction, kind, sourceFile) || first(containingFunction.parameters);
+                insertBefore = findChildOfKind(containingFunction, kind, sourceFile) ?? first(containingFunction.parameters);
                 break;
             default:
                 return;

--- a/src/services/codefixes/fixIncorrectNamedTupleSyntax.ts
+++ b/src/services/codefixes/fixIncorrectNamedTupleSyntax.ts
@@ -39,9 +39,9 @@ namespace ts.codefix {
         }
         const updated = factory.updateNamedTupleMember(
             namedTupleMember,
-            namedTupleMember.dotDotDotToken || (sawRest ? factory.createToken(SyntaxKind.DotDotDotToken) : undefined),
+            namedTupleMember.dotDotDotToken ?? (sawRest ? factory.createToken(SyntaxKind.DotDotDotToken) : undefined),
             namedTupleMember.name,
-            namedTupleMember.questionToken || (sawOptional ? factory.createToken(SyntaxKind.QuestionToken) : undefined),
+            namedTupleMember.questionToken ?? (sawOptional ? factory.createToken(SyntaxKind.QuestionToken) : undefined),
             unwrappedType
         );
         if (updated === namedTupleMember) {

--- a/src/services/codefixes/fixOverrideModifier.ts
+++ b/src/services/codefixes/fixOverrideModifier.ts
@@ -139,7 +139,7 @@ namespace ts.codefix {
             changeTracker.addJSDocTags(sourceFile, classElement, [factory.createJSDocOverrideTag(factory.createIdentifier("override"))]);
             return;
         }
-        const modifiers = classElement.modifiers || emptyArray;
+        const modifiers = classElement.modifiers ?? emptyArray;
         const staticModifier = find(modifiers, isStaticModifier);
         const abstractModifier = find(modifiers, isAbstractModifier);
         const accessibilityModifier = find(modifiers, m => isAccessibilityModifier(m.kind));

--- a/src/services/codefixes/fixReturnTypeInAsyncFunction.ts
+++ b/src/services/codefixes/fixReturnTypeInAsyncFunction.ts
@@ -51,7 +51,7 @@ namespace ts.codefix {
         }
 
         const returnType = checker.getTypeFromTypeNode(returnTypeNode);
-        const promisedType = checker.getAwaitedType(returnType) || checker.getVoidType();
+        const promisedType = checker.getAwaitedType(returnType) ?? checker.getVoidType();
         const promisedTypeNode = checker.typeToTypeNode(promisedType, /*enclosingDeclaration*/ returnTypeNode, /*flags*/ undefined);
         if (promisedTypeNode) {
             return { returnTypeNode, returnType, promisedTypeNode, promisedType };

--- a/src/services/codefixes/fixUnreferenceableDecoratorMetadata.ts
+++ b/src/services/codefixes/fixUnreferenceableDecoratorMetadata.ts
@@ -28,7 +28,7 @@ namespace ts.codefix {
 
         const checker = program.getTypeChecker();
         const symbol = checker.getSymbolAtLocation(identifier);
-        return find(symbol?.declarations || emptyArray, or(isImportClause, isImportSpecifier, isImportEqualsDeclaration) as (n: Node) => n is ImportClause | ImportSpecifier | ImportEqualsDeclaration);
+        return find(symbol?.declarations ?? emptyArray, or(isImportClause, isImportSpecifier, isImportEqualsDeclaration) as (n: Node) => n is ImportClause | ImportSpecifier | ImportEqualsDeclaration);
     }
 
     // Converts the import declaration of the offending import to a type-only import,

--- a/src/services/codefixes/generateAccessors.ts
+++ b/src/services/codefixes/generateAccessors.ts
@@ -187,7 +187,7 @@ namespace ts.codefix {
             declaration,
             modifiers,
             fieldName,
-            declaration.questionToken || declaration.exclamationToken,
+            declaration.questionToken ?? declaration.exclamationToken,
             type,
             declaration.initializer
         );

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -114,7 +114,7 @@ namespace ts.codefix {
                             name,
                             emptyArray,
                             typeNode,
-                            ambient ? undefined : body || createStubbedMethodBody(quotePreference)));
+                            ambient ? undefined : body ?? createStubbedMethodBody(quotePreference)));
                     }
                     else {
                         Debug.assertNode(accessor, isSetAccessorDeclaration, "The counterpart to a getter should be a setter");
@@ -124,7 +124,7 @@ namespace ts.codefix {
                             modifiers,
                             name,
                             createDummyParameters(1, [parameterName], [typeNode], 1, /*inJs*/ false),
-                            ambient ? undefined : body || createStubbedMethodBody(quotePreference)));
+                            ambient ? undefined : body ?? createStubbedMethodBody(quotePreference)));
                     }
                 }
                 break;
@@ -146,7 +146,7 @@ namespace ts.codefix {
                 if (declarations.length === 1) {
                     Debug.assert(signatures.length === 1, "One declaration implies one signature");
                     const signature = signatures[0];
-                    outputMethod(quotePreference, signature, modifiers, name, ambient ? undefined : body || createStubbedMethodBody(quotePreference));
+                    outputMethod(quotePreference, signature, modifiers, name, ambient ? undefined : body ?? createStubbedMethodBody(quotePreference));
                     break;
                 }
 
@@ -158,7 +158,7 @@ namespace ts.codefix {
                 if (!ambient) {
                     if (declarations.length > signatures.length) {
                         const signature = checker.getSignatureFromDeclaration(declarations[declarations.length - 1] as SignatureDeclaration)!;
-                        outputMethod(quotePreference, signature, modifiers, name, body || createStubbedMethodBody(quotePreference));
+                        outputMethod(quotePreference, signature, modifiers, name, body ?? createStubbedMethodBody(quotePreference));
                     }
                     else {
                         Debug.assert(declarations.length === signatures.length, "Declarations and signatures should match count");
@@ -455,7 +455,7 @@ namespace ts.codefix {
             typeParameters,
             parameters,
             returnType,
-            body || createStubbedMethodBody(quotePreference));
+            body ?? createStubbedMethodBody(quotePreference));
     }
 
     function createStubbedMethodBody(quotePreference: QuotePreference) {

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -133,7 +133,7 @@ namespace ts.codefix {
                             entry.defaultImport = { name: symbolName, addAsTypeOnly: reduceAddAsTypeOnlyValues(entry.defaultImport?.addAsTypeOnly, addAsTypeOnly) };
                             break;
                         case ImportKind.Named:
-                            const prevValue = (entry.namedImports ||= new Map()).get(symbolName);
+                            const prevValue = (entry.namedImports ??= new Map()).get(symbolName);
                             entry.namedImports.set(symbolName, reduceAddAsTypeOnlyValues(prevValue, addAsTypeOnly));
                             break;
                         case ImportKind.CommonJS:
@@ -184,7 +184,7 @@ namespace ts.codefix {
                     return newEntry;
                 }
                 if (addAsTypeOnly === AddAsTypeOnly.Allowed && (typeOnlyEntry || nonTypeOnlyEntry)) {
-                    return (typeOnlyEntry || nonTypeOnlyEntry)!;
+                    return (typeOnlyEntry ?? nonTypeOnlyEntry)!;
                 }
                 if (nonTypeOnlyEntry) {
                     return nonTypeOnlyEntry;
@@ -613,13 +613,13 @@ namespace ts.codefix {
             if (isVariableDeclarationInitializedToRequire(i.parent)) {
                 const moduleSymbol = checker.resolveExternalModuleName(moduleSpecifier);
                 if (moduleSymbol) {
-                    (importMap ||= createMultiMap()).add(getSymbolId(moduleSymbol), i.parent);
+                    (importMap ??= createMultiMap()).add(getSymbolId(moduleSymbol), i.parent);
                 }
             }
             else if (i.kind === SyntaxKind.ImportDeclaration || i.kind === SyntaxKind.ImportEqualsDeclaration) {
                 const moduleSymbol = checker.getSymbolAtLocation(moduleSpecifier);
                 if (moduleSymbol) {
-                    (importMap ||= createMultiMap()).add(getSymbolId(moduleSymbol), i);
+                    (importMap ??= createMultiMap()).add(getSymbolId(moduleSymbol), i);
                 }
             }
         }
@@ -1313,7 +1313,7 @@ namespace ts.codefix {
         let statements: RequireVariableStatement | readonly RequireVariableStatement[] | undefined;
         // const { default: foo, bar, etc } = require('./mod');
         if (defaultImport || namedImports?.length) {
-            const bindingElements = namedImports?.map(({ name }) => factory.createBindingElement(/*dotDotDotToken*/ undefined, /*propertyName*/ undefined, name)) || [];
+            const bindingElements = namedImports?.map(({ name }) => factory.createBindingElement(/*dotDotDotToken*/ undefined, /*propertyName*/ undefined, name)) ?? [];
             if (defaultImport) {
                 bindingElements.unshift(factory.createBindingElement(/*dotDotDotToken*/ undefined, "default", defaultImport.name));
             }

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -538,7 +538,7 @@ namespace ts.codefix {
                 cancellationToken.throwIfCancellationRequested();
                 calculateUsageOfNode(reference, usage);
             }
-            const calls = [...usage.constructs || [], ...usage.calls || []];
+            const calls = [...usage.constructs ?? [], ...usage.calls ?? []];
             return declaration.parameters.map((parameter, parameterIndex): ParameterInference => {
                 const types = [];
                 const isRest = isRestParameter(parameter);
@@ -577,7 +577,7 @@ namespace ts.codefix {
                 calculateUsageOfNode(reference, usage);
             }
 
-            return combineTypes(usage.candidateThisTypes || emptyArray);
+            return combineTypes(usage.candidateThisTypes ?? emptyArray);
         }
 
         function inferTypesFromReferencesSingle(references: readonly Identifier[]): Type[] {
@@ -804,10 +804,10 @@ namespace ts.codefix {
 
             calculateUsageOfNode(parent, call.return_);
             if (parent.kind === SyntaxKind.CallExpression) {
-                (usage.calls || (usage.calls = [])).push(call);
+                (usage.calls ??= []).push(call);
             }
             else {
-                (usage.constructs || (usage.constructs = [])).push(call);
+                (usage.constructs ??= []).push(call);
             }
         }
 
@@ -816,7 +816,7 @@ namespace ts.codefix {
             if (!usage.properties) {
                 usage.properties = new Map();
             }
-            const propertyUsage = usage.properties.get(name) || createEmptyUsage();
+            const propertyUsage = usage.properties.get(name) ?? createEmptyUsage();
             calculateUsageOfNode(parent, propertyUsage);
             usage.properties.set(name, propertyUsage);
         }
@@ -965,7 +965,7 @@ namespace ts.codefix {
                 types.push(inferStructuralType(usage));
             }
 
-            const candidateTypes = (usage.candidateTypes || []).map(t => checker.getBaseTypeOfLiteralType(t));
+            const candidateTypes = (usage.candidateTypes ?? []).map(t => checker.getBaseTypeOfLiteralType(t));
             const callsType = usage.calls?.length ? inferStructuralType(usage) : undefined;
             if (callsType && candidateTypes) {
                 types.push(checker.getUnionType([callsType, ...candidateTypes], UnionReduction.Subtype));
@@ -1090,7 +1090,7 @@ namespace ts.codefix {
                     genericParamType = elementType;
                 }
                 const targetType = (usageParam as SymbolLinks).type
-                    || (usageParam.valueDeclaration ? checker.getTypeOfSymbolAtLocation(usageParam, usageParam.valueDeclaration) : checker.getAnyType());
+                ?? (usageParam.valueDeclaration ? checker.getTypeOfSymbolAtLocation(usageParam, usageParam.valueDeclaration) : checker.getAnyType());
                 types.push(...inferTypeParameters(genericParamType, targetType, typeParameter));
             }
             const genericReturn = checker.getReturnTypeOfSignature(genericSig);
@@ -1120,13 +1120,13 @@ namespace ts.codefix {
 
         function addCandidateType(usage: Usage, type: Type | undefined) {
             if (type && !(type.flags & TypeFlags.Any) && !(type.flags & TypeFlags.Never)) {
-                (usage.candidateTypes || (usage.candidateTypes = [])).push(type);
+                (usage.candidateTypes ??= []).push(type);
             }
         }
 
         function addCandidateThisType(usage: Usage, type: Type | undefined) {
             if (type && !(type.flags & TypeFlags.Any) && !(type.flags & TypeFlags.Never)) {
-                (usage.candidateThisTypes || (usage.candidateThisTypes = [])).push(type);
+                (usage.candidateThisTypes ??= []).push(type);
             }
         }
     }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -224,7 +224,7 @@ namespace ts.Completions {
                 if (result) {
                     ambientCount++;
                 }
-                return result || "failed";
+                return result ?? "failed";
             }
             const shouldResolveModuleSpecifier = needsFullResolution || preferences.allowIncompleteCompletions && resolvedCount < moduleSpecifierResolutionLimit;
             const shouldGetModuleSpecifierFromCache = !shouldResolveModuleSpecifier && preferences.allowIncompleteCompletions && cacheAttemptCount < moduleSpecifierResolutionCacheAttemptLimit;
@@ -242,7 +242,7 @@ namespace ts.Completions {
                 cacheAttemptCount++;
             }
 
-            return result || (needsFullResolution ? "failed" : "skipped");
+            return result ?? (needsFullResolution ? "failed" : "skipped");
         }
     }
 
@@ -745,7 +745,7 @@ namespace ts.Completions {
                 insertText = `?.${insertText}`;
             }
 
-            const dot = findChildOfKind(propertyAccessToConvert, SyntaxKind.DotToken, sourceFile) ||
+            const dot = findChildOfKind(propertyAccessToConvert, SyntaxKind.DotToken, sourceFile) ??
                 findChildOfKind(propertyAccessToConvert, SyntaxKind.QuestionDotToken, sourceFile);
             if (!dot) {
                 return undefined;
@@ -1249,7 +1249,7 @@ namespace ts.Completions {
                 const start = baseWriter.getTextPos();
                 write();
                 const end = baseWriter.getTextPos();
-                escapes = append(escapes ||= [], { newText: escaped, span: { start, length: end - start } });
+                escapes = append(escapes ??= [], { newText: escaped, span: { start, length: end - start } });
             }
             else {
                 write();
@@ -1366,7 +1366,7 @@ namespace ts.Completions {
 
     function getInsertTextAndReplacementSpanForImportCompletion(name: string, importCompletionNode: Node, contextToken: Node | undefined, origin: SymbolOriginInfoResolvedExport, useSemicolons: boolean, options: CompilerOptions, preferences: UserPreferences) {
         const sourceFile = importCompletionNode.getSourceFile();
-        const replacementSpan = createTextSpanFromNode(findAncestor(importCompletionNode, or(isImportDeclaration, isImportEqualsDeclaration)) || importCompletionNode, sourceFile);
+        const replacementSpan = createTextSpanFromNode(findAncestor(importCompletionNode, or(isImportDeclaration, isImportEqualsDeclaration)) ?? importCompletionNode, sourceFile);
         const quotedModuleSpecifier = quote(sourceFile, preferences, origin.moduleSpecifier);
         const exportKind =
             origin.isDefaultExport ? ExportKind.Default :
@@ -1648,7 +1648,7 @@ namespace ts.Completions {
                 || getSourceFromOrigin(origin) === entryId.source)
                 ? { type: "symbol" as const, symbol, location, origin, contextToken, previousToken, isJsxInitializer, isTypeOnlyLocation }
                 : undefined;
-        }) || { type: "none" };
+        }) ?? { type: "none" };
     }
 
     export interface CompletionEntryIdentifier {
@@ -1800,7 +1800,7 @@ namespace ts.Completions {
 
         const checker = origin.isFromPackageJson ? host.getPackageJsonAutoImportProvider!()!.getTypeChecker() : program.getTypeChecker();
         const { moduleSymbol } = origin;
-        const targetSymbol = checker.getMergedSymbol(skipAlias(symbol.exportSymbol || symbol, checker));
+        const targetSymbol = checker.getMergedSymbol(skipAlias(symbol.exportSymbol ?? symbol, checker));
         const isJsxOpeningTagName = contextToken?.kind === SyntaxKind.LessThanToken && isJsxOpeningLikeElement(contextToken.parent);
         const { moduleSpecifier, codeAction } = codefix.getImportCompletionAction(
             targetSymbol,
@@ -2446,14 +2446,14 @@ namespace ts.Completions {
                     }
                     else {
                         const fileName = isExternalModuleNameRelative(stripQuotes(moduleSymbol.name)) ? getSourceFileOfModule(moduleSymbol)?.fileName : undefined;
-                        const { moduleSpecifier } = (importSpecifierResolver ||= codefix.createImportSpecifierResolver(sourceFile, program, host, preferences)).getModuleSpecifierForBestExportInfo([{
+                        const { moduleSpecifier } = (importSpecifierResolver ??= codefix.createImportSpecifierResolver(sourceFile, program, host, preferences)).getModuleSpecifierForBestExportInfo([{
                             exportKind: ExportKind.Named,
                             moduleFileName: fileName,
                             isFromPackageJson: false,
                             moduleSymbol,
                             symbol: firstAccessibleSymbol,
                             targetFlags: skipAlias(firstAccessibleSymbol, typeChecker).flags,
-                        }], firstAccessibleSymbol.name, position, isValidTypeOnlyAliasUseSite(location)) || {};
+                        }], firstAccessibleSymbol.name, position, isValidTypeOnlyAliasUseSite(location)) ?? {};
 
                         if (moduleSpecifier) {
                             const origin: SymbolOriginInfoResolvedExport = {
@@ -2591,7 +2591,7 @@ namespace ts.Completions {
                 previousToken.getStart() :
                 position;
 
-            const scopeNode = getScopeNode(contextToken, adjustedPosition, sourceFile) || sourceFile;
+            const scopeNode = getScopeNode(contextToken, adjustedPosition, sourceFile) ?? sourceFile;
             isInSnippetScope = isSnippetScope(scopeNode);
 
             const symbolMeanings = (isTypeOnlyLocation ? SymbolFlags.None : SymbolFlags.Value) | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias;
@@ -2731,7 +2731,7 @@ namespace ts.Completions {
             resolvingModuleSpecifiers(
                 "collectAutoImports",
                 host,
-                importSpecifierResolver ||= codefix.createImportSpecifierResolver(sourceFile, program, host, preferences),
+                importSpecifierResolver ??= codefix.createImportSpecifierResolver(sourceFile, program, host, preferences),
                 program,
                 position,
                 preferences,
@@ -3030,7 +3030,7 @@ namespace ts.Completions {
             if (!typeLiteralNode) return GlobalsSearch.Continue;
 
             const intersectionTypeNode = isIntersectionTypeNode(typeLiteralNode.parent) ? typeLiteralNode.parent : undefined;
-            const containerTypeNode = intersectionTypeNode || typeLiteralNode;
+            const containerTypeNode = intersectionTypeNode ?? typeLiteralNode;
 
             const containerExpectedType = getConstraintOfTypeArgumentProperty(containerTypeNode, typeChecker);
             if (!containerExpectedType) return GlobalsSearch.Continue;
@@ -3080,8 +3080,8 @@ namespace ts.Completions {
                     return GlobalsSearch.Continue;
                 }
                 const completionsType = typeChecker.getContextualType(objectLikeContainer, ContextFlags.Completions);
-                const hasStringIndexType = (completionsType || instantiatedType).getStringIndexType();
-                const hasNumberIndextype = (completionsType || instantiatedType).getNumberIndexType();
+                const hasStringIndexType = (completionsType ?? instantiatedType).getStringIndexType();
+                const hasNumberIndextype = (completionsType ?? instantiatedType).getNumberIndexType();
                 isNewIdentifierLocation = !!hasStringIndexType || !!hasNumberIndextype;
                 typeMembers = getPropertiesForObjectExpression(instantiatedType, completionsType, objectLikeContainer, typeChecker);
                 existingMembers = objectLikeContainer.properties;
@@ -3185,7 +3185,7 @@ namespace ts.Completions {
             completionKind = CompletionKind.MemberLike;
             isNewIdentifierLocation = false;
             const exports = typeChecker.getExportsAndPropertiesOfModule(moduleSpecifierSymbol);
-            const existing = new Set((namedImportsOrExports.elements as NodeArray<ImportOrExportSpecifier>).filter(n => !isCurrentlyEditingNode(n)).map(n => (n.propertyName || n.name).escapedText));
+            const existing = new Set((namedImportsOrExports.elements as NodeArray<ImportOrExportSpecifier>).filter(n => !isCurrentlyEditingNode(n)).map(n => (n.propertyName ?? n.name).escapedText));
             const uniques = exports.filter(e => e.escapedName !== InternalSymbolName.Default && !existing.has(e.escapedName));
             symbols = concatenate(symbols, uniques);
             if (!uniques.length) {
@@ -4277,7 +4277,7 @@ namespace ts.Completions {
         return {
             isKeywordOnlyCompletion,
             keywordCompletion,
-            isNewIdentifierLocation: !!(candidate || keywordCompletion === SyntaxKind.TypeKeyword),
+            isNewIdentifierLocation: !!(candidate ?? keywordCompletion === SyntaxKind.TypeKeyword),
             replacementNode: candidate && rangeIsOnSingleLine(candidate, candidate.getSourceFile())
                 ? candidate
                 : undefined
@@ -4360,7 +4360,7 @@ namespace ts.Completions {
     function symbolCanBeReferencedAtTypeLocation(symbol: Symbol, checker: TypeChecker, seenModules = new Map<SymbolId, true>()): boolean {
         // Since an alias can be merged with a local declaration, we need to test both the alias and its target.
         // This code used to just test the result of `skipAlias`, but that would ignore any locally introduced meanings.
-        return nonAliasCanBeReferencedAtTypeLocation(symbol) || nonAliasCanBeReferencedAtTypeLocation(skipAlias(symbol.exportSymbol || symbol, checker));
+        return nonAliasCanBeReferencedAtTypeLocation(symbol) || nonAliasCanBeReferencedAtTypeLocation(skipAlias(symbol.exportSymbol ?? symbol, checker));
 
         function nonAliasCanBeReferencedAtTypeLocation(symbol: Symbol): boolean {
             return !!(symbol.flags & SymbolFlags.Type) || checker.isUnknownSymbol(symbol) ||

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -16,7 +16,7 @@ namespace ts {
                 return [{ fileName: sourceFile.fileName, highlightSpans }];
             }
 
-            return getSemanticDocumentHighlights(position, node, program, cancellationToken, sourceFilesToSearch) || getSyntacticDocumentHighlights(node, sourceFile);
+            return getSemanticDocumentHighlights(position, node, program, cancellationToken, sourceFilesToSearch) ?? getSyntacticDocumentHighlights(node, sourceFile);
         }
 
         function getHighlightSpanForNode(node: Node, sourceFile: SourceFile): HighlightSpan {

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -206,7 +206,7 @@ namespace ts {
         function rehydrateCachedInfo(info: CachedSymbolExportInfo): SymbolExportInfo {
             if (info.symbol && info.moduleSymbol) return info as SymbolExportInfo;
             const { id, exportKind, targetFlags, isFromPackageJson, moduleFileName } = info;
-            const [cachedSymbol, cachedModuleSymbol] = symbols.get(id) || emptyArray;
+            const [cachedSymbol, cachedModuleSymbol] = symbols.get(id) ?? emptyArray;
             if (cachedSymbol && cachedModuleSymbol) {
                 return {
                     symbol: cachedSymbol,
@@ -220,10 +220,10 @@ namespace ts {
             const checker = (isFromPackageJson
                 ? host.getPackageJsonAutoImportProvider()!
                 : host.getCurrentProgram()!).getTypeChecker();
-            const moduleSymbol = info.moduleSymbol || cachedModuleSymbol || Debug.checkDefined(info.moduleFile
+            const moduleSymbol = info.moduleSymbol ?? cachedModuleSymbol ?? Debug.checkDefined(info.moduleFile
                 ? checker.getMergedSymbol(info.moduleFile.symbol)
                 : checker.tryFindAmbientModule(info.moduleName));
-            const symbol = info.symbol || cachedSymbol || Debug.checkDefined(exportKind === ExportKind.ExportEquals
+            const symbol = info.symbol ?? cachedSymbol ?? Debug.checkDefined(exportKind === ExportKind.ExportEquals
                 ? checker.resolveExternalModuleSymbol(moduleSymbol)
                 : checker.tryGetMemberInModuleExportsAndProperties(unescapeLeadingUnderscores(info.symbolTableKey), moduleSymbol),
                 `Could not find symbol '${info.symbolName}' by key '${info.symbolTableKey}' in module ${moduleSymbol.name}`);
@@ -377,7 +377,7 @@ namespace ts {
         // which will invalidate the export map cache if things change, so pull it before
         // checking the cache.
         host.getPackageJsonAutoImportProvider?.();
-        const cache = host.getCachedExportInfoMap?.() || createCacheableExportInfoMap({
+        const cache = host.getCachedExportInfoMap?.() ?? createCacheableExportInfoMap({
             getCurrentProgram: () => program,
             getPackageJsonAutoImportProvider: () => host.getPackageJsonAutoImportProvider?.(),
             getGlobalTypingsCacheLocation: () => host.getGlobalTypingsCacheLocation?.(),

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -445,7 +445,7 @@ namespace ts.formatting {
                 undefined;
 
             if (tokenInfo) {
-                const parent = findPrecedingToken(tokenInfo.end, sourceFile, enclosingNode)?.parent || previousParent!;
+                const parent = findPrecedingToken(tokenInfo.end, sourceFile, enclosingNode)?.parent ?? previousParent!;
                 processPair(
                     tokenInfo,
                     sourceFile.getLineAndCharacterOfPosition(tokenInfo.pos).line,

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -35,7 +35,7 @@ namespace ts.formatting {
             const precedingToken = findPrecedingToken(position, sourceFile, /*startNode*/ undefined, /*excludeJsdoc*/ true);
 
             // eslint-disable-next-line no-null/no-null
-            const enclosingCommentRange = getRangeOfEnclosingComment(sourceFile, position, precedingToken || null);
+            const enclosingCommentRange = getRangeOfEnclosingComment(sourceFile, position, precedingToken ?? null);
             if (enclosingCommentRange && enclosingCommentRange.kind === SyntaxKind.MultiLineCommentTrivia) {
                 return getCommentIndent(sourceFile, position, options, enclosingCommentRange);
             }
@@ -455,7 +455,7 @@ namespace ts.formatting {
                 case SyntaxKind.Constructor:
                 case SyntaxKind.ConstructorType:
                 case SyntaxKind.ConstructSignature:
-                    return getList((node as SignatureDeclaration).typeParameters) || getList((node as SignatureDeclaration).parameters);
+                    return getList((node as SignatureDeclaration).typeParameters) ?? getList((node as SignatureDeclaration).parameters);
                 case SyntaxKind.GetAccessor:
                     return getList((node as GetAccessorDeclaration).parameters);
                 case SyntaxKind.ClassDeclaration:
@@ -466,7 +466,7 @@ namespace ts.formatting {
                     return getList((node as ClassDeclaration | ClassExpression | InterfaceDeclaration | TypeAliasDeclaration | JSDocTemplateTag).typeParameters);
                 case SyntaxKind.NewExpression:
                 case SyntaxKind.CallExpression:
-                    return getList((node as CallExpression).typeArguments) || getList((node as CallExpression).arguments);
+                    return getList((node as CallExpression).typeArguments) ?? getList((node as CallExpression).arguments);
                 case SyntaxKind.VariableDeclarationList:
                     return getList((node as VariableDeclarationList).declarations);
                 case SyntaxKind.NamedImports:

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -151,7 +151,7 @@ namespace ts.FindAllReferences {
         }
 
         function handleImportCall(importCall: ImportCall) {
-            const top = findAncestor(importCall, isAmbientModuleDeclaration) || importCall.getSourceFile();
+            const top = findAncestor(importCall, isAmbientModuleDeclaration) ?? importCall.getSourceFile();
             addIndirectUser(top, /** addTransitiveDependencies */ !!isExported(importCall, /** stopAtAmbientModule */ true));
         }
 
@@ -263,7 +263,7 @@ namespace ts.FindAllReferences {
                 return;
             }
 
-            const { name, namedBindings } = decl.importClause || { name: undefined, namedBindings: undefined };
+            const { name, namedBindings } = decl.importClause ?? { name: undefined, namedBindings: undefined };
 
             if (namedBindings) {
                 switch (namedBindings.kind) {
@@ -461,7 +461,7 @@ namespace ts.FindAllReferences {
      * @param comingFromExport If we are doing a search for all exports, don't bother looking backwards for the imported symbol, since that's the reason we're here.
      */
     export function getImportOrExportSymbol(node: Node, symbol: Symbol, checker: TypeChecker, comingFromExport: boolean): ImportedSymbol | ExportedSymbol | undefined {
-        return comingFromExport ? getExport() : getExport() || getImport();
+        return comingFromExport ? getExport() : getExport() ?? getImport();
 
         function getExport(): ExportedSymbol | ImportedSymbol | undefined {
             const { parent } = node;

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -118,7 +118,7 @@ namespace ts.NavigationBar {
     function emptyNavigationBarNode(node: Node, name?: DeclarationName): NavigationBarNode {
         return {
             node,
-            name: name || (isDeclaration(node) || isExpression(node) ? getNameOfDeclaration(node) : undefined),
+            name: name ?? (isDeclaration(node) || isExpression(node) ? getNameOfDeclaration(node) : undefined),
             additionalNodes: undefined,
             parent,
             children: undefined,
@@ -469,7 +469,7 @@ namespace ts.NavigationBar {
     function mergeChildren(children: NavigationBarNode[], node: NavigationBarNode): void {
         const nameToItems = new Map<string, NavigationBarNode | NavigationBarNode[]>();
         filterMutate(children, (child, index) => {
-            const declName = child.name || getNameOfDeclaration(child.node as Declaration);
+            const declName = child.name ?? getNameOfDeclaration(child.node as Declaration);
             const name = declName && nodeText(declName);
             if (!name) {
                 // Anonymous items are never merged.
@@ -551,11 +551,11 @@ namespace ts.NavigationBar {
                     const ctor = emptyNavigationBarNode(ctorNode);
                     ctor.indent = a.indent + 1;
                     ctor.children = a.node === ctorFunction ? a.children : b.children;
-                    a.children = a.node === ctorFunction ? concatenate([ctor], b.children || [b]) : concatenate(a.children || [{ ...a }], [ctor]);
+                    a.children = a.node === ctorFunction ? concatenate([ctor], b.children ?? [b]) : concatenate(a.children ?? [{ ...a }], [ctor]);
                 }
                 else {
                     if (a.children || b.children) {
-                        a.children = concatenate(a.children || [{ ...a }], b.children || [b]);
+                        a.children = concatenate(a.children ?? [{ ...a }], b.children ?? [b]);
                         if (a.children) {
                             mergeChildren(a.children, a);
                             sortChildren(a.children);
@@ -656,7 +656,7 @@ namespace ts.NavigationBar {
 
     /** Merge source into target. Source should be thrown away after this is called. */
     function merge(target: NavigationBarNode, source: NavigationBarNode): void {
-        target.additionalNodes = target.additionalNodes || [];
+        target.additionalNodes ??= [];
         target.additionalNodes.push(source.node);
         if (source.additionalNodes) {
             target.additionalNodes.push(...source.additionalNodes);
@@ -834,7 +834,7 @@ namespace ts.NavigationBar {
             kind: getNodeKind(n.node),
             kindModifiers: getModifiers(n.node),
             spans: getSpans(n),
-            childItems: map(n.children, convertToSecondaryNavBarMenuItem) || emptyChildItemArray,
+            childItems: map(n.children, convertToSecondaryNavBarMenuItem) ?? emptyChildItemArray,
             indent: n.indent,
             bolded: false,
             grayed: false

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -333,7 +333,7 @@ namespace ts.OrganizeImports {
             if (importDeclaration.importClause === undefined) {
                 // Only the first such import is interesting - the others are redundant.
                 // Note: Unfortunately, we will lose trivia that was on this node.
-                importWithoutClause = importWithoutClause || importDeclaration;
+                importWithoutClause ??= importDeclaration;
                 continue;
             }
 
@@ -418,7 +418,7 @@ namespace ts.OrganizeImports {
                 if (exportDeclaration.exportClause === undefined) {
                     // Only the first such export is interesting - the others are redundant.
                     // Note: Unfortunately, we will lose trivia that was on this node.
-                    exportWithoutClause = exportWithoutClause || exportDeclaration;
+                    exportWithoutClause ??= exportDeclaration;
                 }
                 else if (exportDeclaration.isTypeOnly) {
                     typeOnlyExports.push(exportDeclaration);
@@ -455,7 +455,7 @@ namespace ts.OrganizeImports {
 
     export function compareImportOrExportSpecifiers<T extends ImportOrExportSpecifier>(s1: T, s2: T) {
         return compareBooleans(s1.isTypeOnly, s2.isTypeOnly)
-            || compareIdentifiers(s1.propertyName || s1.name, s2.propertyName || s2.name)
+            || compareIdentifiers(s1.propertyName ?? s1.name, s2.propertyName ?? s2.name)
             || compareIdentifiers(s1.name, s2.name);
     }
 

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -70,7 +70,7 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
             copyLeadingComments(expression!, returnStatement, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ true);
         }
         else if (actionName === removeBracesAction.name && returnStatement) {
-            const actualExpression = expression || factory.createVoidZero();
+            const actualExpression = expression ?? factory.createVoidZero();
             body = needsParentheses(actualExpression) ? factory.createParenthesizedExpression(actualExpression) : actualExpression;
             copyTrailingAsLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
             copyLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);

--- a/src/services/refactors/convertExport.ts
+++ b/src/services/refactors/convertExport.ts
@@ -89,7 +89,7 @@ namespace ts.refactor {
                 const node = exportNode as FunctionDeclaration | ClassDeclaration | InterfaceDeclaration | EnumDeclaration | TypeAliasDeclaration | NamespaceDeclaration;
                 if (!node.name) return undefined;
                 return noSymbolError(node.name)
-                    || { exportNode: node, exportName: node.name, wasDefault, exportingModuleSymbol };
+                    ?? { exportNode: node, exportName: node.name, wasDefault, exportingModuleSymbol };
             }
             case SyntaxKind.VariableStatement: {
                 const vs = exportNode as VariableStatement;
@@ -101,13 +101,13 @@ namespace ts.refactor {
                 if (!decl.initializer) return undefined;
                 Debug.assert(!wasDefault, "Can't have a default flag here");
                 return noSymbolError(decl.name)
-                    || { exportNode: vs, exportName: decl.name as Identifier, wasDefault, exportingModuleSymbol };
+                    ?? { exportNode: vs, exportName: decl.name as Identifier, wasDefault, exportingModuleSymbol };
             }
             case SyntaxKind.ExportAssignment: {
                 const node = exportNode as ExportAssignment;
                 if (node.isExportEquals) return undefined;
                 return noSymbolError(node.expression)
-                    || { exportNode: node, exportName: node.expression as Identifier, wasDefault, exportingModuleSymbol };
+                    ?? { exportNode: node, exportName: node.expression as Identifier, wasDefault, exportingModuleSymbol };
             }
             default:
                 return undefined;

--- a/src/services/refactors/convertImport.ts
+++ b/src/services/refactors/convertImport.ts
@@ -193,7 +193,7 @@ namespace ts.refactor {
         const neededNamedImports: Set<ImportSpecifier> = new Set();
 
         for (const element of toConvert.elements) {
-            const propertyName = (element.propertyName || element.name).text;
+            const propertyName = (element.propertyName ?? element.name).text;
             FindAllReferences.Core.eachSymbolReferenceInFile(element.name, checker, sourceFile, id => {
                 const access = factory.createPropertyAccessExpression(factory.createIdentifier(namespaceImportName), propertyName);
                 if (isShorthandPropertyAssignment(id.parent)) {

--- a/src/services/refactors/convertOverloadListToSingleSignature.ts
+++ b/src/services/refactors/convertOverloadListToSingleSignature.ts
@@ -143,7 +143,7 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
                 p.dotDotDotToken,
                 p.name,
                 p.questionToken,
-                p.type || factory.createKeywordTypeNode(SyntaxKind.AnyKeyword)
+                p.type ?? factory.createKeywordTypeNode(SyntaxKind.AnyKeyword)
             ), p);
             const parameterDocComment = p.symbol && p.symbol.getDocumentationComment(checker);
             if (parameterDocComment) {

--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -101,7 +101,7 @@ namespace ts.refactor.convertStringOrTemplateLiteral {
             }
         });
 
-        return (container || expr) as Expression;
+        return (container ?? expr) as Expression;
     }
 
     function treeToArray(current: Expression) {

--- a/src/services/refactors/extractType.ts
+++ b/src/services/refactors/extractType.ts
@@ -146,7 +146,7 @@ namespace ts.refactor {
                 if (isIdentifier(node.typeName)) {
                     const typeName = node.typeName;
                     const symbol = checker.resolveName(typeName.text, typeName, SymbolFlags.TypeParameter, /* excludeGlobals */ true);
-                    for (const decl of symbol?.declarations || emptyArray) {
+                    for (const decl of symbol?.declarations ?? emptyArray) {
                         if (isTypeParameterDeclaration(decl) && decl.getSourceFile() === file) {
                             // skip extraction if the type node is in the range of the type parameter declaration.
                             // function foo<T extends { a?: /**/T }>(): void;

--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -622,6 +622,7 @@ namespace ts.refactor {
                 return name;
             case SyntaxKind.ObjectBindingPattern: {
                 // We can't handle nested destructurings or property names well here, so just copy them all.
+                // eslint-disable-next-line prefer-nullish-coalescing-truthy
                 const newElements = name.elements.filter(prop => prop.propertyName || !isIdentifier(prop.name) || keep(prop.name));
                 return newElements.length ? factory.createObjectBindingPattern(newElements) : undefined;
             }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -76,7 +76,7 @@ namespace ts {
 
         public getFullText(sourceFile?: SourceFile): string {
             this.assertHasRealPosition();
-            return (sourceFile || this.getSourceFile()).text.substring(this.pos, this.end);
+            return (sourceFile ?? this.getSourceFile()).text.substring(this.pos, this.end);
         }
 
         public getText(sourceFile?: SourceFile): string {
@@ -97,7 +97,7 @@ namespace ts {
 
         public getChildren(sourceFile?: SourceFileLike): Node[] {
             this.assertHasRealPosition("Node without a real position cannot be scanned and thus has no token nodes - use forEachChild and collect the result if that's fine");
-            return this._children || (this._children = createChildren(this, sourceFile));
+            return this._children ??= createChildren(this, sourceFile);
         }
 
         public getFirstToken(sourceFile?: SourceFileLike): Node | undefined {
@@ -145,7 +145,7 @@ namespace ts {
             return children;
         }
 
-        scanner.setText((sourceFile || node.getSourceFile()).text);
+        scanner.setText((sourceFile ?? node.getSourceFile()).text);
         let pos = node.pos;
         const processNode = (child: Node) => {
             addSyntheticNodes(children, pos, child.pos, node);
@@ -250,7 +250,7 @@ namespace ts {
         }
 
         public getFullText(sourceFile?: SourceFile): string {
-            return (sourceFile || this.getSourceFile()).text.substring(this.pos, this.end);
+            return (sourceFile ?? this.getSourceFile()).text.substring(this.pos, this.end);
         }
 
         public getText(sourceFile?: SourceFile): string {
@@ -269,7 +269,7 @@ namespace ts {
         }
 
         public getChildren(): Node[] {
-            return this.kind === SyntaxKind.EndOfFileToken ? (this as EndOfFileToken).jsDoc || emptyArray : emptyArray;
+            return this.kind === SyntaxKind.EndOfFileToken ? (this as EndOfFileToken).jsDoc ?? emptyArray : emptyArray;
         }
 
         public getFirstToken(): Node | undefined {
@@ -578,11 +578,11 @@ namespace ts {
         }
 
         getDocumentationComment(): SymbolDisplayPart[] {
-            return this.documentationComment || (this.documentationComment = getDocumentationComment(singleElementArray(this.declaration), this.checker));
+            return this.documentationComment ??= getDocumentationComment(singleElementArray(this.declaration), this.checker);
         }
 
         getJsDocTags(): JSDocTagInfo[] {
-            return this.jsDocTags || (this.jsDocTags = getJsDocTagsOfDeclarations(singleElementArray(this.declaration), this.checker));
+            return this.jsDocTags ??= getJsDocTagsOfDeclarations(singleElementArray(this.declaration), this.checker);
         }
     }
 
@@ -1007,7 +1007,7 @@ namespace ts {
                 const options: CreateSourceFileOptions = {
                     languageVersion: ScriptTarget.Latest,
                     impliedNodeFormat: getImpliedNodeFormatForFile(
-                        toPath(fileName, this.host.getCurrentDirectory(), this.host.getCompilerHost?.()?.getCanonicalFileName || hostGetCanonicalFileName(this.host)),
+                        toPath(fileName, this.host.getCurrentDirectory(), this.host.getCompilerHost?.()?.getCanonicalFileName ?? hostGetCanonicalFileName(this.host)),
                         this.host.getCompilerHost?.()?.getModuleResolutionCache?.()?.getPackageJsonInfoCache(),
                         this.host,
                         this.host.getCompilationSettings()
@@ -1287,7 +1287,7 @@ namespace ts {
 
             // Get a fresh cache of the host information
             const newSettings = host.getCompilationSettings() || getDefaultCompilerOptions();
-            const hasInvalidatedResolution: HasInvalidatedResolution = host.hasInvalidatedResolution || returnFalse;
+            const hasInvalidatedResolution: HasInvalidatedResolution = host.hasInvalidatedResolution ?? returnFalse;
             const hasChangedAutomaticTypeDirectiveNames = maybeBind(host, host.hasChangedAutomaticTypeDirectiveNames);
             const projectReferences = host.getProjectReferences?.();
             let parsedCommandLines: ESMap<Path, ParsedCommandLine | false> | undefined;
@@ -1394,7 +1394,7 @@ namespace ts {
                 const result = host.getParsedCommandLine ?
                     host.getParsedCommandLine(fileName) :
                     getParsedCommandLineOfConfigFileUsingSourceFile(fileName);
-                (parsedCommandLines ||= new Map()).set(path, result || false);
+                (parsedCommandLines ??= new Map()).set(path, result ?? false);
                 return result;
             }
 
@@ -2539,7 +2539,7 @@ namespace ts {
 
         function getRenameInfo(fileName: string, position: number, preferences: UserPreferences | RenameInfoOptions | undefined): RenameInfo {
             synchronizeHostData();
-            return Rename.getRenameInfo(program, getValidSourceFile(fileName), position, preferences || {});
+            return Rename.getRenameInfo(program, getValidSourceFile(fileName), position, preferences ?? {});
         }
 
         function getRefactorContext(file: SourceFile, positionOrRange: number | TextRange, preferences: UserPreferences, formatOptions?: FormatCodeSettings, triggerReason?: RefactorTriggerReason, kind?: string): RefactorContext {

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -288,7 +288,7 @@ namespace ts.SignatureHelp {
     }
 
     function getImmediatelyContainingArgumentOrContextualParameterInfo(node: Node, position: number, sourceFile: SourceFile, checker: TypeChecker): ArgumentListInfo | undefined {
-        return tryGetParameterInfo(node, position, sourceFile, checker) || getImmediatelyContainingArgumentInfo(node, position, sourceFile);
+        return tryGetParameterInfo(node, position, sourceFile, checker) ?? getImmediatelyContainingArgumentInfo(node, position, sourceFile);
     }
 
     function getHighestBinary(b: BinaryExpression): BinaryExpression {
@@ -346,7 +346,7 @@ namespace ts.SignatureHelp {
     // The type of a function type node has a symbol at that node, but it's better to use the symbol for a parameter or type alias.
     function chooseBetterSymbol(s: Symbol): Symbol {
         return s.name === InternalSymbolName.Type
-            ? firstDefined(s.declarations, d => isFunctionTypeNode(d) ? d.parent.symbol : undefined) || s
+            ? firstDefined(s.declarations, d => isFunctionTypeNode(d) ? d.parent.symbol : undefined) ?? s
             : s;
     }
 
@@ -611,9 +611,9 @@ namespace ts.SignatureHelp {
     interface SignatureHelpItemInfo { readonly isVariadic: boolean; readonly parameters: SignatureHelpParameter[]; readonly prefix: readonly SymbolDisplayPart[]; readonly suffix: readonly SymbolDisplayPart[]; }
 
     function itemInfoForTypeParameters(candidateSignature: Signature, checker: TypeChecker, enclosingDeclaration: Node, sourceFile: SourceFile): SignatureHelpItemInfo[] {
-        const typeParameters = (candidateSignature.target || candidateSignature).typeParameters;
+        const typeParameters = (candidateSignature.target ?? candidateSignature).typeParameters;
         const printer = createPrinter({ removeComments: true });
-        const parameters = (typeParameters || emptyArray).map(t => createSignatureHelpParameterForTypeParameter(t, checker, enclosingDeclaration, sourceFile, printer));
+        const parameters = (typeParameters ?? emptyArray).map(t => createSignatureHelpParameterForTypeParameter(t, checker, enclosingDeclaration, sourceFile, printer));
         const thisParameter = candidateSignature.thisParameter ? [checker.symbolToParameterDeclaration(candidateSignature.thisParameter, enclosingDeclaration, signatureHelpNodeBuilderFlags)!] : [];
 
         return checker.getExpandedParameters(candidateSignature).map(paramList => {

--- a/src/services/smartSelection.ts
+++ b/src/services/smartSelection.ts
@@ -213,7 +213,7 @@ namespace ts.SmartSelectionRange {
         let group: Node[] | undefined;
         for (const child of children) {
             if (groupOn(child)) {
-                group = group || [];
+                group ??= [];
                 group.push(child);
             }
             else {

--- a/src/services/sourcemaps.ts
+++ b/src/services/sourcemaps.ts
@@ -49,8 +49,8 @@ namespace ts {
                     f => !host.fileExists || host.fileExists(f) ? host.readFile!(f) : undefined
                 );
             }
-            documentPositionMappers.set(path, mapper || identitySourceMapConsumer);
-            return mapper || identitySourceMapConsumer;
+            documentPositionMappers.set(path, mapper ?? identitySourceMapConsumer);
+            return mapper ?? identitySourceMapConsumer;
         }
 
         function tryGetSourcePosition(info: DocumentPosition): DocumentPosition | undefined {
@@ -60,7 +60,7 @@ namespace ts {
             if (!file) return undefined;
 
             const newLoc = getDocumentPositionMapper(info.fileName).getSourcePosition(info);
-            return !newLoc || newLoc === info ? undefined : tryGetSourcePosition(newLoc) || newLoc;
+            return !newLoc || newLoc === info ? undefined : tryGetSourcePosition(newLoc) ?? newLoc;
         }
 
         function tryGetGeneratedPosition(info: DocumentPosition): DocumentPosition | undefined {
@@ -117,7 +117,7 @@ namespace ts {
         // This can be called from source mapper in either source program or program that includes generated file
         function getSourceFileLike(fileName: string) {
             return !host.getSourceFileLike ?
-                getSourceFile(fileName) || getOrCreateSourceFileLike(fileName) :
+                getSourceFile(fileName) ?? getOrCreateSourceFileLike(fileName) :
                 host.getSourceFileLike(fileName);
         }
 

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -800,7 +800,7 @@ namespace ts.Completions.StringCompletions {
         // Check for typings specified in compiler options
         const seen = new Map<string, true>();
 
-        const typeRoots = tryAndIgnoreErrors(() => getEffectiveTypeRoots(options, host)) || emptyArray;
+        const typeRoots = tryAndIgnoreErrors(() => getEffectiveTypeRoots(options, host)) ?? emptyArray;
 
         for (const root of typeRoots) {
             getCompletionEntriesFromDirectories(root);

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -55,7 +55,7 @@ namespace ts {
                 }
 
                 if (codefix.parameterShouldGetTypeFromJSDoc(node)) {
-                    diags.push(createDiagnosticForNode(node.name || node, Diagnostics.JSDoc_types_may_be_moved_to_TypeScript_types));
+                    diags.push(createDiagnosticForNode(node.name ?? node, Diagnostics.JSDoc_types_may_be_moved_to_TypeScript_types));
                 }
             }
 

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -593,7 +593,7 @@ namespace ts.SymbolDisplay {
                 documentation = firstDefined(objectType.isUnion() ? objectType.types : [objectType], t => {
                     const prop = t.getProperty(name);
                     return prop ? prop.getDocumentationComment(typeChecker) : undefined;
-                }) || emptyArray;
+                }) ?? emptyArray;
             }
         }
 
@@ -642,7 +642,7 @@ namespace ts.SymbolDisplay {
             if (alias && symbolToDisplay === symbol) {
                 symbolToDisplay = alias;
             }
-            const fullSymbolDisplayParts = symbolToDisplayParts(typeChecker, symbolToDisplay, enclosingDeclaration || sourceFile, /*meaning*/ undefined,
+            const fullSymbolDisplayParts = symbolToDisplayParts(typeChecker, symbolToDisplay, enclosingDeclaration ?? sourceFile, /*meaning*/ undefined,
                 SymbolFormatFlags.WriteTypeParametersOrArguments | SymbolFormatFlags.UseOnlyExternalAliasing | SymbolFormatFlags.AllowAnyNodeKind);
             addRange(displayParts, fullSymbolDisplayParts);
 

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -202,7 +202,7 @@ namespace ts.textChanges {
         if (hasTrailingComment) {
             // Check first for leading comments as if the node is the first import, we want to exclude the trivia;
             // otherwise we get the trailing comments.
-            const comment = getLeadingCommentRanges(sourceFile.text, fullStart)?.[0] || getTrailingCommentRanges(sourceFile.text, fullStart)?.[0];
+            const comment = getLeadingCommentRanges(sourceFile.text, fullStart)?.[0] ?? getTrailingCommentRanges(sourceFile.text, fullStart)?.[0];
             if (comment) {
                 return skipTrivia(sourceFile.text, comment.end, /*stopAfterLineBreak*/ true, /*stopAtComments*/ true);
             }
@@ -553,7 +553,7 @@ namespace ts.textChanges {
 
         public insertTypeParameters(sourceFile: SourceFile, node: SignatureDeclaration, typeParameters: readonly TypeParameterDeclaration[]): void {
             // If no `(`, is an arrow function `x => x`, so use the pos of the first parameter
-            const start = (findChildOfKind(node, SyntaxKind.OpenParenToken, sourceFile) || first(node.parameters)).getStart(sourceFile);
+            const start = (findChildOfKind(node, SyntaxKind.OpenParenToken, sourceFile) ?? first(node.parameters)).getStart(sourceFile);
             this.insertNodesAt(sourceFile, start, typeParameters, { prefix: "<", suffix: ">", joiner: ", " });
         }
 
@@ -687,7 +687,7 @@ namespace ts.textChanges {
         }
 
         public insertNodeAfterComma(sourceFile: SourceFile, after: Node, newNode: Node): void {
-            const endPosition = this.insertNodeAfterWorker(sourceFile, this.nextCommaToken(sourceFile, after) || after, newNode);
+            const endPosition = this.insertNodeAfterWorker(sourceFile, this.nextCommaToken(sourceFile, after) ?? after, newNode);
             this.insertNodeAt(sourceFile, endPosition, newNode, this.getInsertNodeAfterOptions(sourceFile, after));
         }
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1261,7 +1261,7 @@ namespace ts {
     export function findPrecedingToken(position: number, sourceFile: SourceFileLike, startNode: Node, excludeJsdoc?: boolean): Node | undefined;
     export function findPrecedingToken(position: number, sourceFile: SourceFile, startNode?: Node, excludeJsdoc?: boolean): Node | undefined;
     export function findPrecedingToken(position: number, sourceFile: SourceFileLike, startNode?: Node, excludeJsdoc?: boolean): Node | undefined {
-        const result = find((startNode || sourceFile) as Node);
+        const result = find((startNode ?? sourceFile) as Node);
         Debug.assert(!(result && isWhiteSpaceOnlyJsxText(result)));
         return result;
 
@@ -1793,7 +1793,7 @@ namespace ts {
     }
 
     export function createTextSpanFromNode(node: Node, sourceFile?: SourceFile, endNode?: Node): TextSpan {
-        return createTextSpanFromBounds(node.getStart(sourceFile), (endNode || node).getEnd());
+        return createTextSpanFromBounds(node.getStart(sourceFile), (endNode ?? node).getEnd());
     }
 
     export function createTextSpanFromStringLiteralLikeContent(node: StringLiteralLike) {
@@ -1883,7 +1883,7 @@ namespace ts {
     }
 
     export function skipConstraint(type: Type): Type {
-        return type.isTypeParameter() ? type.getConstraint() || type : type;
+        return type.isTypeParameter() ? type.getConstraint() ?? type : type;
     }
 
     export function getNameFromPropertyName(name: PropertyName): string | undefined {
@@ -1911,7 +1911,7 @@ namespace ts {
             getCurrentDirectory: () => host.getCurrentDirectory(),
             readFile: maybeBind(host, host.readFile),
             useCaseSensitiveFileNames: maybeBind(host, host.useCaseSensitiveFileNames),
-            getSymlinkCache: maybeBind(host, host.getSymlinkCache) || program.getSymlinkCache,
+            getSymlinkCache: maybeBind(host, host.getSymlinkCache) ?? program.getSymlinkCache,
             getModuleSpecifierCache: maybeBind(host, host.getModuleSpecifierCache),
             getPackageJsonInfoCache: () => program.getModuleResolutionCache()?.getPackageJsonInfoCache(),
             getGlobalTypingsCacheLocation: maybeBind(host, host.getGlobalTypingsCacheLocation),
@@ -2369,7 +2369,7 @@ namespace ts {
             const suffix = findLinkNameEnd(link.text);
             const name = getTextOfNode(link.name) + link.text.slice(0, suffix);
             const text = skipSeparatorFromLinkText(link.text.slice(suffix));
-            const decl = symbol?.valueDeclaration || symbol?.declarations?.[0];
+            const decl = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
             if (decl) {
                 parts.push(linkNamePart(name, decl));
                 if (text) parts.push(linkTextPart(text));

--- a/src/testRunner/projectsRunner.ts
+++ b/src/testRunner/projectsRunner.ts
@@ -83,7 +83,7 @@ namespace project {
         }
 
         public get parseConfigHost(): fakes.ParseConfigHost {
-            return this._projectParseConfigHost || (this._projectParseConfigHost = new ProjectParseConfigHost(this.sys, this._testCase));
+            return this._projectParseConfigHost ??= new ProjectParseConfigHost(this.sys, this._testCase);
         }
 
         public getDefaultLibFileName(_options: ts.CompilerOptions) {

--- a/src/testRunner/runner.ts
+++ b/src/testRunner/runner.ts
@@ -152,7 +152,7 @@ ${JSON.stringify(dupes, undefined, 2)}`);
                 return true;
             }
 
-            const runnerConfig = testConfig.runners || testConfig.test;
+            const runnerConfig = testConfig.runners ?? testConfig.test;
             if (runnerConfig && runnerConfig.length > 0) {
                 if (testConfig.runners) {
                     runUnitTests = runnerConfig.indexOf("unittest") !== -1;

--- a/src/testRunner/unittests/config/commandLineParsing.ts
+++ b/src/testRunner/unittests/config/commandLineParsing.ts
@@ -2,7 +2,7 @@ namespace ts {
     describe("unittests:: config:: commandLineParsing:: parseCommandLine", () => {
 
         function assertParseResult(commandLine: string[], expectedParsedCommandLine: ParsedCommandLine, workerDiagnostic?: () => ParseCommandLineWorkerDiagnostics) {
-            const parsed = parseCommandLineWorker(workerDiagnostic?.() || compilerOptionsDidYouMeanDiagnostics, commandLine);
+            const parsed = parseCommandLineWorker(workerDiagnostic?.() ?? compilerOptionsDidYouMeanDiagnostics, commandLine);
             assert.deepEqual(parsed.options, expectedParsedCommandLine.options);
             assert.deepEqual(parsed.watchOptions, expectedParsedCommandLine.watchOptions);
 

--- a/src/testRunner/unittests/config/projectReferences.ts
+++ b/src/testRunner/unittests/config/projectReferences.ts
@@ -53,7 +53,7 @@ namespace ts {
                     outDir: "bin",
                     ...sp.options
                 },
-                references: (sp.references || []).map(r => {
+                references: (sp.references ?? []).map(r => {
                     if (typeof r === "string") {
                         return { path: r };
                     }

--- a/src/testRunner/unittests/incrementalParser.ts
+++ b/src/testRunner/unittests/incrementalParser.ts
@@ -43,7 +43,7 @@ namespace ts {
     // unavoidable.  If it does decrease an investigation should be done to make sure that things
     // are still ok and we're still appropriately reusing most of the tree.
     function compareTrees(oldText: IScriptSnapshot, newText: IScriptSnapshot, textChangeRange: TextChangeRange, expectedReusedElements: number, oldTree?: SourceFile) {
-        oldTree = oldTree || createTree(oldText, /*version:*/ ".");
+        oldTree ??= createTree(oldText, /*version:*/ ".");
         Utils.assertInvariants(oldTree, /*parent:*/ undefined);
 
         // Create a tree for the new text, in a non-incremental fashion.

--- a/src/testRunner/unittests/semver.ts
+++ b/src/testRunner/unittests/semver.ts
@@ -29,8 +29,8 @@ namespace ts {
                 assert.strictEqual(version.major, major);
                 assert.strictEqual(version.minor, minor);
                 assert.strictEqual(version.patch, patch);
-                assert.deepEqual(version.prerelease, prerelease || emptyArray);
-                assert.deepEqual(version.build, build || emptyArray);
+                assert.deepEqual(version.prerelease, prerelease ?? emptyArray);
+                assert.deepEqual(version.build, build ?? emptyArray);
             }
             describe("new", () => {
                 it("text", () => {

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -12,7 +12,7 @@ namespace ts {
                 let oldTranspileResult: string;
                 let oldTranspileDiagnostics: Diagnostic[];
 
-                const transpileOptions: TranspileOptions = testSettings.options || {};
+                const transpileOptions: TranspileOptions = testSettings.options ?? {};
                 if (!transpileOptions.compilerOptions) {
                     transpileOptions.compilerOptions = { };
                 }

--- a/src/testRunner/unittests/tsbuild/helpers.ts
+++ b/src/testRunner/unittests/tsbuild/helpers.ts
@@ -221,7 +221,7 @@ interface Symbol {
     type ReadableProgramBuildInfo = ReadableProgramMultiFileEmitBuildInfo | ReadableProgramBundleEmitBuildInfo;
 
     function isReadableProgramBundleEmitBuildInfo(info: ReadableProgramBuildInfo | undefined): info is ReadableProgramBundleEmitBuildInfo {
-        return !!info && !!outFile(info.options || {});
+        return !!info && !!outFile(info.options ?? {});
     }
     type ReadableBuildInfo = Omit<BuildInfo, "program"> & { program: ReadableProgramBuildInfo | undefined; size: number; };
     function generateBuildInfoProgramBaseline(sys: System, buildInfoPath: string, buildInfo: BuildInfo) {
@@ -330,7 +330,7 @@ interface Symbol {
         if (!buildInfoPath || !sys.writtenFiles!.has(toPathWithSystem(sys, buildInfoPath))) return;
         if (!sys.fileExists(buildInfoPath)) return;
 
-        const buildInfo = getBuildInfo((originalReadCall || sys.readFile).call(sys, buildInfoPath, "utf8")!);
+        const buildInfo = getBuildInfo((originalReadCall ?? sys.readFile).call(sys, buildInfoPath, "utf8")!);
         generateBuildInfoProgramBaseline(sys, buildInfoPath, buildInfo);
 
         if (!outFile(options)) return;
@@ -340,8 +340,8 @@ interface Symbol {
 
         // Write the baselines:
         const baselineRecorder = new Harness.Compiler.WriterAggregator();
-        generateBundleFileSectionInfo(sys, originalReadCall || sys.readFile, baselineRecorder, bundle.js, jsFilePath);
-        generateBundleFileSectionInfo(sys, originalReadCall || sys.readFile, baselineRecorder, bundle.dts, declarationFilePath);
+        generateBundleFileSectionInfo(sys, originalReadCall ?? sys.readFile, baselineRecorder, bundle.js, jsFilePath);
+        generateBundleFileSectionInfo(sys, originalReadCall ?? sys.readFile, baselineRecorder, bundle.dts, declarationFilePath);
         baselineRecorder.Close();
         const text = baselineRecorder.lines.join("\r\n");
         sys.writeFile(`${buildInfoPath}.baseline.txt`, text);
@@ -509,7 +509,7 @@ interface Symbol {
 
         function addBaseline(...text: string[]) {
             if (!baselines || !headerAdded) {
-                (baselines ||= []).push(`${index}:: ${subScenario}`, ...(discrepancyExplanation?.()|| ["*** Needs explanation"]));
+                (baselines ??= []).push(`${index}:: ${subScenario}`, ...(discrepancyExplanation?.() ?? ["*** Needs explanation"]));
                 headerAdded = true;
             }
             baselines.push(...text);
@@ -603,7 +603,7 @@ interface Symbol {
                         subScenario: editScenario || subScenario,
                         diffWithInitial: true,
                         fs: () => index === 0 ? sys.vfs : editsSys[index - 1].vfs,
-                        commandLineArgs: editCommandLineArgs || commandLineArgs,
+                        commandLineArgs: editCommandLineArgs ?? commandLineArgs,
                         modifyFs,
                         baselineSourceMap,
                         baselineReadFileCalls,
@@ -639,7 +639,7 @@ interface Symbol {
                         baselines,
                         baseFs,
                         newSys: editsSys[index],
-                        commandLineArgs: edits[index].commandLineArgs || commandLineArgs,
+                        commandLineArgs: edits[index].commandLineArgs ?? commandLineArgs,
                         discrepancyExplanation: edits[index].discrepancyExplanation,
                         editFs: fs => {
                             for (let i = 0; i <= index; i++) {

--- a/src/testRunner/unittests/tsbuild/outFile.ts
+++ b/src/testRunner/unittests/tsbuild/outFile.ts
@@ -52,7 +52,7 @@ namespace ts {
                 subScenario,
                 fs: () => outFileFs,
                 scenario: "outfile-concat",
-                commandLineArgs: ["--b", "/src/third", "--verbose", ...(additionalCommandLineArgs || [])],
+                commandLineArgs: ["--b", "/src/third", "--verbose", ...(additionalCommandLineArgs ?? [])],
                 baselineSourceMap: true,
                 modifyFs,
                 baselineReadFileCalls: !baselineOnly,

--- a/src/testRunner/unittests/tsc/helpers.ts
+++ b/src/testRunner/unittests/tsc/helpers.ts
@@ -46,7 +46,7 @@ namespace ts {
             cb: program => {
                 if (isAnyProgram(program)) {
                     baselineBuildInfo(program.getCompilerOptions(), sys, originalReadCall);
-                    (programs || (programs = [])).push(isBuilderProgram(program) ?
+                    (programs ??= []).push(isBuilderProgram(program) ?
                         [program.getProgram(), program] :
                         [program]
                     );
@@ -56,7 +56,7 @@ namespace ts {
                 }
             },
             getPrograms: () => {
-                const result = programs || emptyArray;
+                const result = programs ?? emptyArray;
                 programs = undefined;
                 return result;
             }

--- a/src/testRunner/unittests/tscWatch/consoleClearing.ts
+++ b/src/testRunner/unittests/tscWatch/consoleClearing.ts
@@ -16,7 +16,7 @@ namespace ts.tscWatch {
             verifyTscWatch({
                 scenario,
                 subScenario,
-                commandLineArgs: ["--w", file.path, ...commandLineOptions || emptyArray],
+                commandLineArgs: ["--w", file.path, ...commandLineOptions ?? emptyArray],
                 sys: () => createWatchedSystem([file, libFile]),
                 changes: makeChangeToFile,
             });

--- a/src/testRunner/unittests/tscWatch/emit.ts
+++ b/src/testRunner/unittests/tscWatch/emit.ts
@@ -127,7 +127,7 @@ namespace ts.tscWatch {
                         path: configFilePath,
                         content: JSON.stringify(configObj || {})
                     };
-                    const additionalFiles = getAdditionalFileOrFolder?.() || emptyArray;
+                    const additionalFiles = getAdditionalFileOrFolder?.() ?? emptyArray;
                     const files = [moduleFile1, file1Consumer1, file1Consumer2, globalFile3, moduleFile2, configFile, libFile, ...additionalFiles];
                     return createWatchedSystem(firstReloadFileList ?
                         map(firstReloadFileList, fileName => find(files, file => file.path === fileName)!) :

--- a/src/testRunner/unittests/tscWatch/incremental.ts
+++ b/src/testRunner/unittests/tscWatch/incremental.ts
@@ -30,7 +30,7 @@ namespace ts.tscWatch {
         ) {
             const { sys, baseline, oldSnap, cb, getPrograms } = createBaseline(createWatchedSystem(files(), { currentDirectory: project }));
             if (incremental) sys.exit = exitCode => sys.exitCode = exitCode;
-            const argsToPass = [incremental ? "-i" : "-w", ...(optionsToExtend || emptyArray)];
+            const argsToPass = [incremental ? "-i" : "-w", ...(optionsToExtend ?? emptyArray)];
             baseline.push(`${sys.getExecutingFilePath()} ${argsToPass.join(" ")}`);
             let oldPrograms: readonly CommandLineProgram[] = emptyArray;
             build(oldSnap);

--- a/src/testRunner/unittests/tsserver/configuredProjects.ts
+++ b/src/testRunner/unittests/tsserver/configuredProjects.ts
@@ -1016,7 +1016,7 @@ foo();`
                     content: `let b = 1;`
                 };
 
-                const host = createServerHost([alphaExtendedConfig, aConfig, aFile, bravoExtendedConfig, bConfig, bFile, ...(additionalFiles || emptyArray)]);
+                const host = createServerHost([alphaExtendedConfig, aConfig, aFile, bravoExtendedConfig, bConfig, bFile, ...(additionalFiles ?? emptyArray)]);
                 const projectService = createProjectService(host, { logger: createLoggerWithInMemoryLogs() });
                 return { host, projectService, aFile, bFile, aConfig, bConfig, alphaExtendedConfig, bravoExtendedConfig };
             }

--- a/src/testRunner/unittests/tsserver/events/projectUpdatedInBackground.ts
+++ b/src/testRunner/unittests/tsserver/events/projectUpdatedInBackground.ts
@@ -521,7 +521,7 @@ namespace ts.projectSystem {
                 const { session, getEvents, clearEvents } = createSessionWithDefaultEventHandler<protocol.ProjectsUpdatedInBackgroundEvent>(
                     host,
                     server.ProjectsUpdatedInBackgroundEvent,
-                    { noGetErrOnBackgroundUpdate, logger: logger || createHasErrorMessageLogger() }
+                    { noGetErrOnBackgroundUpdate, logger: logger ?? createHasErrorMessageLogger() }
                 );
 
                 return {

--- a/src/testRunner/unittests/tsserver/helpers.ts
+++ b/src/testRunner/unittests/tsserver/helpers.ts
@@ -379,7 +379,7 @@ namespace ts.projectSystem {
             typingsInstaller: undefined!, // TODO: GH#18217
             byteLength: Utils.byteLength,
             hrtime: process.hrtime,
-            logger: opts.logger || createHasErrorMessageLogger(),
+            logger: opts.logger ?? createHasErrorMessageLogger(),
             canUseEvents: false
         };
 
@@ -447,10 +447,10 @@ namespace ts.projectSystem {
     }
 
     export function createProjectService(host: server.ServerHost, options?: Partial<TestProjectServiceOptions>) {
-        const cancellationToken = options?.cancellationToken || server.nullCancellationToken;
-        const logger = options?.logger || createHasErrorMessageLogger();
+        const cancellationToken = options?.cancellationToken ?? server.nullCancellationToken;
+        const logger = options?.logger ?? createHasErrorMessageLogger();
         const useSingleInferredProject = options?.useSingleInferredProject !== undefined ? options.useSingleInferredProject : false;
-        return new TestProjectService(host, logger, cancellationToken, useSingleInferredProject, options?.typingsInstaller || server.nullTypingsInstaller, options);
+        return new TestProjectService(host, logger, cancellationToken, useSingleInferredProject, options?.typingsInstaller ?? server.nullTypingsInstaller, options);
     }
 
     export function checkNumberOfConfiguredProjects(projectService: server.ProjectService, expected: number) {

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -956,7 +956,7 @@ export function bar() {}`
                     content: JSON.stringify({
                         ... (solutionOptions ? { compilerOptions: solutionOptions } : {}),
                         references: configRefs.map(path => ({ path })),
-                        files: solutionFiles || []
+                        files: solutionFiles ?? []
                     })
                 };
                 const dummyFile: File = {
@@ -1234,7 +1234,7 @@ bar;`
                         compilerOptions: {
                             module: "none",
                             composite: true,
-                            ...(extendOptionsProject2 || {})
+                            ...(extendOptionsProject2 ?? {})
                         },
                         references: [
                             { path: "../project1" }
@@ -1437,7 +1437,7 @@ bar;`
                 const config: File = {
                     path: `${tscWatch.projectRoot}/${packageName}/tsconfig.json`,
                     content: JSON.stringify({
-                        compilerOptions: { composite: true, ...optionsToExtend || {} },
+                        compilerOptions: { composite: true, ...optionsToExtend ?? {} },
                         references: references?.map(path => ({ path: `../${path}` }))
                     })
                 };

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -375,7 +375,7 @@ namespace ts.projectSystem {
                 installPackage: notImplemented,
                 enqueueInstallTypingsRequest: (proj, typeAcquisition, unresolvedImports) => {
                     assert.isUndefined(request);
-                    request = JSON.stringify(server.createInstallTypingsRequest(proj, typeAcquisition, unresolvedImports || server.emptyArray, cachePath));
+                    request = JSON.stringify(server.createInstallTypingsRequest(proj, typeAcquisition, unresolvedImports ?? server.emptyArray, cachePath));
                 },
                 attach: noop,
                 onProjectClosed: noop,

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -900,6 +900,7 @@ namespace ts.projectSystem {
             };
             const jsconfig = {
                 path: "/jsconfig.json",
+                // eslint-disable-next-line prefer-nullish-coalescing-truthy
                 content: JSON.stringify(jsconfigContent || {})
             };
             // Should only accept direct dependencies.

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -704,7 +704,7 @@ namespace ts.server {
                     host,
                     cancellationToken,
                     ...options,
-                    typingsInstaller: typingsInstaller || nullTypingsInstaller,
+                    typingsInstaller: typingsInstaller ?? nullTypingsInstaller,
                     byteLength: Buffer.byteLength,
                     hrtime: process.hrtime,
                     logger,
@@ -737,7 +737,7 @@ namespace ts.server {
                         if (this.logger.hasLevel(LogLevel.verbose)) {
                             this.logger.info(`eventPort: event "${eventName}" queued, but socket not yet initialized`);
                         }
-                        (this.socketEventQueue || (this.socketEventQueue = [])).push({ body, eventName });
+                        (this.socketEventQueue ??= []).push({ body, eventName });
                         return;
                     }
                     else {


### PR DESCRIPTION
Benchmarking suggests that this is faster (even when downleveled) than `||`, i.e. the boolean conversion is more expensive than explicit `null` and `undefined` checks. https://jsbench.me/2xl1mre9kv/1