### PR TITLE
Elide import equals in transpileModule if referenced only by export type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -41224,7 +41224,7 @@ namespace ts {
                 if (symbol && (symbol === undefinedSymbol || symbol === globalThisSymbol || symbol.declarations && isGlobalSourceFile(getDeclarationContainer(symbol.declarations[0])))) {
                     error(exportedName, Diagnostics.Cannot_export_0_Only_local_declarations_can_be_exported_from_a_module, idText(exportedName));
                 }
-                else {
+                else if (!node.parent.parent.isTypeOnly) {
                     markExportAsReferenced(node);
                     const target = symbol && (symbol.flags & SymbolFlags.Alias ? resolveAlias(symbol) : symbol);
                     if (!target || target === unknownSymbol || target.flags & SymbolFlags.Value) {

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -485,5 +485,12 @@ export { a as alias };
 export * as alias from './file';`, {
             noSetFileName: true
         });
+
+        transpilesCorrectly("Elides import equals referenced only by export type",
+            `import IFoo = Namespace.IFoo;` +
+            `export type { IFoo };`, {
+                options: { compilerOptions: { module: ModuleKind.CommonJS } }
+            }
+        );
     });
 }

--- a/tests/baselines/reference/transpile/Elides import equals referenced only by export type.js
+++ b/tests/baselines/reference/transpile/Elides import equals referenced only by export type.js
@@ -1,0 +1,3 @@
+"use strict";
+exports.__esModule = true;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Elides import equals referenced only by export type.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Elides import equals referenced only by export type.oldTranspile.js
@@ -1,0 +1,3 @@
+"use strict";
+exports.__esModule = true;
+//# sourceMappingURL=file.js.map


### PR DESCRIPTION
Fixes #49450

See investigation notes in issue. In short, it seems like the removal of the type only "import equals" declaration was not occurring because it relied on type information about the alias itself. We can still elide correctly under `transpileModule` by noticing when an export declaration is type only.