### PR TITLE
Don't uninstall typescript before npm ci in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         check-latest: true
-    - name: Remove existing TypeScript
-      run: |
-        npm uninstall typescript --no-save
-        npm uninstall tslint --no-save
     - run:  npm ci
 
     # Re: https://github.com/actions/setup-node/pull/125

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -12,10 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v3
-    - name: Remove existing TypeScript
-      run: |
-        npm uninstall typescript --no-save
-        npm uninstall tslint --no-save
     - name: npm install and test
       run: |
         npm ci


### PR DESCRIPTION
This has been carried through from #9316, where it was needed to make Travis' caching faster. But, this doesn't have any meaning on GitHub Actions; caching is something you have to opt into, and even if we did opt into it (we don't! I'll send another PR), it wouldn't actually do anything.

Remove this as this interferes with `npm ci`, because `npm uninstall` will modify `package-lock.json`. This is important to keep our Node 14 builder working properly if we were to change our npm version / lockfile verison.

See also #49726, #50061