### PR TITLE
Walk tokens with the correct walker

### DIFF
--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -630,9 +630,9 @@ namespace ts {
             case SyntaxKind.NamedTupleMember:
                 Debug.type<NamedTupleMember>(node);
                 return factory.updateNamedTupleMember(node,
-                    nodeVisitor(node.dotDotDotToken, visitor, isDotDotDotToken),
+                    nodeVisitor(node.dotDotDotToken, tokenVisitor, isDotDotDotToken),
                     nodeVisitor(node.name, visitor, isIdentifier),
-                    nodeVisitor(node.questionToken, visitor, isQuestionToken),
+                    nodeVisitor(node.questionToken, tokenVisitor, isQuestionToken),
                     nodeVisitor(node.type, visitor, isTypeNode),
                 );
 


### PR DESCRIPTION
#49992 wasn't complete, because not only did the old code use the wrong node visitors, it used the wrong visitor callback functions for tokens. Fix this too.

(I really, really wish that the `NodeVisitor` and `NodesVisitor` types were instead `NodeWalker` and `NodesWalker`, to make it clear that they do the walking, and that the callbacks are the actual visitors, but, it's too late for that).