### PR TITLE
Protect against a language service host mutating its underlying source for `getScriptFileNames`

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1283,7 +1283,7 @@ namespace ts {
                 lastTypesRootVersion = typeRootsVersion;
             }
 
-            const rootFileNames = host.getScriptFileNames();
+            const rootFileNames = host.getScriptFileNames().slice();
 
             // Get a fresh cache of the host information
             const newSettings = host.getCompilationSettings() || getDefaultCompilerOptions();

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1283,6 +1283,9 @@ namespace ts {
                 lastTypesRootVersion = typeRootsVersion;
             }
 
+            // This array is retained by the program and will be used to determine if the program is up to date,
+            // so we need to make a copy in case the host mutates the underlying array - otherwise it would look
+            // like every program always has the host's current list of root files.
             const rootFileNames = host.getScriptFileNames().slice();
 
             // Get a fresh cache of the host information


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes a loose thread from #48980: constructing a `HostCache` used to effectively make a copy of this array; now that we no longer need a separate data structure, it seems like we can just use the array, but in fact we still need to make a copy in case the host wants to mutate what it passes as its state changes (I’m reading that mutation by the host is valid by the fact that it’s a `string[]`, not a `readonly string[]`—plus, it’s a lot to ask of every language service consumer to think about this).

This fixes the twoslash/bisect runner, which has been telling us that all TypeScript code has started crashing at #48980 😄 