### PR TITLE
Retire $ExpectError awareness from DefinitelyTypedRunner

### DIFF
--- a/src/testRunner/externalCompileRunner.ts
+++ b/src/testRunner/externalCompileRunner.ts
@@ -18,7 +18,7 @@ namespace Harness {
 
     abstract class ExternalCompileRunnerBase extends RunnerBase {
         abstract testDir: string;
-        abstract report(result: ExecResult, cwd: string): string | null;
+        abstract report(result: ExecResult): string | null;
         enumerateTestFiles() {
             return IO.getDirectories(this.testDir);
         }
@@ -91,7 +91,7 @@ namespace Harness {
                         }
                     }
                     args.push("--noEmit");
-                    Baseline.runBaseline(`${cls.kind()}/${directoryName}.log`, cls.report(cp.spawnSync(`node`, args, { cwd, timeout, shell: true }), cwd));
+                    Baseline.runBaseline(`${cls.kind()}/${directoryName}.log`, cls.report(cp.spawnSync(`node`, args, { cwd, timeout, shell: true })));
 
                     function exec(command: string, args: string[], options: { cwd: string, timeout?: number, stdio?: import("child_process").StdioOptions }): string | undefined {
                         const res = cp.spawnSync(isWorker ? `${command} 2>&1` : command, args, { shell: true, stdio, ...options });
@@ -281,46 +281,18 @@ ${sanitizeDockerfileOutput(result.stderr.toString())}`;
         kind(): TestRunnerKind {
             return "dt";
         }
-        report(result: ExecResult, cwd: string) {
-            const stdout = removeExpectedErrors(result.stdout.toString(), cwd);
-            const stderr = result.stderr.toString();
-
+        report(result: ExecResult) {
             // eslint-disable-next-line no-null/no-null
-            return !stdout.length && !stderr.length ? null : `Exit Code: ${result.status}
+            return !result.stdout.length && !result.stderr.length ? null : `Exit Code: ${result.status}
 Standard output:
-${stdout.replace(/\r\n/g, "\n")}
+${result.stdout.toString().replace(/\r\n/g, "\n")}
 
 
 Standard error:
-${stderr.replace(/\r\n/g, "\n")}`;
+${result.stderr.toString().replace(/\r\n/g, "\n")}`;
         }
     }
 
-    function removeExpectedErrors(errors: string, cwd: string): string {
-        return ts.flatten(splitBy(errors.split("\n"), s => /^\S+/.test(s)).filter(isUnexpectedError(cwd))).join("\n");
-    }
-    /**
-     * Returns true if the line that caused the error contains '$ExpectError',
-     * or if the line before that one contains '$ExpectError'.
-     * '$ExpectError' is a marker used in Definitely Typed tests,
-     * meaning that the error should not contribute toward our error baslines.
-     */
-    function isUnexpectedError(cwd: string) {
-        return (error: string[]) => {
-            ts.Debug.assertGreaterThanOrEqual(error.length, 1);
-            const match = error[0].match(/(.+\.tsx?)\((\d+),\d+\): error TS/);
-            if (!match) {
-                return true;
-            }
-            const [, errorFile, lineNumberString] = match;
-            const lines = fs.readFileSync(path.join(cwd, errorFile), { encoding: "utf8" }).split("\n");
-            const lineNumber = parseInt(lineNumberString) - 1;
-            ts.Debug.assertGreaterThanOrEqual(lineNumber, 0);
-            ts.Debug.assertLessThan(lineNumber, lines.length);
-            const previousLine = lineNumber - 1 > 0 ? lines[lineNumber - 1] : "";
-            return !ts.stringContains(lines[lineNumber], "$ExpectError") && !ts.stringContains(previousLine, "$ExpectError");
-        };
-    }
     /**
      * Split an array into multiple arrays whenever `isStart` returns true.
      * @example


### PR DESCRIPTION
1. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60697#issue-1262554095 replaced `$ExpectError` with `@ts-expect-error` in the DT repo.
2. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61027#issue-1290499623 replaces the few remaining `$ExpectError`s.
3. https://github.com/microsoft/DefinitelyTyped-tools/pull/495#issue-1291728528 removes the `$ExpectError` machinery from dtslint, so errors are suppressible only via `@ts-expect-error` (or `@ts-ignore`).

Can we retire `$ExpectError` awareness from here too? Mostly removing https://github.com/microsoft/TypeScript/pull/19887#issue-272747896.

`$ExpectError`s have already been removed from the DT repo ([the first PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60697#issue-1262554095)) except in packages that were on the [list of expected failures](https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint-runner/expectedFailures.txt), or their dependents ([the second PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61027#issue-1290499623)). To be on the safe side, this PR would land after the remaining [DT](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61027#issue-1290499623) and [DT-tools](https://github.com/microsoft/DefinitelyTyped-tools/pull/495#issue-1291728528) PRs listed above. `@typescript-bot run dt` can confirm everything is ready?

/cc @sandersn