### PR TITLE
Change type of event on('input') to InputEvent

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -5583,7 +5583,7 @@ interface GlobalEventHandlersEventMap {
     "focusout": FocusEvent;
     "formdata": FormDataEvent;
     "gotpointercapture": PointerEvent;
-    "input": Event;
+    "input": InputEvent;
     "invalid": Event;
     "keydown": KeyboardEvent;
     "keypress": KeyboardEvent;


### PR DESCRIPTION
It's been about two years since [this comment](https://github.com/microsoft/TypeScript/issues/39925#issuecomment-669550088) declining a similar change proposal (without PR) due to incomplete browser support, and MDN now reports browser support across the board except in deprecated IE. 

This allows writing a function to handle `.on('input')` events without requiring special type-narrowing code.  Existing code that already has the narrowing shouldn't be affected because an InputEvent is still an Event. 

Fixes #39925.
