### PR TITLE
Fix bugs in module specifier generation with `paths`/`typesVersions`

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -791,10 +791,6 @@ namespace ts.moduleSpecifiers {
                 const packageJsonContent = cachedPackageJson?.packageJsonContent || JSON.parse(host.readFile!(packageJsonPath)!);
                 const importMode = overrideMode || importingSourceFile.impliedNodeFormat;
                 if (getEmitModuleResolutionKind(options) === ModuleResolutionKind.Node16 || getEmitModuleResolutionKind(options) === ModuleResolutionKind.NodeNext) {
-                    // `conditions` *could* be made to go against `importingSourceFile.impliedNodeFormat` if something wanted to generate
-                    // an ImportEqualsDeclaration in an ESM-implied file or an ImportCall in a CJS-implied file. But since this function is
-                    // usually called to conjure an import out of thin air, we don't have an existing usage to call `getModeForUsageAtIndex`
-                    // with, so for now we just stick with the mode of the file.
                     const conditions = ["node", importMode === ModuleKind.ESNext ? "import" : "require", "types"];
                     const fromExports = packageJsonContent.exports && typeof packageJsonContent.name === "string"
                         ? tryGetModuleNameFromExports(options, path, packageRootPath, getPackageNameFromTypesPackageName(packageJsonContent.name), packageJsonContent.exports, conditions)

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -580,14 +580,14 @@ namespace ts.moduleSpecifiers {
                 // causes a module specifier to have an extension, i.e. the extension comes from the module specifier in a JS/TS file
                 // and matches the '*'. For example:
                 //
-                // Module Specifier      | Path Mapping                  | Interpolation       | Resolution Action
+                // Module Specifier      | Path Mapping (key: [pattern]) | Interpolation       | Resolution Action
                 // ---------------------->------------------------------->--------------------->---------------------------------------------------------------
                 // import "@app/foo"    -> "@app/*": ["./src/app/*.ts"] -> "./src/app/foo.ts" -> tryFile("./src/app/foo.ts") || [continue resolution algorithm]
                 // import "@app/foo.ts" -> "@app/*": ["./src/app/*"]    -> "./src/app/foo.ts" -> [continue resolution algorithm]
                 //
                 // (https://github.com/microsoft/TypeScript/blob/ad4ded80e1d58f0bf36ac16bea71bc10d9f09895/src/compiler/moduleNameResolver.ts#L2509-L2516)
                 //
-                // The interpolation produced by both scenarios is identical, but in only the former, where the extension is encoded in
+                // The interpolation produced by both scenarios is identical, but only in the former, where the extension is encoded in
                 // the path mapping rather than in the module specifier, will we prioritize a file lookup on the interpolation result.
                 // (In fact, currently, the latter scenario will necessarily fail since no resolution mode recognizes '.ts' as a valid
                 // extension for a module specifier.)
@@ -607,7 +607,10 @@ namespace ts.moduleSpecifiers {
                 // relative module specifiers to run the interpolation (a) is actually valid for the module resolution mode, (b) takes
                 // into account the existence of other files (e.g. 'dist/wow.js' cannot refer to 'dist/wow.js.js' if 'dist/wow.js'
                 // exists) and (c) that they are ordered by preference. The last row shows that the filename result and module
-                // specifier results are not mutually exclusive.
+                // specifier results are not mutually exclusive. Note that the filename result is a higher priority in module
+                // resolution, but as long criteria (b) above is met, I don't think its result needs to be the highest priority result
+                // in module specifier generation. I have included it last, as it's difficult to tell exactly where it should be
+                // sorted among the others for a particular value of `importModuleSpecifierEnding`.
                 const candidates = deduplicate(allowedEndings.map(ending => removeExtensionAndIndexPostFix(relativeToBaseUrl, ending, compilerOptions, host)), equateValues);
                 if (tryGetExtensionFromPath(pattern)) {
                     pushIfUnique(candidates, relativeToBaseUrl);

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -593,7 +593,7 @@ namespace ts.moduleSpecifiers {
                 // extension for a module specifier.)
                 //
                 // Here, this means we need to be careful about whether we generate a match from the target filename (typically with a
-                // .ts extension) or a series of module specifiers representing :
+                // .ts extension) or the possible relative module specifiers representing that file:
                 //
                 // Filename            | Relative Module Specifier Candidates         | Path Mapping                 | Filename Result    | Module Specifier Results
                 // --------------------<----------------------------------------------<------------------------------<-------------------||----------------------------

--- a/tests/cases/fourslash/importNameCodeFix_pathsWithExtension.ts
+++ b/tests/cases/fourslash/importNameCodeFix_pathsWithExtension.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "target": "ESNext",
+////     "module": "Node16",
+////     "moduleResolution": "Node16",
+////     "rootDir": "./src",
+////     "outDir": "./dist",
+////     "paths": {
+////       "#internals/*": ["./src/internals/*.ts"]
+////     }
+////   },
+////   "include": ["src"]
+//// }
+
+// @Filename: /src/internals/example.ts
+//// export function helloWorld() {}
+
+// @Filename: /src/index.ts
+//// helloWorld/**/
+
+verify.importFixModuleSpecifiers("", ["#internals/example"], { importModuleSpecifierEnding: "js" });

--- a/tests/cases/fourslash/importNameCodeFix_typesVersions.ts
+++ b/tests/cases/fourslash/importNameCodeFix_typesVersions.ts
@@ -6,7 +6,7 @@
 // @Filename: /node_modules/unified/package.json
 //// {
 ////   "name": "unified",
-////   "types": "types/ts3.4/index.d.ts",
+////   "types": "types/ts3.444/index.d.ts",
 ////   "typesVersions": {
 ////     ">=4.0": {
 ////       "types/ts3.444/*": [
@@ -33,5 +33,5 @@ verify.importFixModuleSpecifiers("", [
   // This obviously doesn't look like a desired module specifier, but the package.json is misconfigured
   // (taken from a real-world example). The fact that it resolves (according to TS) is good enough to
   // generate it.
-  "unified/types/ts3.444/index",
+  "unified/types/ts3.444/index.js",
 ], { importModuleSpecifierEnding: "js" });

--- a/tests/cases/fourslash/importNameCodeFix_typesVersions.ts
+++ b/tests/cases/fourslash/importNameCodeFix_typesVersions.ts
@@ -9,14 +9,14 @@
 ////   "types": "types/ts3.4/index.d.ts",
 ////   "typesVersions": {
 ////     ">=4.0": {
-////       "types/ts3.4/*": [
+////       "types/ts3.444/*": [
 ////         "types/ts4.0/*"
 ////       ]
 ////     }
 ////   }
 //// }
 
-// @Filename: /node_modules/unified/types/ts3.4/index.d.ts
+// @Filename: /node_modules/unified/types/ts3.444/index.d.ts
 //// export declare const x: number;
 
 // @Filename: /node_modules/unified/types/ts4.0/index.d.ts
@@ -30,5 +30,8 @@
 
 verify.importFixModuleSpecifiers("", [
   "unified",
-  "unified/types/ts3.4/", // TODO: this is wrong #49034
+  // This obviously doesn't look like a desired module specifier, but the package.json is misconfigured
+  // (taken from a real-world example). The fact that it resolves (according to TS) is good enough to
+  // generate it.
+  "unified/types/ts3.444/index",
 ], { importModuleSpecifierEnding: "js" });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

This was much more difficult to do correctly than I expected, but it fixes more than what I set out to fix.

Fixes #49034
Fixes #49290
