### PR TITLE
Infer instance type arguments as constraint

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1448,7 +1448,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     var noImplicitAny = getStrictOptionValue(compilerOptions, "noImplicitAny");
     var noImplicitThis = getStrictOptionValue(compilerOptions, "noImplicitThis");
     var useUnknownInCatchVariables = getStrictOptionValue(compilerOptions, "useUnknownInCatchVariables");
-    var strictInstanceOfTypeParameters = getStrictOptionValue(compilerOptions, "strictInstanceOfTypeParameters");
+    // Enabling flag by default for testing, do not merge as-is
+    var strictInstanceOfTypeParameters = true;
     var keyofStringsOnly = !!compilerOptions.keyofStringsOnly;
     var freshObjectLiteralFlag = compilerOptions.suppressExcessPropertyErrors ? 0 : ObjectFlags.FreshLiteral;
     var exactOptionalPropertyTypes = compilerOptions.exactOptionalPropertyTypes;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10150,10 +10150,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             const variance = variances[i];
             switch (variance & VarianceFlags.VarianceMask) {
-                case VarianceFlags.Independent:
-                case VarianceFlags.Bivariant:
-                    return anyType;
                 case VarianceFlags.Contravariant:
+                case VarianceFlags.Bivariant:
                     return neverType;
             }
             return getBaseConstraintOfType(typeParameter) || unknownType;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10153,8 +10153,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case VarianceFlags.Independent:
                 case VarianceFlags.Bivariant:
                     return anyType;
-                case VarianceFlags.Invariant:
-                    return unknownType;
+                case VarianceFlags.Contravariant:
+                    return neverType;
             }
             return getBaseConstraintOfType(typeParameter) || unknownType;
         });

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10162,9 +10162,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getTypeOfPrototypeProperty(prototype: Symbol): Type {
-        // TypeScript 1.0 spec (April 2014): 8.4
         // Every class automatically contains a static property member named 'prototype',
         // the type of which is an instantiation of the class type.
+        // Type parameters on this class are instantiated with a type based on their constraint and variance.
         // It is an error to explicitly declare a static property member with the name 'prototype'.
         const classSymbol = getParentOfSymbol(prototype)!;
         return getInstanceTypeOfClassSymbol(classSymbol);

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -882,6 +882,16 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
         defaultValueDescription: false,
     },
     {
+        name: "strictInstanceOfTypeParameters",
+        type: "boolean",
+        affectsSemanticDiagnostics: true,
+        affectsBuildInfo: true,
+        strictFlag: true,
+        category: Diagnostics.Type_Checking,
+        description: Diagnostics.Default_type_arguments_to_parameter_constraint_or_unknown_instead_of_any_for_instance_checks,
+        defaultValueDescription: false,
+    },
+    {
         name: "alwaysStrict",
         type: "boolean",
         affectsSourceFile: true,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6071,7 +6071,10 @@
         "category": "Message",
         "code": 6804
     },
-
+    "Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks.": {
+        "category": "Message",
+        "code": 6805
+    },
     "one of:": {
         "category": "Message",
         "code": 6900

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7108,6 +7108,7 @@ export interface CompilerOptions {
     strictBindCallApply?: boolean;  // Always combine with strict property
     strictNullChecks?: boolean;  // Always combine with strict property
     strictPropertyInitialization?: boolean;  // Always combine with strict property
+    strictInstanceOfTypeParameters?: boolean;
     stripInternal?: boolean;
     suppressExcessPropertyErrors?: boolean;
     suppressImplicitAnyIndexErrors?: boolean;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8490,6 +8490,7 @@ export type StrictOptionName =
     | "strictPropertyInitialization"
     | "alwaysStrict"
     | "useUnknownInCatchVariables"
+    | "strictInstanceOfTypeParameters"
     ;
 
 /** @internal */

--- a/tests/baselines/reference/accessorsOverrideProperty9.types
+++ b/tests/baselines/reference/accessorsOverrideProperty9.types
@@ -68,7 +68,7 @@ function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
   }
 
   return MixedClass;
->MixedClass : ((abstract new (...args: any[]) => MixedClass) & { prototype: ApiItemContainerMixin<any>.MixedClass; }) & TBaseClass
+>MixedClass : ((abstract new (...args: any[]) => MixedClass) & { prototype: ApiItemContainerMixin<IApiItemConstructor>.MixedClass; }) & TBaseClass
 }
 
 // Subclass inheriting from mixin

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7135,6 +7135,7 @@ declare namespace ts {
         strictBindCallApply?: boolean;
         strictNullChecks?: boolean;
         strictPropertyInitialization?: boolean;
+        strictInstanceOfTypeParameters?: boolean;
         stripInternal?: boolean;
         suppressExcessPropertyErrors?: boolean;
         suppressImplicitAnyIndexErrors?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3160,6 +3160,7 @@ declare namespace ts {
         strictBindCallApply?: boolean;
         strictNullChecks?: boolean;
         strictPropertyInitialization?: boolean;
+        strictInstanceOfTypeParameters?: boolean;
         stripInternal?: boolean;
         suppressExcessPropertyErrors?: boolean;
         suppressImplicitAnyIndexErrors?: boolean;

--- a/tests/baselines/reference/config/initTSConfig/Default initialized TSConfig/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Default initialized TSConfig/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --help/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --help/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --watch/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --watch/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with advanced options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with advanced options/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     "noUnusedLocals": true,                              /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with files options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with files options/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options/tsconfig.json
@@ -90,6 +90,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "strictInstanceOfTypeParameters": true,           /* Default type arguments to parameter constraint or 'unknown' instead of 'any' for instance checks. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/inferInstanceTypeArgumentsAsConstraint/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/inferInstanceTypeArgumentsAsConstraint/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictInstanceOfTypeParameters": true
+    }
+}

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/strictInstanceOfTypeParameters/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/strictInstanceOfTypeParameters/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictInstanceOfTypeParameters": true
+    }
+}

--- a/tests/baselines/reference/expressionWithJSDocTypeArguments.types
+++ b/tests/baselines/reference/expressionWithJSDocTypeArguments.types
@@ -49,23 +49,23 @@ type TComeOnFoo = typeof foo<?string?>;
 >foo : <T>(x: T) => T
 
 const WhatBar = Bar<?>;
->WhatBar : { new (x: any): Bar<any>; prototype: Bar<any>; }
->Bar<?> : { new (x: any): Bar<any>; prototype: Bar<any>; }
+>WhatBar : { new (x: any): Bar<any>; prototype: Bar<unknown>; }
+>Bar<?> : { new (x: any): Bar<any>; prototype: Bar<unknown>; }
 >Bar : typeof Bar
 
 const HuhBar = Bar<string?>;
->HuhBar : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
->Bar<string?> : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
+>HuhBar : { new (x: string | null): Bar<string | null>; prototype: Bar<unknown>; }
+>Bar<string?> : { new (x: string | null): Bar<string | null>; prototype: Bar<unknown>; }
 >Bar : typeof Bar
 
 const NopeBar = Bar<?string>;
->NopeBar : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
->Bar<?string> : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
+>NopeBar : { new (x: string | null): Bar<string | null>; prototype: Bar<unknown>; }
+>Bar<?string> : { new (x: string | null): Bar<string | null>; prototype: Bar<unknown>; }
 >Bar : typeof Bar
 
 const ComeOnBar = Bar<?string?>;
->ComeOnBar : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
->Bar<?string?> : { new (x: string | null): Bar<string | null>; prototype: Bar<any>; }
+>ComeOnBar : { new (x: string | null): Bar<string | null>; prototype: Bar<unknown>; }
+>Bar<?string?> : { new (x: string | null): Bar<string | null>; prototype: Bar<unknown>; }
 >Bar : typeof Bar
 
 type TWhatBar = typeof Bar<?>;

--- a/tests/baselines/reference/instantiationExpressions.errors.txt
+++ b/tests/baselines/reference/instantiationExpressions.errors.txt
@@ -67,7 +67,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpr
     }
     
     function f3() {
-        let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+        let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
         let f1 = C.f<string>;  // (x: string) => string[]
     }
     

--- a/tests/baselines/reference/instantiationExpressions.js
+++ b/tests/baselines/reference/instantiationExpressions.js
@@ -31,7 +31,7 @@ declare class C<T> {
 }
 
 function f3() {
-    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
     let f1 = C.f<string>;  // (x: string) => string[]
 }
 
@@ -187,7 +187,7 @@ function f2() {
     var A2 = (Array); // Error
 }
 function f3() {
-    var c1 = (C); // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+    var c1 = (C); // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
     var f1 = (C.f); // (x: string) => string[]
 }
 function f10(f) {

--- a/tests/baselines/reference/instantiationExpressions.symbols
+++ b/tests/baselines/reference/instantiationExpressions.symbols
@@ -107,7 +107,7 @@ declare class C<T> {
 function f3() {
 >f3 : Symbol(f3, Decl(instantiationExpressions.ts, 29, 1))
 
-    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
 >c1 : Symbol(c1, Decl(instantiationExpressions.ts, 32, 7))
 >C : Symbol(C, Decl(instantiationExpressions.ts, 24, 40))
 

--- a/tests/baselines/reference/instantiationExpressions.types
+++ b/tests/baselines/reference/instantiationExpressions.types
@@ -98,8 +98,8 @@ function f3() {
 >f3 : () => void
 
     let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
->c1 : { new (x: string): C<string>; prototype: C<any>; f<U>(x: U): U[]; }
->C<string> : { new (x: string): C<string>; prototype: C<any>; f<U>(x: U): U[]; }
+>c1 : { new (x: string): C<string>; prototype: C<unknown>; f<U>(x: U): U[]; }
+>C<string> : { new (x: string): C<string>; prototype: C<unknown>; f<U>(x: U): U[]; }
 >C : typeof C
 
     let f1 = C.f<string>;  // (x: string) => string[]

--- a/tests/baselines/reference/instantiationExpressions.types
+++ b/tests/baselines/reference/instantiationExpressions.types
@@ -97,7 +97,7 @@ declare class C<T> {
 function f3() {
 >f3 : () => void
 
-    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
 >c1 : { new (x: string): C<string>; prototype: C<any>; f<U>(x: U): U[]; }
 >C<string> : { new (x: string): C<string>; prototype: C<any>; f<U>(x: U): U[]; }
 >C : typeof C

--- a/tests/baselines/reference/overrideBaseIntersectionMethod.types
+++ b/tests/baselines/reference/overrideBaseIntersectionMethod.types
@@ -6,10 +6,10 @@ type Constructor<T> = new (...args: any[]) => T;
 >args : any[]
 
 const WithLocation = <T extends Constructor<Point>>(Base: T) => class extends Base {
->WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
-><T extends Constructor<Point>>(Base: T) => class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
+>WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<Constructor<Point>>.(Anonymous class); } & T
+><T extends Constructor<Point>>(Base: T) => class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<Constructor<Point>>.(Anonymous class); } & T
 >Base : T
->class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
+>class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : { new (...args: any[]): (Anonymous class); prototype: WithLocation<Constructor<Point>>.(Anonymous class); } & T
 >Base : Point
 
   getLocation(): [number, number] {
@@ -58,7 +58,7 @@ class Point {
 class Foo extends WithLocation(Point) {
 >Foo : Foo
 >WithLocation(Point) : WithLocation<typeof Point>.(Anonymous class) & Point
->WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
+>WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<Constructor<Point>>.(Anonymous class); } & T
 >Point : typeof Point
 
   calculate() {

--- a/tests/baselines/reference/showConfig/Shows tsconfig for single option/inferInstanceTypeArgumentsAsConstraint/tsconfig.json
+++ b/tests/baselines/reference/showConfig/Shows tsconfig for single option/inferInstanceTypeArgumentsAsConstraint/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictInstanceOfTypeParameters": true
+    }
+}

--- a/tests/baselines/reference/strictInstanceOfTypeParameters.errors.txt
+++ b/tests/baselines/reference/strictInstanceOfTypeParameters.errors.txt
@@ -1,0 +1,54 @@
+tests/cases/compiler/strictInstanceOfTypeParameters.ts(9,13): error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
+tests/cases/compiler/strictInstanceOfTypeParameters.ts(10,5): error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/strictInstanceOfTypeParameters.ts(11,7): error TS2349: This expression is not callable.
+  Type '{}' has no call signatures.
+tests/cases/compiler/strictInstanceOfTypeParameters.ts(35,12): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+
+
+==== tests/cases/compiler/strictInstanceOfTypeParameters.ts (4 errors) ====
+    class Unconstrained<T> {
+        value: T;
+        read: (value: T) => void;
+    }
+    
+    declare const x: unknown;
+    
+    if (x instanceof Unconstrained) {
+        x.value.toUpperCase();
+                ~~~~~~~~~~~
+!!! error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
+        x.value++;
+        ~~~~~~~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+        x.value();
+          ~~~~~
+!!! error TS2349: This expression is not callable.
+!!! error TS2349:   Type '{}' has no call signatures.
+    
+        if (typeof x.value === "string") {
+            x.value.toUpperCase();
+        }
+        if (typeof x.value === "number") {
+            x.value++;
+        }
+    
+        x.read(1);
+        x.read("foo");
+    }
+    
+    class Constrained<T extends number> {
+        value: T;
+        read: (value: T) => void;
+    }
+    
+    declare const y: unknown;
+    
+    if (y instanceof Constrained) {
+        y.value++;
+    
+        y.read(1);
+        y.read("foo");
+               ~~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+    }
+    

--- a/tests/baselines/reference/strictInstanceOfTypeParameters.js
+++ b/tests/baselines/reference/strictInstanceOfTypeParameters.js
@@ -1,0 +1,68 @@
+//// [strictInstanceOfTypeParameters.ts]
+class Unconstrained<T> {
+    value: T;
+    read: (value: T) => void;
+}
+
+declare const x: unknown;
+
+if (x instanceof Unconstrained) {
+    x.value.toUpperCase();
+    x.value++;
+    x.value();
+
+    if (typeof x.value === "string") {
+        x.value.toUpperCase();
+    }
+    if (typeof x.value === "number") {
+        x.value++;
+    }
+
+    x.read(1);
+    x.read("foo");
+}
+
+class Constrained<T extends number> {
+    value: T;
+    read: (value: T) => void;
+}
+
+declare const y: unknown;
+
+if (y instanceof Constrained) {
+    y.value++;
+
+    y.read(1);
+    y.read("foo");
+}
+
+
+//// [strictInstanceOfTypeParameters.js]
+var Unconstrained = /** @class */ (function () {
+    function Unconstrained() {
+    }
+    return Unconstrained;
+}());
+if (x instanceof Unconstrained) {
+    x.value.toUpperCase();
+    x.value++;
+    x.value();
+    if (typeof x.value === "string") {
+        x.value.toUpperCase();
+    }
+    if (typeof x.value === "number") {
+        x.value++;
+    }
+    x.read(1);
+    x.read("foo");
+}
+var Constrained = /** @class */ (function () {
+    function Constrained() {
+    }
+    return Constrained;
+}());
+if (y instanceof Constrained) {
+    y.value++;
+    y.read(1);
+    y.read("foo");
+}

--- a/tests/baselines/reference/strictInstanceOfTypeParameters.symbols
+++ b/tests/baselines/reference/strictInstanceOfTypeParameters.symbols
@@ -1,0 +1,108 @@
+=== tests/cases/compiler/strictInstanceOfTypeParameters.ts ===
+class Unconstrained<T> {
+>Unconstrained : Symbol(Unconstrained, Decl(strictInstanceOfTypeParameters.ts, 0, 0))
+>T : Symbol(T, Decl(strictInstanceOfTypeParameters.ts, 0, 20))
+
+    value: T;
+>value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+>T : Symbol(T, Decl(strictInstanceOfTypeParameters.ts, 0, 20))
+
+    read: (value: T) => void;
+>read : Symbol(Unconstrained.read, Decl(strictInstanceOfTypeParameters.ts, 1, 13))
+>value : Symbol(value, Decl(strictInstanceOfTypeParameters.ts, 2, 11))
+>T : Symbol(T, Decl(strictInstanceOfTypeParameters.ts, 0, 20))
+}
+
+declare const x: unknown;
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+
+if (x instanceof Unconstrained) {
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+>Unconstrained : Symbol(Unconstrained, Decl(strictInstanceOfTypeParameters.ts, 0, 0))
+
+    x.value.toUpperCase();
+>x.value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+>value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+
+    x.value++;
+>x.value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+>value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+
+    x.value();
+>x.value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+>value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+
+    if (typeof x.value === "string") {
+>x.value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+>value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+
+        x.value.toUpperCase();
+>x.value.toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+>x.value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+>value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+    }
+    if (typeof x.value === "number") {
+>x.value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+>value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+
+        x.value++;
+>x.value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+>value : Symbol(Unconstrained.value, Decl(strictInstanceOfTypeParameters.ts, 0, 24))
+    }
+
+    x.read(1);
+>x.read : Symbol(Unconstrained.read, Decl(strictInstanceOfTypeParameters.ts, 1, 13))
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+>read : Symbol(Unconstrained.read, Decl(strictInstanceOfTypeParameters.ts, 1, 13))
+
+    x.read("foo");
+>x.read : Symbol(Unconstrained.read, Decl(strictInstanceOfTypeParameters.ts, 1, 13))
+>x : Symbol(x, Decl(strictInstanceOfTypeParameters.ts, 5, 13))
+>read : Symbol(Unconstrained.read, Decl(strictInstanceOfTypeParameters.ts, 1, 13))
+}
+
+class Constrained<T extends number> {
+>Constrained : Symbol(Constrained, Decl(strictInstanceOfTypeParameters.ts, 21, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParameters.ts, 23, 18))
+
+    value: T;
+>value : Symbol(Constrained.value, Decl(strictInstanceOfTypeParameters.ts, 23, 37))
+>T : Symbol(T, Decl(strictInstanceOfTypeParameters.ts, 23, 18))
+
+    read: (value: T) => void;
+>read : Symbol(Constrained.read, Decl(strictInstanceOfTypeParameters.ts, 24, 13))
+>value : Symbol(value, Decl(strictInstanceOfTypeParameters.ts, 25, 11))
+>T : Symbol(T, Decl(strictInstanceOfTypeParameters.ts, 23, 18))
+}
+
+declare const y: unknown;
+>y : Symbol(y, Decl(strictInstanceOfTypeParameters.ts, 28, 13))
+
+if (y instanceof Constrained) {
+>y : Symbol(y, Decl(strictInstanceOfTypeParameters.ts, 28, 13))
+>Constrained : Symbol(Constrained, Decl(strictInstanceOfTypeParameters.ts, 21, 1))
+
+    y.value++;
+>y.value : Symbol(Constrained.value, Decl(strictInstanceOfTypeParameters.ts, 23, 37))
+>y : Symbol(y, Decl(strictInstanceOfTypeParameters.ts, 28, 13))
+>value : Symbol(Constrained.value, Decl(strictInstanceOfTypeParameters.ts, 23, 37))
+
+    y.read(1);
+>y.read : Symbol(Constrained.read, Decl(strictInstanceOfTypeParameters.ts, 24, 13))
+>y : Symbol(y, Decl(strictInstanceOfTypeParameters.ts, 28, 13))
+>read : Symbol(Constrained.read, Decl(strictInstanceOfTypeParameters.ts, 24, 13))
+
+    y.read("foo");
+>y.read : Symbol(Constrained.read, Decl(strictInstanceOfTypeParameters.ts, 24, 13))
+>y : Symbol(y, Decl(strictInstanceOfTypeParameters.ts, 28, 13))
+>read : Symbol(Constrained.read, Decl(strictInstanceOfTypeParameters.ts, 24, 13))
+}
+

--- a/tests/baselines/reference/strictInstanceOfTypeParameters.types
+++ b/tests/baselines/reference/strictInstanceOfTypeParameters.types
@@ -1,0 +1,126 @@
+=== tests/cases/compiler/strictInstanceOfTypeParameters.ts ===
+class Unconstrained<T> {
+>Unconstrained : Unconstrained<T>
+
+    value: T;
+>value : T
+
+    read: (value: T) => void;
+>read : (value: T) => void
+>value : T
+}
+
+declare const x: unknown;
+>x : unknown
+
+if (x instanceof Unconstrained) {
+>x instanceof Unconstrained : boolean
+>x : unknown
+>Unconstrained : typeof Unconstrained
+
+    x.value.toUpperCase();
+>x.value.toUpperCase() : any
+>x.value.toUpperCase : any
+>x.value : unknown
+>x : Unconstrained<unknown>
+>value : unknown
+>toUpperCase : any
+
+    x.value++;
+>x.value++ : number
+>x.value : unknown
+>x : Unconstrained<unknown>
+>value : unknown
+
+    x.value();
+>x.value() : any
+>x.value : unknown
+>x : Unconstrained<unknown>
+>value : unknown
+
+    if (typeof x.value === "string") {
+>typeof x.value === "string" : boolean
+>typeof x.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x.value : unknown
+>x : Unconstrained<unknown>
+>value : unknown
+>"string" : "string"
+
+        x.value.toUpperCase();
+>x.value.toUpperCase() : string
+>x.value.toUpperCase : () => string
+>x.value : string
+>x : Unconstrained<unknown>
+>value : string
+>toUpperCase : () => string
+    }
+    if (typeof x.value === "number") {
+>typeof x.value === "number" : boolean
+>typeof x.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x.value : unknown
+>x : Unconstrained<unknown>
+>value : unknown
+>"number" : "number"
+
+        x.value++;
+>x.value++ : number
+>x.value : number
+>x : Unconstrained<unknown>
+>value : number
+    }
+
+    x.read(1);
+>x.read(1) : void
+>x.read : (value: unknown) => void
+>x : Unconstrained<unknown>
+>read : (value: unknown) => void
+>1 : 1
+
+    x.read("foo");
+>x.read("foo") : void
+>x.read : (value: unknown) => void
+>x : Unconstrained<unknown>
+>read : (value: unknown) => void
+>"foo" : "foo"
+}
+
+class Constrained<T extends number> {
+>Constrained : Constrained<T>
+
+    value: T;
+>value : T
+
+    read: (value: T) => void;
+>read : (value: T) => void
+>value : T
+}
+
+declare const y: unknown;
+>y : unknown
+
+if (y instanceof Constrained) {
+>y instanceof Constrained : boolean
+>y : unknown
+>Constrained : typeof Constrained
+
+    y.value++;
+>y.value++ : number
+>y.value : number
+>y : Constrained<number>
+>value : number
+
+    y.read(1);
+>y.read(1) : void
+>y.read : (value: number) => void
+>y : Constrained<number>
+>read : (value: number) => void
+>1 : 1
+
+    y.read("foo");
+>y.read("foo") : void
+>y.read : (value: number) => void
+>y : Constrained<number>
+>read : (value: number) => void
+>"foo" : "foo"
+}
+

--- a/tests/baselines/reference/strictInstanceOfTypeParametersFromPrivateNameInInExpression.errors.txt
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersFromPrivateNameInInExpression.errors.txt
@@ -1,0 +1,36 @@
+tests/cases/compiler/strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts(9,13): error TS2322: Type 'unknown' is not assignable to type 'T'.
+  'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.
+tests/cases/compiler/strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts(19,13): error TS2322: Type 'string' is not assignable to type 'T'.
+  'string' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'string'.
+
+
+==== tests/cases/compiler/strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts (2 errors) ====
+    class UnconstrainedWithPrivate<T> {
+        #brand;
+        value: T;
+        constructor(value: T) {
+            this.value = value;
+        }
+        copyValue(other: object) {
+            if (#brand in other) {
+                this.value = other.value;
+                ~~~~~~~~~~
+!!! error TS2322: Type 'unknown' is not assignable to type 'T'.
+!!! error TS2322:   'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.
+            }
+        }
+    }
+    
+    class ConstrainedWithPrivate<T extends string> {
+        #brand;
+        value: T;
+        copyValue(other: object) {
+            if (#brand in other) {
+                this.value = other.value;
+                ~~~~~~~~~~
+!!! error TS2322: Type 'string' is not assignable to type 'T'.
+!!! error TS2322:   'string' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'string'.
+            }
+        }
+    }
+    

--- a/tests/baselines/reference/strictInstanceOfTypeParametersFromPrivateNameInInExpression.js
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersFromPrivateNameInInExpression.js
@@ -1,0 +1,54 @@
+//// [strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts]
+class UnconstrainedWithPrivate<T> {
+    #brand;
+    value: T;
+    constructor(value: T) {
+        this.value = value;
+    }
+    copyValue(other: object) {
+        if (#brand in other) {
+            this.value = other.value;
+        }
+    }
+}
+
+class ConstrainedWithPrivate<T extends string> {
+    #brand;
+    value: T;
+    copyValue(other: object) {
+        if (#brand in other) {
+            this.value = other.value;
+        }
+    }
+}
+
+
+//// [strictInstanceOfTypeParametersFromPrivateNameInInExpression.js]
+var __classPrivateFieldIn = (this && this.__classPrivateFieldIn) || function(state, receiver) {
+    if (receiver === null || (typeof receiver !== "object" && typeof receiver !== "function")) throw new TypeError("Cannot use 'in' operator on non-object");
+    return typeof state === "function" ? receiver === state : state.has(receiver);
+};
+var _UnconstrainedWithPrivate_brand, _ConstrainedWithPrivate_brand;
+class UnconstrainedWithPrivate {
+    constructor(value) {
+        _UnconstrainedWithPrivate_brand.set(this, void 0);
+        this.value = value;
+    }
+    copyValue(other) {
+        if (__classPrivateFieldIn(_UnconstrainedWithPrivate_brand, other)) {
+            this.value = other.value;
+        }
+    }
+}
+_UnconstrainedWithPrivate_brand = new WeakMap();
+class ConstrainedWithPrivate {
+    constructor() {
+        _ConstrainedWithPrivate_brand.set(this, void 0);
+    }
+    copyValue(other) {
+        if (__classPrivateFieldIn(_ConstrainedWithPrivate_brand, other)) {
+            this.value = other.value;
+        }
+    }
+}
+_ConstrainedWithPrivate_brand = new WeakMap();

--- a/tests/baselines/reference/strictInstanceOfTypeParametersFromPrivateNameInInExpression.symbols
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersFromPrivateNameInInExpression.symbols
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts ===
+class UnconstrainedWithPrivate<T> {
+>UnconstrainedWithPrivate : Symbol(UnconstrainedWithPrivate, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 0, 0))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 0, 31))
+
+    #brand;
+>#brand : Symbol(UnconstrainedWithPrivate.#brand, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 0, 35))
+
+    value: T;
+>value : Symbol(UnconstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 1, 11))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 0, 31))
+
+    constructor(value: T) {
+>value : Symbol(value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 3, 16))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 0, 31))
+
+        this.value = value;
+>this.value : Symbol(UnconstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 1, 11))
+>this : Symbol(UnconstrainedWithPrivate, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 0, 0))
+>value : Symbol(UnconstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 1, 11))
+>value : Symbol(value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 3, 16))
+    }
+    copyValue(other: object) {
+>copyValue : Symbol(UnconstrainedWithPrivate.copyValue, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 5, 5))
+>other : Symbol(other, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 6, 14))
+
+        if (#brand in other) {
+>#brand : Symbol(UnconstrainedWithPrivate.#brand, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 0, 35))
+>other : Symbol(other, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 6, 14))
+
+            this.value = other.value;
+>this.value : Symbol(UnconstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 1, 11))
+>this : Symbol(UnconstrainedWithPrivate, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 0, 0))
+>value : Symbol(UnconstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 1, 11))
+>other.value : Symbol(UnconstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 1, 11))
+>other : Symbol(other, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 6, 14))
+>value : Symbol(UnconstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 1, 11))
+        }
+    }
+}
+
+class ConstrainedWithPrivate<T extends string> {
+>ConstrainedWithPrivate : Symbol(ConstrainedWithPrivate, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 11, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 13, 29))
+
+    #brand;
+>#brand : Symbol(ConstrainedWithPrivate.#brand, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 13, 48))
+
+    value: T;
+>value : Symbol(ConstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 14, 11))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 13, 29))
+
+    copyValue(other: object) {
+>copyValue : Symbol(ConstrainedWithPrivate.copyValue, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 15, 13))
+>other : Symbol(other, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 16, 14))
+
+        if (#brand in other) {
+>#brand : Symbol(ConstrainedWithPrivate.#brand, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 13, 48))
+>other : Symbol(other, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 16, 14))
+
+            this.value = other.value;
+>this.value : Symbol(ConstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 14, 11))
+>this : Symbol(ConstrainedWithPrivate, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 11, 1))
+>value : Symbol(ConstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 14, 11))
+>other.value : Symbol(ConstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 14, 11))
+>other : Symbol(other, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 16, 14))
+>value : Symbol(ConstrainedWithPrivate.value, Decl(strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts, 14, 11))
+        }
+    }
+}
+

--- a/tests/baselines/reference/strictInstanceOfTypeParametersFromPrivateNameInInExpression.types
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersFromPrivateNameInInExpression.types
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts ===
+class UnconstrainedWithPrivate<T> {
+>UnconstrainedWithPrivate : UnconstrainedWithPrivate<T>
+
+    #brand;
+>#brand : any
+
+    value: T;
+>value : T
+
+    constructor(value: T) {
+>value : T
+
+        this.value = value;
+>this.value = value : T
+>this.value : T
+>this : this
+>value : T
+>value : T
+    }
+    copyValue(other: object) {
+>copyValue : (other: object) => void
+>other : object
+
+        if (#brand in other) {
+>#brand in other : boolean
+>#brand : any
+>other : object
+
+            this.value = other.value;
+>this.value = other.value : unknown
+>this.value : T
+>this : this
+>value : T
+>other.value : unknown
+>other : UnconstrainedWithPrivate<unknown>
+>value : unknown
+        }
+    }
+}
+
+class ConstrainedWithPrivate<T extends string> {
+>ConstrainedWithPrivate : ConstrainedWithPrivate<T>
+
+    #brand;
+>#brand : any
+
+    value: T;
+>value : T
+
+    copyValue(other: object) {
+>copyValue : (other: object) => void
+>other : object
+
+        if (#brand in other) {
+>#brand in other : boolean
+>#brand : any
+>other : object
+
+            this.value = other.value;
+>this.value = other.value : string
+>this.value : T
+>this : this
+>value : T
+>other.value : string
+>other : ConstrainedWithPrivate<string>
+>value : string
+        }
+    }
+}
+

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.errors.txt
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.errors.txt
@@ -1,119 +1,145 @@
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(20,13): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(30,14): error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(31,5): error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(32,8): error TS2349: This expression is not callable.
-  Type '{}' has no call signatures.
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(60,14): error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(61,5): error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(62,8): error TS2349: This expression is not callable.
-  Type '{}' has no call signatures.
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(83,5): error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(9,9): error TS2322: Type 'UnconstrainedCovariant<unknown>' is not assignable to type 'UnconstrainedCovariant<never>'.
+  Type 'unknown' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(11,9): error TS2322: Type 'UnconstrainedCovariant<unknown>' is not assignable to type 'UnconstrainedCovariant<"literal">'.
+  Type 'unknown' is not assignable to type '"literal"'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(21,9): error TS2322: Type 'ConstrainedCovariant<string>' is not assignable to type 'ConstrainedCovariant<never>'.
+  Type 'string' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(24,9): error TS2322: Type 'ConstrainedCovariant<string>' is not assignable to type 'ConstrainedCovariant<"literal">'.
+  Type 'string' is not assignable to type '"literal"'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(62,9): error TS2322: Type 'UnconstrainedInvariant<unknown>' is not assignable to type 'UnconstrainedInvariant<never>'.
+  The types returned by 'f(...)' are incompatible between these types.
+    Type 'unknown' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(64,9): error TS2322: Type 'UnconstrainedInvariant<unknown>' is not assignable to type 'UnconstrainedInvariant<string>'.
+  The types returned by 'f(...)' are incompatible between these types.
+    Type 'unknown' is not assignable to type 'string'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(65,9): error TS2322: Type 'UnconstrainedInvariant<unknown>' is not assignable to type 'UnconstrainedInvariant<"literal">'.
+  The types returned by 'f(...)' are incompatible between these types.
+    Type 'unknown' is not assignable to type '"literal"'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(75,9): error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<never>'.
+  The types returned by 'f(...)' are incompatible between these types.
+    Type 'unknown' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(77,9): error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<string>'.
+  The types returned by 'f(...)' are incompatible between these types.
+    Type 'unknown' is not assignable to type 'string'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(78,9): error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<"literal">'.
+  The types returned by 'f(...)' are incompatible between these types.
+    Type 'unknown' is not assignable to type '"literal"'.
 
 
-==== tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts (8 errors) ====
-    class UnconstrainedIn<in T> {
-        read: (value: T) => void;
+==== tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts (10 errors) ====
+    class UnconstrainedCovariant<out T> {
+        x: T;
     }
     
-    declare const x1: unknown;
+    declare const unc_covariant: unknown;
     
-    if (x1 instanceof UnconstrainedIn) {
-        x1.read(1);
-        x1.read("foo");
+    if (unc_covariant instanceof UnconstrainedCovariant) {
+        let unknown_covariant: UnconstrainedCovariant<unknown> = unc_covariant;
+        let never_covariant: UnconstrainedCovariant<never> = unc_covariant;  // Error
+            ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'UnconstrainedCovariant<unknown>' is not assignable to type 'UnconstrainedCovariant<never>'.
+!!! error TS2322:   Type 'unknown' is not assignable to type 'never'.
+        let any_covariant: UnconstrainedCovariant<any> = unc_covariant;
+        let sub_covariant: UnconstrainedCovariant<"literal"> = unc_covariant;  // Error
+            ~~~~~~~~~~~~~
+!!! error TS2322: Type 'UnconstrainedCovariant<unknown>' is not assignable to type 'UnconstrainedCovariant<"literal">'.
+!!! error TS2322:   Type 'unknown' is not assignable to type '"literal"'.
     }
     
-    class ConstrainedIn<in T extends number> {
-        read: (value: T) => void;
+    class ConstrainedCovariant<out T extends string> {
+        x: T;
     }
     
-    declare const y1: unknown;
+    declare const con_covariant: unknown;
     
-    if (y1 instanceof ConstrainedIn) {
-        y1.read(1);
-        y1.read("foo");
-                ~~~~~
-!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+    if (con_covariant instanceof ConstrainedCovariant) {
+        let never_covariant: ConstrainedCovariant<never> = con_covariant;  // Error
+            ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'ConstrainedCovariant<string>' is not assignable to type 'ConstrainedCovariant<never>'.
+!!! error TS2322:   Type 'string' is not assignable to type 'never'.
+        let any_covariant: ConstrainedCovariant<any> = con_covariant;
+        let constraint_covariant: ConstrainedCovariant<string> = con_covariant;
+        let sub_covariant: ConstrainedCovariant<"literal"> = con_covariant;  // Error
+            ~~~~~~~~~~~~~
+!!! error TS2322: Type 'ConstrainedCovariant<string>' is not assignable to type 'ConstrainedCovariant<"literal">'.
+!!! error TS2322:   Type 'string' is not assignable to type '"literal"'.
     }
     
-    class UnconstrainedOut<out T> {
-        value: T;
+    class UnconstrainedContravariant<in T> {
+        f: (x: T) => void;
     }
     
-    declare const x2: unknown;
+    declare const unc_contravariant: unknown;
     
-    if (x2 instanceof UnconstrainedOut) {
-        x2.value.toUpperCase();
-                 ~~~~~~~~~~~
-!!! error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
-        x2.value++;
-        ~~~~~~~~
-!!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
-        x2.value();
-           ~~~~~
-!!! error TS2349: This expression is not callable.
-!!! error TS2349:   Type '{}' has no call signatures.
-    
-        if (typeof x2.value === "string") {
-            x2.value.toUpperCase();
-        }
-        if (typeof x2.value === "number") {
-            x2.value++;
-        }
+    if (unc_contravariant instanceof UnconstrainedContravariant) {
+        let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;
+        let never_covariant: UnconstrainedContravariant<never> = unc_contravariant;
+        let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;
+        let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;
+        let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;
     }
     
-    class ConstrainedOut<out T extends number> {
-        value: T;
+    class ConstrainedContravariant<in T extends string> {
+        f: (x: T) => void;
     }
     
-    declare const y2: unknown;
+    declare const con_contravariant: unknown;
     
-    if (y2 instanceof ConstrainedOut) {
-        y2.value++;
+    if (con_contravariant instanceof ConstrainedContravariant) {
+        let never_covariant: ConstrainedContravariant<never> = con_contravariant;
+        let any_covariant: ConstrainedContravariant<any> = con_contravariant;
+        let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;
+        let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;
     }
     
-    class UnconstrainedInOut<in out T> {
-        value: T;
-        read: (value: T) => void;
+    class UnconstrainedInvariant<in out T> {
+        f: (x: T) => T;
     }
     
-    declare const x3: unknown;
+    declare const unc_invariant: unknown;
     
-    if (x3 instanceof UnconstrainedInOut) {
-        x3.value.toUpperCase();
-                 ~~~~~~~~~~~
-!!! error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
-        x3.value++;
-        ~~~~~~~~
-!!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
-        x3.value();
-           ~~~~~
-!!! error TS2349: This expression is not callable.
-!!! error TS2349:   Type '{}' has no call signatures.
-    
-        if (typeof x3.value === "string") {
-            x3.value.toUpperCase();
-        }
-        if (typeof x3.value === "number") {
-            x3.value++;
-        }
-    
-        x3.read(1);
-        x3.read("foo");
+    if (unc_invariant instanceof UnconstrainedInvariant) {
+        let unknown_covariant: UnconstrainedInvariant<unknown> = unc_invariant;
+        let never_covariant: UnconstrainedInvariant<never> = unc_invariant;  // Error
+            ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'UnconstrainedInvariant<unknown>' is not assignable to type 'UnconstrainedInvariant<never>'.
+!!! error TS2322:   The types returned by 'f(...)' are incompatible between these types.
+!!! error TS2322:     Type 'unknown' is not assignable to type 'never'.
+        let any_covariant: UnconstrainedInvariant<any> = unc_invariant;
+        let constraint_covariant: UnconstrainedInvariant<string> = unc_invariant;  // Error
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'UnconstrainedInvariant<unknown>' is not assignable to type 'UnconstrainedInvariant<string>'.
+!!! error TS2322:   The types returned by 'f(...)' are incompatible between these types.
+!!! error TS2322:     Type 'unknown' is not assignable to type 'string'.
+        let sub_covariant: UnconstrainedInvariant<"literal"> = unc_invariant;  // Error
+            ~~~~~~~~~~~~~
+!!! error TS2322: Type 'UnconstrainedInvariant<unknown>' is not assignable to type 'UnconstrainedInvariant<"literal">'.
+!!! error TS2322:   The types returned by 'f(...)' are incompatible between these types.
+!!! error TS2322:     Type 'unknown' is not assignable to type '"literal"'.
     }
     
-    class ConstrainedInOut<in out T extends number> {
-        value: T;
-        read: (value: T) => void;
+    class ConstrainedInvariant<in out T extends string> {
+        f: (x: T) => T;
     }
     
-    declare const y3: unknown;
+    declare const con_invariant: unknown;
     
-    if (y3 instanceof ConstrainedInOut) {
-        y3.value++;
-        ~~~~~~~~
-!!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
-    
-        y3.read(1);
-        y3.read("foo");
+    if (con_invariant instanceof ConstrainedInvariant) {
+        let never_covariant: ConstrainedInvariant<never> = con_invariant;  // Error
+            ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<never>'.
+!!! error TS2322:   The types returned by 'f(...)' are incompatible between these types.
+!!! error TS2322:     Type 'unknown' is not assignable to type 'never'.
+        let any_covariant: ConstrainedInvariant<any> = con_invariant;
+        let constraint_covariant: ConstrainedInvariant<string> = con_invariant;  // Error
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<string>'.
+!!! error TS2322:   The types returned by 'f(...)' are incompatible between these types.
+!!! error TS2322:     Type 'unknown' is not assignable to type 'string'.
+        let sub_covariant: ConstrainedInvariant<"literal"> = con_invariant;  // Error
+            ~~~~~~~~~~~~~
+!!! error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<"literal">'.
+!!! error TS2322:   The types returned by 'f(...)' are incompatible between these types.
+!!! error TS2322:     Type 'unknown' is not assignable to type '"literal"'.
     }
     

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.errors.txt
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.errors.txt
@@ -6,6 +6,20 @@ tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(21
   Type 'string' is not assignable to type 'never'.
 tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(24,9): error TS2322: Type 'ConstrainedCovariant<string>' is not assignable to type 'ConstrainedCovariant<"literal">'.
   Type 'string' is not assignable to type '"literal"'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(34,9): error TS2322: Type 'UnconstrainedContravariant<never>' is not assignable to type 'UnconstrainedContravariant<unknown>'.
+  Type 'unknown' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(36,9): error TS2322: Type 'UnconstrainedContravariant<never>' is not assignable to type 'UnconstrainedContravariant<any>'.
+  Type 'any' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(37,9): error TS2322: Type 'UnconstrainedContravariant<never>' is not assignable to type 'UnconstrainedContravariant<string>'.
+  Type 'string' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(38,9): error TS2322: Type 'UnconstrainedContravariant<never>' is not assignable to type 'UnconstrainedContravariant<"literal">'.
+  Type 'string' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(49,9): error TS2322: Type 'ConstrainedContravariant<never>' is not assignable to type 'ConstrainedContravariant<any>'.
+  Type 'any' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(50,9): error TS2322: Type 'ConstrainedContravariant<never>' is not assignable to type 'ConstrainedContravariant<string>'.
+  Type 'string' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(51,9): error TS2322: Type 'ConstrainedContravariant<never>' is not assignable to type 'ConstrainedContravariant<"literal">'.
+  Type 'string' is not assignable to type 'never'.
 tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(62,9): error TS2322: Type 'UnconstrainedInvariant<unknown>' is not assignable to type 'UnconstrainedInvariant<never>'.
   The types returned by 'f(...)' are incompatible between these types.
     Type 'unknown' is not assignable to type 'never'.
@@ -15,18 +29,15 @@ tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(64
 tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(65,9): error TS2322: Type 'UnconstrainedInvariant<unknown>' is not assignable to type 'UnconstrainedInvariant<"literal">'.
   The types returned by 'f(...)' are incompatible between these types.
     Type 'unknown' is not assignable to type '"literal"'.
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(75,9): error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<never>'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(75,9): error TS2322: Type 'ConstrainedInvariant<string>' is not assignable to type 'ConstrainedInvariant<never>'.
   The types returned by 'f(...)' are incompatible between these types.
-    Type 'unknown' is not assignable to type 'never'.
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(77,9): error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<string>'.
+    Type 'string' is not assignable to type 'never'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(78,9): error TS2322: Type 'ConstrainedInvariant<string>' is not assignable to type 'ConstrainedInvariant<"literal">'.
   The types returned by 'f(...)' are incompatible between these types.
-    Type 'unknown' is not assignable to type 'string'.
-tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(78,9): error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<"literal">'.
-  The types returned by 'f(...)' are incompatible between these types.
-    Type 'unknown' is not assignable to type '"literal"'.
+    Type 'string' is not assignable to type '"literal"'.
 
 
-==== tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts (10 errors) ====
+==== tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts (16 errors) ====
     class UnconstrainedCovariant<out T> {
         x: T;
     }
@@ -72,11 +83,23 @@ tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(78
     declare const unc_contravariant: unknown;
     
     if (unc_contravariant instanceof UnconstrainedContravariant) {
-        let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;
+        let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;  // Error
+            ~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'UnconstrainedContravariant<never>' is not assignable to type 'UnconstrainedContravariant<unknown>'.
+!!! error TS2322:   Type 'unknown' is not assignable to type 'never'.
         let never_covariant: UnconstrainedContravariant<never> = unc_contravariant;
-        let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;
-        let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;
-        let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;
+        let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;  // Error
+            ~~~~~~~~~~~~~
+!!! error TS2322: Type 'UnconstrainedContravariant<never>' is not assignable to type 'UnconstrainedContravariant<any>'.
+!!! error TS2322:   Type 'any' is not assignable to type 'never'.
+        let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;  // Error
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'UnconstrainedContravariant<never>' is not assignable to type 'UnconstrainedContravariant<string>'.
+!!! error TS2322:   Type 'string' is not assignable to type 'never'.
+        let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;  // Error
+            ~~~~~~~~~~~~~
+!!! error TS2322: Type 'UnconstrainedContravariant<never>' is not assignable to type 'UnconstrainedContravariant<"literal">'.
+!!! error TS2322:   Type 'string' is not assignable to type 'never'.
     }
     
     class ConstrainedContravariant<in T extends string> {
@@ -87,9 +110,18 @@ tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(78
     
     if (con_contravariant instanceof ConstrainedContravariant) {
         let never_covariant: ConstrainedContravariant<never> = con_contravariant;
-        let any_covariant: ConstrainedContravariant<any> = con_contravariant;
-        let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;
-        let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;
+        let any_covariant: ConstrainedContravariant<any> = con_contravariant;  // Error
+            ~~~~~~~~~~~~~
+!!! error TS2322: Type 'ConstrainedContravariant<never>' is not assignable to type 'ConstrainedContravariant<any>'.
+!!! error TS2322:   Type 'any' is not assignable to type 'never'.
+        let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;  // Error
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'ConstrainedContravariant<never>' is not assignable to type 'ConstrainedContravariant<string>'.
+!!! error TS2322:   Type 'string' is not assignable to type 'never'.
+        let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;  // Error
+            ~~~~~~~~~~~~~
+!!! error TS2322: Type 'ConstrainedContravariant<never>' is not assignable to type 'ConstrainedContravariant<"literal">'.
+!!! error TS2322:   Type 'string' is not assignable to type 'never'.
     }
     
     class UnconstrainedInvariant<in out T> {
@@ -127,19 +159,15 @@ tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(78
     if (con_invariant instanceof ConstrainedInvariant) {
         let never_covariant: ConstrainedInvariant<never> = con_invariant;  // Error
             ~~~~~~~~~~~~~~~
-!!! error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<never>'.
+!!! error TS2322: Type 'ConstrainedInvariant<string>' is not assignable to type 'ConstrainedInvariant<never>'.
 !!! error TS2322:   The types returned by 'f(...)' are incompatible between these types.
-!!! error TS2322:     Type 'unknown' is not assignable to type 'never'.
+!!! error TS2322:     Type 'string' is not assignable to type 'never'.
         let any_covariant: ConstrainedInvariant<any> = con_invariant;
-        let constraint_covariant: ConstrainedInvariant<string> = con_invariant;  // Error
-            ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<string>'.
-!!! error TS2322:   The types returned by 'f(...)' are incompatible between these types.
-!!! error TS2322:     Type 'unknown' is not assignable to type 'string'.
+        let constraint_covariant: ConstrainedInvariant<string> = con_invariant;
         let sub_covariant: ConstrainedInvariant<"literal"> = con_invariant;  // Error
             ~~~~~~~~~~~~~
-!!! error TS2322: Type 'ConstrainedInvariant<unknown>' is not assignable to type 'ConstrainedInvariant<"literal">'.
+!!! error TS2322: Type 'ConstrainedInvariant<string>' is not assignable to type 'ConstrainedInvariant<"literal">'.
 !!! error TS2322:   The types returned by 'f(...)' are incompatible between these types.
-!!! error TS2322:     Type 'unknown' is not assignable to type '"literal"'.
+!!! error TS2322:     Type 'string' is not assignable to type '"literal"'.
     }
     

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.errors.txt
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.errors.txt
@@ -1,0 +1,119 @@
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(20,13): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(30,14): error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(31,5): error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(32,8): error TS2349: This expression is not callable.
+  Type '{}' has no call signatures.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(60,14): error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(61,5): error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(62,8): error TS2349: This expression is not callable.
+  Type '{}' has no call signatures.
+tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts(83,5): error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+
+
+==== tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts (8 errors) ====
+    class UnconstrainedIn<in T> {
+        read: (value: T) => void;
+    }
+    
+    declare const x1: unknown;
+    
+    if (x1 instanceof UnconstrainedIn) {
+        x1.read(1);
+        x1.read("foo");
+    }
+    
+    class ConstrainedIn<in T extends number> {
+        read: (value: T) => void;
+    }
+    
+    declare const y1: unknown;
+    
+    if (y1 instanceof ConstrainedIn) {
+        y1.read(1);
+        y1.read("foo");
+                ~~~~~
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+    }
+    
+    class UnconstrainedOut<out T> {
+        value: T;
+    }
+    
+    declare const x2: unknown;
+    
+    if (x2 instanceof UnconstrainedOut) {
+        x2.value.toUpperCase();
+                 ~~~~~~~~~~~
+!!! error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
+        x2.value++;
+        ~~~~~~~~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+        x2.value();
+           ~~~~~
+!!! error TS2349: This expression is not callable.
+!!! error TS2349:   Type '{}' has no call signatures.
+    
+        if (typeof x2.value === "string") {
+            x2.value.toUpperCase();
+        }
+        if (typeof x2.value === "number") {
+            x2.value++;
+        }
+    }
+    
+    class ConstrainedOut<out T extends number> {
+        value: T;
+    }
+    
+    declare const y2: unknown;
+    
+    if (y2 instanceof ConstrainedOut) {
+        y2.value++;
+    }
+    
+    class UnconstrainedInOut<in out T> {
+        value: T;
+        read: (value: T) => void;
+    }
+    
+    declare const x3: unknown;
+    
+    if (x3 instanceof UnconstrainedInOut) {
+        x3.value.toUpperCase();
+                 ~~~~~~~~~~~
+!!! error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
+        x3.value++;
+        ~~~~~~~~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+        x3.value();
+           ~~~~~
+!!! error TS2349: This expression is not callable.
+!!! error TS2349:   Type '{}' has no call signatures.
+    
+        if (typeof x3.value === "string") {
+            x3.value.toUpperCase();
+        }
+        if (typeof x3.value === "number") {
+            x3.value++;
+        }
+    
+        x3.read(1);
+        x3.read("foo");
+    }
+    
+    class ConstrainedInOut<in out T extends number> {
+        value: T;
+        read: (value: T) => void;
+    }
+    
+    declare const y3: unknown;
+    
+    if (y3 instanceof ConstrainedInOut) {
+        y3.value++;
+        ~~~~~~~~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+    
+        y3.read(1);
+        y3.read("foo");
+    }
+    

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.js
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.js
@@ -1,161 +1,151 @@
 //// [strictInstanceOfTypeParametersWithVarianceAnnotations.ts]
-class UnconstrainedIn<in T> {
-    read: (value: T) => void;
+class UnconstrainedCovariant<out T> {
+    x: T;
 }
 
-declare const x1: unknown;
+declare const unc_covariant: unknown;
 
-if (x1 instanceof UnconstrainedIn) {
-    x1.read(1);
-    x1.read("foo");
+if (unc_covariant instanceof UnconstrainedCovariant) {
+    let unknown_covariant: UnconstrainedCovariant<unknown> = unc_covariant;
+    let never_covariant: UnconstrainedCovariant<never> = unc_covariant;  // Error
+    let any_covariant: UnconstrainedCovariant<any> = unc_covariant;
+    let sub_covariant: UnconstrainedCovariant<"literal"> = unc_covariant;  // Error
 }
 
-class ConstrainedIn<in T extends number> {
-    read: (value: T) => void;
+class ConstrainedCovariant<out T extends string> {
+    x: T;
 }
 
-declare const y1: unknown;
+declare const con_covariant: unknown;
 
-if (y1 instanceof ConstrainedIn) {
-    y1.read(1);
-    y1.read("foo");
+if (con_covariant instanceof ConstrainedCovariant) {
+    let never_covariant: ConstrainedCovariant<never> = con_covariant;  // Error
+    let any_covariant: ConstrainedCovariant<any> = con_covariant;
+    let constraint_covariant: ConstrainedCovariant<string> = con_covariant;
+    let sub_covariant: ConstrainedCovariant<"literal"> = con_covariant;  // Error
 }
 
-class UnconstrainedOut<out T> {
-    value: T;
+class UnconstrainedContravariant<in T> {
+    f: (x: T) => void;
 }
 
-declare const x2: unknown;
+declare const unc_contravariant: unknown;
 
-if (x2 instanceof UnconstrainedOut) {
-    x2.value.toUpperCase();
-    x2.value++;
-    x2.value();
-
-    if (typeof x2.value === "string") {
-        x2.value.toUpperCase();
-    }
-    if (typeof x2.value === "number") {
-        x2.value++;
-    }
+if (unc_contravariant instanceof UnconstrainedContravariant) {
+    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;
+    let never_covariant: UnconstrainedContravariant<never> = unc_contravariant;
+    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;
+    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;
+    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;
 }
 
-class ConstrainedOut<out T extends number> {
-    value: T;
+class ConstrainedContravariant<in T extends string> {
+    f: (x: T) => void;
 }
 
-declare const y2: unknown;
+declare const con_contravariant: unknown;
 
-if (y2 instanceof ConstrainedOut) {
-    y2.value++;
+if (con_contravariant instanceof ConstrainedContravariant) {
+    let never_covariant: ConstrainedContravariant<never> = con_contravariant;
+    let any_covariant: ConstrainedContravariant<any> = con_contravariant;
+    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;
+    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;
 }
 
-class UnconstrainedInOut<in out T> {
-    value: T;
-    read: (value: T) => void;
+class UnconstrainedInvariant<in out T> {
+    f: (x: T) => T;
 }
 
-declare const x3: unknown;
+declare const unc_invariant: unknown;
 
-if (x3 instanceof UnconstrainedInOut) {
-    x3.value.toUpperCase();
-    x3.value++;
-    x3.value();
-
-    if (typeof x3.value === "string") {
-        x3.value.toUpperCase();
-    }
-    if (typeof x3.value === "number") {
-        x3.value++;
-    }
-
-    x3.read(1);
-    x3.read("foo");
+if (unc_invariant instanceof UnconstrainedInvariant) {
+    let unknown_covariant: UnconstrainedInvariant<unknown> = unc_invariant;
+    let never_covariant: UnconstrainedInvariant<never> = unc_invariant;  // Error
+    let any_covariant: UnconstrainedInvariant<any> = unc_invariant;
+    let constraint_covariant: UnconstrainedInvariant<string> = unc_invariant;  // Error
+    let sub_covariant: UnconstrainedInvariant<"literal"> = unc_invariant;  // Error
 }
 
-class ConstrainedInOut<in out T extends number> {
-    value: T;
-    read: (value: T) => void;
+class ConstrainedInvariant<in out T extends string> {
+    f: (x: T) => T;
 }
 
-declare const y3: unknown;
+declare const con_invariant: unknown;
 
-if (y3 instanceof ConstrainedInOut) {
-    y3.value++;
-
-    y3.read(1);
-    y3.read("foo");
+if (con_invariant instanceof ConstrainedInvariant) {
+    let never_covariant: ConstrainedInvariant<never> = con_invariant;  // Error
+    let any_covariant: ConstrainedInvariant<any> = con_invariant;
+    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;  // Error
+    let sub_covariant: ConstrainedInvariant<"literal"> = con_invariant;  // Error
 }
 
 
 //// [strictInstanceOfTypeParametersWithVarianceAnnotations.js]
-var UnconstrainedIn = /** @class */ (function () {
-    function UnconstrainedIn() {
+var UnconstrainedCovariant = /** @class */ (function () {
+    function UnconstrainedCovariant() {
     }
-    return UnconstrainedIn;
+    return UnconstrainedCovariant;
 }());
-if (x1 instanceof UnconstrainedIn) {
-    x1.read(1);
-    x1.read("foo");
+if (unc_covariant instanceof UnconstrainedCovariant) {
+    var unknown_covariant = unc_covariant;
+    var never_covariant = unc_covariant; // Error
+    var any_covariant = unc_covariant;
+    var sub_covariant = unc_covariant; // Error
 }
-var ConstrainedIn = /** @class */ (function () {
-    function ConstrainedIn() {
+var ConstrainedCovariant = /** @class */ (function () {
+    function ConstrainedCovariant() {
     }
-    return ConstrainedIn;
+    return ConstrainedCovariant;
 }());
-if (y1 instanceof ConstrainedIn) {
-    y1.read(1);
-    y1.read("foo");
+if (con_covariant instanceof ConstrainedCovariant) {
+    var never_covariant = con_covariant; // Error
+    var any_covariant = con_covariant;
+    var constraint_covariant = con_covariant;
+    var sub_covariant = con_covariant; // Error
 }
-var UnconstrainedOut = /** @class */ (function () {
-    function UnconstrainedOut() {
+var UnconstrainedContravariant = /** @class */ (function () {
+    function UnconstrainedContravariant() {
     }
-    return UnconstrainedOut;
+    return UnconstrainedContravariant;
 }());
-if (x2 instanceof UnconstrainedOut) {
-    x2.value.toUpperCase();
-    x2.value++;
-    x2.value();
-    if (typeof x2.value === "string") {
-        x2.value.toUpperCase();
-    }
-    if (typeof x2.value === "number") {
-        x2.value++;
-    }
+if (unc_contravariant instanceof UnconstrainedContravariant) {
+    var unknown_covariant = unc_contravariant;
+    var never_covariant = unc_contravariant;
+    var any_covariant = unc_contravariant;
+    var constraint_covariant = unc_contravariant;
+    var sub_covariant = unc_contravariant;
 }
-var ConstrainedOut = /** @class */ (function () {
-    function ConstrainedOut() {
+var ConstrainedContravariant = /** @class */ (function () {
+    function ConstrainedContravariant() {
     }
-    return ConstrainedOut;
+    return ConstrainedContravariant;
 }());
-if (y2 instanceof ConstrainedOut) {
-    y2.value++;
+if (con_contravariant instanceof ConstrainedContravariant) {
+    var never_covariant = con_contravariant;
+    var any_covariant = con_contravariant;
+    var constraint_covariant = con_contravariant;
+    var sub_covariant = con_contravariant;
 }
-var UnconstrainedInOut = /** @class */ (function () {
-    function UnconstrainedInOut() {
+var UnconstrainedInvariant = /** @class */ (function () {
+    function UnconstrainedInvariant() {
     }
-    return UnconstrainedInOut;
+    return UnconstrainedInvariant;
 }());
-if (x3 instanceof UnconstrainedInOut) {
-    x3.value.toUpperCase();
-    x3.value++;
-    x3.value();
-    if (typeof x3.value === "string") {
-        x3.value.toUpperCase();
-    }
-    if (typeof x3.value === "number") {
-        x3.value++;
-    }
-    x3.read(1);
-    x3.read("foo");
+if (unc_invariant instanceof UnconstrainedInvariant) {
+    var unknown_covariant = unc_invariant;
+    var never_covariant = unc_invariant; // Error
+    var any_covariant = unc_invariant;
+    var constraint_covariant = unc_invariant; // Error
+    var sub_covariant = unc_invariant; // Error
 }
-var ConstrainedInOut = /** @class */ (function () {
-    function ConstrainedInOut() {
+var ConstrainedInvariant = /** @class */ (function () {
+    function ConstrainedInvariant() {
     }
-    return ConstrainedInOut;
+    return ConstrainedInvariant;
 }());
-if (y3 instanceof ConstrainedInOut) {
-    y3.value++;
-    y3.read(1);
-    y3.read("foo");
+if (con_invariant instanceof ConstrainedInvariant) {
+    var never_covariant = con_invariant; // Error
+    var any_covariant = con_invariant;
+    var constraint_covariant = con_invariant; // Error
+    var sub_covariant = con_invariant; // Error
 }

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.js
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.js
@@ -32,11 +32,11 @@ class UnconstrainedContravariant<in T> {
 declare const unc_contravariant: unknown;
 
 if (unc_contravariant instanceof UnconstrainedContravariant) {
-    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;
+    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;  // Error
     let never_covariant: UnconstrainedContravariant<never> = unc_contravariant;
-    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;
-    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;
-    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;
+    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;  // Error
+    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;  // Error
+    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;  // Error
 }
 
 class ConstrainedContravariant<in T extends string> {
@@ -47,9 +47,9 @@ declare const con_contravariant: unknown;
 
 if (con_contravariant instanceof ConstrainedContravariant) {
     let never_covariant: ConstrainedContravariant<never> = con_contravariant;
-    let any_covariant: ConstrainedContravariant<any> = con_contravariant;
-    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;
-    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;
+    let any_covariant: ConstrainedContravariant<any> = con_contravariant;  // Error
+    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;  // Error
+    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;  // Error
 }
 
 class UnconstrainedInvariant<in out T> {
@@ -75,7 +75,7 @@ declare const con_invariant: unknown;
 if (con_invariant instanceof ConstrainedInvariant) {
     let never_covariant: ConstrainedInvariant<never> = con_invariant;  // Error
     let any_covariant: ConstrainedInvariant<any> = con_invariant;
-    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;  // Error
+    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;
     let sub_covariant: ConstrainedInvariant<"literal"> = con_invariant;  // Error
 }
 
@@ -109,11 +109,11 @@ var UnconstrainedContravariant = /** @class */ (function () {
     return UnconstrainedContravariant;
 }());
 if (unc_contravariant instanceof UnconstrainedContravariant) {
-    var unknown_covariant = unc_contravariant;
+    var unknown_covariant = unc_contravariant; // Error
     var never_covariant = unc_contravariant;
-    var any_covariant = unc_contravariant;
-    var constraint_covariant = unc_contravariant;
-    var sub_covariant = unc_contravariant;
+    var any_covariant = unc_contravariant; // Error
+    var constraint_covariant = unc_contravariant; // Error
+    var sub_covariant = unc_contravariant; // Error
 }
 var ConstrainedContravariant = /** @class */ (function () {
     function ConstrainedContravariant() {
@@ -122,9 +122,9 @@ var ConstrainedContravariant = /** @class */ (function () {
 }());
 if (con_contravariant instanceof ConstrainedContravariant) {
     var never_covariant = con_contravariant;
-    var any_covariant = con_contravariant;
-    var constraint_covariant = con_contravariant;
-    var sub_covariant = con_contravariant;
+    var any_covariant = con_contravariant; // Error
+    var constraint_covariant = con_contravariant; // Error
+    var sub_covariant = con_contravariant; // Error
 }
 var UnconstrainedInvariant = /** @class */ (function () {
     function UnconstrainedInvariant() {
@@ -146,6 +146,6 @@ var ConstrainedInvariant = /** @class */ (function () {
 if (con_invariant instanceof ConstrainedInvariant) {
     var never_covariant = con_invariant; // Error
     var any_covariant = con_invariant;
-    var constraint_covariant = con_invariant; // Error
+    var constraint_covariant = con_invariant;
     var sub_covariant = con_invariant; // Error
 }

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.js
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.js
@@ -1,0 +1,161 @@
+//// [strictInstanceOfTypeParametersWithVarianceAnnotations.ts]
+class UnconstrainedIn<in T> {
+    read: (value: T) => void;
+}
+
+declare const x1: unknown;
+
+if (x1 instanceof UnconstrainedIn) {
+    x1.read(1);
+    x1.read("foo");
+}
+
+class ConstrainedIn<in T extends number> {
+    read: (value: T) => void;
+}
+
+declare const y1: unknown;
+
+if (y1 instanceof ConstrainedIn) {
+    y1.read(1);
+    y1.read("foo");
+}
+
+class UnconstrainedOut<out T> {
+    value: T;
+}
+
+declare const x2: unknown;
+
+if (x2 instanceof UnconstrainedOut) {
+    x2.value.toUpperCase();
+    x2.value++;
+    x2.value();
+
+    if (typeof x2.value === "string") {
+        x2.value.toUpperCase();
+    }
+    if (typeof x2.value === "number") {
+        x2.value++;
+    }
+}
+
+class ConstrainedOut<out T extends number> {
+    value: T;
+}
+
+declare const y2: unknown;
+
+if (y2 instanceof ConstrainedOut) {
+    y2.value++;
+}
+
+class UnconstrainedInOut<in out T> {
+    value: T;
+    read: (value: T) => void;
+}
+
+declare const x3: unknown;
+
+if (x3 instanceof UnconstrainedInOut) {
+    x3.value.toUpperCase();
+    x3.value++;
+    x3.value();
+
+    if (typeof x3.value === "string") {
+        x3.value.toUpperCase();
+    }
+    if (typeof x3.value === "number") {
+        x3.value++;
+    }
+
+    x3.read(1);
+    x3.read("foo");
+}
+
+class ConstrainedInOut<in out T extends number> {
+    value: T;
+    read: (value: T) => void;
+}
+
+declare const y3: unknown;
+
+if (y3 instanceof ConstrainedInOut) {
+    y3.value++;
+
+    y3.read(1);
+    y3.read("foo");
+}
+
+
+//// [strictInstanceOfTypeParametersWithVarianceAnnotations.js]
+var UnconstrainedIn = /** @class */ (function () {
+    function UnconstrainedIn() {
+    }
+    return UnconstrainedIn;
+}());
+if (x1 instanceof UnconstrainedIn) {
+    x1.read(1);
+    x1.read("foo");
+}
+var ConstrainedIn = /** @class */ (function () {
+    function ConstrainedIn() {
+    }
+    return ConstrainedIn;
+}());
+if (y1 instanceof ConstrainedIn) {
+    y1.read(1);
+    y1.read("foo");
+}
+var UnconstrainedOut = /** @class */ (function () {
+    function UnconstrainedOut() {
+    }
+    return UnconstrainedOut;
+}());
+if (x2 instanceof UnconstrainedOut) {
+    x2.value.toUpperCase();
+    x2.value++;
+    x2.value();
+    if (typeof x2.value === "string") {
+        x2.value.toUpperCase();
+    }
+    if (typeof x2.value === "number") {
+        x2.value++;
+    }
+}
+var ConstrainedOut = /** @class */ (function () {
+    function ConstrainedOut() {
+    }
+    return ConstrainedOut;
+}());
+if (y2 instanceof ConstrainedOut) {
+    y2.value++;
+}
+var UnconstrainedInOut = /** @class */ (function () {
+    function UnconstrainedInOut() {
+    }
+    return UnconstrainedInOut;
+}());
+if (x3 instanceof UnconstrainedInOut) {
+    x3.value.toUpperCase();
+    x3.value++;
+    x3.value();
+    if (typeof x3.value === "string") {
+        x3.value.toUpperCase();
+    }
+    if (typeof x3.value === "number") {
+        x3.value++;
+    }
+    x3.read(1);
+    x3.read("foo");
+}
+var ConstrainedInOut = /** @class */ (function () {
+    function ConstrainedInOut() {
+    }
+    return ConstrainedInOut;
+}());
+if (y3 instanceof ConstrainedInOut) {
+    y3.value++;
+    y3.read(1);
+    y3.read("foo");
+}

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.symbols
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.symbols
@@ -90,7 +90,7 @@ if (unc_contravariant instanceof UnconstrainedContravariant) {
 >unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
 >UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
 
-    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;
+    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;  // Error
 >unknown_covariant : Symbol(unknown_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 33, 7))
 >UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
 >unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
@@ -100,17 +100,17 @@ if (unc_contravariant instanceof UnconstrainedContravariant) {
 >UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
 >unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
 
-    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;
+    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;  // Error
 >any_covariant : Symbol(any_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 35, 7))
 >UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
 >unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
 
-    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;
+    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;  // Error
 >constraint_covariant : Symbol(constraint_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 36, 7))
 >UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
 >unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
 
-    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;
+    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;  // Error
 >sub_covariant : Symbol(sub_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 37, 7))
 >UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
 >unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
@@ -138,17 +138,17 @@ if (con_contravariant instanceof ConstrainedContravariant) {
 >ConstrainedContravariant : Symbol(ConstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 38, 1))
 >con_contravariant : Symbol(con_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 44, 13))
 
-    let any_covariant: ConstrainedContravariant<any> = con_contravariant;
+    let any_covariant: ConstrainedContravariant<any> = con_contravariant;  // Error
 >any_covariant : Symbol(any_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 48, 7))
 >ConstrainedContravariant : Symbol(ConstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 38, 1))
 >con_contravariant : Symbol(con_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 44, 13))
 
-    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;
+    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;  // Error
 >constraint_covariant : Symbol(constraint_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 49, 7))
 >ConstrainedContravariant : Symbol(ConstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 38, 1))
 >con_contravariant : Symbol(con_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 44, 13))
 
-    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;
+    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;  // Error
 >sub_covariant : Symbol(sub_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 50, 7))
 >ConstrainedContravariant : Symbol(ConstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 38, 1))
 >con_contravariant : Symbol(con_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 44, 13))
@@ -226,7 +226,7 @@ if (con_invariant instanceof ConstrainedInvariant) {
 >ConstrainedInvariant : Symbol(ConstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 65, 1))
 >con_invariant : Symbol(con_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 71, 13))
 
-    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;  // Error
+    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;
 >constraint_covariant : Symbol(constraint_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 76, 7))
 >ConstrainedInvariant : Symbol(ConstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 65, 1))
 >con_invariant : Symbol(con_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 71, 13))

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.symbols
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.symbols
@@ -1,241 +1,239 @@
 === tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts ===
-class UnconstrainedIn<in T> {
->UnconstrainedIn : Symbol(UnconstrainedIn, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 0))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 22))
+class UnconstrainedCovariant<out T> {
+>UnconstrainedCovariant : Symbol(UnconstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 0))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
 
-    read: (value: T) => void;
->read : Symbol(UnconstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
->value : Symbol(value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 1, 11))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 22))
+    x: T;
+>x : Symbol(UnconstrainedCovariant.x, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 37))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
 }
 
-declare const x1: unknown;
->x1 : Symbol(x1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
+declare const unc_covariant: unknown;
+>unc_covariant : Symbol(unc_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
 
-if (x1 instanceof UnconstrainedIn) {
->x1 : Symbol(x1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
->UnconstrainedIn : Symbol(UnconstrainedIn, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 0))
+if (unc_covariant instanceof UnconstrainedCovariant) {
+>unc_covariant : Symbol(unc_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
+>UnconstrainedCovariant : Symbol(UnconstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 0))
 
-    x1.read(1);
->x1.read : Symbol(UnconstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
->x1 : Symbol(x1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
->read : Symbol(UnconstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
+    let unknown_covariant: UnconstrainedCovariant<unknown> = unc_covariant;
+>unknown_covariant : Symbol(unknown_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 7, 7))
+>UnconstrainedCovariant : Symbol(UnconstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 0))
+>unc_covariant : Symbol(unc_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
 
-    x1.read("foo");
->x1.read : Symbol(UnconstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
->x1 : Symbol(x1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
->read : Symbol(UnconstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
+    let never_covariant: UnconstrainedCovariant<never> = unc_covariant;  // Error
+>never_covariant : Symbol(never_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 8, 7))
+>UnconstrainedCovariant : Symbol(UnconstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 0))
+>unc_covariant : Symbol(unc_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
+
+    let any_covariant: UnconstrainedCovariant<any> = unc_covariant;
+>any_covariant : Symbol(any_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 9, 7))
+>UnconstrainedCovariant : Symbol(UnconstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 0))
+>unc_covariant : Symbol(unc_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
+
+    let sub_covariant: UnconstrainedCovariant<"literal"> = unc_covariant;  // Error
+>sub_covariant : Symbol(sub_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 10, 7))
+>UnconstrainedCovariant : Symbol(UnconstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 0))
+>unc_covariant : Symbol(unc_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
 }
 
-class ConstrainedIn<in T extends number> {
->ConstrainedIn : Symbol(ConstrainedIn, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 9, 1))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 20))
+class ConstrainedCovariant<out T extends string> {
+>ConstrainedCovariant : Symbol(ConstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 13, 27))
 
-    read: (value: T) => void;
->read : Symbol(ConstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 42))
->value : Symbol(value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 12, 11))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 20))
+    x: T;
+>x : Symbol(ConstrainedCovariant.x, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 13, 50))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 13, 27))
 }
 
-declare const y1: unknown;
->y1 : Symbol(y1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 15, 13))
+declare const con_covariant: unknown;
+>con_covariant : Symbol(con_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 17, 13))
 
-if (y1 instanceof ConstrainedIn) {
->y1 : Symbol(y1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 15, 13))
->ConstrainedIn : Symbol(ConstrainedIn, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 9, 1))
+if (con_covariant instanceof ConstrainedCovariant) {
+>con_covariant : Symbol(con_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 17, 13))
+>ConstrainedCovariant : Symbol(ConstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 1))
 
-    y1.read(1);
->y1.read : Symbol(ConstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 42))
->y1 : Symbol(y1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 15, 13))
->read : Symbol(ConstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 42))
+    let never_covariant: ConstrainedCovariant<never> = con_covariant;  // Error
+>never_covariant : Symbol(never_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 20, 7))
+>ConstrainedCovariant : Symbol(ConstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 1))
+>con_covariant : Symbol(con_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 17, 13))
 
-    y1.read("foo");
->y1.read : Symbol(ConstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 42))
->y1 : Symbol(y1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 15, 13))
->read : Symbol(ConstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 42))
+    let any_covariant: ConstrainedCovariant<any> = con_covariant;
+>any_covariant : Symbol(any_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 21, 7))
+>ConstrainedCovariant : Symbol(ConstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 1))
+>con_covariant : Symbol(con_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 17, 13))
+
+    let constraint_covariant: ConstrainedCovariant<string> = con_covariant;
+>constraint_covariant : Symbol(constraint_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 7))
+>ConstrainedCovariant : Symbol(ConstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 1))
+>con_covariant : Symbol(con_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 17, 13))
+
+    let sub_covariant: ConstrainedCovariant<"literal"> = con_covariant;  // Error
+>sub_covariant : Symbol(sub_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 23, 7))
+>ConstrainedCovariant : Symbol(ConstrainedCovariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 1))
+>con_covariant : Symbol(con_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 17, 13))
 }
 
-class UnconstrainedOut<out T> {
->UnconstrainedOut : Symbol(UnconstrainedOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 20, 1))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 23))
+class UnconstrainedContravariant<in T> {
+>UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 33))
 
-    value: T;
->value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 23))
+    f: (x: T) => void;
+>f : Symbol(UnconstrainedContravariant.f, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 40))
+>x : Symbol(x, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 27, 8))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 33))
 }
 
-declare const x2: unknown;
->x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
+declare const unc_contravariant: unknown;
+>unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
 
-if (x2 instanceof UnconstrainedOut) {
->x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
->UnconstrainedOut : Symbol(UnconstrainedOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 20, 1))
+if (unc_contravariant instanceof UnconstrainedContravariant) {
+>unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
+>UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
 
-    x2.value.toUpperCase();
->x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
->x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
->value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;
+>unknown_covariant : Symbol(unknown_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 33, 7))
+>UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
+>unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
 
-    x2.value++;
->x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
->x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
->value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+    let never_covariant: UnconstrainedContravariant<never> = unc_contravariant;
+>never_covariant : Symbol(never_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 34, 7))
+>UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
+>unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
 
-    x2.value();
->x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
->x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
->value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;
+>any_covariant : Symbol(any_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 35, 7))
+>UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
+>unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
 
-    if (typeof x2.value === "string") {
->x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
->x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
->value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;
+>constraint_covariant : Symbol(constraint_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 36, 7))
+>UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
+>unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
 
-        x2.value.toUpperCase();
->x2.value.toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
->x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
->x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
->value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
->toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
-    }
-    if (typeof x2.value === "number") {
->x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
->x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
->value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
-
-        x2.value++;
->x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
->x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
->value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
-    }
+    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;
+>sub_covariant : Symbol(sub_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 37, 7))
+>UnconstrainedContravariant : Symbol(UnconstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 24, 1))
+>unc_contravariant : Symbol(unc_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 30, 13))
 }
 
-class ConstrainedOut<out T extends number> {
->ConstrainedOut : Symbol(ConstrainedOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 39, 1))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 21))
+class ConstrainedContravariant<in T extends string> {
+>ConstrainedContravariant : Symbol(ConstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 38, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 40, 31))
 
-    value: T;
->value : Symbol(ConstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 44))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 21))
+    f: (x: T) => void;
+>f : Symbol(ConstrainedContravariant.f, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 40, 53))
+>x : Symbol(x, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 8))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 40, 31))
 }
 
-declare const y2: unknown;
->y2 : Symbol(y2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 45, 13))
+declare const con_contravariant: unknown;
+>con_contravariant : Symbol(con_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 44, 13))
 
-if (y2 instanceof ConstrainedOut) {
->y2 : Symbol(y2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 45, 13))
->ConstrainedOut : Symbol(ConstrainedOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 39, 1))
+if (con_contravariant instanceof ConstrainedContravariant) {
+>con_contravariant : Symbol(con_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 44, 13))
+>ConstrainedContravariant : Symbol(ConstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 38, 1))
 
-    y2.value++;
->y2.value : Symbol(ConstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 44))
->y2 : Symbol(y2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 45, 13))
->value : Symbol(ConstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 44))
+    let never_covariant: ConstrainedContravariant<never> = con_contravariant;
+>never_covariant : Symbol(never_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 47, 7))
+>ConstrainedContravariant : Symbol(ConstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 38, 1))
+>con_contravariant : Symbol(con_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 44, 13))
+
+    let any_covariant: ConstrainedContravariant<any> = con_contravariant;
+>any_covariant : Symbol(any_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 48, 7))
+>ConstrainedContravariant : Symbol(ConstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 38, 1))
+>con_contravariant : Symbol(con_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 44, 13))
+
+    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;
+>constraint_covariant : Symbol(constraint_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 49, 7))
+>ConstrainedContravariant : Symbol(ConstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 38, 1))
+>con_contravariant : Symbol(con_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 44, 13))
+
+    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;
+>sub_covariant : Symbol(sub_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 50, 7))
+>ConstrainedContravariant : Symbol(ConstrainedContravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 38, 1))
+>con_contravariant : Symbol(con_contravariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 44, 13))
 }
 
-class UnconstrainedInOut<in out T> {
->UnconstrainedInOut : Symbol(UnconstrainedInOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 49, 1))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 25))
+class UnconstrainedInvariant<in out T> {
+>UnconstrainedInvariant : Symbol(UnconstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 53, 29))
 
-    value: T;
->value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 25))
-
-    read: (value: T) => void;
->read : Symbol(UnconstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 52, 13))
->value : Symbol(value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 53, 11))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 25))
+    f: (x: T) => T;
+>f : Symbol(UnconstrainedInvariant.f, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 53, 40))
+>x : Symbol(x, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 54, 8))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 53, 29))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 53, 29))
 }
 
-declare const x3: unknown;
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+declare const unc_invariant: unknown;
+>unc_invariant : Symbol(unc_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 57, 13))
 
-if (x3 instanceof UnconstrainedInOut) {
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
->UnconstrainedInOut : Symbol(UnconstrainedInOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 49, 1))
+if (unc_invariant instanceof UnconstrainedInvariant) {
+>unc_invariant : Symbol(unc_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 57, 13))
+>UnconstrainedInvariant : Symbol(UnconstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 1))
 
-    x3.value.toUpperCase();
->x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
->value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+    let unknown_covariant: UnconstrainedInvariant<unknown> = unc_invariant;
+>unknown_covariant : Symbol(unknown_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 60, 7))
+>UnconstrainedInvariant : Symbol(UnconstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 1))
+>unc_invariant : Symbol(unc_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 57, 13))
 
-    x3.value++;
->x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
->value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+    let never_covariant: UnconstrainedInvariant<never> = unc_invariant;  // Error
+>never_covariant : Symbol(never_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 61, 7))
+>UnconstrainedInvariant : Symbol(UnconstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 1))
+>unc_invariant : Symbol(unc_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 57, 13))
 
-    x3.value();
->x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
->value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+    let any_covariant: UnconstrainedInvariant<any> = unc_invariant;
+>any_covariant : Symbol(any_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 62, 7))
+>UnconstrainedInvariant : Symbol(UnconstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 1))
+>unc_invariant : Symbol(unc_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 57, 13))
 
-    if (typeof x3.value === "string") {
->x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
->value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+    let constraint_covariant: UnconstrainedInvariant<string> = unc_invariant;  // Error
+>constraint_covariant : Symbol(constraint_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 63, 7))
+>UnconstrainedInvariant : Symbol(UnconstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 1))
+>unc_invariant : Symbol(unc_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 57, 13))
 
-        x3.value.toUpperCase();
->x3.value.toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
->x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
->value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
->toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
-    }
-    if (typeof x3.value === "number") {
->x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
->value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
-
-        x3.value++;
->x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
->value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
-    }
-
-    x3.read(1);
->x3.read : Symbol(UnconstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 52, 13))
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
->read : Symbol(UnconstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 52, 13))
-
-    x3.read("foo");
->x3.read : Symbol(UnconstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 52, 13))
->x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
->read : Symbol(UnconstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 52, 13))
+    let sub_covariant: UnconstrainedInvariant<"literal"> = unc_invariant;  // Error
+>sub_covariant : Symbol(sub_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 64, 7))
+>UnconstrainedInvariant : Symbol(UnconstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 1))
+>unc_invariant : Symbol(unc_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 57, 13))
 }
 
-class ConstrainedInOut<in out T extends number> {
->ConstrainedInOut : Symbol(ConstrainedInOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 72, 1))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 23))
+class ConstrainedInvariant<in out T extends string> {
+>ConstrainedInvariant : Symbol(ConstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 65, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 67, 27))
 
-    value: T;
->value : Symbol(ConstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 49))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 23))
-
-    read: (value: T) => void;
->read : Symbol(ConstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 13))
->value : Symbol(value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 76, 11))
->T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 23))
+    f: (x: T) => T;
+>f : Symbol(ConstrainedInvariant.f, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 67, 53))
+>x : Symbol(x, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 68, 8))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 67, 27))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 67, 27))
 }
 
-declare const y3: unknown;
->y3 : Symbol(y3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 79, 13))
+declare const con_invariant: unknown;
+>con_invariant : Symbol(con_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 71, 13))
 
-if (y3 instanceof ConstrainedInOut) {
->y3 : Symbol(y3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 79, 13))
->ConstrainedInOut : Symbol(ConstrainedInOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 72, 1))
+if (con_invariant instanceof ConstrainedInvariant) {
+>con_invariant : Symbol(con_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 71, 13))
+>ConstrainedInvariant : Symbol(ConstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 65, 1))
 
-    y3.value++;
->y3.value : Symbol(ConstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 49))
->y3 : Symbol(y3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 79, 13))
->value : Symbol(ConstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 49))
+    let never_covariant: ConstrainedInvariant<never> = con_invariant;  // Error
+>never_covariant : Symbol(never_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 7))
+>ConstrainedInvariant : Symbol(ConstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 65, 1))
+>con_invariant : Symbol(con_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 71, 13))
 
-    y3.read(1);
->y3.read : Symbol(ConstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 13))
->y3 : Symbol(y3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 79, 13))
->read : Symbol(ConstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 13))
+    let any_covariant: ConstrainedInvariant<any> = con_invariant;
+>any_covariant : Symbol(any_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 7))
+>ConstrainedInvariant : Symbol(ConstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 65, 1))
+>con_invariant : Symbol(con_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 71, 13))
 
-    y3.read("foo");
->y3.read : Symbol(ConstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 13))
->y3 : Symbol(y3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 79, 13))
->read : Symbol(ConstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 13))
+    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;  // Error
+>constraint_covariant : Symbol(constraint_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 76, 7))
+>ConstrainedInvariant : Symbol(ConstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 65, 1))
+>con_invariant : Symbol(con_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 71, 13))
+
+    let sub_covariant: ConstrainedInvariant<"literal"> = con_invariant;  // Error
+>sub_covariant : Symbol(sub_covariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 77, 7))
+>ConstrainedInvariant : Symbol(ConstrainedInvariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 65, 1))
+>con_invariant : Symbol(con_invariant, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 71, 13))
 }
 

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.symbols
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.symbols
@@ -1,0 +1,241 @@
+=== tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts ===
+class UnconstrainedIn<in T> {
+>UnconstrainedIn : Symbol(UnconstrainedIn, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 0))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 22))
+
+    read: (value: T) => void;
+>read : Symbol(UnconstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
+>value : Symbol(value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 1, 11))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 22))
+}
+
+declare const x1: unknown;
+>x1 : Symbol(x1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
+
+if (x1 instanceof UnconstrainedIn) {
+>x1 : Symbol(x1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
+>UnconstrainedIn : Symbol(UnconstrainedIn, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 0))
+
+    x1.read(1);
+>x1.read : Symbol(UnconstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
+>x1 : Symbol(x1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
+>read : Symbol(UnconstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
+
+    x1.read("foo");
+>x1.read : Symbol(UnconstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
+>x1 : Symbol(x1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 4, 13))
+>read : Symbol(UnconstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 0, 29))
+}
+
+class ConstrainedIn<in T extends number> {
+>ConstrainedIn : Symbol(ConstrainedIn, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 9, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 20))
+
+    read: (value: T) => void;
+>read : Symbol(ConstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 42))
+>value : Symbol(value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 12, 11))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 20))
+}
+
+declare const y1: unknown;
+>y1 : Symbol(y1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 15, 13))
+
+if (y1 instanceof ConstrainedIn) {
+>y1 : Symbol(y1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 15, 13))
+>ConstrainedIn : Symbol(ConstrainedIn, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 9, 1))
+
+    y1.read(1);
+>y1.read : Symbol(ConstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 42))
+>y1 : Symbol(y1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 15, 13))
+>read : Symbol(ConstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 42))
+
+    y1.read("foo");
+>y1.read : Symbol(ConstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 42))
+>y1 : Symbol(y1, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 15, 13))
+>read : Symbol(ConstrainedIn.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 11, 42))
+}
+
+class UnconstrainedOut<out T> {
+>UnconstrainedOut : Symbol(UnconstrainedOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 20, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 23))
+
+    value: T;
+>value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 23))
+}
+
+declare const x2: unknown;
+>x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
+
+if (x2 instanceof UnconstrainedOut) {
+>x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
+>UnconstrainedOut : Symbol(UnconstrainedOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 20, 1))
+
+    x2.value.toUpperCase();
+>x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+>x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
+>value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+
+    x2.value++;
+>x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+>x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
+>value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+
+    x2.value();
+>x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+>x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
+>value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+
+    if (typeof x2.value === "string") {
+>x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+>x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
+>value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+
+        x2.value.toUpperCase();
+>x2.value.toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+>x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+>x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
+>value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+    }
+    if (typeof x2.value === "number") {
+>x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+>x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
+>value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+
+        x2.value++;
+>x2.value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+>x2 : Symbol(x2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 26, 13))
+>value : Symbol(UnconstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 22, 31))
+    }
+}
+
+class ConstrainedOut<out T extends number> {
+>ConstrainedOut : Symbol(ConstrainedOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 39, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 21))
+
+    value: T;
+>value : Symbol(ConstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 44))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 21))
+}
+
+declare const y2: unknown;
+>y2 : Symbol(y2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 45, 13))
+
+if (y2 instanceof ConstrainedOut) {
+>y2 : Symbol(y2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 45, 13))
+>ConstrainedOut : Symbol(ConstrainedOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 39, 1))
+
+    y2.value++;
+>y2.value : Symbol(ConstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 44))
+>y2 : Symbol(y2, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 45, 13))
+>value : Symbol(ConstrainedOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 41, 44))
+}
+
+class UnconstrainedInOut<in out T> {
+>UnconstrainedInOut : Symbol(UnconstrainedInOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 49, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 25))
+
+    value: T;
+>value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 25))
+
+    read: (value: T) => void;
+>read : Symbol(UnconstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 52, 13))
+>value : Symbol(value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 53, 11))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 25))
+}
+
+declare const x3: unknown;
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+
+if (x3 instanceof UnconstrainedInOut) {
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+>UnconstrainedInOut : Symbol(UnconstrainedInOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 49, 1))
+
+    x3.value.toUpperCase();
+>x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+>value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+
+    x3.value++;
+>x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+>value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+
+    x3.value();
+>x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+>value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+
+    if (typeof x3.value === "string") {
+>x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+>value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+
+        x3.value.toUpperCase();
+>x3.value.toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+>x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+>value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+    }
+    if (typeof x3.value === "number") {
+>x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+>value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+
+        x3.value++;
+>x3.value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+>value : Symbol(UnconstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 51, 36))
+    }
+
+    x3.read(1);
+>x3.read : Symbol(UnconstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 52, 13))
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+>read : Symbol(UnconstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 52, 13))
+
+    x3.read("foo");
+>x3.read : Symbol(UnconstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 52, 13))
+>x3 : Symbol(x3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 56, 13))
+>read : Symbol(UnconstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 52, 13))
+}
+
+class ConstrainedInOut<in out T extends number> {
+>ConstrainedInOut : Symbol(ConstrainedInOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 72, 1))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 23))
+
+    value: T;
+>value : Symbol(ConstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 49))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 23))
+
+    read: (value: T) => void;
+>read : Symbol(ConstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 13))
+>value : Symbol(value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 76, 11))
+>T : Symbol(T, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 23))
+}
+
+declare const y3: unknown;
+>y3 : Symbol(y3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 79, 13))
+
+if (y3 instanceof ConstrainedInOut) {
+>y3 : Symbol(y3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 79, 13))
+>ConstrainedInOut : Symbol(ConstrainedInOut, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 72, 1))
+
+    y3.value++;
+>y3.value : Symbol(ConstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 49))
+>y3 : Symbol(y3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 79, 13))
+>value : Symbol(ConstrainedInOut.value, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 74, 49))
+
+    y3.read(1);
+>y3.read : Symbol(ConstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 13))
+>y3 : Symbol(y3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 79, 13))
+>read : Symbol(ConstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 13))
+
+    y3.read("foo");
+>y3.read : Symbol(ConstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 13))
+>y3 : Symbol(y3, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 79, 13))
+>read : Symbol(ConstrainedInOut.read, Decl(strictInstanceOfTypeParametersWithVarianceAnnotations.ts, 75, 13))
+}
+

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.types
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.types
@@ -1,277 +1,205 @@
 === tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts ===
-class UnconstrainedIn<in T> {
->UnconstrainedIn : UnconstrainedIn<T>
+class UnconstrainedCovariant<out T> {
+>UnconstrainedCovariant : UnconstrainedCovariant<T>
 
-    read: (value: T) => void;
->read : (value: T) => void
->value : T
+    x: T;
+>x : T
 }
 
-declare const x1: unknown;
->x1 : unknown
+declare const unc_covariant: unknown;
+>unc_covariant : unknown
 
-if (x1 instanceof UnconstrainedIn) {
->x1 instanceof UnconstrainedIn : boolean
->x1 : unknown
->UnconstrainedIn : typeof UnconstrainedIn
+if (unc_covariant instanceof UnconstrainedCovariant) {
+>unc_covariant instanceof UnconstrainedCovariant : boolean
+>unc_covariant : unknown
+>UnconstrainedCovariant : typeof UnconstrainedCovariant
 
-    x1.read(1);
->x1.read(1) : void
->x1.read : (value: unknown) => void
->x1 : UnconstrainedIn<unknown>
->read : (value: unknown) => void
->1 : 1
+    let unknown_covariant: UnconstrainedCovariant<unknown> = unc_covariant;
+>unknown_covariant : UnconstrainedCovariant<unknown>
+>unc_covariant : UnconstrainedCovariant<unknown>
 
-    x1.read("foo");
->x1.read("foo") : void
->x1.read : (value: unknown) => void
->x1 : UnconstrainedIn<unknown>
->read : (value: unknown) => void
->"foo" : "foo"
+    let never_covariant: UnconstrainedCovariant<never> = unc_covariant;  // Error
+>never_covariant : UnconstrainedCovariant<never>
+>unc_covariant : UnconstrainedCovariant<unknown>
+
+    let any_covariant: UnconstrainedCovariant<any> = unc_covariant;
+>any_covariant : UnconstrainedCovariant<any>
+>unc_covariant : UnconstrainedCovariant<unknown>
+
+    let sub_covariant: UnconstrainedCovariant<"literal"> = unc_covariant;  // Error
+>sub_covariant : UnconstrainedCovariant<"literal">
+>unc_covariant : UnconstrainedCovariant<unknown>
 }
 
-class ConstrainedIn<in T extends number> {
->ConstrainedIn : ConstrainedIn<T>
+class ConstrainedCovariant<out T extends string> {
+>ConstrainedCovariant : ConstrainedCovariant<T>
 
-    read: (value: T) => void;
->read : (value: T) => void
->value : T
+    x: T;
+>x : T
 }
 
-declare const y1: unknown;
->y1 : unknown
+declare const con_covariant: unknown;
+>con_covariant : unknown
 
-if (y1 instanceof ConstrainedIn) {
->y1 instanceof ConstrainedIn : boolean
->y1 : unknown
->ConstrainedIn : typeof ConstrainedIn
+if (con_covariant instanceof ConstrainedCovariant) {
+>con_covariant instanceof ConstrainedCovariant : boolean
+>con_covariant : unknown
+>ConstrainedCovariant : typeof ConstrainedCovariant
 
-    y1.read(1);
->y1.read(1) : void
->y1.read : (value: number) => void
->y1 : ConstrainedIn<number>
->read : (value: number) => void
->1 : 1
+    let never_covariant: ConstrainedCovariant<never> = con_covariant;  // Error
+>never_covariant : ConstrainedCovariant<never>
+>con_covariant : ConstrainedCovariant<string>
 
-    y1.read("foo");
->y1.read("foo") : void
->y1.read : (value: number) => void
->y1 : ConstrainedIn<number>
->read : (value: number) => void
->"foo" : "foo"
+    let any_covariant: ConstrainedCovariant<any> = con_covariant;
+>any_covariant : ConstrainedCovariant<any>
+>con_covariant : ConstrainedCovariant<string>
+
+    let constraint_covariant: ConstrainedCovariant<string> = con_covariant;
+>constraint_covariant : ConstrainedCovariant<string>
+>con_covariant : ConstrainedCovariant<string>
+
+    let sub_covariant: ConstrainedCovariant<"literal"> = con_covariant;  // Error
+>sub_covariant : ConstrainedCovariant<"literal">
+>con_covariant : ConstrainedCovariant<string>
 }
 
-class UnconstrainedOut<out T> {
->UnconstrainedOut : UnconstrainedOut<T>
+class UnconstrainedContravariant<in T> {
+>UnconstrainedContravariant : UnconstrainedContravariant<T>
 
-    value: T;
->value : T
+    f: (x: T) => void;
+>f : (x: T) => void
+>x : T
 }
 
-declare const x2: unknown;
->x2 : unknown
+declare const unc_contravariant: unknown;
+>unc_contravariant : unknown
 
-if (x2 instanceof UnconstrainedOut) {
->x2 instanceof UnconstrainedOut : boolean
->x2 : unknown
->UnconstrainedOut : typeof UnconstrainedOut
+if (unc_contravariant instanceof UnconstrainedContravariant) {
+>unc_contravariant instanceof UnconstrainedContravariant : boolean
+>unc_contravariant : unknown
+>UnconstrainedContravariant : typeof UnconstrainedContravariant
 
-    x2.value.toUpperCase();
->x2.value.toUpperCase() : any
->x2.value.toUpperCase : any
->x2.value : unknown
->x2 : UnconstrainedOut<unknown>
->value : unknown
->toUpperCase : any
+    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;
+>unknown_covariant : UnconstrainedContravariant<unknown>
+>unc_contravariant : UnconstrainedContravariant<unknown>
 
-    x2.value++;
->x2.value++ : number
->x2.value : unknown
->x2 : UnconstrainedOut<unknown>
->value : unknown
+    let never_covariant: UnconstrainedContravariant<never> = unc_contravariant;
+>never_covariant : UnconstrainedContravariant<never>
+>unc_contravariant : UnconstrainedContravariant<unknown>
 
-    x2.value();
->x2.value() : any
->x2.value : unknown
->x2 : UnconstrainedOut<unknown>
->value : unknown
+    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;
+>any_covariant : UnconstrainedContravariant<any>
+>unc_contravariant : UnconstrainedContravariant<unknown>
 
-    if (typeof x2.value === "string") {
->typeof x2.value === "string" : boolean
->typeof x2.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
->x2.value : unknown
->x2 : UnconstrainedOut<unknown>
->value : unknown
->"string" : "string"
+    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;
+>constraint_covariant : UnconstrainedContravariant<string>
+>unc_contravariant : UnconstrainedContravariant<unknown>
 
-        x2.value.toUpperCase();
->x2.value.toUpperCase() : string
->x2.value.toUpperCase : () => string
->x2.value : string
->x2 : UnconstrainedOut<unknown>
->value : string
->toUpperCase : () => string
-    }
-    if (typeof x2.value === "number") {
->typeof x2.value === "number" : boolean
->typeof x2.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
->x2.value : unknown
->x2 : UnconstrainedOut<unknown>
->value : unknown
->"number" : "number"
-
-        x2.value++;
->x2.value++ : number
->x2.value : number
->x2 : UnconstrainedOut<unknown>
->value : number
-    }
+    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;
+>sub_covariant : UnconstrainedContravariant<"literal">
+>unc_contravariant : UnconstrainedContravariant<unknown>
 }
 
-class ConstrainedOut<out T extends number> {
->ConstrainedOut : ConstrainedOut<T>
+class ConstrainedContravariant<in T extends string> {
+>ConstrainedContravariant : ConstrainedContravariant<T>
 
-    value: T;
->value : T
+    f: (x: T) => void;
+>f : (x: T) => void
+>x : T
 }
 
-declare const y2: unknown;
->y2 : unknown
+declare const con_contravariant: unknown;
+>con_contravariant : unknown
 
-if (y2 instanceof ConstrainedOut) {
->y2 instanceof ConstrainedOut : boolean
->y2 : unknown
->ConstrainedOut : typeof ConstrainedOut
+if (con_contravariant instanceof ConstrainedContravariant) {
+>con_contravariant instanceof ConstrainedContravariant : boolean
+>con_contravariant : unknown
+>ConstrainedContravariant : typeof ConstrainedContravariant
 
-    y2.value++;
->y2.value++ : number
->y2.value : number
->y2 : ConstrainedOut<number>
->value : number
+    let never_covariant: ConstrainedContravariant<never> = con_contravariant;
+>never_covariant : ConstrainedContravariant<never>
+>con_contravariant : ConstrainedContravariant<string>
+
+    let any_covariant: ConstrainedContravariant<any> = con_contravariant;
+>any_covariant : ConstrainedContravariant<any>
+>con_contravariant : ConstrainedContravariant<string>
+
+    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;
+>constraint_covariant : ConstrainedContravariant<string>
+>con_contravariant : ConstrainedContravariant<string>
+
+    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;
+>sub_covariant : ConstrainedContravariant<"literal">
+>con_contravariant : ConstrainedContravariant<string>
 }
 
-class UnconstrainedInOut<in out T> {
->UnconstrainedInOut : UnconstrainedInOut<T>
+class UnconstrainedInvariant<in out T> {
+>UnconstrainedInvariant : UnconstrainedInvariant<T>
 
-    value: T;
->value : T
-
-    read: (value: T) => void;
->read : (value: T) => void
->value : T
+    f: (x: T) => T;
+>f : (x: T) => T
+>x : T
 }
 
-declare const x3: unknown;
->x3 : unknown
+declare const unc_invariant: unknown;
+>unc_invariant : unknown
 
-if (x3 instanceof UnconstrainedInOut) {
->x3 instanceof UnconstrainedInOut : boolean
->x3 : unknown
->UnconstrainedInOut : typeof UnconstrainedInOut
+if (unc_invariant instanceof UnconstrainedInvariant) {
+>unc_invariant instanceof UnconstrainedInvariant : boolean
+>unc_invariant : unknown
+>UnconstrainedInvariant : typeof UnconstrainedInvariant
 
-    x3.value.toUpperCase();
->x3.value.toUpperCase() : any
->x3.value.toUpperCase : any
->x3.value : unknown
->x3 : UnconstrainedInOut<unknown>
->value : unknown
->toUpperCase : any
+    let unknown_covariant: UnconstrainedInvariant<unknown> = unc_invariant;
+>unknown_covariant : UnconstrainedInvariant<unknown>
+>unc_invariant : UnconstrainedInvariant<unknown>
 
-    x3.value++;
->x3.value++ : number
->x3.value : unknown
->x3 : UnconstrainedInOut<unknown>
->value : unknown
+    let never_covariant: UnconstrainedInvariant<never> = unc_invariant;  // Error
+>never_covariant : UnconstrainedInvariant<never>
+>unc_invariant : UnconstrainedInvariant<unknown>
 
-    x3.value();
->x3.value() : any
->x3.value : unknown
->x3 : UnconstrainedInOut<unknown>
->value : unknown
+    let any_covariant: UnconstrainedInvariant<any> = unc_invariant;
+>any_covariant : UnconstrainedInvariant<any>
+>unc_invariant : UnconstrainedInvariant<unknown>
 
-    if (typeof x3.value === "string") {
->typeof x3.value === "string" : boolean
->typeof x3.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
->x3.value : unknown
->x3 : UnconstrainedInOut<unknown>
->value : unknown
->"string" : "string"
+    let constraint_covariant: UnconstrainedInvariant<string> = unc_invariant;  // Error
+>constraint_covariant : UnconstrainedInvariant<string>
+>unc_invariant : UnconstrainedInvariant<unknown>
 
-        x3.value.toUpperCase();
->x3.value.toUpperCase() : string
->x3.value.toUpperCase : () => string
->x3.value : string
->x3 : UnconstrainedInOut<unknown>
->value : string
->toUpperCase : () => string
-    }
-    if (typeof x3.value === "number") {
->typeof x3.value === "number" : boolean
->typeof x3.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
->x3.value : unknown
->x3 : UnconstrainedInOut<unknown>
->value : unknown
->"number" : "number"
-
-        x3.value++;
->x3.value++ : number
->x3.value : number
->x3 : UnconstrainedInOut<unknown>
->value : number
-    }
-
-    x3.read(1);
->x3.read(1) : void
->x3.read : (value: unknown) => void
->x3 : UnconstrainedInOut<unknown>
->read : (value: unknown) => void
->1 : 1
-
-    x3.read("foo");
->x3.read("foo") : void
->x3.read : (value: unknown) => void
->x3 : UnconstrainedInOut<unknown>
->read : (value: unknown) => void
->"foo" : "foo"
+    let sub_covariant: UnconstrainedInvariant<"literal"> = unc_invariant;  // Error
+>sub_covariant : UnconstrainedInvariant<"literal">
+>unc_invariant : UnconstrainedInvariant<unknown>
 }
 
-class ConstrainedInOut<in out T extends number> {
->ConstrainedInOut : ConstrainedInOut<T>
+class ConstrainedInvariant<in out T extends string> {
+>ConstrainedInvariant : ConstrainedInvariant<T>
 
-    value: T;
->value : T
-
-    read: (value: T) => void;
->read : (value: T) => void
->value : T
+    f: (x: T) => T;
+>f : (x: T) => T
+>x : T
 }
 
-declare const y3: unknown;
->y3 : unknown
+declare const con_invariant: unknown;
+>con_invariant : unknown
 
-if (y3 instanceof ConstrainedInOut) {
->y3 instanceof ConstrainedInOut : boolean
->y3 : unknown
->ConstrainedInOut : typeof ConstrainedInOut
+if (con_invariant instanceof ConstrainedInvariant) {
+>con_invariant instanceof ConstrainedInvariant : boolean
+>con_invariant : unknown
+>ConstrainedInvariant : typeof ConstrainedInvariant
 
-    y3.value++;
->y3.value++ : number
->y3.value : unknown
->y3 : ConstrainedInOut<unknown>
->value : unknown
+    let never_covariant: ConstrainedInvariant<never> = con_invariant;  // Error
+>never_covariant : ConstrainedInvariant<never>
+>con_invariant : ConstrainedInvariant<unknown>
 
-    y3.read(1);
->y3.read(1) : void
->y3.read : (value: unknown) => void
->y3 : ConstrainedInOut<unknown>
->read : (value: unknown) => void
->1 : 1
+    let any_covariant: ConstrainedInvariant<any> = con_invariant;
+>any_covariant : ConstrainedInvariant<any>
+>con_invariant : ConstrainedInvariant<unknown>
 
-    y3.read("foo");
->y3.read("foo") : void
->y3.read : (value: unknown) => void
->y3 : ConstrainedInOut<unknown>
->read : (value: unknown) => void
->"foo" : "foo"
+    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;  // Error
+>constraint_covariant : ConstrainedInvariant<string>
+>con_invariant : ConstrainedInvariant<unknown>
+
+    let sub_covariant: ConstrainedInvariant<"literal"> = con_invariant;  // Error
+>sub_covariant : ConstrainedInvariant<"literal">
+>con_invariant : ConstrainedInvariant<unknown>
 }
 

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.types
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.types
@@ -79,25 +79,25 @@ if (unc_contravariant instanceof UnconstrainedContravariant) {
 >unc_contravariant : unknown
 >UnconstrainedContravariant : typeof UnconstrainedContravariant
 
-    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;
+    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;  // Error
 >unknown_covariant : UnconstrainedContravariant<unknown>
->unc_contravariant : UnconstrainedContravariant<unknown>
+>unc_contravariant : UnconstrainedContravariant<never>
 
     let never_covariant: UnconstrainedContravariant<never> = unc_contravariant;
 >never_covariant : UnconstrainedContravariant<never>
->unc_contravariant : UnconstrainedContravariant<unknown>
+>unc_contravariant : UnconstrainedContravariant<never>
 
-    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;
+    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;  // Error
 >any_covariant : UnconstrainedContravariant<any>
->unc_contravariant : UnconstrainedContravariant<unknown>
+>unc_contravariant : UnconstrainedContravariant<never>
 
-    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;
+    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;  // Error
 >constraint_covariant : UnconstrainedContravariant<string>
->unc_contravariant : UnconstrainedContravariant<unknown>
+>unc_contravariant : UnconstrainedContravariant<never>
 
-    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;
+    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;  // Error
 >sub_covariant : UnconstrainedContravariant<"literal">
->unc_contravariant : UnconstrainedContravariant<unknown>
+>unc_contravariant : UnconstrainedContravariant<never>
 }
 
 class ConstrainedContravariant<in T extends string> {
@@ -118,19 +118,19 @@ if (con_contravariant instanceof ConstrainedContravariant) {
 
     let never_covariant: ConstrainedContravariant<never> = con_contravariant;
 >never_covariant : ConstrainedContravariant<never>
->con_contravariant : ConstrainedContravariant<string>
+>con_contravariant : ConstrainedContravariant<never>
 
-    let any_covariant: ConstrainedContravariant<any> = con_contravariant;
+    let any_covariant: ConstrainedContravariant<any> = con_contravariant;  // Error
 >any_covariant : ConstrainedContravariant<any>
->con_contravariant : ConstrainedContravariant<string>
+>con_contravariant : ConstrainedContravariant<never>
 
-    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;
+    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;  // Error
 >constraint_covariant : ConstrainedContravariant<string>
->con_contravariant : ConstrainedContravariant<string>
+>con_contravariant : ConstrainedContravariant<never>
 
-    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;
+    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;  // Error
 >sub_covariant : ConstrainedContravariant<"literal">
->con_contravariant : ConstrainedContravariant<string>
+>con_contravariant : ConstrainedContravariant<never>
 }
 
 class UnconstrainedInvariant<in out T> {
@@ -188,18 +188,18 @@ if (con_invariant instanceof ConstrainedInvariant) {
 
     let never_covariant: ConstrainedInvariant<never> = con_invariant;  // Error
 >never_covariant : ConstrainedInvariant<never>
->con_invariant : ConstrainedInvariant<unknown>
+>con_invariant : ConstrainedInvariant<string>
 
     let any_covariant: ConstrainedInvariant<any> = con_invariant;
 >any_covariant : ConstrainedInvariant<any>
->con_invariant : ConstrainedInvariant<unknown>
+>con_invariant : ConstrainedInvariant<string>
 
-    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;  // Error
+    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;
 >constraint_covariant : ConstrainedInvariant<string>
->con_invariant : ConstrainedInvariant<unknown>
+>con_invariant : ConstrainedInvariant<string>
 
     let sub_covariant: ConstrainedInvariant<"literal"> = con_invariant;  // Error
 >sub_covariant : ConstrainedInvariant<"literal">
->con_invariant : ConstrainedInvariant<unknown>
+>con_invariant : ConstrainedInvariant<string>
 }
 

--- a/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.types
+++ b/tests/baselines/reference/strictInstanceOfTypeParametersWithVarianceAnnotations.types
@@ -1,0 +1,277 @@
+=== tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts ===
+class UnconstrainedIn<in T> {
+>UnconstrainedIn : UnconstrainedIn<T>
+
+    read: (value: T) => void;
+>read : (value: T) => void
+>value : T
+}
+
+declare const x1: unknown;
+>x1 : unknown
+
+if (x1 instanceof UnconstrainedIn) {
+>x1 instanceof UnconstrainedIn : boolean
+>x1 : unknown
+>UnconstrainedIn : typeof UnconstrainedIn
+
+    x1.read(1);
+>x1.read(1) : void
+>x1.read : (value: unknown) => void
+>x1 : UnconstrainedIn<unknown>
+>read : (value: unknown) => void
+>1 : 1
+
+    x1.read("foo");
+>x1.read("foo") : void
+>x1.read : (value: unknown) => void
+>x1 : UnconstrainedIn<unknown>
+>read : (value: unknown) => void
+>"foo" : "foo"
+}
+
+class ConstrainedIn<in T extends number> {
+>ConstrainedIn : ConstrainedIn<T>
+
+    read: (value: T) => void;
+>read : (value: T) => void
+>value : T
+}
+
+declare const y1: unknown;
+>y1 : unknown
+
+if (y1 instanceof ConstrainedIn) {
+>y1 instanceof ConstrainedIn : boolean
+>y1 : unknown
+>ConstrainedIn : typeof ConstrainedIn
+
+    y1.read(1);
+>y1.read(1) : void
+>y1.read : (value: number) => void
+>y1 : ConstrainedIn<number>
+>read : (value: number) => void
+>1 : 1
+
+    y1.read("foo");
+>y1.read("foo") : void
+>y1.read : (value: number) => void
+>y1 : ConstrainedIn<number>
+>read : (value: number) => void
+>"foo" : "foo"
+}
+
+class UnconstrainedOut<out T> {
+>UnconstrainedOut : UnconstrainedOut<T>
+
+    value: T;
+>value : T
+}
+
+declare const x2: unknown;
+>x2 : unknown
+
+if (x2 instanceof UnconstrainedOut) {
+>x2 instanceof UnconstrainedOut : boolean
+>x2 : unknown
+>UnconstrainedOut : typeof UnconstrainedOut
+
+    x2.value.toUpperCase();
+>x2.value.toUpperCase() : any
+>x2.value.toUpperCase : any
+>x2.value : unknown
+>x2 : UnconstrainedOut<unknown>
+>value : unknown
+>toUpperCase : any
+
+    x2.value++;
+>x2.value++ : number
+>x2.value : unknown
+>x2 : UnconstrainedOut<unknown>
+>value : unknown
+
+    x2.value();
+>x2.value() : any
+>x2.value : unknown
+>x2 : UnconstrainedOut<unknown>
+>value : unknown
+
+    if (typeof x2.value === "string") {
+>typeof x2.value === "string" : boolean
+>typeof x2.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x2.value : unknown
+>x2 : UnconstrainedOut<unknown>
+>value : unknown
+>"string" : "string"
+
+        x2.value.toUpperCase();
+>x2.value.toUpperCase() : string
+>x2.value.toUpperCase : () => string
+>x2.value : string
+>x2 : UnconstrainedOut<unknown>
+>value : string
+>toUpperCase : () => string
+    }
+    if (typeof x2.value === "number") {
+>typeof x2.value === "number" : boolean
+>typeof x2.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x2.value : unknown
+>x2 : UnconstrainedOut<unknown>
+>value : unknown
+>"number" : "number"
+
+        x2.value++;
+>x2.value++ : number
+>x2.value : number
+>x2 : UnconstrainedOut<unknown>
+>value : number
+    }
+}
+
+class ConstrainedOut<out T extends number> {
+>ConstrainedOut : ConstrainedOut<T>
+
+    value: T;
+>value : T
+}
+
+declare const y2: unknown;
+>y2 : unknown
+
+if (y2 instanceof ConstrainedOut) {
+>y2 instanceof ConstrainedOut : boolean
+>y2 : unknown
+>ConstrainedOut : typeof ConstrainedOut
+
+    y2.value++;
+>y2.value++ : number
+>y2.value : number
+>y2 : ConstrainedOut<number>
+>value : number
+}
+
+class UnconstrainedInOut<in out T> {
+>UnconstrainedInOut : UnconstrainedInOut<T>
+
+    value: T;
+>value : T
+
+    read: (value: T) => void;
+>read : (value: T) => void
+>value : T
+}
+
+declare const x3: unknown;
+>x3 : unknown
+
+if (x3 instanceof UnconstrainedInOut) {
+>x3 instanceof UnconstrainedInOut : boolean
+>x3 : unknown
+>UnconstrainedInOut : typeof UnconstrainedInOut
+
+    x3.value.toUpperCase();
+>x3.value.toUpperCase() : any
+>x3.value.toUpperCase : any
+>x3.value : unknown
+>x3 : UnconstrainedInOut<unknown>
+>value : unknown
+>toUpperCase : any
+
+    x3.value++;
+>x3.value++ : number
+>x3.value : unknown
+>x3 : UnconstrainedInOut<unknown>
+>value : unknown
+
+    x3.value();
+>x3.value() : any
+>x3.value : unknown
+>x3 : UnconstrainedInOut<unknown>
+>value : unknown
+
+    if (typeof x3.value === "string") {
+>typeof x3.value === "string" : boolean
+>typeof x3.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x3.value : unknown
+>x3 : UnconstrainedInOut<unknown>
+>value : unknown
+>"string" : "string"
+
+        x3.value.toUpperCase();
+>x3.value.toUpperCase() : string
+>x3.value.toUpperCase : () => string
+>x3.value : string
+>x3 : UnconstrainedInOut<unknown>
+>value : string
+>toUpperCase : () => string
+    }
+    if (typeof x3.value === "number") {
+>typeof x3.value === "number" : boolean
+>typeof x3.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x3.value : unknown
+>x3 : UnconstrainedInOut<unknown>
+>value : unknown
+>"number" : "number"
+
+        x3.value++;
+>x3.value++ : number
+>x3.value : number
+>x3 : UnconstrainedInOut<unknown>
+>value : number
+    }
+
+    x3.read(1);
+>x3.read(1) : void
+>x3.read : (value: unknown) => void
+>x3 : UnconstrainedInOut<unknown>
+>read : (value: unknown) => void
+>1 : 1
+
+    x3.read("foo");
+>x3.read("foo") : void
+>x3.read : (value: unknown) => void
+>x3 : UnconstrainedInOut<unknown>
+>read : (value: unknown) => void
+>"foo" : "foo"
+}
+
+class ConstrainedInOut<in out T extends number> {
+>ConstrainedInOut : ConstrainedInOut<T>
+
+    value: T;
+>value : T
+
+    read: (value: T) => void;
+>read : (value: T) => void
+>value : T
+}
+
+declare const y3: unknown;
+>y3 : unknown
+
+if (y3 instanceof ConstrainedInOut) {
+>y3 instanceof ConstrainedInOut : boolean
+>y3 : unknown
+>ConstrainedInOut : typeof ConstrainedInOut
+
+    y3.value++;
+>y3.value++ : number
+>y3.value : unknown
+>y3 : ConstrainedInOut<unknown>
+>value : unknown
+
+    y3.read(1);
+>y3.read(1) : void
+>y3.read : (value: unknown) => void
+>y3 : ConstrainedInOut<unknown>
+>read : (value: unknown) => void
+>1 : 1
+
+    y3.read("foo");
+>y3.read("foo") : void
+>y3.read : (value: unknown) => void
+>y3 : ConstrainedInOut<unknown>
+>read : (value: unknown) => void
+>"foo" : "foo"
+}
+

--- a/tests/cases/compiler/strictInstanceOfTypeParameters.ts
+++ b/tests/cases/compiler/strictInstanceOfTypeParameters.ts
@@ -1,0 +1,38 @@
+// @strictInstanceOfTypeParameters: true
+
+class Unconstrained<T> {
+    value: T;
+    read: (value: T) => void;
+}
+
+declare const x: unknown;
+
+if (x instanceof Unconstrained) {
+    x.value.toUpperCase();
+    x.value++;
+    x.value();
+
+    if (typeof x.value === "string") {
+        x.value.toUpperCase();
+    }
+    if (typeof x.value === "number") {
+        x.value++;
+    }
+
+    x.read(1);
+    x.read("foo");
+}
+
+class Constrained<T extends number> {
+    value: T;
+    read: (value: T) => void;
+}
+
+declare const y: unknown;
+
+if (y instanceof Constrained) {
+    y.value++;
+
+    y.read(1);
+    y.read("foo");
+}

--- a/tests/cases/compiler/strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts
+++ b/tests/cases/compiler/strictInstanceOfTypeParametersFromPrivateNameInInExpression.ts
@@ -1,0 +1,25 @@
+// @strictInstanceOfTypeParameters: true
+// @target: es2015
+
+class UnconstrainedWithPrivate<T> {
+    #brand;
+    value: T;
+    constructor(value: T) {
+        this.value = value;
+    }
+    copyValue(other: object) {
+        if (#brand in other) {
+            this.value = other.value;
+        }
+    }
+}
+
+class ConstrainedWithPrivate<T extends string> {
+    #brand;
+    value: T;
+    copyValue(other: object) {
+        if (#brand in other) {
+            this.value = other.value;
+        }
+    }
+}

--- a/tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts
+++ b/tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts
@@ -1,89 +1,81 @@
 // @strictInstanceOfTypeParameters: true
 
-class UnconstrainedIn<in T> {
-    read: (value: T) => void;
+class UnconstrainedCovariant<out T> {
+    x: T;
 }
 
-declare const x1: unknown;
+declare const unc_covariant: unknown;
 
-if (x1 instanceof UnconstrainedIn) {
-    x1.read(1);
-    x1.read("foo");
+if (unc_covariant instanceof UnconstrainedCovariant) {
+    let unknown_covariant: UnconstrainedCovariant<unknown> = unc_covariant;
+    let never_covariant: UnconstrainedCovariant<never> = unc_covariant;  // Error
+    let any_covariant: UnconstrainedCovariant<any> = unc_covariant;
+    let sub_covariant: UnconstrainedCovariant<"literal"> = unc_covariant;  // Error
 }
 
-class ConstrainedIn<in T extends number> {
-    read: (value: T) => void;
+class ConstrainedCovariant<out T extends string> {
+    x: T;
 }
 
-declare const y1: unknown;
+declare const con_covariant: unknown;
 
-if (y1 instanceof ConstrainedIn) {
-    y1.read(1);
-    y1.read("foo");
+if (con_covariant instanceof ConstrainedCovariant) {
+    let never_covariant: ConstrainedCovariant<never> = con_covariant;  // Error
+    let any_covariant: ConstrainedCovariant<any> = con_covariant;
+    let constraint_covariant: ConstrainedCovariant<string> = con_covariant;
+    let sub_covariant: ConstrainedCovariant<"literal"> = con_covariant;  // Error
 }
 
-class UnconstrainedOut<out T> {
-    value: T;
+class UnconstrainedContravariant<in T> {
+    f: (x: T) => void;
 }
 
-declare const x2: unknown;
+declare const unc_contravariant: unknown;
 
-if (x2 instanceof UnconstrainedOut) {
-    x2.value.toUpperCase();
-    x2.value++;
-    x2.value();
-
-    if (typeof x2.value === "string") {
-        x2.value.toUpperCase();
-    }
-    if (typeof x2.value === "number") {
-        x2.value++;
-    }
+if (unc_contravariant instanceof UnconstrainedContravariant) {
+    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;
+    let never_covariant: UnconstrainedContravariant<never> = unc_contravariant;
+    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;
+    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;
+    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;
 }
 
-class ConstrainedOut<out T extends number> {
-    value: T;
+class ConstrainedContravariant<in T extends string> {
+    f: (x: T) => void;
 }
 
-declare const y2: unknown;
+declare const con_contravariant: unknown;
 
-if (y2 instanceof ConstrainedOut) {
-    y2.value++;
+if (con_contravariant instanceof ConstrainedContravariant) {
+    let never_covariant: ConstrainedContravariant<never> = con_contravariant;
+    let any_covariant: ConstrainedContravariant<any> = con_contravariant;
+    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;
+    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;
 }
 
-class UnconstrainedInOut<in out T> {
-    value: T;
-    read: (value: T) => void;
+class UnconstrainedInvariant<in out T> {
+    f: (x: T) => T;
 }
 
-declare const x3: unknown;
+declare const unc_invariant: unknown;
 
-if (x3 instanceof UnconstrainedInOut) {
-    x3.value.toUpperCase();
-    x3.value++;
-    x3.value();
-
-    if (typeof x3.value === "string") {
-        x3.value.toUpperCase();
-    }
-    if (typeof x3.value === "number") {
-        x3.value++;
-    }
-
-    x3.read(1);
-    x3.read("foo");
+if (unc_invariant instanceof UnconstrainedInvariant) {
+    let unknown_covariant: UnconstrainedInvariant<unknown> = unc_invariant;
+    let never_covariant: UnconstrainedInvariant<never> = unc_invariant;  // Error
+    let any_covariant: UnconstrainedInvariant<any> = unc_invariant;
+    let constraint_covariant: UnconstrainedInvariant<string> = unc_invariant;  // Error
+    let sub_covariant: UnconstrainedInvariant<"literal"> = unc_invariant;  // Error
 }
 
-class ConstrainedInOut<in out T extends number> {
-    value: T;
-    read: (value: T) => void;
+class ConstrainedInvariant<in out T extends string> {
+    f: (x: T) => T;
 }
 
-declare const y3: unknown;
+declare const con_invariant: unknown;
 
-if (y3 instanceof ConstrainedInOut) {
-    y3.value++;
-
-    y3.read(1);
-    y3.read("foo");
+if (con_invariant instanceof ConstrainedInvariant) {
+    let never_covariant: ConstrainedInvariant<never> = con_invariant;  // Error
+    let any_covariant: ConstrainedInvariant<any> = con_invariant;
+    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;  // Error
+    let sub_covariant: ConstrainedInvariant<"literal"> = con_invariant;  // Error
 }

--- a/tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts
+++ b/tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts
@@ -33,11 +33,11 @@ class UnconstrainedContravariant<in T> {
 declare const unc_contravariant: unknown;
 
 if (unc_contravariant instanceof UnconstrainedContravariant) {
-    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;
+    let unknown_covariant: UnconstrainedContravariant<unknown> = unc_contravariant;  // Error
     let never_covariant: UnconstrainedContravariant<never> = unc_contravariant;
-    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;
-    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;
-    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;
+    let any_covariant: UnconstrainedContravariant<any> = unc_contravariant;  // Error
+    let constraint_covariant: UnconstrainedContravariant<string> = unc_contravariant;  // Error
+    let sub_covariant: UnconstrainedContravariant<"literal"> = unc_contravariant;  // Error
 }
 
 class ConstrainedContravariant<in T extends string> {
@@ -48,9 +48,9 @@ declare const con_contravariant: unknown;
 
 if (con_contravariant instanceof ConstrainedContravariant) {
     let never_covariant: ConstrainedContravariant<never> = con_contravariant;
-    let any_covariant: ConstrainedContravariant<any> = con_contravariant;
-    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;
-    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;
+    let any_covariant: ConstrainedContravariant<any> = con_contravariant;  // Error
+    let constraint_covariant: ConstrainedContravariant<string> = con_contravariant;  // Error
+    let sub_covariant: ConstrainedContravariant<"literal"> = con_contravariant;  // Error
 }
 
 class UnconstrainedInvariant<in out T> {
@@ -76,6 +76,6 @@ declare const con_invariant: unknown;
 if (con_invariant instanceof ConstrainedInvariant) {
     let never_covariant: ConstrainedInvariant<never> = con_invariant;  // Error
     let any_covariant: ConstrainedInvariant<any> = con_invariant;
-    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;  // Error
+    let constraint_covariant: ConstrainedInvariant<string> = con_invariant;
     let sub_covariant: ConstrainedInvariant<"literal"> = con_invariant;  // Error
 }

--- a/tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts
+++ b/tests/cases/compiler/strictInstanceOfTypeParametersWithVarianceAnnotations.ts
@@ -1,0 +1,89 @@
+// @strictInstanceOfTypeParameters: true
+
+class UnconstrainedIn<in T> {
+    read: (value: T) => void;
+}
+
+declare const x1: unknown;
+
+if (x1 instanceof UnconstrainedIn) {
+    x1.read(1);
+    x1.read("foo");
+}
+
+class ConstrainedIn<in T extends number> {
+    read: (value: T) => void;
+}
+
+declare const y1: unknown;
+
+if (y1 instanceof ConstrainedIn) {
+    y1.read(1);
+    y1.read("foo");
+}
+
+class UnconstrainedOut<out T> {
+    value: T;
+}
+
+declare const x2: unknown;
+
+if (x2 instanceof UnconstrainedOut) {
+    x2.value.toUpperCase();
+    x2.value++;
+    x2.value();
+
+    if (typeof x2.value === "string") {
+        x2.value.toUpperCase();
+    }
+    if (typeof x2.value === "number") {
+        x2.value++;
+    }
+}
+
+class ConstrainedOut<out T extends number> {
+    value: T;
+}
+
+declare const y2: unknown;
+
+if (y2 instanceof ConstrainedOut) {
+    y2.value++;
+}
+
+class UnconstrainedInOut<in out T> {
+    value: T;
+    read: (value: T) => void;
+}
+
+declare const x3: unknown;
+
+if (x3 instanceof UnconstrainedInOut) {
+    x3.value.toUpperCase();
+    x3.value++;
+    x3.value();
+
+    if (typeof x3.value === "string") {
+        x3.value.toUpperCase();
+    }
+    if (typeof x3.value === "number") {
+        x3.value++;
+    }
+
+    x3.read(1);
+    x3.read("foo");
+}
+
+class ConstrainedInOut<in out T extends number> {
+    value: T;
+    read: (value: T) => void;
+}
+
+declare const y3: unknown;
+
+if (y3 instanceof ConstrainedInOut) {
+    y3.value++;
+
+    y3.read(1);
+    y3.read("foo");
+}

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressions.ts
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressions.ts
@@ -33,7 +33,7 @@ declare class C<T> {
 }
 
 function f3() {
-    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
     let f1 = C.f<string>;  // (x: string) => string[]
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

In JavaScript, there are several runtime checks that can determine if an object is an instance of a specific class. However, due to the fact that TypeScript type parameters only exist at the type level, there are limited options for how to handle these when building the class instance reference type. At the moment, there are two different approaches used by the two different kind of checks: one defaults to `any` and the other re-uses the type argument from the enclosing class. The first could be stricter and the second is possibly too strict in some cases.

The proposed change is to modify the way TypeScript handles these checks such that the type arguments are inferred as the constraint from the corresponding type parameter. This would default to `unknown` if no constraint was specified as that is the "default constraint".

### Fixes #17473 - Infer constrained generic parameters after instanceof check

For `instanceof` checks, TypeScript mirrors the underlying behavior of JavaScript and looks at the `Class.prototype` property. This property is computed dynamically in the checker and is then used to narrow the target of the `instanceof` expression. If the class in question has any type parameters, TypeScript returns a type reference where all of the type arguments are `any`. This is documented as being part of the "TypeScript 1.0 spec" so it is very long-standing behavior. The proposed change in behavior would constitute a breaking change as it would narrow some types from `any` to the constraint type or `unknown`.

```ts
class Box<T> { value: T }
Box.prototype; // changes from `Box<any>` to `Box<unknown>`
declare const box: any;
if (box instanceof Box) {
    box; // changes from `Box<any>` to `Box<unknown>`
}

class StringBox<T extends string> { value: T }
StringBox.prototype; // changes from `StringBox<any>` to `StringBox<string>`
declare const stringBox: any;
if (stringBox instanceof StringBox) {
    stringBox; // changes from `StringBox<any>` to `StringBox<string>`
}
```

### Fixes #46668 - Private field check narrows generic class too far

For `#brand in obj` checks, TypeScript can infer that if an object has a private identifier then it must be an instance of the enclosing class. If the class in question has any type parameters, TypeScript sets all of the type arguments of the inferred type to match the type arguments of `this` (see thread for potential issues). This behavior was only introduced recently via [ergonomic brand checks for private fields](https://github.com/microsoft/TypeScript/pull/44648). The proposed change in behavior is technically a breaking change, but less so than the `instanceof` check as in some cases it would loosen type arguments to match their constraint.

```ts
class PrivateBox<T> {
    #brand;
    value: T;
    copyValueFrom(other: object) {
        if (#brand in other) {
            other; // changes from `PrivateBox<T>` to `PrivateBox<unknown>`
        }
    }
}

class PrivateStringBox<T extends string> {
    #brand;
    value: T;
    copyValueFrom(other: object) {
        if (#brand in other) {
            other; // changes from `PrivateStringBox<T>` to `PrivateStringBox<string>`
        }
    }
}
```

## Breaking Changes

In order to deal with these breaking changes, this change should be gated behind a new strict compiler option `inferInstanceTypeArgumentsAsConstraint`. This would be similar to the `useUnknownInCatchVariables` option that narrowed catch variables from `any` to `unknown` ([#41013](https://github.com/microsoft/TypeScript/issues/41013)).

For individual instances of this issue, it should be possible to re-widen the narrowed type with a cast:
```ts
if (obj instanceof Box) {
    someCodeThatWorksWithAny(obj.value); // now fails with Box<unknown>
    someCodeThatWorksWithAny((obj as Box<any>).value);
}
```

*Addendum on Name:* I am aware that this new compiler option name is very verbose, and could potentially be improved. I considered something that referenced "runtime instance checks" but it's hard to include that verbiage in the name and not make it potentially confusing. (ex: Would someone see `strictRuntimeInstanceChecks` and then assume that it somehow changes runtime behavior?) Also considered `useConstraintAsDefaultInstanceTypeArgument` or `strictDefaultInstanceTypeArguments`.