### PR TITLE
Fix trailing formatting edit when range ends mid-token

### DIFF
--- a/tests/cases/fourslash/formatTemplateStringOnPaste.ts
+++ b/tests/cases/fourslash/formatTemplateStringOnPaste.ts
@@ -1,0 +1,6 @@
+/// <reference path="fourslash.ts" />
+
+//// const x = `${0}/*0*/abc/*1*/`;
+
+format.selection("0", "1");
+verify.currentFileContentIs("const x = `${0}abc`;");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #50076
