### PR TITLE
Remove dependence on `module` compiler option to consider mts/cts files always modules

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6319,7 +6319,7 @@ namespace ts {
         // Excludes declaration files - they still require an explicit `export {}` or the like
         // for back compat purposes. The only non-declaration files _not_ forced to be a module are `.js` files
         // that aren't esm-mode (meaning not in a `type: module` scope).
-        return (file.impliedNodeFormat === ModuleKind.ESNext || (fileExtensionIsOneOf(file.fileName, [Extension.Cjs, Extension.Cts]))) && !file.isDeclarationFile ? true : undefined;
+        return (file.impliedNodeFormat === ModuleKind.ESNext || (fileExtensionIsOneOf(file.fileName, [Extension.Cjs, Extension.Cts, Extension.Mjs, Extension.Mts]))) && !file.isDeclarationFile ? true : undefined;
     }
 
     export function getSetExternalModuleIndicator(options: CompilerOptions): (file: SourceFile) => void {
@@ -6343,10 +6343,7 @@ namespace ts {
                 if (options.jsx === JsxEmit.ReactJSX || options.jsx === JsxEmit.ReactJSXDev) {
                     checks.push(isFileModuleFromUsingJSXTag);
                 }
-                const moduleKind = getEmitModuleKind(options);
-                if (moduleKind === ModuleKind.Node16 || moduleKind === ModuleKind.NodeNext) {
-                    checks.push(isFileForcedToBeModuleByFormat);
-                }
+                checks.push(isFileForcedToBeModuleByFormat);
                 const combined = or(...checks);
                 const callback = (file: SourceFile) => void (file.externalModuleIndicator = combined(file));
                 return callback;

--- a/tests/baselines/reference/moduleDetectionIsolatedModulesCjsFileScope.js
+++ b/tests/baselines/reference/moduleDetectionIsolatedModulesCjsFileScope.js
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/moduleDetectionIsolatedModulesCjsFileScope.ts] ////
+
+//// [filename.cts]
+const a = 2;
+//// [filename.mts]
+const a = 2;
+
+//// [filename.cjs]
+const a = 2;
+export {};
+//// [filename.mjs]
+const a = 2;
+export {};
+
+
+//// [filename.d.cts]
+export {};
+//// [filename.d.mts]
+export {};

--- a/tests/baselines/reference/moduleDetectionIsolatedModulesCjsFileScope.symbols
+++ b/tests/baselines/reference/moduleDetectionIsolatedModulesCjsFileScope.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/filename.cts ===
+const a = 2;
+>a : Symbol(a, Decl(filename.cts, 0, 5))
+
+=== tests/cases/compiler/filename.mts ===
+const a = 2;
+>a : Symbol(a, Decl(filename.mts, 0, 5))
+

--- a/tests/baselines/reference/moduleDetectionIsolatedModulesCjsFileScope.types
+++ b/tests/baselines/reference/moduleDetectionIsolatedModulesCjsFileScope.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/filename.cts ===
+const a = 2;
+>a : 2
+>2 : 2
+
+=== tests/cases/compiler/filename.mts ===
+const a = 2;
+>a : 2
+>2 : 2
+

--- a/tests/cases/compiler/moduleDetectionIsolatedModulesCjsFileScope.ts
+++ b/tests/cases/compiler/moduleDetectionIsolatedModulesCjsFileScope.ts
@@ -1,0 +1,9 @@
+// @target: esnext
+// @module: esnext
+// @declaration: true
+// @moduleResolution: node
+// @isolatedModules: true
+// @filename: filename.cts
+const a = 2;
+// @filename: filename.mts
+const a = 2;


### PR DESCRIPTION
We didn't explicitly specify if the mjs/cjs module parsing behavior should be conditioned on the presence of the new `module` flag when #49268 was merged, but it was, and it looks like we want it to not be, given our confused reaction in #49207.

Fixes #49207 ([this comment](https://github.com/microsoft/TypeScript/issues/49207#issuecomment-1148460567)).
