### PR TITLE
feat(49358): [refactoring] Move to a new file should pick a name based on exported names rather than the first named thing encountered

### DIFF
--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -62,7 +62,7 @@ namespace ts.refactor {
 
         const currentDirectory = getDirectoryPath(oldFile.fileName);
         const extension = extensionFromPath(oldFile.fileName);
-        const newModuleName = makeUniqueModuleName(getNewModuleName(usage.movedSymbols), extension, currentDirectory, host);
+        const newModuleName = makeUniqueModuleName(getNewModuleName(usage.oldFileImportsFromNewFile, usage.movedSymbols), extension, currentDirectory, host);
         const newFileNameWithExtension = newModuleName + extension;
 
         // If previous file was global, this is easy.
@@ -478,8 +478,8 @@ namespace ts.refactor {
         }
     }
 
-    function getNewModuleName(movedSymbols: ReadonlySymbolSet): string {
-        return movedSymbols.forEachEntry(symbolNameNoDefault) || "newFile";
+    function getNewModuleName(importsFromNewFile: ReadonlySymbolSet, movedSymbols: ReadonlySymbolSet): string {
+        return importsFromNewFile.forEachEntry(symbolNameNoDefault) || movedSymbols.forEachEntry(symbolNameNoDefault) || "newFile";
     }
 
     interface UsageInfo {

--- a/tests/cases/fourslash/moveToNewFile_fileNameBasedOnExportedName.ts
+++ b/tests/cases/fourslash/moveToNewFile_fileNameBasedOnExportedName.ts
@@ -1,0 +1,39 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.ts
+////[|type Props = {
+////    a: number;
+////}
+////class Foo {
+////    readonly a: number;
+////    constructor({ a }: Props) {
+////        this.a = a;
+////    }
+////}|]
+////
+////export default function f() {
+////    return new Foo({ a: 1 });
+////}
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/a.ts":
+`import { Foo } from "./Foo";
+
+export default function f() {
+    return new Foo({ a: 1 });
+}`,
+
+        "/Foo.ts":
+`type Props = {
+    a: number;
+};
+export class Foo {
+    readonly a: number;
+    constructor({ a }: Props) {
+        this.a = a;
+    }
+}
+`,
+    },
+});


### PR DESCRIPTION
Fixes #49358