### PR TITLE
Bump target up to ES2015

### DIFF
--- a/scripts/importDefinitelyTypedTests/tsconfig.json
+++ b/scripts/importDefinitelyTypedTests/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "ES5",
+        "target": "ES2015",
         "outDir": "./",
         "rootDir": ".",
         "newLine": "lf",

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27009,10 +27009,10 @@ namespace ts {
                 case AssignmentDeclarationKind.ExportsProperty:
                 case AssignmentDeclarationKind.Prototype:
                 case AssignmentDeclarationKind.PrototypeProperty:
-                    let valueDeclaration = binaryExpression.left.symbol?.valueDeclaration;
-                    // falls through
                 case AssignmentDeclarationKind.ModuleExports:
-                    valueDeclaration ||= binaryExpression.symbol?.valueDeclaration;
+                    const valueDeclaration = kind !== AssignmentDeclarationKind.ModuleExports
+                        ? binaryExpression.left.symbol?.valueDeclaration
+                        : binaryExpression.symbol?.valueDeclaration;
                     const annotated = valueDeclaration && getEffectiveTypeAnnotationNode(valueDeclaration);
                     return annotated ? getTypeFromTypeNode(annotated) : undefined;
                 case AssignmentDeclarationKind.ObjectDefinePropertyValue:

--- a/src/instrumenter/tsconfig.json
+++ b/src/instrumenter/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "ES2015",
         "lib": [
             "es6",
             "dom",

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1363,6 +1363,8 @@ namespace ts {
                 onUnRecoverableConfigFileDiagnostic: noop,
             };
 
+            const documentRegistryBucketKey = documentRegistry.getKeyForCompilationSettings(newSettings);
+
             // If the program is already up-to-date, we can reuse it
             if (isProgramUptoDate(program, rootFileNames, newSettings, (_path, fileName) => host.getScriptVersion(fileName), fileName => compilerHost!.fileExists(fileName), hasInvalidatedResolution, hasChangedAutomaticTypeDirectiveNames, getParsedCommandLine, projectReferences)) {
                 return;
@@ -1374,7 +1376,6 @@ namespace ts {
             // the program points to old source files that have been invalidated because of
             // incremental parsing.
 
-            const documentRegistryBucketKey = documentRegistry.getKeyForCompilationSettings(newSettings);
             const options: CreateProgramOptions = {
                 rootNames: rootFileNames,
                 options: newSettings,

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "pretty": true,
         "lib": ["es2015.iterable", "es2015.generator", "es5"],
-        "target": "es5",
+        "target": "ES2015",
         "moduleResolution": "node",
         "rootDir": ".",
 


### PR DESCRIPTION
Wanting to see how expensive this turns out to be performance wise, since this brings in let/const.

The two changes are interesting; they're only bugs when there's `var`. The switch case one is... weird code and I feel like this deserves an error somehow if the target isn't going to lower to `var`. The other one is a logic bug where we get a key that's `undefined` because it hasn't been calculated yet, but we can't determine that statically.