### PR TITLE
Downgrade es5-ext via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1922,6 +1922,23 @@
                 "type": "^1.0.1"
             }
         },
+        "node_modules/d/node_modules/es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "dependencies": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "node_modules/d/node_modules/next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+            "dev": true
+        },
         "node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2260,21 +2277,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/es5-ext": {
-            "version": "0.10.62",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-            "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "es6-iterator": "^2.0.3",
-                "es6-symbol": "^3.1.3",
-                "next-tick": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/es6-iterator": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
@@ -2285,6 +2287,23 @@
                 "es5-ext": "^0.10.35",
                 "es6-symbol": "^3.1.1"
             }
+        },
+        "node_modules/es6-iterator/node_modules/es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "dependencies": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "node_modules/es6-iterator/node_modules/next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+            "dev": true
         },
         "node_modules/es6-symbol": {
             "version": "3.1.3",
@@ -2307,6 +2326,23 @@
                 "es6-iterator": "^2.0.3",
                 "es6-symbol": "^3.1.1"
             }
+        },
+        "node_modules/es6-weak-map/node_modules/es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "dependencies": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "node_modules/es6-weak-map/node_modules/next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+            "dev": true
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -2694,6 +2730,23 @@
                 "d": "1",
                 "es5-ext": "~0.10.14"
             }
+        },
+        "node_modules/event-emitter/node_modules/es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "dependencies": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "node_modules/event-emitter/node_modules/next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+            "dev": true
         },
         "node_modules/expand-brackets": {
             "version": "2.1.4",
@@ -5189,6 +5242,23 @@
                 "es5-ext": "~0.10.2"
             }
         },
+        "node_modules/lru-queue/node_modules/es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "dependencies": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "node_modules/lru-queue/node_modules/next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+            "dev": true
+        },
         "node_modules/make-iterator": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -5458,6 +5528,23 @@
                 "next-tick": "^1.1.0",
                 "timers-ext": "^0.1.7"
             }
+        },
+        "node_modules/memoizee/node_modules/es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "dependencies": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "node_modules/memoizee/node_modules/es5-ext/node_modules/next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+            "dev": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -7859,6 +7946,23 @@
                 "next-tick": "1"
             }
         },
+        "node_modules/timers-ext/node_modules/es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "dependencies": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
+        "node_modules/timers-ext/node_modules/next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+            "dev": true
+        },
         "node_modules/to-absolute-glob": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -10110,8 +10214,27 @@
             "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
             "dev": true,
             "requires": {
-                "es5-ext": "^0.10.50",
+                "es5-ext": "0.10.53",
                 "type": "^1.0.1"
+            },
+            "dependencies": {
+                "es5-ext": {
+                    "version": "0.10.53",
+                    "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+                    "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+                    "dev": true,
+                    "requires": {
+                        "es6-iterator": "~2.0.3",
+                        "es6-symbol": "~3.1.3",
+                        "next-tick": "~1.0.0"
+                    }
+                },
+                "next-tick": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+                    "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+                    "dev": true
+                }
             }
         },
         "debug": {
@@ -10387,17 +10510,6 @@
                 "is-symbol": "^1.0.2"
             }
         },
-        "es5-ext": {
-            "version": "0.10.62",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-            "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-            "dev": true,
-            "requires": {
-                "es6-iterator": "^2.0.3",
-                "es6-symbol": "^3.1.3",
-                "next-tick": "^1.1.0"
-            }
-        },
         "es6-iterator": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
@@ -10405,8 +10517,27 @@
             "dev": true,
             "requires": {
                 "d": "1",
-                "es5-ext": "^0.10.35",
+                "es5-ext": "0.10.53",
                 "es6-symbol": "^3.1.1"
+            },
+            "dependencies": {
+                "es5-ext": {
+                    "version": "0.10.53",
+                    "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+                    "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+                    "dev": true,
+                    "requires": {
+                        "es6-iterator": "~2.0.3",
+                        "es6-symbol": "~3.1.3",
+                        "next-tick": "~1.0.0"
+                    }
+                },
+                "next-tick": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+                    "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+                    "dev": true
+                }
             }
         },
         "es6-symbol": {
@@ -10426,9 +10557,28 @@
             "dev": true,
             "requires": {
                 "d": "1",
-                "es5-ext": "^0.10.46",
+                "es5-ext": "0.10.53",
                 "es6-iterator": "^2.0.3",
                 "es6-symbol": "^3.1.1"
+            },
+            "dependencies": {
+                "es5-ext": {
+                    "version": "0.10.53",
+                    "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+                    "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+                    "dev": true,
+                    "requires": {
+                        "es6-iterator": "~2.0.3",
+                        "es6-symbol": "~3.1.3",
+                        "next-tick": "~1.0.0"
+                    }
+                },
+                "next-tick": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+                    "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+                    "dev": true
+                }
             }
         },
         "escalade": {
@@ -10731,7 +10881,26 @@
             "dev": true,
             "requires": {
                 "d": "1",
-                "es5-ext": "~0.10.14"
+                "es5-ext": "0.10.53"
+            },
+            "dependencies": {
+                "es5-ext": {
+                    "version": "0.10.53",
+                    "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+                    "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+                    "dev": true,
+                    "requires": {
+                        "es6-iterator": "~2.0.3",
+                        "es6-symbol": "~3.1.3",
+                        "next-tick": "~1.0.0"
+                    }
+                },
+                "next-tick": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+                    "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+                    "dev": true
+                }
             }
         },
         "expand-brackets": {
@@ -12698,7 +12867,26 @@
             "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
             "dev": true,
             "requires": {
-                "es5-ext": "~0.10.2"
+                "es5-ext": "0.10.53"
+            },
+            "dependencies": {
+                "es5-ext": {
+                    "version": "0.10.53",
+                    "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+                    "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+                    "dev": true,
+                    "requires": {
+                        "es6-iterator": "~2.0.3",
+                        "es6-symbol": "~3.1.3",
+                        "next-tick": "~1.0.0"
+                    }
+                },
+                "next-tick": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+                    "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+                    "dev": true
+                }
             }
         },
         "make-iterator": {
@@ -12912,13 +13100,34 @@
             "dev": true,
             "requires": {
                 "d": "^1.0.1",
-                "es5-ext": "^0.10.53",
+                "es5-ext": "0.10.53",
                 "es6-weak-map": "^2.0.3",
                 "event-emitter": "^0.3.5",
                 "is-promise": "^2.2.2",
                 "lru-queue": "^0.1.0",
                 "next-tick": "^1.1.0",
                 "timers-ext": "^0.1.7"
+            },
+            "dependencies": {
+                "es5-ext": {
+                    "version": "0.10.53",
+                    "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+                    "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+                    "dev": true,
+                    "requires": {
+                        "es6-iterator": "~2.0.3",
+                        "es6-symbol": "~3.1.3",
+                        "next-tick": "~1.0.0"
+                    },
+                    "dependencies": {
+                        "next-tick": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+                            "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+                            "dev": true
+                        }
+                    }
+                }
             }
         },
         "merge2": {
@@ -14760,8 +14969,27 @@
             "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
             "dev": true,
             "requires": {
-                "es5-ext": "~0.10.46",
+                "es5-ext": "0.10.53",
                 "next-tick": "1"
+            },
+            "dependencies": {
+                "es5-ext": {
+                    "version": "0.10.53",
+                    "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+                    "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+                    "dev": true,
+                    "requires": {
+                        "es6-iterator": "~2.0.3",
+                        "es6-symbol": "~3.1.3",
+                        "next-tick": "~1.0.0"
+                    }
+                },
+                "next-tick": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+                    "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg==",
+                    "dev": true
+                }
             }
         },
         "to-absolute-glob": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,9 @@
         "vinyl-sourcemaps-apply": "latest",
         "xml2js": "^0.4.23"
     },
+    "overrides": {
+        "es5-ext": "0.10.53"
+    },
     "scripts": {
         "prepare": "gulp build-eslint-rules",
         "pretest": "gulp tests",


### PR DESCRIPTION
This dependency triggers a CG warning (previously failed DT enough we had to delete packages, not sure why TS is also not failing somewhere).

Now that we use npm 8, we can use overrides to downgrade it.