### PR TITLE
feat(49786): Typescript: Add intellisense on extended types (ie: interface Itest extends Pick<T, keyof T>) 

### DIFF
--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -142,9 +142,9 @@ namespace ts.Completions.StringCompletions {
             case SyntaxKind.LiteralType: {
                 const grandParent = walkUpParentheses(parent.parent);
                 switch (grandParent.kind) {
+                    case SyntaxKind.ExpressionWithTypeArguments:
                     case SyntaxKind.TypeReference: {
-                        const typeReference = grandParent as TypeReferenceNode;
-                        const typeArgument = findAncestor(parent, n => n.parent === typeReference) as LiteralTypeNode;
+                        const typeArgument = findAncestor(parent, n => n.parent === grandParent) as LiteralTypeNode;
                         if (typeArgument) {
                             return { kind: StringLiteralCompletionKind.Types, types: getStringLiteralTypes(typeChecker.getTypeArgumentConstraint(typeArgument)), isNewIdentifier: false };
                         }

--- a/tests/cases/fourslash/completionsAtTypeArguments.ts
+++ b/tests/cases/fourslash/completionsAtTypeArguments.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+////interface I {
+////    a: string;
+////    b: number;
+////}
+
+////type T1 = Pick<I, "/*1*/">;
+////interface T2 extends Pick<I, "/*2*/"> {}
+
+verify.completions({ marker: ["1", "2"], exact: ["a", "b"] });


### PR DESCRIPTION
Fixes #49786