### PR TITLE
Fixed closing JSDoc when adding multiple blocks

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -357,8 +357,12 @@ namespace ts.JsDoc {
         }
 
         const { commentOwner, parameters, hasReturn } = commentOwnerInfo;
-        const commentOwnerJSDoc = hasJSDocNodes(commentOwner) && commentOwner.jsDoc ? lastOrUndefined(commentOwner.jsDoc) : undefined;
-        if (commentOwner.getStart(sourceFile) < position || commentOwnerJSDoc && commentOwnerJSDoc !== existingDocComment) {
+        const commentOwnerJsDoc = hasJSDocNodes(commentOwner) && commentOwner.jsDoc ? commentOwner.jsDoc : undefined;
+        const lastJsDoc = lastOrUndefined(commentOwnerJsDoc);
+        if (commentOwner.getStart(sourceFile) < position
+            || lastJsDoc
+                && existingDocComment
+                && lastJsDoc !== existingDocComment) {
             return undefined;
         }
 
@@ -378,7 +382,18 @@ namespace ts.JsDoc {
         // * if the caret was directly in front of the object, then we add an extra line and indentation.
         const openComment = "/**";
         const closeComment = " */";
-        if (tags) {
+        
+        // If any of the existing jsDoc has tags, ignore adding new ones.
+        let hasTag = false;
+        for (let jsDoc of commentOwnerJsDoc || []) {
+            if (jsDoc.tags) {
+                hasTag = true;
+                break;
+            }
+        }
+
+
+        if (tags && !hasTag) {
             const preamble = openComment + newLine + indentationStr + " * ";
             const endLine = tokenStart === position ? newLine + indentationStr : "";
             const result = preamble + newLine + tags + indentationStr + closeComment + endLine;

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -382,10 +382,10 @@ namespace ts.JsDoc {
         // * if the caret was directly in front of the object, then we add an extra line and indentation.
         const openComment = "/**";
         const closeComment = " */";
-        
+
         // If any of the existing jsDoc has tags, ignore adding new ones.
         let hasTag = false;
-        for (let jsDoc of commentOwnerJsDoc || []) {
+        for (const jsDoc of commentOwnerJsDoc || []) {
             if (jsDoc.tags) {
                 hasTag = true;
                 break;

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -386,7 +386,6 @@ namespace ts.JsDoc {
         // If any of the existing jsDoc has tags, ignore adding new ones.
         const hasTag = (commentOwnerJsDoc || []).some(jsDoc => !!jsDoc.tags);
 
-
         if (tags && !hasTag) {
             const preamble = openComment + newLine + indentationStr + " * ";
             const endLine = tokenStart === position ? newLine + indentationStr : "";

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -384,13 +384,7 @@ namespace ts.JsDoc {
         const closeComment = " */";
 
         // If any of the existing jsDoc has tags, ignore adding new ones.
-        let hasTag = false;
-        for (const jsDoc of commentOwnerJsDoc || []) {
-            if (jsDoc.tags) {
-                hasTag = true;
-                break;
-            }
-        }
+        const hasTag = (commentOwnerJsDoc || []).some(jsDoc => !!jsDoc.tags);
 
 
         if (tags && !hasTag) {

--- a/tests/cases/fourslash/docCommentTemplateWithMultipleJSDoc.ts
+++ b/tests/cases/fourslash/docCommentTemplateWithMultipleJSDoc.ts
@@ -1,0 +1,7 @@
+/// <reference path='fourslash.ts' />
+
+/////** */
+/////*/**/
+////function foo() {}
+
+verify.docCommentTemplateAt("", 3, "/** */");

--- a/tests/cases/fourslash/docCommentTemplateWithMultipleJSDocAndParameters.ts
+++ b/tests/cases/fourslash/docCommentTemplateWithMultipleJSDocAndParameters.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts' />
+
+/////** */
+/////**
+//// * 
+//// * @param p 
+//// */
+/////** */
+/////*/**/
+////function foo(p) {}
+
+verify.docCommentTemplateAt("", 3, "/** */");


### PR DESCRIPTION
Fixes autocompletion of JSDocs when multiple blocks are present.

i.e. 
```ts
/** */
/**|
function foo() {}
```
Before the PR, the second block does not autocomplete. After the PR the scenario is working now.