### PR TITLE
Allow more jumps within if statements when extracting functions

### DIFF
--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -231,6 +231,7 @@ namespace ts.refactor.extractSymbol {
          * The range is in a function which needs the 'static' modifier in a class
          */
         InStaticRegion = 1 << 5,
+        InLoop = 1 << 6
     }
 
     /**
@@ -551,7 +552,9 @@ namespace ts.refactor.extractSymbol {
                 const savedPermittedJumps = permittedJumps;
                 switch (node.kind) {
                     case SyntaxKind.IfStatement:
-                        permittedJumps = PermittedJumps.None;
+                        if (!(rangeFacts & RangeFacts.InLoop)) {
+                            permittedJumps = PermittedJumps.None;
+                        }
                         break;
                     case SyntaxKind.TryStatement:
                         // forbid all jumps inside try blocks
@@ -572,6 +575,7 @@ namespace ts.refactor.extractSymbol {
                         if (isIterationStatement(node, /*lookInLabeledStatements*/ false)) {
                             // allow unlabeled break/continue inside loops
                             permittedJumps |= PermittedJumps.Break | PermittedJumps.Continue;
+                            rangeFacts |= RangeFacts.InLoop;
                         }
                         break;
                 }

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -231,7 +231,6 @@ namespace ts.refactor.extractSymbol {
          * The range is in a function which needs the 'static' modifier in a class
          */
         InStaticRegion = 1 << 5,
-        InLoop = 1 << 6
     }
 
     /**
@@ -552,9 +551,7 @@ namespace ts.refactor.extractSymbol {
                 const savedPermittedJumps = permittedJumps;
                 switch (node.kind) {
                     case SyntaxKind.IfStatement:
-                        if (!(rangeFacts & RangeFacts.InLoop)) {
-                            permittedJumps = PermittedJumps.None;
-                        }
+                        permittedJumps &= ~PermittedJumps.Return;
                         break;
                     case SyntaxKind.TryStatement:
                         // forbid all jumps inside try blocks
@@ -575,7 +572,6 @@ namespace ts.refactor.extractSymbol {
                         if (isIterationStatement(node, /*lookInLabeledStatements*/ false)) {
                             // allow unlabeled break/continue inside loops
                             permittedJumps |= PermittedJumps.Break | PermittedJumps.Continue;
-                            rangeFacts |= RangeFacts.InLoop;
                         }
                         break;
                 }

--- a/tests/cases/fourslash/extract-method45.ts
+++ b/tests/cases/fourslash/extract-method45.ts
@@ -1,0 +1,54 @@
+/// <reference path="fourslash.ts" />
+
+////export function fn(m: number) {
+////    const mode = m >= 0 ? "a" : "b";
+////    let result: number = 0;
+////
+////    if (mode === "a") {
+////        /*a*/for (let i = 0; i < 10; i++) {
+////            const rand = Math.random();
+////            if (rand > 0.5) {
+////                result = rand;
+////                break;
+////            }
+////        }/*b*/
+////    }
+////    else {
+////        result = 0;
+////    }
+////
+////    return result;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "function_scope_1",
+    actionDescription: "Extract to function in module scope",
+    newContent:
+`export function fn(m: number) {
+    const mode = m >= 0 ? "a" : "b";
+    let result: number = 0;
+
+    if (mode === "a") {
+        result = /*RENAME*/newFunction(result);
+    }
+    else {
+        result = 0;
+    }
+
+    return result;
+}
+
+function newFunction(result: number) {
+    for (let i = 0; i < 10; i++) {
+        const rand = Math.random();
+        if (rand > 0.5) {
+            result = rand;
+            break;
+        }
+    }
+    return result;
+}
+`
+});

--- a/tests/cases/fourslash/extract-method46.ts
+++ b/tests/cases/fourslash/extract-method46.ts
@@ -1,0 +1,54 @@
+/// <reference path="fourslash.ts" />
+
+////export function fn(m: number, n: number) {
+////    const mode = m >= 0 ? "a" : "b";
+////    let result: number = 0;
+////
+////    if (mode === "a") {
+////        /*a*/for (let i = 0; i < n; i++) {
+////            const rand = Math.random();
+////            if (rand > 0.5) {
+////                result = rand;
+////                break;
+////            }
+////        }/*b*/
+////    }
+////    else {
+////        result = 0;
+////    }
+////
+////    return result;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "function_scope_1",
+    actionDescription: "Extract to function in module scope",
+    newContent:
+`export function fn(m: number, n: number) {
+    const mode = m >= 0 ? "a" : "b";
+    let result: number = 0;
+
+    if (mode === "a") {
+        result = /*RENAME*/newFunction(n, result);
+    }
+    else {
+        result = 0;
+    }
+
+    return result;
+}
+
+function newFunction(n: number, result: number) {
+    for (let i = 0; i < n; i++) {
+        const rand = Math.random();
+        if (rand > 0.5) {
+            result = rand;
+            break;
+        }
+    }
+    return result;
+}
+`
+});


### PR DESCRIPTION
Old: Disallow all jumps
New: Disallow only returns (permissibility of break and continue is determined by surrounding nodes)
    
Fixes #49838
Inspiration and tests from #49840