### PR TITLE
Resolve parsingContextErrors TODO

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1497,6 +1497,10 @@
         "category": "Error",
         "code": 1477
     },
+    "Identifier or string literal expected.": {
+        "category": "Error",
+        "code": 1478
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2780,7 +2780,9 @@ namespace ts {
                 case ParsingContext.ImportOrExportSpecifiers: return parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
                 case ParsingContext.JsxAttributes: return parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
                 case ParsingContext.JsxChildren: return parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
-                default: return [undefined!]; // TODO: GH#18217 `default: Debug.assertNever(context);`
+                case ParsingContext.AssertEntries: return parseErrorAtCurrentToken(Diagnostics.Identifier_or_string_literal_expected); // AssertionKey.
+                case ParsingContext.Count: return Debug.fail("ParsingContext.Count used as a context"); // Not a real context, only a marker.
+                default: Debug.assertNever(context);
             }
         }
 

--- a/tests/baselines/reference/parseAssertEntriesError.errors.txt
+++ b/tests/baselines/reference/parseAssertEntriesError.errors.txt
@@ -1,5 +1,5 @@
 /index.ts(2,7): error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
-/index.ts(2,32): error TS1005: '}' expected.
+/index.ts(2,32): error TS1478: Identifier or string literal expected.
 /index.ts(2,32): error TS2695: Left side of comma operator is unused and has no side effects.
 /index.ts(2,55): error TS1005: ';' expected.
 /index.ts(2,66): error TS1128: Declaration or statement expected.
@@ -10,7 +10,7 @@
 /index.ts(3,36): error TS1005: ':' expected.
 /index.ts(3,70): error TS2339: Property 'ImportInterface' does not exist on type 'Promise<{ default: typeof import("/node_modules/pkg/import"); }>'.
 /index.ts(5,34): error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
-/index.ts(5,59): error TS1005: '}' expected.
+/index.ts(5,59): error TS1478: Identifier or string literal expected.
 /index.ts(5,59): error TS2695: Left side of comma operator is unused and has no side effects.
 /index.ts(5,82): error TS1005: ';' expected.
 /index.ts(5,93): error TS1128: Declaration or statement expected.
@@ -21,7 +21,7 @@
 /index.ts(5,98): error TS2304: Cannot find name 'RequireInterface'.
 /index.ts(5,114): error TS1128: Declaration or statement expected.
 /index.ts(6,34): error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
-/index.ts(6,59): error TS1005: '}' expected.
+/index.ts(6,59): error TS1478: Identifier or string literal expected.
 /index.ts(6,59): error TS2695: Left side of comma operator is unused and has no side effects.
 /index.ts(6,82): error TS1005: ';' expected.
 /index.ts(6,92): error TS1128: Declaration or statement expected.
@@ -39,9 +39,7 @@
           ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
                                    ~~~~
-!!! error TS1005: '}' expected.
-!!! related TS1007 /index.ts:2:31: The parser expected to find a '}' to match the '{' token here.
-!!! related TS1007 /index.ts:2:21: The parser expected to find a '}' to match the '{' token here.
+!!! error TS1478: Identifier or string literal expected.
                                    ~~~~
 !!! error TS2695: Left side of comma operator is unused and has no side effects.
                                                           ~
@@ -66,9 +64,7 @@
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
                                                               ~~~~
-!!! error TS1005: '}' expected.
-!!! related TS1007 /index.ts:5:58: The parser expected to find a '}' to match the '{' token here.
-!!! related TS1007 /index.ts:5:48: The parser expected to find a '}' to match the '{' token here.
+!!! error TS1478: Identifier or string literal expected.
                                                               ~~~~
 !!! error TS2695: Left side of comma operator is unused and has no side effects.
                                                                                      ~
@@ -91,9 +87,7 @@
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
                                                               ~~~~
-!!! error TS1005: '}' expected.
-!!! related TS1007 /index.ts:6:58: The parser expected to find a '}' to match the '{' token here.
-!!! related TS1007 /index.ts:6:48: The parser expected to find a '}' to match the '{' token here.
+!!! error TS1478: Identifier or string literal expected.
                                                               ~~~~
 !!! error TS2695: Left side of comma operator is unused and has no side effects.
                                                                                      ~

--- a/tests/baselines/reference/parseAssertEntriesError.errors.txt
+++ b/tests/baselines/reference/parseAssertEntriesError.errors.txt
@@ -1,0 +1,128 @@
+/index.ts(2,7): error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
+/index.ts(2,32): error TS1005: '}' expected.
+/index.ts(2,32): error TS2695: Left side of comma operator is unused and has no side effects.
+/index.ts(2,55): error TS1005: ';' expected.
+/index.ts(2,66): error TS1128: Declaration or statement expected.
+/index.ts(2,68): error TS1128: Declaration or statement expected.
+/index.ts(2,69): error TS1128: Declaration or statement expected.
+/index.ts(2,70): error TS1128: Declaration or statement expected.
+/index.ts(2,71): error TS2304: Cannot find name 'RequireInterface'.
+/index.ts(3,36): error TS1005: ':' expected.
+/index.ts(3,70): error TS2339: Property 'ImportInterface' does not exist on type 'Promise<{ default: typeof import("/node_modules/pkg/import"); }>'.
+/index.ts(5,34): error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
+/index.ts(5,59): error TS1005: '}' expected.
+/index.ts(5,59): error TS2695: Left side of comma operator is unused and has no side effects.
+/index.ts(5,82): error TS1005: ';' expected.
+/index.ts(5,93): error TS1128: Declaration or statement expected.
+/index.ts(5,95): error TS1128: Declaration or statement expected.
+/index.ts(5,96): error TS1128: Declaration or statement expected.
+/index.ts(5,97): error TS1128: Declaration or statement expected.
+/index.ts(5,98): error TS1434: Unexpected keyword or identifier.
+/index.ts(5,98): error TS2304: Cannot find name 'RequireInterface'.
+/index.ts(5,114): error TS1128: Declaration or statement expected.
+/index.ts(6,34): error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
+/index.ts(6,59): error TS1005: '}' expected.
+/index.ts(6,59): error TS2695: Left side of comma operator is unused and has no side effects.
+/index.ts(6,82): error TS1005: ';' expected.
+/index.ts(6,92): error TS1128: Declaration or statement expected.
+/index.ts(6,94): error TS1128: Declaration or statement expected.
+/index.ts(6,95): error TS1128: Declaration or statement expected.
+/index.ts(6,96): error TS1128: Declaration or statement expected.
+/index.ts(6,97): error TS1434: Unexpected keyword or identifier.
+/index.ts(6,97): error TS2304: Cannot find name 'ImportInterface'.
+/index.ts(6,112): error TS1128: Declaration or statement expected.
+
+
+==== /index.ts (33 errors) ====
+    export type LocalInterface =
+        & import("pkg", { assert: {1234, "resolution-mode": "require"} }).RequireInterface
+          ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
+                                   ~~~~
+!!! error TS1005: '}' expected.
+!!! related TS1007 /index.ts:2:31: The parser expected to find a '}' to match the '{' token here.
+!!! related TS1007 /index.ts:2:21: The parser expected to find a '}' to match the '{' token here.
+                                   ~~~~
+!!! error TS2695: Left side of comma operator is unused and has no side effects.
+                                                          ~
+!!! error TS1005: ';' expected.
+                                                                     ~
+!!! error TS1128: Declaration or statement expected.
+                                                                       ~
+!!! error TS1128: Declaration or statement expected.
+                                                                        ~
+!!! error TS1128: Declaration or statement expected.
+                                                                         ~
+!!! error TS1128: Declaration or statement expected.
+                                                                          ~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'RequireInterface'.
+        & import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface;
+                                       ~
+!!! error TS1005: ':' expected.
+                                                                         ~~~~~~~~~~~~~~~
+!!! error TS2339: Property 'ImportInterface' does not exist on type 'Promise<{ default: typeof import("/node_modules/pkg/import"); }>'.
+    
+    export const a = (null as any as import("pkg", { assert: {1234, "resolution-mode": "require"} }).RequireInterface);
+                                     ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
+                                                              ~~~~
+!!! error TS1005: '}' expected.
+!!! related TS1007 /index.ts:5:58: The parser expected to find a '}' to match the '{' token here.
+!!! related TS1007 /index.ts:5:48: The parser expected to find a '}' to match the '{' token here.
+                                                              ~~~~
+!!! error TS2695: Left side of comma operator is unused and has no side effects.
+                                                                                     ~
+!!! error TS1005: ';' expected.
+                                                                                                ~
+!!! error TS1128: Declaration or statement expected.
+                                                                                                  ~
+!!! error TS1128: Declaration or statement expected.
+                                                                                                   ~
+!!! error TS1128: Declaration or statement expected.
+                                                                                                    ~
+!!! error TS1128: Declaration or statement expected.
+                                                                                                     ~~~~~~~~~~~~~~~~
+!!! error TS1434: Unexpected keyword or identifier.
+                                                                                                     ~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'RequireInterface'.
+                                                                                                                     ~
+!!! error TS1128: Declaration or statement expected.
+    export const b = (null as any as import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface);
+                                     ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1340: Module 'pkg' does not refer to a type, but is used as a type here. Did you mean 'typeof import('pkg')'?
+                                                              ~~~~
+!!! error TS1005: '}' expected.
+!!! related TS1007 /index.ts:6:58: The parser expected to find a '}' to match the '{' token here.
+!!! related TS1007 /index.ts:6:48: The parser expected to find a '}' to match the '{' token here.
+                                                              ~~~~
+!!! error TS2695: Left side of comma operator is unused and has no side effects.
+                                                                                     ~
+!!! error TS1005: ';' expected.
+                                                                                               ~
+!!! error TS1128: Declaration or statement expected.
+                                                                                                 ~
+!!! error TS1128: Declaration or statement expected.
+                                                                                                  ~
+!!! error TS1128: Declaration or statement expected.
+                                                                                                   ~
+!!! error TS1128: Declaration or statement expected.
+                                                                                                    ~~~~~~~~~~~~~~~
+!!! error TS1434: Unexpected keyword or identifier.
+                                                                                                    ~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'ImportInterface'.
+                                                                                                                   ~
+!!! error TS1128: Declaration or statement expected.
+    
+==== /node_modules/pkg/package.json (0 errors) ====
+    {
+        "name": "pkg",
+        "version": "0.0.1",
+        "exports": {
+            "import": "./import.js",
+            "require": "./require.js"
+        }
+    }
+==== /node_modules/pkg/import.d.ts (0 errors) ====
+    export interface ImportInterface {}
+==== /node_modules/pkg/require.d.ts (0 errors) ====
+    export interface RequireInterface {}

--- a/tests/baselines/reference/parseAssertEntriesError.js
+++ b/tests/baselines/reference/parseAssertEntriesError.js
@@ -1,0 +1,48 @@
+//// [tests/cases/compiler/parseAssertEntriesError.ts] ////
+
+//// [package.json]
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+//// [import.d.ts]
+export interface ImportInterface {}
+//// [require.d.ts]
+export interface RequireInterface {}
+//// [index.ts]
+export type LocalInterface =
+    & import("pkg", { assert: {1234, "resolution-mode": "require"} }).RequireInterface
+    & import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface;
+
+export const a = (null as any as import("pkg", { assert: {1234, "resolution-mode": "require"} }).RequireInterface);
+export const b = (null as any as import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface);
+
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.b = exports.a = void 0;
+1234, "resolution-mode";
+"require";
+RequireInterface
+    & import("pkg", { assert: { 1234: , "resolution-mode": "import" } }).ImportInterface;
+exports.a = null;
+1234, "resolution-mode";
+"require";
+RequireInterface;
+;
+exports.b = null;
+1234, "resolution-mode";
+"import";
+ImportInterface;
+;
+
+
+//// [index.d.ts]
+export declare type LocalInterface = import("pkg", { assert: {} });
+export declare const a: any;
+export declare const b: any;

--- a/tests/baselines/reference/parseAssertEntriesError.symbols
+++ b/tests/baselines/reference/parseAssertEntriesError.symbols
@@ -1,0 +1,25 @@
+=== /index.ts ===
+export type LocalInterface =
+>LocalInterface : Symbol(LocalInterface, Decl(index.ts, 0, 0))
+
+    & import("pkg", { assert: {1234, "resolution-mode": "require"} }).RequireInterface
+    & import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface;
+>"pkg" : Symbol("/node_modules/pkg/import", Decl(import.d.ts, 0, 0))
+>assert : Symbol(assert, Decl(index.ts, 2, 21))
+>1234 : Symbol(1234, Decl(index.ts, 2, 31))
+>"resolution-mode" : Symbol("resolution-mode", Decl(index.ts, 2, 36))
+
+export const a = (null as any as import("pkg", { assert: {1234, "resolution-mode": "require"} }).RequireInterface);
+>a : Symbol(a, Decl(index.ts, 4, 12))
+
+export const b = (null as any as import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface);
+>b : Symbol(b, Decl(index.ts, 5, 12))
+
+=== /node_modules/pkg/import.d.ts ===
+export interface ImportInterface {}
+>ImportInterface : Symbol(ImportInterface, Decl(import.d.ts, 0, 0))
+
+=== /node_modules/pkg/require.d.ts ===
+export interface RequireInterface {}
+>RequireInterface : Symbol(RequireInterface, Decl(require.d.ts, 0, 0))
+

--- a/tests/baselines/reference/parseAssertEntriesError.types
+++ b/tests/baselines/reference/parseAssertEntriesError.types
@@ -1,0 +1,54 @@
+=== /index.ts ===
+export type LocalInterface =
+>LocalInterface : any
+
+    & import("pkg", { assert: {1234, "resolution-mode": "require"} }).RequireInterface
+>1234, "resolution-mode" : "resolution-mode"
+>1234 : 1234
+>"resolution-mode" : "resolution-mode"
+>"require" : "require"
+>RequireInterface    & import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface : number
+>RequireInterface : any
+
+    & import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface;
+>import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface : any
+>import("pkg", { assert: {1234, "resolution-mode": "import"} }) : Promise<{ default: typeof import("/node_modules/pkg/import"); }>
+>"pkg" : "pkg"
+>{ assert: {1234, "resolution-mode": "import"} } : { assert: { 1234: any; "resolution-mode": string; }; }
+>assert : { 1234: any; "resolution-mode": string; }
+>{1234, "resolution-mode": "import"} : { 1234: any; "resolution-mode": string; }
+>1234 : any
+> : any
+>"resolution-mode" : string
+>"import" : "import"
+>ImportInterface : any
+
+export const a = (null as any as import("pkg", { assert: {1234, "resolution-mode": "require"} }).RequireInterface);
+>a : any
+>(null as any as import("pkg", { assert: { : any
+>null as any as import("pkg", { assert: { : any
+>null as any : any
+>null : null
+>1234, "resolution-mode" : "resolution-mode"
+>1234 : 1234
+>"resolution-mode" : "resolution-mode"
+>"require" : "require"
+>RequireInterface : any
+
+export const b = (null as any as import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface);
+>b : any
+>(null as any as import("pkg", { assert: { : any
+>null as any as import("pkg", { assert: { : any
+>null as any : any
+>null : null
+>1234, "resolution-mode" : "resolution-mode"
+>1234 : 1234
+>"resolution-mode" : "resolution-mode"
+>"import" : "import"
+>ImportInterface : any
+
+=== /node_modules/pkg/import.d.ts ===
+export interface ImportInterface {}
+No type information for this code.=== /node_modules/pkg/require.d.ts ===
+export interface RequireInterface {}
+No type information for this code.

--- a/tests/cases/compiler/parseAssertEntriesError.ts
+++ b/tests/cases/compiler/parseAssertEntriesError.ts
@@ -1,0 +1,24 @@
+// @noImplicitReferences: true
+// @module: nodenext
+// @declaration: true
+// @outDir: out
+// @filename: /node_modules/pkg/package.json
+{
+    "name": "pkg",
+    "version": "0.0.1",
+    "exports": {
+        "import": "./import.js",
+        "require": "./require.js"
+    }
+}
+// @filename: /node_modules/pkg/import.d.ts
+export interface ImportInterface {}
+// @filename: /node_modules/pkg/require.d.ts
+export interface RequireInterface {}
+// @filename: /index.ts
+export type LocalInterface =
+    & import("pkg", { assert: {1234, "resolution-mode": "require"} }).RequireInterface
+    & import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface;
+
+export const a = (null as any as import("pkg", { assert: {1234, "resolution-mode": "require"} }).RequireInterface);
+export const b = (null as any as import("pkg", { assert: {1234, "resolution-mode": "import"} }).ImportInterface);


### PR DESCRIPTION
Something I noticed when going through #18217 TODOs.

This switch/case was missing an entry for `AssertEntries`, which was leading to suboptimal parsing errors (see the diff in https://github.com/microsoft/TypeScript/pull/50011/commits/1b9ea99e4ec8e0755e5139c98af31398615bb449). Make sure the switch/case is exhaustive.