### PR TITLE
Favor asserted type in type predicate narrowing

### DIFF
--- a/tests/baselines/reference/controlFlowBinaryOrExpression.symbols
+++ b/tests/baselines/reference/controlFlowBinaryOrExpression.symbols
@@ -64,9 +64,9 @@ if (isNodeList(sourceObj)) {
 >sourceObj : Symbol(sourceObj, Decl(controlFlowBinaryOrExpression.ts, 23, 3))
 
     sourceObj.length;
->sourceObj.length : Symbol(length, Decl(controlFlowBinaryOrExpression.ts, 10, 27), Decl(controlFlowBinaryOrExpression.ts, 14, 33))
+>sourceObj.length : Symbol(NodeList.length, Decl(controlFlowBinaryOrExpression.ts, 10, 27))
 >sourceObj : Symbol(sourceObj, Decl(controlFlowBinaryOrExpression.ts, 23, 3))
->length : Symbol(length, Decl(controlFlowBinaryOrExpression.ts, 10, 27), Decl(controlFlowBinaryOrExpression.ts, 14, 33))
+>length : Symbol(NodeList.length, Decl(controlFlowBinaryOrExpression.ts, 10, 27))
 }
 
 if (isHTMLCollection(sourceObj)) {
@@ -74,9 +74,9 @@ if (isHTMLCollection(sourceObj)) {
 >sourceObj : Symbol(sourceObj, Decl(controlFlowBinaryOrExpression.ts, 23, 3))
 
     sourceObj.length;
->sourceObj.length : Symbol(length, Decl(controlFlowBinaryOrExpression.ts, 10, 27), Decl(controlFlowBinaryOrExpression.ts, 14, 33))
+>sourceObj.length : Symbol(HTMLCollection.length, Decl(controlFlowBinaryOrExpression.ts, 14, 33))
 >sourceObj : Symbol(sourceObj, Decl(controlFlowBinaryOrExpression.ts, 23, 3))
->length : Symbol(length, Decl(controlFlowBinaryOrExpression.ts, 10, 27), Decl(controlFlowBinaryOrExpression.ts, 14, 33))
+>length : Symbol(HTMLCollection.length, Decl(controlFlowBinaryOrExpression.ts, 14, 33))
 }
 
 if (isNodeList(sourceObj) || isHTMLCollection(sourceObj)) {

--- a/tests/baselines/reference/controlFlowBinaryOrExpression.types
+++ b/tests/baselines/reference/controlFlowBinaryOrExpression.types
@@ -69,18 +69,18 @@ if (isNodeList(sourceObj)) {
 
     sourceObj.length;
 >sourceObj.length : number
->sourceObj : NodeList | HTMLCollection
+>sourceObj : NodeList
 >length : number
 }
 
 if (isHTMLCollection(sourceObj)) {
 >isHTMLCollection(sourceObj) : boolean
 >isHTMLCollection : (sourceObj: any) => sourceObj is HTMLCollection
->sourceObj : EventTargetLike
+>sourceObj : NodeList | { a: string; }
 
     sourceObj.length;
 >sourceObj.length : number
->sourceObj : NodeList | HTMLCollection
+>sourceObj : HTMLCollection
 >length : number
 }
 
@@ -88,7 +88,7 @@ if (isNodeList(sourceObj) || isHTMLCollection(sourceObj)) {
 >isNodeList(sourceObj) || isHTMLCollection(sourceObj) : boolean
 >isNodeList(sourceObj) : boolean
 >isNodeList : (sourceObj: any) => sourceObj is NodeList
->sourceObj : EventTargetLike
+>sourceObj : HTMLCollection | { a: string; }
 >isHTMLCollection(sourceObj) : boolean
 >isHTMLCollection : (sourceObj: any) => sourceObj is HTMLCollection
 >sourceObj : { a: string; }

--- a/tests/baselines/reference/instanceofWithStructurallyIdenticalTypes.symbols
+++ b/tests/baselines/reference/instanceofWithStructurallyIdenticalTypes.symbols
@@ -95,9 +95,9 @@ function foo2(x: C1 | C2 | C3): string {
 >x : Symbol(x, Decl(instanceofWithStructurallyIdenticalTypes.ts, 23, 14))
 
         return x.item;
->x.item : Symbol(item, Decl(instanceofWithStructurallyIdenticalTypes.ts, 2, 10), Decl(instanceofWithStructurallyIdenticalTypes.ts, 4, 10))
+>x.item : Symbol(C1.item, Decl(instanceofWithStructurallyIdenticalTypes.ts, 2, 10))
 >x : Symbol(x, Decl(instanceofWithStructurallyIdenticalTypes.ts, 23, 14))
->item : Symbol(item, Decl(instanceofWithStructurallyIdenticalTypes.ts, 2, 10), Decl(instanceofWithStructurallyIdenticalTypes.ts, 4, 10))
+>item : Symbol(C1.item, Decl(instanceofWithStructurallyIdenticalTypes.ts, 2, 10))
     }
     else if (isC2(x)) {
 >isC2 : Symbol(isC2, Decl(instanceofWithStructurallyIdenticalTypes.ts, 19, 66))

--- a/tests/baselines/reference/instanceofWithStructurallyIdenticalTypes.types
+++ b/tests/baselines/reference/instanceofWithStructurallyIdenticalTypes.types
@@ -85,7 +85,7 @@ function foo2(x: C1 | C2 | C3): string {
 
         return x.item;
 >x.item : string
->x : C1 | C3
+>x : C1
 >item : string
     }
     else if (isC2(x)) {

--- a/tests/baselines/reference/typePredicateStructuralMatch.symbols
+++ b/tests/baselines/reference/typePredicateStructuralMatch.symbols
@@ -51,9 +51,9 @@ function getResults1(value: Results | { data: Results }): Results {
     return isResponseInData(value) ? value.data : value;
 >isResponseInData : Symbol(isResponseInData, Decl(typePredicateStructuralMatch.ts, 9, 24))
 >value : Symbol(value, Decl(typePredicateStructuralMatch.ts, 15, 21))
->value.data : Symbol(data, Decl(typePredicateStructuralMatch.ts, 15, 39))
+>value.data : Symbol(data, Decl(typePredicateStructuralMatch.ts, 11, 63))
 >value : Symbol(value, Decl(typePredicateStructuralMatch.ts, 15, 21))
->data : Symbol(data, Decl(typePredicateStructuralMatch.ts, 15, 39))
+>data : Symbol(data, Decl(typePredicateStructuralMatch.ts, 11, 63))
 >value : Symbol(value, Decl(typePredicateStructuralMatch.ts, 15, 21))
 }
 

--- a/tests/baselines/reference/unionWithIndexSignature.types
+++ b/tests/baselines/reference/unionWithIndexSignature.types
@@ -55,7 +55,7 @@ export function flatten<T extends number|TypedArray>(arr: T) {
 
       arr[1];
 >arr[1] : number
->arr : TypedArray
+>arr : Int32Array | Uint8Array
 >1 : 1
   }
 }


### PR DESCRIPTION
With this PR we consistently favor the asserted type in a type predicate narrowing when both the argument type and the asserted type are subtypes of each other. We used to do this for non-union argument types, but not for unions. Fixes the issue reported [here](https://github.com/microsoft/TypeScript/issues/49988#issuecomment-1192016929).

In an ideal world we'd fix this issue by having the subtype relationship only consider _fresh_ object literal types subtypes of object types with index signatures, but unfortunately this is too much of a breaking change (I tried in #50013, but I will need to abandon that PR).

Adding a bit more context...

This is our inconsistent behavior in 4.7 (adding `undefined` shouldn't cause an error):

```ts
declare function isObject(value: unknown): value is Record<string, unknown>;

declare const obj1: {};
obj1;  // {}
if (isObject(obj1)) {
    obj1;  // Record<string, unknown>
    obj1['attr'];
}
obj1;  // Record<string, unknown>

declare const obj2: {} | undefined;
obj2;  // {} | undefined
if (isObject(obj2)) {
    obj2;  // {}
    obj2['attr'];  // Error!
}
obj2;  // {} | undefined
```

In #49625 we changed both of the above to error. That's more consistent, but a breaking change with the new error. With this PR we instead consistently favor the asserted type:

```ts
declare function isObject(value: unknown): value is Record<string, unknown>;

declare const obj1: {};
obj1;  // {}
if (isObject(obj1)) {
    obj1;  // Record<string, unknown>
    obj1['attr'];
}
obj1;  // Record<string, unknown>

declare const obj2: {} | undefined;
obj2;  // {} | undefined
if (isObject(obj2)) {
    obj2;  // Record<string, unknown>
    obj2['attr'];
}
obj2;  // Record<string, unknown> | undefined
```

Note that one issue with favoring the asserted type is that CFA continues with that type after the conditional block. Though undesired, that's an effect of how CFA works in the face of mutual subtypes. This behavior was already present for singleton types, but now also extends to union types.

Fixes #49988 (at least partially).