### PR TITLE
fixAddMissingMemberTruncation

### DIFF
--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -514,7 +514,7 @@ namespace ts.codefix {
         }
         if (type.flags & TypeFlags.EnumLike) {
             const enumMember = type.symbol.exports ? firstOrUndefined(arrayFrom(type.symbol.exports.values())) : type.symbol;
-            const name = checker.symbolToExpression(type.symbol.parent ? type.symbol.parent : type.symbol, SymbolFlags.Value, /*enclosingDeclaration*/ undefined, /*flags*/ undefined);
+            const name = checker.symbolToExpression(type.symbol.parent ? type.symbol.parent : type.symbol, SymbolFlags.Value, /*enclosingDeclaration*/ undefined, /*flags*/ NodeBuilderFlags.NoTruncation);
             return enumMember === undefined || name === undefined ? factory.createNumericLiteral(0) : factory.createPropertyAccessExpression(name, checker.symbolToString(enumMember));
         }
         if (type.flags & TypeFlags.NumberLiteral) {


### PR DESCRIPTION
One of the checker function calls was missing the NodeBuilderFlags which was interfering with the successful application of quick fixes by ts-fix.