### PR TITLE
Add debug format helpers for more enums

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -61,7 +61,7 @@ namespace ts {
         GeneratorYield,
     }
 
-    const enum TypeFacts {
+    export const enum TypeFacts {
         None = 0,
         TypeofEQString = 1 << 0,      // typeof x === "string"
         TypeofEQNumber = 1 << 1,      // typeof x === "number"
@@ -169,7 +169,7 @@ namespace ts {
         WriteType,
     }
 
-    const enum CheckMode {
+    export const enum CheckMode {
         Normal = 0,                                     // Normal type checking
         Contextual = 1 << 0,                            // Explicitly assigned contextual type, therefore not cacheable
         Inferential = 1 << 1,                           // Inferential typing
@@ -182,7 +182,7 @@ namespace ts {
                                                         //   we need to preserve generic types instead of substituting them for constraints
     }
 
-    const enum SignatureCheckMode {
+    export const enum SignatureCheckMode {
         BivariantCallback = 1 << 0,
         StrictCallback    = 1 << 1,
         IgnoreReturnTypes = 1 << 2,

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -394,6 +394,22 @@ namespace ts {
             return formatEnum(flags, (ts as any).FlowFlags, /*isFlags*/ true);
         }
 
+        export function formatRelationComparisonResult(result: RelationComparisonResult | undefined): string {
+            return formatEnum(result, (ts as any).RelationComparisonResult, /*isFlags*/ true);
+        }
+
+        export function formatCheckMode(mode: CheckMode | undefined): string {
+            return formatEnum(mode, (ts as any).CheckMode, /*isFlags*/ true);
+        }
+
+        export function formatSignatureCheckMode(mode: SignatureCheckMode | undefined): string {
+            return formatEnum(mode, (ts as any).SignatureCheckMode, /*isFlags*/ true);
+        }
+
+        export function formatTypeFacts(facts: TypeFacts | undefined): string {
+            return formatEnum(facts, (ts as any).TypeFacts, /*isFlags*/ true);
+        }
+
         let isDebugInfoEnabled = false;
 
         interface ExtendedDebugModule {


### PR DESCRIPTION
I've found myself wanting to format these while debugging fairly often, especially since they are all flags and you can't just do `ts.CheckMode[checkMode]` to inspect it. I've had a few of these sitting in my git stash for a while but best to just commit them.