### PR TITLE
Add variance results to tracing, capture variance verification on annotated type params

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20785,7 +20785,7 @@ namespace ts {
                     variances.push(variance);
                 }
                 links.variances = variances;
-                tracing?.pop();
+                tracing?.pop({ variances: variances.map(Debug.formatVariance) });
             }
             return links.variances;
         }
@@ -35055,12 +35055,14 @@ namespace ts {
                         error(node, Diagnostics.Variance_annotations_are_only_supported_in_type_aliases_for_object_function_constructor_and_mapped_types);
                     }
                     else if (modifiers === ModifierFlags.In || modifiers === ModifierFlags.Out) {
+                        tracing?.push(tracing.Phase.CheckTypes, "checkTypeParameterDeferred", { parent: getTypeId(getDeclaredTypeOfSymbol(symbol)), id: getTypeId(typeParameter) });
                         const source = createMarkerType(symbol, typeParameter, modifiers === ModifierFlags.Out ? markerSubTypeForCheck : markerSuperTypeForCheck);
                         const target = createMarkerType(symbol, typeParameter, modifiers === ModifierFlags.Out ? markerSuperTypeForCheck : markerSubTypeForCheck);
                         const saveVarianceTypeParameter = typeParameter;
                         varianceTypeParameter = typeParameter;
                         checkTypeAssignableTo(source, target, node, Diagnostics.Type_0_is_not_assignable_to_type_1_as_implied_by_variance_annotation);
                         varianceTypeParameter = saveVarianceTypeParameter;
+                        tracing?.pop();
                     }
                 }
             }

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -748,5 +748,22 @@ namespace ts {
             const deprecation = createDeprecation(options?.name ?? getFunctionName(func), options);
             return wrapFunction(deprecation, func);
         }
+
+        export function formatVariance(varianceFlags: VarianceFlags) {
+            const variance = varianceFlags & VarianceFlags.VarianceMask;
+            let result =
+                variance === VarianceFlags.Invariant ? "in out" :
+                variance === VarianceFlags.Bivariant ? "[bivariant]" :
+                variance === VarianceFlags.Contravariant ? "in" :
+                variance === VarianceFlags.Covariant ? "out" :
+                variance === VarianceFlags.Independent ? "[independent]" : "";
+            if (varianceFlags & VarianceFlags.Unmeasurable) {
+                result += " (unmeasurable)";
+            }
+            else if (varianceFlags & VarianceFlags.Unreliable) {
+                result += " (unreliable)";
+            }
+            return result;
+        }
     }
 }

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -147,13 +147,13 @@ namespace ts { // eslint-disable-line one-namespace-per-file
         const sampleInterval = 1000 * 10;
         function writeStackEvent(index: number, endTime: number, results?: Args) {
             const { phase, name, args, time, separateBeginAndEnd } = eventStack[index];
-            const combinedArgs = { ...args, ...results };
             if (separateBeginAndEnd) {
-                writeEvent("E", phase, name, combinedArgs, /*extras*/ undefined, endTime);
+                Debug.assert(!results, "`results` are not supported for events with `separateBeginAndEnd`");
+                writeEvent("E", phase, name, args, /*extras*/ undefined, endTime);
             }
             // test if [time,endTime) straddles a sampling point
             else if (sampleInterval - (time % sampleInterval) <= endTime - time) {
-                writeEvent("X", phase, name, combinedArgs, `"dur":${endTime - time}`, time);
+                writeEvent("X", phase, name, { ...args, results }, `"dur":${endTime - time}`, time);
             }
         }
 

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -131,9 +131,9 @@ namespace ts { // eslint-disable-line one-namespace-per-file
             }
             eventStack.push({ phase, name, args, time: 1000 * timestamp(), separateBeginAndEnd });
         }
-        export function pop() {
+        export function pop(results?: Args) {
             Debug.assert(eventStack.length > 0);
-            writeStackEvent(eventStack.length - 1, 1000 * timestamp());
+            writeStackEvent(eventStack.length - 1, 1000 * timestamp(), results);
             eventStack.length--;
         }
         export function popAll() {
@@ -145,14 +145,15 @@ namespace ts { // eslint-disable-line one-namespace-per-file
         }
         // sample every 10ms
         const sampleInterval = 1000 * 10;
-        function writeStackEvent(index: number, endTime: number) {
+        function writeStackEvent(index: number, endTime: number, results?: Args) {
             const { phase, name, args, time, separateBeginAndEnd } = eventStack[index];
+            const combinedArgs = { ...args, ...results };
             if (separateBeginAndEnd) {
-                writeEvent("E", phase, name, args, /*extras*/ undefined, endTime);
+                writeEvent("E", phase, name, combinedArgs, /*extras*/ undefined, endTime);
             }
             // test if [time,endTime) straddles a sampling point
             else if (sampleInterval - (time % sampleInterval) <= endTime - time) {
-                writeEvent("X", phase, name, args, `"dur":${endTime - time}`, time);
+                writeEvent("X", phase, name, combinedArgs, `"dur":${endTime - time}`, time);
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

1. Records results of variance measurement in tracing events. Example output:
   ```
   {"pid":1,"tid":1,"ph":"X","cat":"checkTypes","ts":2139027.110002935,"name":"getVariancesWorker","dur":230516.6899971664,"args":{"arity":8,"id":26793,"variances":["in out (unreliable)","in","out (unreliable)","out","out","[independent]","[independent]","[independent]"]}}
   ```
2. Adds a tracing event for `checkTypeParameterDeferred` when the type parameter has a (non-invariant) variance annotation, as variance verification needs to happen there and can be fairly expensive; this should make it straightforward to see exactly what work you are exchanging when you write a variance annotation by looking at traces before and after the change.