### PR TITLE
Empty object not subtype of object with index signature

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20621,7 +20621,8 @@ namespace ts {
                 if (sourceInfo) {
                     return indexInfoRelatedTo(sourceInfo, targetInfo, reportErrors);
                 }
-                if (!(intersectionState & IntersectionState.Source) && isObjectTypeWithInferableIndex(source)) {
+                if (!(intersectionState & IntersectionState.Source) && isObjectTypeWithInferableIndex(source) &&
+                    !((relation === subtypeRelation || relation === strictSubtypeRelation) && isEmptyAnonymousObjectType(source) && !(getObjectFlags(source) & ObjectFlags.FreshLiteral))) {
                     // Intersection constituents are never considered to have an inferred index signature
                     return membersRelatedToIndexInfo(source, targetInfo, reportErrors);
                 }

--- a/tests/baselines/reference/emptyObjectNarrowing.js
+++ b/tests/baselines/reference/emptyObjectNarrowing.js
@@ -1,0 +1,22 @@
+//// [emptyObjectNarrowing.ts]
+// Repro from #49988
+
+declare function isObject(value: unknown): value is Record<string, unknown>;
+const obj = {};
+if (isObject(obj)) {
+    obj['attr'];
+}
+
+
+//// [emptyObjectNarrowing.js]
+"use strict";
+// Repro from #49988
+var obj = {};
+if (isObject(obj)) {
+    obj['attr'];
+}
+
+
+//// [emptyObjectNarrowing.d.ts]
+declare function isObject(value: unknown): value is Record<string, unknown>;
+declare const obj: {};

--- a/tests/baselines/reference/emptyObjectNarrowing.symbols
+++ b/tests/baselines/reference/emptyObjectNarrowing.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/emptyObjectNarrowing.ts ===
+// Repro from #49988
+
+declare function isObject(value: unknown): value is Record<string, unknown>;
+>isObject : Symbol(isObject, Decl(emptyObjectNarrowing.ts, 0, 0))
+>value : Symbol(value, Decl(emptyObjectNarrowing.ts, 2, 26))
+>value : Symbol(value, Decl(emptyObjectNarrowing.ts, 2, 26))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+const obj = {};
+>obj : Symbol(obj, Decl(emptyObjectNarrowing.ts, 3, 5))
+
+if (isObject(obj)) {
+>isObject : Symbol(isObject, Decl(emptyObjectNarrowing.ts, 0, 0))
+>obj : Symbol(obj, Decl(emptyObjectNarrowing.ts, 3, 5))
+
+    obj['attr'];
+>obj : Symbol(obj, Decl(emptyObjectNarrowing.ts, 3, 5))
+}
+

--- a/tests/baselines/reference/emptyObjectNarrowing.types
+++ b/tests/baselines/reference/emptyObjectNarrowing.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/emptyObjectNarrowing.ts ===
+// Repro from #49988
+
+declare function isObject(value: unknown): value is Record<string, unknown>;
+>isObject : (value: unknown) => value is Record<string, unknown>
+>value : unknown
+
+const obj = {};
+>obj : {}
+>{} : {}
+
+if (isObject(obj)) {
+>isObject(obj) : boolean
+>isObject : (value: unknown) => value is Record<string, unknown>
+>obj : {}
+
+    obj['attr'];
+>obj['attr'] : unknown
+>obj : Record<string, unknown>
+>'attr' : "attr"
+}
+

--- a/tests/baselines/reference/useObjectValuesAndEntries1.types
+++ b/tests/baselines/reference/useObjectValuesAndEntries1.types
@@ -77,16 +77,16 @@ var values2 = Object.values({ a: true, b: 2 });     // (number|boolean)[]
 >2 : 2
 
 var entries3 = Object.entries({});                  // [string, {}][]
->entries3 : [string, unknown][]
->Object.entries({}) : [string, unknown][]
+>entries3 : [string, any][]
+>Object.entries({}) : [string, any][]
 >Object.entries : { <T>(o: { [s: string]: T; } | ArrayLike<T>): [string, T][]; (o: {}): [string, any][]; }
 >Object : ObjectConstructor
 >entries : { <T>(o: { [s: string]: T; } | ArrayLike<T>): [string, T][]; (o: {}): [string, any][]; }
 >{} : {}
 
 var values3 = Object.values({});                    // {}[]
->values3 : unknown[]
->Object.values({}) : unknown[]
+>values3 : any[]
+>Object.values({}) : any[]
 >Object.values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
 >Object : ObjectConstructor
 >values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }

--- a/tests/cases/compiler/emptyObjectNarrowing.ts
+++ b/tests/cases/compiler/emptyObjectNarrowing.ts
@@ -1,0 +1,10 @@
+// @strict: true
+// @declaration: true
+
+// Repro from #49988
+
+declare function isObject(value: unknown): value is Record<string, unknown>;
+const obj = {};
+if (isObject(obj)) {
+    obj['attr'];
+}


### PR DESCRIPTION
This PR tightens the subtype relation such that a non-fresh `{}` is not considered a subtype of `{ [x: string]: xxx }`. Currently, such types are subtypes in both directions, which causes issues in narrowing.

This fixes the issue reported [here](https://github.com/microsoft/TypeScript/issues/49988#issuecomment-1192016929).