### PR TITLE
For missing constraint quickfix insert position, Use node name end rather than related span end

### DIFF
--- a/src/services/codefixes/fixAddMissingConstraint.ts
+++ b/src/services/codefixes/fixAddMissingConstraint.ts
@@ -51,7 +51,7 @@ namespace ts.codefix {
         if (!newConstraint) return;
         const newConstraintText = newConstraint[1];
 
-        changes.insertText(related.file!, related.start! + related.length!, ` extends ${newConstraintText}`);
+        changes.insertText(related.file!, decl.name.end, ` extends ${newConstraintText}`);
     }
 
     function findAncestorMatchingSpan(sourceFile: SourceFile, span: TextSpan): Node {

--- a/tests/cases/fourslash/quickfixAddMissingConstraint3.ts
+++ b/tests/cases/fourslash/quickfixAddMissingConstraint3.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: file.ts
+////function f<T = `${number}`>(x: T) {
+////    const y: `${number}` = x/**/;
+////}
+goTo.marker("");
+verify.codeFix({
+    index: 0,
+    description: "Add `extends` constraint.",
+    newFileContent: {
+        "/tests/cases/fourslash/file.ts":
+`function f<T extends \`$\{number}\` = \`$\{number}\`>(x: T) {
+    const y: \`$\{number}\` = x;
+}`
+    }
+});


### PR DESCRIPTION
Fixes a bug in the quickfix where it'd insert the new constraint after the type parameter default rather than before (since the actual related span includes the default).

Thanks @danay1999 for pointing this out!