### PR TITLE
Add reference to TypeScript-Compiler-Notes in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,10 @@ The files in `lib/` are used to bootstrap compilation and usually **should not**
 
 The files `src/lib/dom.generated.d.ts` and `src/lib/webworker.generated.d.ts` both represent type declarations for the DOM and are auto-generated. To make any modifications to them, you will have to direct changes to https://github.com/Microsoft/TSJS-lib-generator
 
+## Documentation on TypeScript Compiler
+
+If you need a head start understanding how the compiler works, or how the code in different parts of the compiler works, there is a separate repo: [TypeScript Compiler Notes](https://github.com/microsoft/TypeScript-Compiler-Notes). As the name implies, it contains notes understood by different engineers about different parts of the compiler.
+
 ## Running the Tests
 
 To run all tests, invoke the `runtests-parallel` target using gulp:


### PR DESCRIPTION
I tried a lot in the past few weeks to find a documentation on TS Compiler, I couldn't find any. I opened an issue asking for the documentation: https://github.com/microsoft/TypeScript-Website/issues/2428 and then I got to know the TypeScript-Compiler-Notes repository. I believe it could help a lot if it was in CONTRIBUTING.md file.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/TypeScript-Website/issues/2428
