### PR TITLE
No synthetic Awaited for unconstrained type when not a type variable

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36712,9 +36712,11 @@ namespace ts {
             // We only need `Awaited<T>` if `T` contains possibly non-primitive types.
             if (isGenericObjectType(type)) {
                 const baseConstraint = getBaseConstraintOfType(type);
-                // We only need `Awaited<T>` if `T` has no base constraint, or the base constraint of `T` is `any`, `unknown`, `{}`, `object`,
+                // We only need `Awaited<T>` if `T` is a type variable that has no base constraint, or the base constraint of `T` is `any`, `unknown`, `{}`, `object`,
                 // or is promise-like.
-                if (!baseConstraint || (baseConstraint.flags & TypeFlags.AnyOrUnknown) || isEmptyObjectType(baseConstraint) || isThenableType(baseConstraint)) {
+                if (baseConstraint ?
+                    baseConstraint.flags & TypeFlags.AnyOrUnknown || isEmptyObjectType(baseConstraint) || isThenableType(baseConstraint) :
+                    maybeTypeOfKind(type, TypeFlags.TypeVariable)) {
                     return true;
                 }
             }

--- a/tests/baselines/reference/awaitedType.errors.txt
+++ b/tests/baselines/reference/awaitedType.errors.txt
@@ -178,3 +178,13 @@ tests/cases/compiler/awaitedType.ts(22,12): error TS2589: Type instantiation is 
         const x = await f17(async () => 123 as const);
         return { x };
     }
+    
+    // https://github.com/microsoft/TypeScript/issues/47144
+    type GenericStructure<
+      AcceptableKeyType extends string = string
+    > = Record<AcceptableKeyType, number>;
+    
+    async function brokenExample<AcceptableKeyType extends string = string>(structurePromise: Promise<GenericStructure<AcceptableKeyType>>, key: AcceptableKeyType): Promise<void> {
+      const structure = await structurePromise;
+      structure[key] = 1;
+    }

--- a/tests/baselines/reference/awaitedType.js
+++ b/tests/baselines/reference/awaitedType.js
@@ -171,6 +171,16 @@ async function f17_usage() {
     return { x };
 }
 
+// https://github.com/microsoft/TypeScript/issues/47144
+type GenericStructure<
+  AcceptableKeyType extends string = string
+> = Record<AcceptableKeyType, number>;
+
+async function brokenExample<AcceptableKeyType extends string = string>(structurePromise: Promise<GenericStructure<AcceptableKeyType>>, key: AcceptableKeyType): Promise<void> {
+  const structure = await structurePromise;
+  structure[key] = 1;
+}
+
 //// [awaitedType.js]
 async function main() {
     let aaa;
@@ -280,4 +290,8 @@ async function f17(fn) {
 async function f17_usage() {
     const x = await f17(async () => 123);
     return { x };
+}
+async function brokenExample(structurePromise, key) {
+    const structure = await structurePromise;
+    structure[key] = 1;
 }

--- a/tests/baselines/reference/awaitedType.symbols
+++ b/tests/baselines/reference/awaitedType.symbols
@@ -433,3 +433,34 @@ async function f17_usage() {
     return { x };
 >x : Symbol(x, Decl(awaitedType.ts, 169, 12))
 }
+
+// https://github.com/microsoft/TypeScript/issues/47144
+type GenericStructure<
+>GenericStructure : Symbol(GenericStructure, Decl(awaitedType.ts, 170, 1))
+
+  AcceptableKeyType extends string = string
+>AcceptableKeyType : Symbol(AcceptableKeyType, Decl(awaitedType.ts, 173, 22))
+
+> = Record<AcceptableKeyType, number>;
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>AcceptableKeyType : Symbol(AcceptableKeyType, Decl(awaitedType.ts, 173, 22))
+
+async function brokenExample<AcceptableKeyType extends string = string>(structurePromise: Promise<GenericStructure<AcceptableKeyType>>, key: AcceptableKeyType): Promise<void> {
+>brokenExample : Symbol(brokenExample, Decl(awaitedType.ts, 175, 38))
+>AcceptableKeyType : Symbol(AcceptableKeyType, Decl(awaitedType.ts, 177, 29))
+>structurePromise : Symbol(structurePromise, Decl(awaitedType.ts, 177, 72))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>GenericStructure : Symbol(GenericStructure, Decl(awaitedType.ts, 170, 1))
+>AcceptableKeyType : Symbol(AcceptableKeyType, Decl(awaitedType.ts, 177, 29))
+>key : Symbol(key, Decl(awaitedType.ts, 177, 135))
+>AcceptableKeyType : Symbol(AcceptableKeyType, Decl(awaitedType.ts, 177, 29))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+  const structure = await structurePromise;
+>structure : Symbol(structure, Decl(awaitedType.ts, 178, 7))
+>structurePromise : Symbol(structurePromise, Decl(awaitedType.ts, 177, 72))
+
+  structure[key] = 1;
+>structure : Symbol(structure, Decl(awaitedType.ts, 178, 7))
+>key : Symbol(key, Decl(awaitedType.ts, 177, 135))
+}

--- a/tests/baselines/reference/awaitedType.types
+++ b/tests/baselines/reference/awaitedType.types
@@ -392,3 +392,28 @@ async function f17_usage() {
 >{ x } : { x: 123; }
 >x : 123
 }
+
+// https://github.com/microsoft/TypeScript/issues/47144
+type GenericStructure<
+>GenericStructure : GenericStructure<AcceptableKeyType>
+
+  AcceptableKeyType extends string = string
+> = Record<AcceptableKeyType, number>;
+
+async function brokenExample<AcceptableKeyType extends string = string>(structurePromise: Promise<GenericStructure<AcceptableKeyType>>, key: AcceptableKeyType): Promise<void> {
+>brokenExample : <AcceptableKeyType extends string = string>(structurePromise: Promise<GenericStructure<AcceptableKeyType>>, key: AcceptableKeyType) => Promise<void>
+>structurePromise : Promise<GenericStructure<AcceptableKeyType>>
+>key : AcceptableKeyType
+
+  const structure = await structurePromise;
+>structure : GenericStructure<AcceptableKeyType>
+>await structurePromise : GenericStructure<AcceptableKeyType>
+>structurePromise : Promise<GenericStructure<AcceptableKeyType>>
+
+  structure[key] = 1;
+>structure[key] = 1 : 1
+>structure[key] : GenericStructure<AcceptableKeyType>[AcceptableKeyType]
+>structure : GenericStructure<AcceptableKeyType>
+>key : AcceptableKeyType
+>1 : 1
+}

--- a/tests/cases/compiler/awaitedType.ts
+++ b/tests/cases/compiler/awaitedType.ts
@@ -172,3 +172,13 @@ async function f17_usage() {
     const x = await f17(async () => 123 as const);
     return { x };
 }
+
+// https://github.com/microsoft/TypeScript/issues/47144
+type GenericStructure<
+  AcceptableKeyType extends string = string
+> = Record<AcceptableKeyType, number>;
+
+async function brokenExample<AcceptableKeyType extends string = string>(structurePromise: Promise<GenericStructure<AcceptableKeyType>>, key: AcceptableKeyType): Promise<void> {
+  const structure = await structurePromise;
+  structure[key] = 1;
+}


### PR DESCRIPTION
`await` should only produce `Awaited<T>` when `T`'s base constraint is `any`, `unknown`, `{}`, or `object`, or when `T` is an unconstrained generic. Prior to this change, a `Record` type with a generic key would satisfy the `isGenericObjectType` condition, but would have no base constraint, resulting in the introduction of an unnecessary `Awaited` wrapper around the type. 

Fixes #47144
