### PR TITLE
Demote priority of JS completions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -508,38 +508,35 @@ namespace ts.Completions {
 
         const entries = createSortedArray<CompletionEntry>();
         const isChecked = isCheckedFile(sourceFile, compilerOptions);
-        if (isChecked) {
-            if (!isNewIdentifierLocation && (!symbols || symbols.length === 0) && keywordFilters === KeywordCompletionFilters.None) {
-                return undefined;
-            }
-
-            getCompletionEntriesFromSymbols(
-                symbols,
-                entries,
-                /*replacementToken*/ undefined,
-                contextToken,
-                location,
-                sourceFile,
-                host,
-                program,
-                getEmitScriptTarget(compilerOptions),
-                log,
-                completionKind,
-                preferences,
-                compilerOptions,
-                formatContext,
-                isTypeOnlyLocation,
-                propertyAccessToConvert,
-                isJsxIdentifierExpected,
-                isJsxInitializer,
-                importCompletionNode,
-                recommendedCompletion,
-                symbolToOriginInfoMap,
-                symbolToSortTextMap,
-                isJsxIdentifierExpected,
-                isRightOfOpenTag,
-            );
+        if (isChecked && !isNewIdentifierLocation && (!symbols || symbols.length === 0) && keywordFilters === KeywordCompletionFilters.None) {
+            return undefined;
         }
+        const uniqueNames = getCompletionEntriesFromSymbols(
+            symbols,
+            entries,
+            /*replacementToken*/ undefined,
+            contextToken,
+            location,
+            sourceFile,
+            host,
+            program,
+            getEmitScriptTarget(compilerOptions),
+            log,
+            completionKind,
+            preferences,
+            compilerOptions,
+            formatContext,
+            isTypeOnlyLocation,
+            propertyAccessToConvert,
+            isJsxIdentifierExpected,
+            isJsxInitializer,
+            importCompletionNode,
+            recommendedCompletion,
+            symbolToOriginInfoMap,
+            symbolToSortTextMap,
+            isJsxIdentifierExpected,
+            isRightOfOpenTag,
+        );
 
         if (keywordFilters !== KeywordCompletionFilters.None) {
             const entryNames = new Set(entries.map(e => e.name));
@@ -562,32 +559,6 @@ namespace ts.Completions {
         }
 
         if (!isChecked) {
-            const uniqueNames = getCompletionEntriesFromSymbols(
-                symbols,
-                entries,
-                /*replacementToken*/ undefined,
-                contextToken,
-                location,
-                sourceFile,
-                host,
-                program,
-                getEmitScriptTarget(compilerOptions),
-                log,
-                completionKind,
-                preferences,
-                compilerOptions,
-                formatContext,
-                isTypeOnlyLocation,
-                propertyAccessToConvert,
-                isJsxIdentifierExpected,
-                isJsxInitializer,
-                importCompletionNode,
-                recommendedCompletion,
-                symbolToOriginInfoMap,
-                symbolToSortTextMap,
-                isJsxIdentifierExpected,
-                isRightOfOpenTag,
-            );
             getJSCompletionEntries(sourceFile, location.pos, uniqueNames, getEmitScriptTarget(compilerOptions), entries);
         }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -539,23 +539,25 @@ namespace ts.Completions {
         );
 
         if (keywordFilters !== KeywordCompletionFilters.None) {
-            const entryNames = new Set(entries.map(e => e.name));
             for (const keywordEntry of getKeywordCompletions(keywordFilters, !insideJsDocTagTypeExpression && isSourceFileJS(sourceFile))) {
-                if (isTypeOnlyLocation && isTypeKeyword(stringToToken(keywordEntry.name)!) || !entryNames.has(keywordEntry.name)) {
+                if (isTypeOnlyLocation && isTypeKeyword(stringToToken(keywordEntry.name)!) || !uniqueNames.has(keywordEntry.name)) {
+                    uniqueNames.add(keywordEntry.name)
                     insertSorted(entries, keywordEntry, compareCompletionEntries, /*allowDuplicates*/ true);
                 }
             }
         }
 
-        const entryNames = new Set(entries.map(e => e.name));
         for (const keywordEntry of getContextualKeywords(contextToken, position)) {
-            if (!entryNames.has(keywordEntry.name)) {
+            if (!uniqueNames.has(keywordEntry.name)) {
+                uniqueNames.add(keywordEntry.name)
                 insertSorted(entries, keywordEntry, compareCompletionEntries, /*allowDuplicates*/ true);
             }
         }
 
         for (const literal of literals) {
-            insertSorted(entries, createCompletionEntryForLiteral(sourceFile, preferences, literal), compareCompletionEntries, /*allowDuplicates*/ true);
+            const literalEntry = createCompletionEntryForLiteral(sourceFile, preferences, literal);
+            uniqueNames.add(literalEntry.name)
+            insertSorted(entries, literalEntry, compareCompletionEntries, /*allowDuplicates*/ true);
         }
 
         if (!isChecked) {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -541,7 +541,7 @@ namespace ts.Completions {
         if (keywordFilters !== KeywordCompletionFilters.None) {
             for (const keywordEntry of getKeywordCompletions(keywordFilters, !insideJsDocTagTypeExpression && isSourceFileJS(sourceFile))) {
                 if (isTypeOnlyLocation && isTypeKeyword(stringToToken(keywordEntry.name)!) || !uniqueNames.has(keywordEntry.name)) {
-                    uniqueNames.add(keywordEntry.name)
+                    uniqueNames.add(keywordEntry.name);
                     insertSorted(entries, keywordEntry, compareCompletionEntries, /*allowDuplicates*/ true);
                 }
             }
@@ -549,14 +549,14 @@ namespace ts.Completions {
 
         for (const keywordEntry of getContextualKeywords(contextToken, position)) {
             if (!uniqueNames.has(keywordEntry.name)) {
-                uniqueNames.add(keywordEntry.name)
+                uniqueNames.add(keywordEntry.name);
                 insertSorted(entries, keywordEntry, compareCompletionEntries, /*allowDuplicates*/ true);
             }
         }
 
         for (const literal of literals) {
             const literalEntry = createCompletionEntryForLiteral(sourceFile, preferences, literal);
-            uniqueNames.add(literalEntry.name)
+            uniqueNames.add(literalEntry.name);
             insertSorted(entries, literalEntry, compareCompletionEntries, /*allowDuplicates*/ true);
         }
 
@@ -642,7 +642,6 @@ namespace ts.Completions {
         uniqueNames: UniqueNameSet,
         target: ScriptTarget,
         entries: SortedArray<CompletionEntry>): void {
-        const entryNames = new Set(entries.map(e => e.name));
         getNameTable(sourceFile).forEach((pos, name) => {
             // Skip identifiers produced only from the current location
             if (pos === position) {
@@ -651,15 +650,13 @@ namespace ts.Completions {
             const realName = unescapeLeadingUnderscores(name);
             if (!uniqueNames.has(realName) && isIdentifierText(realName, target)) {
                 uniqueNames.add(realName);
-                if (!entryNames.has(realName)) {
-                    insertSorted(entries, {
-                        name: realName,
-                        kind: ScriptElementKind.warning,
-                        kindModifiers: "",
-                        sortText: SortText.JavascriptIdentifiers,
-                        isFromUncheckedFile: true
-                    }, compareCompletionEntries);
-                }
+                insertSorted(entries, {
+                    name: realName,
+                    kind: ScriptElementKind.warning,
+                    kindModifiers: "",
+                    sortText: SortText.JavascriptIdentifiers,
+                    isFromUncheckedFile: true
+                }, compareCompletionEntries);
             }
         });
     }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -507,7 +507,7 @@ namespace ts.Completions {
         }
 
         const entries = createSortedArray<CompletionEntry>();
-        const isChecked = !isUncheckedFile(sourceFile, compilerOptions);
+        const isChecked = isCheckedFile(sourceFile, compilerOptions);
         if (isChecked) {
             if (!isNewIdentifierLocation && (!symbols || symbols.length === 0) && keywordFilters === KeywordCompletionFilters.None) {
                 return undefined;
@@ -602,8 +602,8 @@ namespace ts.Completions {
         };
     }
 
-    function isUncheckedFile(sourceFile: SourceFile, compilerOptions: CompilerOptions): boolean {
-        return isSourceFileJS(sourceFile) && !isCheckJsEnabledForFile(sourceFile, compilerOptions);
+    function isCheckedFile(sourceFile: SourceFile, compilerOptions: CompilerOptions): boolean {
+        return !isSourceFileJS(sourceFile) || !!isCheckJsEnabledForFile(sourceFile, compilerOptions);
     }
 
     function isMemberCompletionKind(kind: CompletionKind): boolean {
@@ -1946,7 +1946,7 @@ namespace ts.Completions {
         cancellationToken?: CancellationToken,
     ): CompletionData | Request | undefined {
         const typeChecker = program.getTypeChecker();
-        const inUncheckedFile = isUncheckedFile(sourceFile, compilerOptions);
+        const inCheckedFile = isCheckedFile(sourceFile, compilerOptions);
         let start = timestamp();
         let currentToken = getTokenAtPosition(sourceFile, position); // TODO: GH#15853
         // We will check for jsdoc comments with insideComment and getJsDocTagAtPosition. (TODO: that seems rather inefficient to check the same thing so many times.)
@@ -2400,20 +2400,20 @@ namespace ts.Completions {
             }
 
             const propertyAccess = node.kind === SyntaxKind.ImportType ? node as ImportTypeNode : node.parent as PropertyAccessExpression | QualifiedName;
-            if (inUncheckedFile) {
+            if (inCheckedFile) {
+                for (const symbol of type.getApparentProperties()) {
+                    if (typeChecker.isValidPropertyAccessForCompletions(propertyAccess, type, symbol)) {
+                        addPropertySymbol(symbol, /* insertAwait */ false, insertQuestionDot);
+                    }
+                }
+            }
+            else {
                 // In javascript files, for union types, we don't just get the members that
                 // the individual types have in common, we also include all the members that
                 // each individual type has. This is because we're going to add all identifiers
                 // anyways. So we might as well elevate the members that were at least part
                 // of the individual types to a higher status since we know what they are.
                 symbols.push(...filter(getPropertiesForCompletion(type, typeChecker), s => typeChecker.isValidPropertyAccessForCompletions(propertyAccess, type, s)));
-            }
-            else {
-                for (const symbol of type.getApparentProperties()) {
-                    if (typeChecker.isValidPropertyAccessForCompletions(propertyAccess, type, symbol)) {
-                        addPropertySymbol(symbol, /* insertAwait */ false, insertQuestionDot);
-                    }
-                }
             }
 
             if (insertAwait && preferences.includeCompletionsWithInsertText) {

--- a/tests/cases/fourslash/completionInJSDocFunctionNew.ts
+++ b/tests/cases/fourslash/completionInJSDocFunctionNew.ts
@@ -5,4 +5,4 @@
 /////** @type {function (new: string, string): string} */
 ////var f = function () { return new/**/; }
 
-verify.completions({ marker: "", includes: { name: "new", sortText: completion.SortText.JavascriptIdentifiers } });
+verify.completions({ marker: "", includes: { name: "new", sortText: completion.SortText.GlobalsOrKeywords } });

--- a/tests/cases/fourslash/completionInJSDocFunctionThis.ts
+++ b/tests/cases/fourslash/completionInJSDocFunctionThis.ts
@@ -4,4 +4,4 @@
 /////** @type {function (this: string, string): string} */
 ////var f = function (s) { return this/**/; }
 
-verify.completions({ marker: "", includes: { name: "this", sortText: completion.SortText.JavascriptIdentifiers } });
+verify.completions({ marker: "", includes: { name: "this", sortText: completion.SortText.GlobalsOrKeywords } });

--- a/tests/cases/fourslash/completionListClassThisJS.ts
+++ b/tests/cases/fourslash/completionListClassThisJS.ts
@@ -1,0 +1,20 @@
+/// <reference path="fourslash.ts" />
+// @Filename: completionListClassThisJS.js
+// @allowJs: true
+/////** @typedef {number} CallbackContext */
+////class Foo {
+////    bar() {
+////       this/**/
+////    }
+////    /** @param {function (this: CallbackContext): any} cb */
+////    baz(cb) {
+////    }
+////}
+
+verify.completions({ marker: "", isNewIdentifierLocation: false, includes: [{
+    name: "this",
+    // kind: "warning",
+    kind: "keyword",
+    sortText: completion.SortText.GlobalsOrKeywords,
+    // sortText: completion.SortText.JavascriptIdentifiers,
+}] });


### PR DESCRIPTION
Fixes #48498

Unchecked JS files gather identifier-based completions. Currently, this search happens instead of `getCompletionEntriesFromSymbols` for TS/checked JS files. However, identifier-based completions are much lower quality and can be ignored by some editors.

Identifier-based completions should be gathered last, after gathering other completions. That's what this PR does.
