### PR TITLE
Fixed an issue with unsound indexed access on unknown type param

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28892,7 +28892,7 @@ namespace ts {
                 return errorType;
             }
             const facts = getTypeFacts(type);
-            if (facts & TypeFacts.IsUndefinedOrNull) {
+            if (facts & TypeFacts.IsUndefinedOrNull || type.flags & (TypeFlags.Intersection | TypeFlags.Instantiable) && (getBaseConstraintOfType(type) || unknownType) === unknownType) {
                 reportError(node, facts);
                 const t = getNonNullableType(type);
                 return t.flags & (TypeFlags.Nullable | TypeFlags.Never) ? errorType : t;

--- a/tests/baselines/reference/genericUnknownTypeParamWithKeyofIndexedAccess.errors.txt
+++ b/tests/baselines/reference/genericUnknownTypeParamWithKeyofIndexedAccess.errors.txt
@@ -1,0 +1,26 @@
+tests/cases/compiler/genericUnknownTypeParamWithKeyofIndexedAccess.ts(2,12): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/genericUnknownTypeParamWithKeyofIndexedAccess.ts(5,12): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+tests/cases/compiler/genericUnknownTypeParamWithKeyofIndexedAccess.ts(8,12): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/genericUnknownTypeParamWithKeyofIndexedAccess.ts(11,13): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+
+
+==== tests/cases/compiler/genericUnknownTypeParamWithKeyofIndexedAccess.ts (4 errors) ====
+    function test<T, K extends keyof T>(t: T, k: K) {
+        return t[k];
+               ~
+!!! error TS2531: Object is possibly 'null'.
+    }
+    
+    test(null, 'foo')
+               ~~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+    
+    function test2<T extends unknown, K extends keyof T>(t: T, k: K) {
+        return t[k];
+               ~
+!!! error TS2531: Object is possibly 'null'.
+    }
+    
+    test2(null, 'foo')
+                ~~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.

--- a/tests/baselines/reference/genericUnknownTypeParamWithKeyofIndexedAccess.symbols
+++ b/tests/baselines/reference/genericUnknownTypeParamWithKeyofIndexedAccess.symbols
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/genericUnknownTypeParamWithKeyofIndexedAccess.ts ===
+function test<T, K extends keyof T>(t: T, k: K) {
+>test : Symbol(test, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 0))
+>T : Symbol(T, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 14))
+>K : Symbol(K, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 16))
+>T : Symbol(T, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 14))
+>t : Symbol(t, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 36))
+>T : Symbol(T, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 14))
+>k : Symbol(k, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 41))
+>K : Symbol(K, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 16))
+
+    return t[k];
+>t : Symbol(t, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 36))
+>k : Symbol(k, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 41))
+}
+
+test(null, 'foo')
+>test : Symbol(test, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 0, 0))
+
+function test2<T extends unknown, K extends keyof T>(t: T, k: K) {
+>test2 : Symbol(test2, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 4, 17))
+>T : Symbol(T, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 6, 15))
+>K : Symbol(K, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 6, 33))
+>T : Symbol(T, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 6, 15))
+>t : Symbol(t, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 6, 53))
+>T : Symbol(T, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 6, 15))
+>k : Symbol(k, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 6, 58))
+>K : Symbol(K, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 6, 33))
+
+    return t[k];
+>t : Symbol(t, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 6, 53))
+>k : Symbol(k, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 6, 58))
+}
+
+test2(null, 'foo')
+>test2 : Symbol(test2, Decl(genericUnknownTypeParamWithKeyofIndexedAccess.ts, 4, 17))
+

--- a/tests/baselines/reference/genericUnknownTypeParamWithKeyofIndexedAccess.types
+++ b/tests/baselines/reference/genericUnknownTypeParamWithKeyofIndexedAccess.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/genericUnknownTypeParamWithKeyofIndexedAccess.ts ===
+function test<T, K extends keyof T>(t: T, k: K) {
+>test : <T, K extends keyof T>(t: T, k: K) => NonNullable<T>[K]
+>t : T
+>k : K
+
+    return t[k];
+>t[k] : NonNullable<T>[K]
+>t : T
+>k : K
+}
+
+test(null, 'foo')
+>test(null, 'foo') : never
+>test : <T, K extends keyof T>(t: T, k: K) => NonNullable<T>[K]
+>null : null
+>'foo' : "foo"
+
+function test2<T extends unknown, K extends keyof T>(t: T, k: K) {
+>test2 : <T extends unknown, K extends keyof T>(t: T, k: K) => NonNullable<T>[K]
+>t : T
+>k : K
+
+    return t[k];
+>t[k] : NonNullable<T>[K]
+>t : T
+>k : K
+}
+
+test2(null, 'foo')
+>test2(null, 'foo') : never
+>test2 : <T extends unknown, K extends keyof T>(t: T, k: K) => NonNullable<T>[K]
+>null : null
+>'foo' : "foo"
+

--- a/tests/cases/compiler/genericUnknownTypeParamWithKeyofIndexedAccess.ts
+++ b/tests/cases/compiler/genericUnknownTypeParamWithKeyofIndexedAccess.ts
@@ -1,0 +1,14 @@
+// @strict: true
+// @noEmit: true
+
+function test<T, K extends keyof T>(t: T, k: K) {
+    return t[k];
+}
+
+test(null, 'foo')
+
+function test2<T extends unknown, K extends keyof T>(t: T, k: K) {
+    return t[k];
+}
+
+test2(null, 'foo')


### PR DESCRIPTION
given the changed behavior from https://github.com/microsoft/TypeScript/pull/49119 those indexed accesses within those generic functions should error as mentioned by @RyanCavanaugh here: https://github.com/microsoft/TypeScript/pull/49696#discussion_r908739090