### PR TITLE
Use cache for program creation on watch mode

### DIFF
--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -440,7 +440,11 @@ namespace ts {
 
             // All resolutions are invalid if user provided resolutions
             const hasInvalidatedResolution = resolutionCache.createHasInvalidatedResolution(userProvidedResolution);
-            if (isProgramUptoDate(getCurrentProgram(), rootFileNames, compilerOptions, getSourceVersion, fileExists, hasInvalidatedResolution, hasChangedAutomaticTypeDirectiveNames, getParsedCommandLine, projectReferences)) {
+            const {
+                originalReadFile, originalFileExists, originalDirectoryExists,
+                originalCreateDirectory, originalWriteFile,
+            } = changeCompilerHostLikeToUseCache(compilerHost, toPath);
+            if (isProgramUptoDate(getCurrentProgram(), rootFileNames, compilerOptions, getSourceVersion, fileName => compilerHost.fileExists(fileName), hasInvalidatedResolution, hasChangedAutomaticTypeDirectiveNames, getParsedCommandLine, projectReferences)) {
                 if (hasChangedConfigFileParsingErrors) {
                     if (reportFileChangeDetectedOnCreateProgram) {
                         reportWatchDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation);
@@ -457,10 +461,15 @@ namespace ts {
             }
 
             reportFileChangeDetectedOnCreateProgram = false;
-
             if (host.afterProgramCreate && program !== builderProgram) {
                 host.afterProgramCreate(builderProgram);
             }
+
+            compilerHost.readFile = originalReadFile;
+            compilerHost.fileExists = originalFileExists;
+            compilerHost.directoryExists = originalDirectoryExists;
+            compilerHost.createDirectory = originalCreateDirectory;
+            compilerHost.writeFile = originalWriteFile!;
 
             return builderProgram;
         }


### PR DESCRIPTION
This change is similar to change #48980 for `tsc --watch`
