### PR TITLE
Reuse computed type of condition expressions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34108,7 +34108,7 @@ namespace ts {
                                 || isBinaryExpression(parent) && (parent.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken || parent.operatorToken.kind === SyntaxKind.BarBarToken)) {
                                 parent = parent.parent;
                             }
-                            checkTestingKnownTruthyCallableOrAwaitableType(node.left, isIfStatement(parent) ? parent.thenStatement : undefined);
+                            checkTestingKnownTruthyCallableOrAwaitableType(node.left, leftType, isIfStatement(parent) ? parent.thenStatement : undefined);
                         }
                         checkTruthinessOfType(leftType, node.left);
                     }
@@ -34692,8 +34692,8 @@ namespace ts {
         }
 
         function checkConditionalExpression(node: ConditionalExpression, checkMode?: CheckMode): Type {
-            checkTruthinessExpression(node.condition);
-            checkTestingKnownTruthyCallableOrAwaitableType(node.condition, node.whenTrue);
+            const type = checkTruthinessExpression(node.condition);
+            checkTestingKnownTruthyCallableOrAwaitableType(node.condition, type, node.whenTrue);
             const type1 = checkExpression(node.whenTrue, checkMode);
             const type2 = checkExpression(node.whenFalse, checkMode);
             return getUnionType([type1, type2], UnionReduction.Subtype);
@@ -38398,8 +38398,8 @@ namespace ts {
         function checkIfStatement(node: IfStatement) {
             // Grammar checking
             checkGrammarStatementInAmbientContext(node);
-            checkTruthinessExpression(node.expression);
-            checkTestingKnownTruthyCallableOrAwaitableType(node.expression, node.thenStatement);
+            const type = checkTruthinessExpression(node.expression);
+            checkTestingKnownTruthyCallableOrAwaitableType(node.expression, type, node.thenStatement);
             checkSourceElement(node.thenStatement);
 
             if (node.thenStatement.kind === SyntaxKind.EmptyStatement) {
@@ -38409,7 +38409,7 @@ namespace ts {
             checkSourceElement(node.elseStatement);
         }
 
-        function checkTestingKnownTruthyCallableOrAwaitableType(condExpr: Expression, body?: Statement | Expression) {
+        function checkTestingKnownTruthyCallableOrAwaitableType(condExpr: Expression, condType: Type, body?: Statement | Expression) {
             if (!strictNullChecks) return;
 
             helper(condExpr, body);
@@ -38424,7 +38424,7 @@ namespace ts {
                     ? condExpr.right
                     : condExpr;
                 if (isModuleExportsAccessExpression(location)) return;
-                const type = checkTruthinessExpression(location);
+                const type = location === condExpr ? condType : checkTruthinessExpression(location);
                 const isPropertyExpressionCast = isPropertyAccessExpression(location) && isTypeAssertion(location.expression);
                 if (!(getTypeFacts(type) & TypeFacts.Truthy) || isPropertyExpressionCast) return;
 

--- a/tests/baselines/reference/uncalledFunctionChecksInConditionalPerf.js
+++ b/tests/baselines/reference/uncalledFunctionChecksInConditionalPerf.js
@@ -1,0 +1,8 @@
+//// [uncalledFunctionChecksInConditionalPerf.ts]
+declare const b: boolean;
+
+((((((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b);
+
+
+//// [uncalledFunctionChecksInConditionalPerf.js]
+((((((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b);

--- a/tests/baselines/reference/uncalledFunctionChecksInConditionalPerf.symbols
+++ b/tests/baselines/reference/uncalledFunctionChecksInConditionalPerf.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/uncalledFunctionChecksInConditionalPerf.ts ===
+declare const b: boolean;
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+
+((((((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b);
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+>b : Symbol(b, Decl(uncalledFunctionChecksInConditionalPerf.ts, 0, 13))
+

--- a/tests/baselines/reference/uncalledFunctionChecksInConditionalPerf.types
+++ b/tests/baselines/reference/uncalledFunctionChecksInConditionalPerf.types
@@ -1,0 +1,83 @@
+=== tests/cases/compiler/uncalledFunctionChecksInConditionalPerf.ts ===
+declare const b: boolean;
+>b : boolean
+
+((((((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b);
+>((((((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>(((((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>(((((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>((((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>((((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>(((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>(((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>(((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>(((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>(((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>(((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>(((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>(((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>(((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>(((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>(((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>(((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>(((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>(((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>(((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>(((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>((((((((b) && b) && b) && b) && b) && b) && b) && b) && b : boolean
+>((((((((b) && b) && b) && b) && b) && b) && b) && b) : boolean
+>(((((((b) && b) && b) && b) && b) && b) && b) && b : boolean
+>(((((((b) && b) && b) && b) && b) && b) && b) : boolean
+>((((((b) && b) && b) && b) && b) && b) && b : boolean
+>((((((b) && b) && b) && b) && b) && b) : boolean
+>(((((b) && b) && b) && b) && b) && b : boolean
+>(((((b) && b) && b) && b) && b) : boolean
+>((((b) && b) && b) && b) && b : boolean
+>((((b) && b) && b) && b) : boolean
+>(((b) && b) && b) && b : boolean
+>(((b) && b) && b) : boolean
+>((b) && b) && b : boolean
+>((b) && b) : boolean
+>(b) && b : boolean
+>(b) : boolean
+>b : boolean
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+>b : true
+

--- a/tests/cases/compiler/uncalledFunctionChecksInConditionalPerf.ts
+++ b/tests/cases/compiler/uncalledFunctionChecksInConditionalPerf.ts
@@ -1,0 +1,5 @@
+// @strictNullChecks: true
+
+declare const b: boolean;
+
+((((((((((((((((((((((((((b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b) && b);


### PR DESCRIPTION
Fixes #49845

This change threads the computed type of conditional expressions into `checkTestingKnownTruthyCallableOrAwaitableType` to avoid recursively revisiting expression subtrees, resulting in an exponential performance drop. The changed code is similar to how it was before #42835.

The test case used to run in ~13s on my laptop before the fix, and now completes instantly again (check time reported as `0.00s`)