### PR TITLE
Allow some per file compiler options

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -285,7 +285,7 @@ namespace ts {
         return bindSourceFile;
 
         function bindInStrictMode(file: SourceFile, opts: CompilerOptions): boolean {
-            if (getStrictOptionValue(opts, "alwaysStrict") && !file.isDeclarationFile) {
+            if (getStrictOptionValue(file, opts, "alwaysStrict") && !file.isDeclarationFile) {
                 // bind in strict mode source files with alwaysStrict option
                 return true;
             }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -4,6 +4,7 @@ namespace ts {
         name: "compileOnSave",
         type: "boolean",
         defaultValueDescription: false,
+        category: Diagnostics.Editor_Support
     };
 
     const jsxOptionMap = new Map(getEntries({
@@ -163,6 +164,7 @@ namespace ts {
             type: "list",
             element: {
                 name: "excludeDirectory",
+                category: Diagnostics.Watch_and_Build_Modes,
                 type: "string",
                 isFilePath: true,
                 extraValidation: specToDiagnostic
@@ -175,6 +177,7 @@ namespace ts {
             type: "list",
             element: {
                 name: "excludeFile",
+                category: Diagnostics.Watch_and_Build_Modes,
                 type: "string",
                 isFilePath: true,
                 extraValidation: specToDiagnostic
@@ -185,7 +188,7 @@ namespace ts {
     ];
 
     /* @internal */
-    export const commonOptionsWithBuild: CommandLineOption[] = [
+    export const commonOptionsWithBuild = is<readonly CommandLineOption[]>()([
         {
             name: "help",
             shortName: "h",
@@ -200,6 +203,7 @@ namespace ts {
             shortName: "?",
             type: "boolean",
             defaultValueDescription: false,
+            category: Diagnostics.Command_line_Options,
         },
         {
             name: "watch",
@@ -314,10 +318,10 @@ namespace ts {
             description: Diagnostics.Set_the_language_of_the_messaging_from_TypeScript_This_does_not_affect_emit,
             defaultValueDescription: Diagnostics.Platform_specific
         },
-    ];
+    ] as const);
 
     /* @internal */
-    export const targetOptionDeclaration: CommandLineOptionOfCustomType = {
+    export const targetOptionDeclaration = is<CommandLineOptionOfCustomType>()({
         name: "target",
         shortName: "t",
         type: new Map(getEntries({
@@ -343,10 +347,10 @@ namespace ts {
         category: Diagnostics.Language_and_Environment,
         description: Diagnostics.Set_the_JavaScript_language_version_for_emitted_JavaScript_and_include_compatible_library_declarations,
         defaultValueDescription: ScriptTarget.ES3,
-    };
+    } as const);
 
     /*@internal*/
-    export const moduleOptionDeclaration: CommandLineOptionOfCustomType = {
+    export const moduleOptionDeclaration = is<CommandLineOptionOfCustomType>()({
         name: "module",
         shortName: "m",
         type: new Map(getEntries({
@@ -371,9 +375,9 @@ namespace ts {
         category: Diagnostics.Modules,
         description: Diagnostics.Specify_what_module_code_is_generated,
         defaultValueDescription: undefined,
-    };
+    });
 
-    const commandOptionsWithoutBuild: CommandLineOption[] = [
+    const commandOptionsWithoutBuild = is<readonly CommandLineOption[]>()([
         // CommandLine only options
         {
             name: "all",
@@ -449,6 +453,7 @@ namespace ts {
             element: {
                 name: "lib",
                 type: libMap,
+                category: Diagnostics.Language_and_Environment,
                 defaultValueDescription: undefined,
             },
             affectsProgramStructure: true,
@@ -668,6 +673,7 @@ namespace ts {
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Enable_all_strict_type_checking_options,
             defaultValueDescription: false,
+            allowedAsPragma: true,
         },
         {
             name: "noImplicitAny",
@@ -677,7 +683,8 @@ namespace ts {
             strictFlag: true,
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Enable_error_reporting_for_expressions_and_declarations_with_an_implied_any_type,
-            defaultValueDescription: Diagnostics.false_unless_strict_is_set
+            defaultValueDescription: Diagnostics.false_unless_strict_is_set,
+            allowedAsPragma: true,
         },
         {
             name: "strictNullChecks",
@@ -687,7 +694,8 @@ namespace ts {
             strictFlag: true,
             category: Diagnostics.Type_Checking,
             description: Diagnostics.When_type_checking_take_into_account_null_and_undefined,
-            defaultValueDescription: Diagnostics.false_unless_strict_is_set
+            defaultValueDescription: Diagnostics.false_unless_strict_is_set,
+            allowedAsPragma: true,
         },
         {
             name: "strictFunctionTypes",
@@ -697,7 +705,8 @@ namespace ts {
             strictFlag: true,
             category: Diagnostics.Type_Checking,
             description: Diagnostics.When_assigning_functions_check_to_ensure_parameters_and_the_return_values_are_subtype_compatible,
-            defaultValueDescription: Diagnostics.false_unless_strict_is_set
+            defaultValueDescription: Diagnostics.false_unless_strict_is_set,
+            allowedAsPragma: true,
         },
         {
             name: "strictBindCallApply",
@@ -707,7 +716,8 @@ namespace ts {
             strictFlag: true,
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Check_that_the_arguments_for_bind_call_and_apply_methods_match_the_original_function,
-            defaultValueDescription: Diagnostics.false_unless_strict_is_set
+            defaultValueDescription: Diagnostics.false_unless_strict_is_set,
+            allowedAsPragma: true,
         },
         {
             name: "strictPropertyInitialization",
@@ -717,7 +727,8 @@ namespace ts {
             strictFlag: true,
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Check_for_class_properties_that_are_declared_but_not_set_in_the_constructor,
-            defaultValueDescription: Diagnostics.false_unless_strict_is_set
+            defaultValueDescription: Diagnostics.false_unless_strict_is_set,
+            allowedAsPragma: true,
         },
         {
             name: "noImplicitThis",
@@ -727,7 +738,8 @@ namespace ts {
             strictFlag: true,
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Enable_error_reporting_when_this_is_given_the_type_any,
-            defaultValueDescription: Diagnostics.false_unless_strict_is_set
+            defaultValueDescription: Diagnostics.false_unless_strict_is_set,
+            allowedAsPragma: true,
         },
         {
             name: "useUnknownInCatchVariables",
@@ -738,6 +750,7 @@ namespace ts {
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Default_catch_clause_variables_as_unknown_instead_of_any,
             defaultValueDescription: false,
+            allowedAsPragma: true,
         },
         {
             name: "alwaysStrict",
@@ -748,7 +761,8 @@ namespace ts {
             strictFlag: true,
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Ensure_use_strict_is_always_emitted,
-            defaultValueDescription: Diagnostics.false_unless_strict_is_set
+            defaultValueDescription: Diagnostics.false_unless_strict_is_set,
+            allowedAsPragma: true,
         },
 
         // Additional Checks
@@ -760,6 +774,7 @@ namespace ts {
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Enable_error_reporting_when_local_variables_aren_t_read,
             defaultValueDescription: false,
+            allowedAsPragma: true,
         },
         {
             name: "noUnusedParameters",
@@ -769,6 +784,7 @@ namespace ts {
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Raise_an_error_when_a_function_parameter_isn_t_read,
             defaultValueDescription: false,
+            allowedAsPragma: true,
         },
         {
             name: "exactOptionalPropertyTypes",
@@ -778,6 +794,7 @@ namespace ts {
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Interpret_optional_property_types_as_written_rather_than_adding_undefined,
             defaultValueDescription: false,
+            allowedAsPragma: true,
         },
         {
             name: "noImplicitReturns",
@@ -787,6 +804,7 @@ namespace ts {
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Enable_error_reporting_for_codepaths_that_do_not_explicitly_return_in_a_function,
             defaultValueDescription: false,
+            allowedAsPragma: true,
         },
         {
             name: "noFallthroughCasesInSwitch",
@@ -797,6 +815,7 @@ namespace ts {
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Enable_error_reporting_for_fallthrough_cases_in_switch_statements,
             defaultValueDescription: false,
+            allowedAsPragma: true,
         },
         {
             name: "noUncheckedIndexedAccess",
@@ -806,6 +825,7 @@ namespace ts {
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Add_undefined_to_a_type_when_accessed_using_an_index,
             defaultValueDescription: false,
+            allowedAsPragma: true,
         },
         {
             name: "noImplicitOverride",
@@ -815,6 +835,7 @@ namespace ts {
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Ensure_overriding_members_in_derived_classes_are_marked_with_an_override_modifier,
             defaultValueDescription: false,
+            allowedAsPragma: true,
         },
         {
             name: "noPropertyAccessFromIndexSignature",
@@ -825,6 +846,7 @@ namespace ts {
             category: Diagnostics.Type_Checking,
             description: Diagnostics.Enforces_using_indexed_accessors_for_keys_declared_using_an_indexed_type,
             defaultValueDescription: false,
+            allowedAsPragma: true,
         },
 
         // Module Resolution
@@ -870,6 +892,7 @@ namespace ts {
             element: {
                 name: "rootDirs",
                 type: "string",
+                category: Diagnostics.Modules,
                 isFilePath: true
             },
             affectsModuleResolution: true,
@@ -884,6 +907,7 @@ namespace ts {
             element: {
                 name: "typeRoots",
                 type: "string",
+                category: Diagnostics.Modules,
                 isFilePath: true
             },
             affectsModuleResolution: true,
@@ -895,6 +919,7 @@ namespace ts {
             type: "list",
             element: {
                 name: "types",
+                category: Diagnostics.Modules,
                 type: "string"
             },
             affectsProgramStructure: true,
@@ -944,6 +969,7 @@ namespace ts {
             type: "list",
             element: {
                 name: "suffix",
+                category: Diagnostics.Modules,
                 type: "string",
             },
             listPreserveFalsyValues: true,
@@ -1334,6 +1360,7 @@ namespace ts {
             isTSConfigOnly: true,
             element: {
                 name: "plugin",
+                category: Diagnostics.Editor_Support,
                 type: "object"
             },
             description: Diagnostics.Specify_a_list_of_language_service_plugins_to_include,
@@ -1352,37 +1379,123 @@ namespace ts {
             category: Diagnostics.Language_and_Environment,
             defaultValueDescription: Diagnostics.auto_Colon_Treat_files_with_imports_exports_import_meta_jsx_with_jsx_Colon_react_jsx_or_esm_format_with_module_Colon_node16_as_modules,
         }
-    ];
+    ] as const);
 
     /* @internal */
-    export const optionDeclarations: CommandLineOption[] = [
+    export const optionDeclarations = is<readonly CommandLineOption[]>()([
         ...commonOptionsWithBuild,
         ...commandOptionsWithoutBuild,
-    ];
+    ] as const);
+
+    type WithTrue<T, K extends keyof T> = T extends unknown ? K extends unknown ? T[K] extends true ? T : never : never : never;
+
+    function isAffectsSemanticDiagnosticsOption<T extends CommandLineOption>(option: T): option is WithTrue<T, "affectsSemanticDiagnostics"> {
+        return !!option.affectsSemanticDiagnostics;
+    }
 
     /* @internal */
-    export const semanticDiagnosticsOptionDeclarations: readonly CommandLineOption[] =
-        optionDeclarations.filter(option => !!option.affectsSemanticDiagnostics);
+    export const semanticDiagnosticsOptionDeclarations = optionDeclarations.filter(isAffectsSemanticDiagnosticsOption);
+
+    function isAffectsEmitOption<T extends CommandLineOption>(option: T): option is WithTrue<T, "affectsEmit"> {
+        return !!option.affectsEmit;
+    }
 
     /* @internal */
-    export const affectsEmitOptionDeclarations: readonly CommandLineOption[] =
-        optionDeclarations.filter(option => !!option.affectsEmit);
+    export const affectsEmitOptionDeclarations = optionDeclarations.filter(isAffectsEmitOption);
+
+    function isAffectsDeclarationPathOption<T extends CommandLineOption>(option: T): option is WithTrue<T, "affectsDeclarationPath"> {
+        return !!option.affectsDeclarationPath;
+    }
 
     /* @internal */
-    export const affectsDeclarationPathOptionDeclarations: readonly CommandLineOption[] =
-        optionDeclarations.filter(option => !!option.affectsDeclarationPath);
+    export const affectsDeclarationPathOptionDeclarations = optionDeclarations.filter(isAffectsDeclarationPathOption);
+
+    function isAffectsModuleResolutionOption<T extends CommandLineOption>(option: T): option is WithTrue<T, "affectsModuleResolution"> {
+        return !!option.affectsModuleResolution;
+    }
 
     /* @internal */
-    export const moduleResolutionOptionDeclarations: readonly CommandLineOption[] =
-        optionDeclarations.filter(option => !!option.affectsModuleResolution);
+    export const moduleResolutionOptionDeclarations = optionDeclarations.filter(isAffectsModuleResolutionOption);
+
+    function isSourceFileAffectingOptions<T extends CommandLineOption>(option: T): option is WithTrue<T, "affectsSourceFile" | "affectsModuleResolution" | "affectsBindDiagnostics"> {
+        return !!option.affectsSourceFile || !!option.affectsModuleResolution || !!option.affectsBindDiagnostics;
+    }
 
     /* @internal */
-    export const sourceFileAffectingCompilerOptions: readonly CommandLineOption[] = optionDeclarations.filter(option =>
-        !!option.affectsSourceFile || !!option.affectsModuleResolution || !!option.affectsBindDiagnostics);
+    export const sourceFileAffectingCompilerOptions = optionDeclarations.filter(isSourceFileAffectingOptions);
+
+    function isAffectsProgramStructureOption<T extends CommandLineOption>(option: T): option is WithTrue<T, "affectsProgramStructure"> {
+        return !!option.affectsProgramStructure;
+    }
 
     /* @internal */
-    export const optionsAffectingProgramStructure: readonly CommandLineOption[] =
-        optionDeclarations.filter(option => !!option.affectsProgramStructure);
+    export const optionsAffectingProgramStructure = optionDeclarations.filter(isAffectsProgramStructureOption);
+
+    function isAllowedAsPragmaOption<T extends CommandLineOption>(option: T): option is WithTrue<T, "allowedAsPragma"> {
+        return !!option.allowedAsPragma;
+    }
+
+    /* @internal */
+    export const optionsAllowedAsPragmaOption = optionDeclarations.filter(isAllowedAsPragmaOption);
+
+    /* @internal */
+    type CompilerOptionsIntoPragmaDefinitions<T extends CommandLineOption> = UnionToIntersection<T extends unknown ? {[K in T["name"] & string as `ts-${K}`]: { readonly kind: PragmaKindFlags, readonly args: readonly [{ readonly name: "value", readonly optional: true }] }} : never>;
+
+    function convertCompilerOptionsIntoPragmasSpecs<T extends readonly CommandLineOption[]>(options: T): CompilerOptionsIntoPragmaDefinitions<T[number]> {
+        const result = {} as CompilerOptionsIntoPragmaDefinitions<T[number]>;
+        for (const elem of options) {
+            result[`ts-${elem.name}` as keyof typeof result] = {
+                args: [{ name: "value", optional: true }],
+                kind: PragmaKindFlags.SingleLine | PragmaKindFlags.MultiLine
+            } as any;
+        }
+        return result;
+    }
+
+    /* @internal */
+    export const commentPragmas = {
+        "reference": {
+            args: [
+                { name: "types", optional: true, captureSpan: true },
+                { name: "lib", optional: true, captureSpan: true },
+                { name: "path", optional: true, captureSpan: true },
+                { name: "no-default-lib", optional: true },
+                { name: "resolution-mode", optional: true }
+            ],
+            kind: PragmaKindFlags.TripleSlashXML
+        },
+        "amd-dependency": {
+            args: [{ name: "path" }, { name: "name", optional: true }],
+            kind: PragmaKindFlags.TripleSlashXML
+        },
+        "amd-module": {
+            args: [{ name: "name" }],
+            kind: PragmaKindFlags.TripleSlashXML
+        },
+        "ts-check": {
+            kind: PragmaKindFlags.SingleLine
+        },
+        "ts-nocheck": {
+            kind: PragmaKindFlags.SingleLine
+        },
+        "jsx": {
+            args: [{ name: "factory" }],
+            kind: PragmaKindFlags.MultiLine
+        },
+        "jsxfrag": {
+            args: [{ name: "factory" }],
+            kind: PragmaKindFlags.MultiLine
+        },
+        "jsximportsource": {
+            args: [{ name: "factory" }],
+            kind: PragmaKindFlags.MultiLine
+        },
+        "jsxruntime": {
+            args: [{ name: "factory" }],
+            kind: PragmaKindFlags.MultiLine
+        },
+        ...convertCompilerOptionsIntoPragmasSpecs(optionsAllowedAsPragmaOption)
+    } as const;
 
     /* @internal */
     export const transpileOptionValueCompilerOptions: readonly CommandLineOption[] = optionDeclarations.filter(option =>
@@ -1438,11 +1551,13 @@ namespace ts {
              */
             name: "enableAutoDiscovery",
             type: "boolean",
+            category: Diagnostics.File_Management,
             defaultValueDescription: false,
         },
         {
             name: "enable",
             type: "boolean",
+            category: Diagnostics.File_Management,
             defaultValueDescription: false,
         },
         {
@@ -1450,20 +1565,25 @@ namespace ts {
             type: "list",
             element: {
                 name: "include",
+                category: Diagnostics.File_Management,
                 type: "string"
-            }
+            },
+            category: Diagnostics.File_Management,
         },
         {
             name: "exclude",
             type: "list",
             element: {
                 name: "exclude",
+                category: Diagnostics.File_Management,
                 type: "string"
-            }
+            },
+            category: Diagnostics.File_Management,
         },
         {
             name: "disableFilenameBasedTypeAcquisition",
             type: "boolean",
+            category: Diagnostics.File_Management,
             defaultValueDescription: false,
         },
     ];
@@ -1977,30 +2097,35 @@ namespace ts {
             _tsconfigRootOptions = {
                 name: undefined!, // should never be needed since this is root
                 type: "object",
+                category: Diagnostics.Command_line_Options,
                 elementOptions: commandLineOptionsToMap([
                     {
                         name: "compilerOptions",
                         type: "object",
                         elementOptions: getCommandLineCompilerOptionsMap(),
                         extraKeyDiagnostics: compilerOptionsDidYouMeanDiagnostics,
+                        category: Diagnostics.Command_line_Options,
                     },
                     {
                         name: "watchOptions",
                         type: "object",
                         elementOptions: getCommandLineWatchOptionsMap(),
                         extraKeyDiagnostics: watchOptionsDidYouMeanDiagnostics,
+                        category: Diagnostics.Command_line_Options,
                     },
                     {
                         name: "typingOptions",
                         type: "object",
                         elementOptions: getCommandLineTypeAcquisitionMap(),
                         extraKeyDiagnostics: typeAcquisitionDidYouMeanDiagnostics,
+                        category: Diagnostics.Command_line_Options,
                     },
                     {
                         name: "typeAcquisition",
                         type: "object",
                         elementOptions: getCommandLineTypeAcquisitionMap(),
-                        extraKeyDiagnostics: typeAcquisitionDidYouMeanDiagnostics
+                        extraKeyDiagnostics: typeAcquisitionDidYouMeanDiagnostics,
+                        category: Diagnostics.Command_line_Options,
                     },
                     {
                         name: "extends",
@@ -2012,6 +2137,7 @@ namespace ts {
                         type: "list",
                         element: {
                             name: "references",
+                            category: Diagnostics.Projects,
                             type: "object"
                         },
                         category: Diagnostics.Projects,
@@ -2021,6 +2147,7 @@ namespace ts {
                         type: "list",
                         element: {
                             name: "files",
+                            category: Diagnostics.File_Management,
                             type: "string"
                         },
                         category: Diagnostics.File_Management,
@@ -2030,6 +2157,7 @@ namespace ts {
                         type: "list",
                         element: {
                             name: "include",
+                            category: Diagnostics.File_Management,
                             type: "string"
                         },
                         category: Diagnostics.File_Management,
@@ -2040,6 +2168,7 @@ namespace ts {
                         type: "list",
                         element: {
                             name: "exclude",
+                            category: Diagnostics.File_Management,
                             type: "string"
                         },
                         category: Diagnostics.File_Management,
@@ -2583,7 +2712,7 @@ namespace ts {
                 const { category } = option;
 
                 if (isAllowedOptionForOutput(option)) {
-                    categorizedOptions.add(getLocaleSpecificMessage(category!), option);
+                    categorizedOptions.add(getLocaleSpecificMessage(category), option);
                 }
             }
 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1444,12 +1444,12 @@ namespace ts {
     export const optionsAllowedAsPragmaOption = optionDeclarations.filter(isAllowedAsPragmaOption);
 
     /* @internal */
-    type CompilerOptionsIntoPragmaDefinitions<T extends CommandLineOption> = UnionToIntersection<T extends unknown ? {[K in T["name"] & string as `ts-${K}`]: { readonly kind: PragmaKindFlags, readonly args: readonly [{ readonly name: "value", readonly optional: true }] }} : never>;
+    type CompilerOptionsIntoPragmaDefinitions<T extends CommandLineOption> = UnionToIntersection<T extends unknown ? {[K in T["name"] & string as `ts-${Lowercase<K>}`]: { readonly kind: PragmaKindFlags, readonly args: readonly [{ readonly name: "value", readonly optional: true }] }} : never>;
 
     function convertCompilerOptionsIntoPragmasSpecs<T extends readonly CommandLineOption[]>(options: T): CompilerOptionsIntoPragmaDefinitions<T[number]> {
         const result = {} as CompilerOptionsIntoPragmaDefinitions<T[number]>;
         for (const elem of options) {
-            result[`ts-${elem.name}` as keyof typeof result] = {
+            result[`ts-${elem.name.toLowerCase()}` as keyof typeof result] = {
                 args: [{ name: "value", optional: true }],
                 kind: PragmaKindFlags.SingleLine | PragmaKindFlags.MultiLine
             } as any;

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1431,6 +1431,11 @@ namespace ts {
     /* @internal */
     export const optionsAffectingProgramStructure = optionDeclarations.filter(isAffectsProgramStructureOption);
 
+    /* @internal */
+    export function isStrictOption<T extends CommandLineOption>(option: T): option is WithTrue<T, "strictFlag"> {
+        return !!option.strictFlag === true;
+    }
+
     function isAllowedAsPragmaOption<T extends CommandLineOption>(option: T): option is WithTrue<T, "allowedAsPragma"> {
         return !!option.allowedAsPragma;
     }
@@ -1790,10 +1795,11 @@ namespace ts {
         }
     }
 
-    function parseOptionValue(
+    /* @internal */
+    export function parseOptionValue(
         args: readonly string[],
         i: number,
-        diagnostics: ParseCommandLineWorkerDiagnostics,
+        diagnostics: ParseCommandLineWorkerDiagnostics | undefined,
         opt: CommandLineOption,
         options: OptionsBase,
         errors: Diagnostic[]
@@ -1821,7 +1827,7 @@ namespace ts {
         }
         else {
             // Check to see if no argument was provided (e.g. "--locale" is the last command-line argument).
-            if (!args[i] && opt.type !== "boolean") {
+            if (!args[i] && opt.type !== "boolean" && diagnostics) {
                 errors.push(createCompilerDiagnostic(diagnostics.optionTypeMismatchDiagnostic, opt.name, getCompilerOptionValueTypeString(opt)));
             }
 

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2104,7 +2104,7 @@ namespace ts {
      *        (0.4 allows 1 substitution/transposition for every 5 characters,
      *         and 1 insertion/deletion at 3 characters)
      */
-    export function getSpellingSuggestion<T>(name: string, candidates: T[], getName: (candidate: T) => string | undefined): T | undefined {
+    export function getSpellingSuggestion<T>(name: string, candidates: readonly T[], getName: (candidate: T) => string | undefined): T | undefined {
         const maximumLengthDifference = Math.min(2, Math.floor(name.length * 0.34));
         let bestDistance = Math.floor(name.length * 0.4) + 1; // If the best result is worse than this, don't bother.
         let bestCandidate: T | undefined;
@@ -2509,5 +2509,9 @@ namespace ts {
             end--;
         }
         return s.slice(0, end + 1);
+    }
+
+    export function is<T>(): <U extends T>(arg: U) => U {
+        return identity;
     }
 }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -9642,29 +9642,29 @@ namespace ts {
                     break;
                 }
                 case "ts-strict":
-                case "ts-noImplicitAny":
-                case "ts-strictNullChecks":
-                case "ts-strictFunctionTypes":
-                case "ts-strictBindCallApply":
-                case "ts-noImplicitThis":
-                case "ts-strictPropertyInitialization":
-                case "ts-useUnknownInCatchVariables":
-                case "ts-alwaysStrict":
-                case "ts-noUnusedLocals":
-                case "ts-noUnusedParameters":
-                case "ts-exactOptionalPropertyTypes":
-                case "ts-noPropertyAccessFromIndexSignature":
-                case "ts-noImplicitReturns":
-                case "ts-noFallthroughCasesInSwitch":
-                case "ts-noUncheckedIndexedAccess":
-                case "ts-noImplicitOverride": {
+                case "ts-noimplicitany":
+                case "ts-strictnullchecks":
+                case "ts-strictfunctiontypes":
+                case "ts-strictbindcallapply":
+                case "ts-noimplicitthis":
+                case "ts-strictpropertyinitialization":
+                case "ts-useunknownincatchvariables":
+                case "ts-alwaysstrict":
+                case "ts-nounusedlocals":
+                case "ts-nounusedparameters":
+                case "ts-exactoptionalpropertytypes":
+                case "ts-nopropertyaccessfromindexsignature":
+                case "ts-noimplicitreturns":
+                case "ts-nofallthroughcasesinswitch":
+                case "ts-nouncheckedindexedaccess":
+                case "ts-noimplicitoverride": {
                     const optName = key.slice(3);
-                    const opt = find(optionsAllowedAsPragmaOption, o => o.name === optName)!;
+                    const opt = find(optionsAllowedAsPragmaOption, o => o.name.toLowerCase() === optName)!;
                     const entry = (isArray(entryOrList) ? last(entryOrList) : entryOrList);
-                    const unparsedValue = (entry.arguments as PragmaArgumentType<`ts-${FileLocalOptionName}`>).value;
+                    const unparsedValue = (entry.arguments as PragmaArgumentType<`ts-${Lowercase<FileLocalOptionName>}`>).value;
                     const optContainer: OptionsBase = {};
                     const errors: Diagnostic[] = []
-                    const parsedValue = unparsedValue === undefined ? true : (parseOptionValue([unparsedValue], 0, /*diagnostics*/ undefined, opt, optContainer, errors), optContainer[unparsedValue]);
+                    const parsedValue = unparsedValue === undefined ? true : (parseOptionValue([unparsedValue], 0, /*diagnostics*/ undefined, opt, optContainer, errors), optContainer[opt.name]);
                     if (unparsedValue === undefined && opt.type !== "boolean") {
                         errors.push(createCompilerDiagnostic(Diagnostics.Compiler_option_0_expects_an_argument, optName));
                     }
@@ -9679,7 +9679,7 @@ namespace ts {
                         });
                     }
                     if (!length(errors)) {
-                        (context.localOptions ??= {})[optName] = parsedValue;
+                        (context.localOptions ??= {})[opt.name as string] = parsedValue;
                     }
                 }
                 case "jsx":

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -9643,8 +9643,16 @@ namespace ts {
                 case "jsxfrag":
                 case "jsximportsource":
                 case "jsxruntime":
+                case "ts-strict":
+                case "ts-noImplicitAny":
+                case "ts-strictNullChecks":
+                case "ts-strictFunctionTypes":
+                case "ts-strictBindCallApply":
+                case "ts-strictProeprtyInitialization":
+                case "ts-noImplicitThis":
+                
                     return; // Accessed directly
-                default: Debug.fail("Unhandled pragma kind"); // Can this be made into an assertNever in the future?
+                default: Debug.assertNever(key, `Unhandled pragma kind: ${key}`);
             }
         });
     }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3259,7 +3259,7 @@ namespace ts {
                     // Don't add the file if it has a bad extension (e.g. 'tsx' if we don't have '--allowJs')
                     // This may still end up being an untyped module -- the file won't be included but imports will be allowed.
                     const shouldAddFile = resolvedFileName
-                        && !getResolutionDiagnostic(optionsForFile, resolution)
+                        && !getResolutionDiagnostic(file, optionsForFile, resolution)
                         && !optionsForFile.noResolve
                         && index < file.imports.length
                         && !elideImport
@@ -3361,10 +3361,10 @@ namespace ts {
         }
 
         function verifyCompilerOptions() {
-            if (options.strictPropertyInitialization && !getStrictOptionValue(options, "strictNullChecks")) {
+            if (options.strictPropertyInitialization && !getStrictOptionValue(/*file*/ undefined, options, "strictNullChecks")) {
                 createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_without_specifying_option_1, "strictPropertyInitialization", "strictNullChecks");
             }
-            if (options.exactOptionalPropertyTypes && !getStrictOptionValue(options, "strictNullChecks")) {
+            if (options.exactOptionalPropertyTypes && !getStrictOptionValue(/*file*/ undefined, options, "strictNullChecks")) {
                 createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_without_specifying_option_1, "exactOptionalPropertyTypes", "strictNullChecks");
             }
 
@@ -3493,7 +3493,7 @@ namespace ts {
                 createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "lib", "noLib");
             }
 
-            if (options.noImplicitUseStrict && getStrictOptionValue(options, "alwaysStrict")) {
+            if (options.noImplicitUseStrict && getStrictOptionValue(/*file*/undefined, options, "alwaysStrict")) {
                 createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "noImplicitUseStrict", "alwaysStrict");
             }
 
@@ -4293,7 +4293,7 @@ namespace ts {
      * The DiagnosticMessage's parameters are the imported module name, and the filename it resolved to.
      * This returns a diagnostic even if the module will be an untyped module.
      */
-    export function getResolutionDiagnostic(options: CompilerOptions, { extension }: ResolvedModuleFull): DiagnosticMessage | undefined {
+    export function getResolutionDiagnostic(file: SourceFile, options: CompilerOptions, { extension }: ResolvedModuleFull): DiagnosticMessage | undefined {
         switch (extension) {
             case Extension.Ts:
             case Extension.Dts:
@@ -4313,7 +4313,7 @@ namespace ts {
             return options.jsx ? undefined : Diagnostics.Module_0_was_resolved_to_1_but_jsx_is_not_set;
         }
         function needAllowJs() {
-            return getAllowJSCompilerOption(options) || !getStrictOptionValue(options, "noImplicitAny") ? undefined : Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type;
+            return getAllowJSCompilerOption(options) || !getStrictOptionValue(file, options, "noImplicitAny") ? undefined : Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type;
         }
         function needResolveJsonModule() {
             return options.resolveJsonModule ? undefined : Diagnostics.Module_0_was_resolved_to_1_but_resolveJsonModule_is_not_used;

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -93,7 +93,7 @@ namespace ts {
             startLexicalEnvironment();
 
             const statements: Statement[] = [];
-            const ensureUseStrict = getStrictOptionValue(compilerOptions, "alwaysStrict") || (!compilerOptions.noImplicitUseStrict && isExternalModule(currentSourceFile));
+            const ensureUseStrict = getStrictOptionValue(node, compilerOptions, "alwaysStrict") || (!compilerOptions.noImplicitUseStrict && isExternalModule(currentSourceFile));
             const statementOffset = factory.copyPrologue(node.statements, statements, ensureUseStrict && !isJsonSourceFile(node), topLevelVisitor);
 
             if (shouldEmitUnderscoreUnderscoreESModule()) {

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -222,7 +222,7 @@ namespace ts {
             startLexicalEnvironment();
 
             // Add any prologue directives.
-            const ensureUseStrict = getStrictOptionValue(compilerOptions, "alwaysStrict") || (!compilerOptions.noImplicitUseStrict && isExternalModule(currentSourceFile));
+            const ensureUseStrict = getStrictOptionValue(node, compilerOptions, "alwaysStrict") || (!compilerOptions.noImplicitUseStrict && isExternalModule(currentSourceFile));
             const statementOffset = factory.copyPrologue(node.statements, statements, ensureUseStrict, topLevelVisitor);
 
             // var __moduleName = context_1 && context_1.id;

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -574,7 +574,7 @@ namespace ts {
         }
 
         function visitSourceFile(node: SourceFile) {
-            const alwaysStrict = getStrictOptionValue(compilerOptions, "alwaysStrict") &&
+            const alwaysStrict = getStrictOptionValue(node, compilerOptions, "alwaysStrict") &&
                 !(isExternalModule(node) && moduleKind >= ModuleKind.ES2015) &&
                 !isJsonSourceFile(node);
 

--- a/src/compiler/transformers/typeSerializer.ts
+++ b/src/compiler/transformers/typeSerializer.ts
@@ -63,7 +63,6 @@ namespace ts {
         const resolver = context.getEmitResolver();
         const compilerOptions = context.getCompilerOptions();
         const languageVersion = getEmitScriptTarget(compilerOptions);
-        const strictNullChecks = getStrictOptionValue(compilerOptions, "strictNullChecks");
 
         let currentLexicalScope: SourceFile | CaseBlock | ModuleBlock | Block;
         let currentNameScope: ClassLikeDeclaration | undefined;
@@ -344,7 +343,7 @@ namespace ts {
                     return factory.createIdentifier("Object"); // Reduce to `any` in a union or intersection
                 }
 
-                if (!strictNullChecks && ((isLiteralTypeNode(typeNode) && typeNode.literal.kind === SyntaxKind.NullKeyword) || typeNode.kind === SyntaxKind.UndefinedKeyword)) {
+                if (!getStrictOptionValue(getSourceFileOfNode(currentLexicalScope), compilerOptions, "strictNullChecks") && ((isLiteralTypeNode(typeNode) && typeNode.literal.kind === SyntaxKind.NullKeyword) || typeNode.kind === SyntaxKind.UndefinedKeyword)) {
                     continue; // Elide null and undefined from unions for metadata, just like what we did prior to the implementation of strict null checks
                 }
 

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -188,7 +188,7 @@ namespace ts {
     function getCompilerOptionsOfBuildOptions(buildOptions: BuildOptions): CompilerOptions {
         const result = {} as CompilerOptions;
         commonOptionsWithBuild.forEach(option => {
-            if (hasProperty(buildOptions, option.name)) result[option.name] = buildOptions[option.name];
+            if (hasProperty(buildOptions, option.name)) result[option.name as string] = buildOptions[option.name];
         });
         return result;
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3857,6 +3857,7 @@ namespace ts {
         /* @internal */ checkJsDirective?: CheckJsDirective;
         /* @internal */ version: string;
         /* @internal */ pragmas: ReadonlyPragmaMap;
+        /* @internal */ localOptions?: CompilerOptions;
         /* @internal */ localJsxNamespace?: __String;
         /* @internal */ localJsxFragmentNamespace?: __String;
         /* @internal */ localJsxFactory?: EntityName;
@@ -8887,7 +8888,7 @@ namespace ts {
      * Maps a pragma definition into the desired shape for its arguments object
      */
     /* @internal */
-    type PragmaArgumentType<KPrag extends keyof ConcretePragmaSpecs> =
+    export type PragmaArgumentType<KPrag extends keyof ConcretePragmaSpecs> =
         ConcretePragmaSpecs[KPrag] extends { args: readonly PragmaArgumentSpecification<any>[] }
             ? UnionToIntersection<ArgumentDefinitionToFieldUnion<ConcretePragmaSpecs[KPrag]["args"]>>
             : never;

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -82,7 +82,7 @@ namespace ts {
         // Sort our options by their names, (e.g. "--noImplicitAny" comes before "--watch")
         return !!commandLine.options.all ?
             sort(optionDeclarations, (a, b) => compareStringsCaseInsensitive(a.name, b.name)) :
-            filter(optionDeclarations.slice(), v => !!v.showInSimplifiedHelpView);
+            filter(optionDeclarations.slice(), v => !!(v as CommandLineOption).showInSimplifiedHelpView);
     }
 
     function printVersion(sys: System) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -157,7 +157,7 @@ namespace ts.server {
         [name: string]: { match: RegExp, exclude?: (string | number)[][], types?: string[] };
     }
 
-    function prepareConvertersForEnumLikeCompilerOptions(commandLineOptions: CommandLineOption[]): ESMap<string, ESMap<string, number>> {
+    function prepareConvertersForEnumLikeCompilerOptions(commandLineOptions: readonly CommandLineOption[]): ESMap<string, ESMap<string, number>> {
         const map = new Map<string, ESMap<string, number>>();
         for (const option of commandLineOptions) {
             if (typeof option.type === "object") {

--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -125,7 +125,7 @@ namespace ts {
     export function fixupCompilerOptions(options: CompilerOptions, diagnostics: Diagnostic[]): CompilerOptions {
         // Lazily create this value to fix module loading errors.
         commandLineOptionsStringToEnum = commandLineOptionsStringToEnum ||
-            filter(optionDeclarations, o => typeof o.type === "object" && !forEachEntry(o.type, v => typeof v !== "number")) as CommandLineOptionOfCustomType[];
+            filter(optionDeclarations, o => typeof o.type === "object" && !forEachEntry((o as CommandLineOptionOfCustomType).type, v => typeof v !== "number")) as CommandLineOptionOfCustomType[];
 
         options = cloneCompilerOptions(options);
 


### PR DESCRIPTION
In this PR, we allow certain compiler options to be configured via comments within a file for the scope of that file. This means you can write, for example:
```ts
// @ts-noImplicitAny

const cb = a => a + 1; // issues an implicit `any` error on `a`
```


Fixes #31035

I've wanted to look into this since I originally added the generic pragma-parsing infrastructure for `@ts-check` and related comments.

To start, I'm aiming to allow every compiler option in the "Strictness" category as a per-file configurable option. That way you can toss a `// @ts-strict` into a (potentially javascript) file and get strict mode checking in it. Currently in this PR, every option in that category is supported except for `strictNullChecks` and `exactOptionalPropertyTypes` - they do some global type-identity configuration that's taking me a bit longer to abstract away into a per-file configuration. (Also `strictNullChecks` just straight up is referenced more than any other compiler option.)

To start off the discussion, in the linked issue, @RyanCavanaugh asked:
>  It's not really even clear what this means - if you have a type declared in file A, another type in file B, and you try to relate them in file C, whose value of strictFunctionTypes is in play?

Currently in this PR, whichever is stricter. If either file the types originated from has it set, it's related strictly. Could go the other way and relate loosely if either is explicitly non-strict if looser checking is more preferable. Honestly, _most_ of these "which context controls the flag" already have fairly canonical answers, either because we already look up a context to check JS-y-ness (for JS-file-specific-behaviors or error ignoring), or to issue an error in (in which case the error node location is a pretty logical context).

Anyways, I'm hoping this implementation can jumpstart discussion on the value of in-file pragmas for compiler options, specifically with the goal of bikeshedding the syntax and what options we should ultimately expose on a per-file basis. (Technically, I've tried to make the internal APIs for adding new per-file pragmas very type-safe and very easy to use.)

TODO list:
- [ ] File-local support for `strictNullChecks`
- [ ] File-local support for `exactOptionalPropertyTypes`
- [ ] Errors on conflicting file-local options/redeclarations (silently uses the last declaration and silently discards invalid arguments right now)
- [ ] Copious testing (thus far I've just been prototyping in a sample project)