### PR TITLE
Update lib.dom.d.ts, `MutationObserverInit.attributeFilter` can accept an iterator

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -894,7 +894,7 @@ interface MutationObserverInit {
     /**
      * Set to a list of attribute local names (without namespace) if not all attribute mutations need to be observed and attributes is true or omitted.
      */
-    attributeFilter?: string[];
+    attributeFilter?: string[] || IterableIterator<string>;
     /**
      * Set to true if attributes is true or omitted and target's attribute value before the mutation needs to be recorded.
      */


### PR DESCRIPTION
I have a feeling this is in the wrong place, but figured I'd get started and then redirected. Iterators work fine in this location:

```js
const obs = new MutationObserver(...)

const m = new Map()
// ... set some keys on the map ...

obs.observe(el, {
  attributeFilter: m.keys() // it works
})
```

Further explanation: https://github.com/whatwg/dom/issues/1092

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #
