### PR TITLE
Add an additional test for favoring the asserted type in type predicate narrowing

### DIFF
--- a/tests/baselines/reference/controlFlowFavorAssertedTypeThroughTypePredicate.errors.txt
+++ b/tests/baselines/reference/controlFlowFavorAssertedTypeThroughTypePredicate.errors.txt
@@ -1,0 +1,51 @@
+tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts(26,5): error TS7053: Element implicitly has an 'any' type because expression of type '"attr"' can't be used to index type '{}'.
+  Property 'attr' does not exist on type '{}'.
+tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts(34,5): error TS7053: Element implicitly has an 'any' type because expression of type '"attr"' can't be used to index type '{}'.
+  Property 'attr' does not exist on type '{}'.
+
+
+==== tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts (2 errors) ====
+    // repro 49988#issuecomment-1192016929
+    
+    declare function isObject1(value: unknown): value is Record<string, unknown>;
+    
+    declare const obj1: {};
+    if (isObject1(obj1)) {
+        obj1;
+        obj1['attr'];
+    }
+    // check type after conditional block
+    obj1;
+    
+    declare const obj2: {} | undefined;
+    if (isObject1(obj2)) {
+        obj2;
+        obj2['attr'];
+    }
+    // check type after conditional block
+    obj2;
+    
+    declare function isObject2(value: unknown): value is {};
+    
+    declare const obj3: Record<string, unknown>;
+    if (isObject2(obj3)) {
+        obj3;
+        obj3['attr'];
+        ~~~~~~~~~~~~
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '"attr"' can't be used to index type '{}'.
+!!! error TS7053:   Property 'attr' does not exist on type '{}'.
+    }
+    // check type after conditional block
+    obj3;
+    
+    declare const obj4: Record<string, unknown> | undefined;
+    if (isObject2(obj4)) {
+        obj4;
+        obj4['attr'];
+        ~~~~~~~~~~~~
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '"attr"' can't be used to index type '{}'.
+!!! error TS7053:   Property 'attr' does not exist on type '{}'.
+    }
+    // check type after conditional block
+    obj4;
+    

--- a/tests/baselines/reference/controlFlowFavorAssertedTypeThroughTypePredicate.symbols
+++ b/tests/baselines/reference/controlFlowFavorAssertedTypeThroughTypePredicate.symbols
@@ -1,0 +1,47 @@
+=== tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts ===
+// repro 49988#issuecomment-1192016929
+
+declare function isObject(value: unknown): value is Record<string, unknown>;
+>isObject : Symbol(isObject, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 0, 0))
+>value : Symbol(value, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 2, 26))
+>value : Symbol(value, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 2, 26))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+declare const obj1: {};
+>obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
+
+obj1;  // {}
+>obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
+
+if (isObject(obj1)) {
+>isObject : Symbol(isObject, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 0, 0))
+>obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
+
+    obj1;  // Record<string, unknown>
+>obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
+
+    obj1['attr'];
+>obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
+}
+obj1;  // Record<string, unknown>
+>obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
+
+declare const obj2: {} | undefined;
+>obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
+
+obj2;  // {} | undefined
+>obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
+
+if (isObject(obj2)) {
+>isObject : Symbol(isObject, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 0, 0))
+>obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
+
+    obj2;  // Record<string, unknown>
+>obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
+
+    obj2['attr'];
+>obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
+}
+obj2;  // Record<string, unknown> | undefined
+>obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
+

--- a/tests/baselines/reference/controlFlowFavorAssertedTypeThroughTypePredicate.symbols
+++ b/tests/baselines/reference/controlFlowFavorAssertedTypeThroughTypePredicate.symbols
@@ -1,47 +1,84 @@
 === tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts ===
 // repro 49988#issuecomment-1192016929
 
-declare function isObject(value: unknown): value is Record<string, unknown>;
->isObject : Symbol(isObject, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 0, 0))
->value : Symbol(value, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 2, 26))
->value : Symbol(value, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 2, 26))
+declare function isObject1(value: unknown): value is Record<string, unknown>;
+>isObject1 : Symbol(isObject1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 0, 0))
+>value : Symbol(value, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 2, 27))
+>value : Symbol(value, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 2, 27))
 >Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
 
 declare const obj1: {};
 >obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
 
-obj1;  // {}
+if (isObject1(obj1)) {
+>isObject1 : Symbol(isObject1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 0, 0))
 >obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
 
-if (isObject(obj1)) {
->isObject : Symbol(isObject, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 0, 0))
->obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
-
-    obj1;  // Record<string, unknown>
+    obj1;
 >obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
 
     obj1['attr'];
 >obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
 }
-obj1;  // Record<string, unknown>
+// check type after conditional block
+obj1;
 >obj1 : Symbol(obj1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 4, 13))
 
 declare const obj2: {} | undefined;
 >obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
 
-obj2;  // {} | undefined
+if (isObject1(obj2)) {
+>isObject1 : Symbol(isObject1, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 0, 0))
 >obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
 
-if (isObject(obj2)) {
->isObject : Symbol(isObject, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 0, 0))
->obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
-
-    obj2;  // Record<string, unknown>
+    obj2;
 >obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
 
     obj2['attr'];
 >obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
 }
-obj2;  // Record<string, unknown> | undefined
+// check type after conditional block
+obj2;
 >obj2 : Symbol(obj2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 12, 13))
+
+declare function isObject2(value: unknown): value is {};
+>isObject2 : Symbol(isObject2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 18, 5))
+>value : Symbol(value, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 20, 27))
+>value : Symbol(value, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 20, 27))
+
+declare const obj3: Record<string, unknown>;
+>obj3 : Symbol(obj3, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 22, 13))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+if (isObject2(obj3)) {
+>isObject2 : Symbol(isObject2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 18, 5))
+>obj3 : Symbol(obj3, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 22, 13))
+
+    obj3;
+>obj3 : Symbol(obj3, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 22, 13))
+
+    obj3['attr'];
+>obj3 : Symbol(obj3, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 22, 13))
+}
+// check type after conditional block
+obj3;
+>obj3 : Symbol(obj3, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 22, 13))
+
+declare const obj4: Record<string, unknown> | undefined;
+>obj4 : Symbol(obj4, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 30, 13))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+if (isObject2(obj4)) {
+>isObject2 : Symbol(isObject2, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 18, 5))
+>obj4 : Symbol(obj4, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 30, 13))
+
+    obj4;
+>obj4 : Symbol(obj4, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 30, 13))
+
+    obj4['attr'];
+>obj4 : Symbol(obj4, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 30, 13))
+}
+// check type after conditional block
+obj4;
+>obj4 : Symbol(obj4, Decl(controlFlowFavorAssertedTypeThroughTypePredicate.ts, 30, 13))
 

--- a/tests/baselines/reference/controlFlowFavorAssertedTypeThroughTypePredicate.types
+++ b/tests/baselines/reference/controlFlowFavorAssertedTypeThroughTypePredicate.types
@@ -1,22 +1,19 @@
 === tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts ===
 // repro 49988#issuecomment-1192016929
 
-declare function isObject(value: unknown): value is Record<string, unknown>;
->isObject : (value: unknown) => value is Record<string, unknown>
+declare function isObject1(value: unknown): value is Record<string, unknown>;
+>isObject1 : (value: unknown) => value is Record<string, unknown>
 >value : unknown
 
 declare const obj1: {};
 >obj1 : {}
 
-obj1;  // {}
+if (isObject1(obj1)) {
+>isObject1(obj1) : boolean
+>isObject1 : (value: unknown) => value is Record<string, unknown>
 >obj1 : {}
 
-if (isObject(obj1)) {
->isObject(obj1) : boolean
->isObject : (value: unknown) => value is Record<string, unknown>
->obj1 : {}
-
-    obj1;  // Record<string, unknown>
+    obj1;
 >obj1 : Record<string, unknown>
 
     obj1['attr'];
@@ -24,21 +21,19 @@ if (isObject(obj1)) {
 >obj1 : Record<string, unknown>
 >'attr' : "attr"
 }
-obj1;  // Record<string, unknown>
+// check type after conditional block
+obj1;
 >obj1 : Record<string, unknown>
 
 declare const obj2: {} | undefined;
 >obj2 : {} | undefined
 
-obj2;  // {} | undefined
+if (isObject1(obj2)) {
+>isObject1(obj2) : boolean
+>isObject1 : (value: unknown) => value is Record<string, unknown>
 >obj2 : {} | undefined
 
-if (isObject(obj2)) {
->isObject(obj2) : boolean
->isObject : (value: unknown) => value is Record<string, unknown>
->obj2 : {} | undefined
-
-    obj2;  // Record<string, unknown>
+    obj2;
 >obj2 : Record<string, unknown>
 
     obj2['attr'];
@@ -46,6 +41,51 @@ if (isObject(obj2)) {
 >obj2 : Record<string, unknown>
 >'attr' : "attr"
 }
-obj2;  // Record<string, unknown> | undefined
+// check type after conditional block
+obj2;
 >obj2 : Record<string, unknown> | undefined
+
+declare function isObject2(value: unknown): value is {};
+>isObject2 : (value: unknown) => value is {}
+>value : unknown
+
+declare const obj3: Record<string, unknown>;
+>obj3 : Record<string, unknown>
+
+if (isObject2(obj3)) {
+>isObject2(obj3) : boolean
+>isObject2 : (value: unknown) => value is {}
+>obj3 : Record<string, unknown>
+
+    obj3;
+>obj3 : {}
+
+    obj3['attr'];
+>obj3['attr'] : any
+>obj3 : {}
+>'attr' : "attr"
+}
+// check type after conditional block
+obj3;
+>obj3 : {}
+
+declare const obj4: Record<string, unknown> | undefined;
+>obj4 : Record<string, unknown> | undefined
+
+if (isObject2(obj4)) {
+>isObject2(obj4) : boolean
+>isObject2 : (value: unknown) => value is {}
+>obj4 : Record<string, unknown> | undefined
+
+    obj4;
+>obj4 : {}
+
+    obj4['attr'];
+>obj4['attr'] : any
+>obj4 : {}
+>'attr' : "attr"
+}
+// check type after conditional block
+obj4;
+>obj4 : {} | undefined
 

--- a/tests/baselines/reference/controlFlowFavorAssertedTypeThroughTypePredicate.types
+++ b/tests/baselines/reference/controlFlowFavorAssertedTypeThroughTypePredicate.types
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts ===
+// repro 49988#issuecomment-1192016929
+
+declare function isObject(value: unknown): value is Record<string, unknown>;
+>isObject : (value: unknown) => value is Record<string, unknown>
+>value : unknown
+
+declare const obj1: {};
+>obj1 : {}
+
+obj1;  // {}
+>obj1 : {}
+
+if (isObject(obj1)) {
+>isObject(obj1) : boolean
+>isObject : (value: unknown) => value is Record<string, unknown>
+>obj1 : {}
+
+    obj1;  // Record<string, unknown>
+>obj1 : Record<string, unknown>
+
+    obj1['attr'];
+>obj1['attr'] : unknown
+>obj1 : Record<string, unknown>
+>'attr' : "attr"
+}
+obj1;  // Record<string, unknown>
+>obj1 : Record<string, unknown>
+
+declare const obj2: {} | undefined;
+>obj2 : {} | undefined
+
+obj2;  // {} | undefined
+>obj2 : {} | undefined
+
+if (isObject(obj2)) {
+>isObject(obj2) : boolean
+>isObject : (value: unknown) => value is Record<string, unknown>
+>obj2 : {} | undefined
+
+    obj2;  // Record<string, unknown>
+>obj2 : Record<string, unknown>
+
+    obj2['attr'];
+>obj2['attr'] : unknown
+>obj2 : Record<string, unknown>
+>'attr' : "attr"
+}
+obj2;  // Record<string, unknown> | undefined
+>obj2 : Record<string, unknown> | undefined
+

--- a/tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts
+++ b/tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts
@@ -3,20 +3,38 @@
 
 // repro 49988#issuecomment-1192016929
 
-declare function isObject(value: unknown): value is Record<string, unknown>;
+declare function isObject1(value: unknown): value is Record<string, unknown>;
 
 declare const obj1: {};
-obj1;  // {}
-if (isObject(obj1)) {
-    obj1;  // Record<string, unknown>
+if (isObject1(obj1)) {
+    obj1;
     obj1['attr'];
 }
-obj1;  // Record<string, unknown>
+// check type after conditional block
+obj1;
 
 declare const obj2: {} | undefined;
-obj2;  // {} | undefined
-if (isObject(obj2)) {
-    obj2;  // Record<string, unknown>
+if (isObject1(obj2)) {
+    obj2;
     obj2['attr'];
 }
-obj2;  // Record<string, unknown> | undefined
+// check type after conditional block
+obj2;
+
+declare function isObject2(value: unknown): value is {};
+
+declare const obj3: Record<string, unknown>;
+if (isObject2(obj3)) {
+    obj3;
+    obj3['attr'];
+}
+// check type after conditional block
+obj3;
+
+declare const obj4: Record<string, unknown> | undefined;
+if (isObject2(obj4)) {
+    obj4;
+    obj4['attr'];
+}
+// check type after conditional block
+obj4;

--- a/tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts
+++ b/tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts
@@ -1,0 +1,22 @@
+// @noEmit: true
+// @strict: true
+
+// repro 49988#issuecomment-1192016929
+
+declare function isObject(value: unknown): value is Record<string, unknown>;
+
+declare const obj1: {};
+obj1;  // {}
+if (isObject(obj1)) {
+    obj1;  // Record<string, unknown>
+    obj1['attr'];
+}
+obj1;  // Record<string, unknown>
+
+declare const obj2: {} | undefined;
+obj2;  // {} | undefined
+if (isObject(obj2)) {
+    obj2;  // Record<string, unknown>
+    obj2['attr'];
+}
+obj2;  // Record<string, unknown> | undefined


### PR DESCRIPTION
I've noticed that the https://github.com/microsoft/TypeScript/pull/50044 didn't introduce a new test related to the issue that it closed and I've figured out that it might be nice to add it