### PR TITLE
Report every instance of TS1208

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3509,11 +3509,12 @@ namespace ts {
                     createDiagnosticForOptionName(Diagnostics.Option_preserveConstEnums_cannot_be_disabled_when_isolatedModules_is_enabled, "preserveConstEnums", "isolatedModules");
                 }
 
-                const firstNonExternalModuleSourceFile = find(files, f => !isExternalModule(f) && !isSourceFileJS(f) && !f.isDeclarationFile && f.scriptKind !== ScriptKind.JSON);
-                if (firstNonExternalModuleSourceFile) {
-                    const span = getErrorSpanForNode(firstNonExternalModuleSourceFile, firstNonExternalModuleSourceFile);
-                    programDiagnostics.add(createFileDiagnostic(firstNonExternalModuleSourceFile, span.start, span.length,
-                        Diagnostics._0_cannot_be_compiled_under_isolatedModules_because_it_is_considered_a_global_script_file_Add_an_import_export_or_an_empty_export_statement_to_make_it_a_module, getBaseFileName(firstNonExternalModuleSourceFile.fileName)));
+                for (const file of files) {
+                    if (!isExternalModule(file) && !isSourceFileJS(file) && !file.isDeclarationFile && file.scriptKind !== ScriptKind.JSON) {
+                        const span = getErrorSpanForNode(file, file);
+                        programDiagnostics.add(createFileDiagnostic(file, span.start, span.length,
+                            Diagnostics._0_cannot_be_compiled_under_isolatedModules_because_it_is_considered_a_global_script_file_Add_an_import_export_or_an_empty_export_statement_to_make_it_a_module, getBaseFileName(file.fileName)));
+                    }
                 }
             }
             else if (firstNonAmbientExternalModuleSourceFile && languageVersion < ScriptTarget.ES2015 && options.module === ModuleKind.None) {

--- a/tests/baselines/reference/isolatedModulesExternalModuleForced.js
+++ b/tests/baselines/reference/isolatedModulesExternalModuleForced.js
@@ -1,0 +1,6 @@
+//// [file1.ts]
+var x;
+
+//// [file1.js]
+var x;
+export {};

--- a/tests/baselines/reference/isolatedModulesExternalModuleForced.symbols
+++ b/tests/baselines/reference/isolatedModulesExternalModuleForced.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/file1.ts ===
+var x;
+>x : Symbol(x, Decl(file1.ts, 0, 3))
+

--- a/tests/baselines/reference/isolatedModulesExternalModuleForced.types
+++ b/tests/baselines/reference/isolatedModulesExternalModuleForced.types
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/file1.ts ===
+var x;
+>x : any
+

--- a/tests/baselines/reference/isolatedModulesNoExternalModuleMultiple.errors.txt
+++ b/tests/baselines/reference/isolatedModulesNoExternalModuleMultiple.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/compiler/file1.ts(1,1): error TS1208: 'file1.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.
+tests/cases/compiler/file2.ts(1,1): error TS1208: 'file2.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.
+tests/cases/compiler/file3.ts(1,1): error TS1208: 'file3.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.
+
+
+==== tests/cases/compiler/file1.ts (1 errors) ====
+    var x;
+    ~~~
+!!! error TS1208: 'file1.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.
+    
+==== tests/cases/compiler/file2.ts (1 errors) ====
+    var y;
+    ~~~
+!!! error TS1208: 'file2.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.
+    
+==== tests/cases/compiler/file3.ts (1 errors) ====
+    var z;
+    ~~~
+!!! error TS1208: 'file3.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.
+    

--- a/tests/baselines/reference/isolatedModulesNoExternalModuleMultiple.js
+++ b/tests/baselines/reference/isolatedModulesNoExternalModuleMultiple.js
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/isolatedModulesNoExternalModuleMultiple.ts] ////
+
+//// [file1.ts]
+var x;
+
+//// [file2.ts]
+var y;
+
+//// [file3.ts]
+var z;
+
+
+//// [file1.js]
+var x;
+//// [file2.js]
+var y;
+//// [file3.js]
+var z;

--- a/tests/baselines/reference/isolatedModulesNoExternalModuleMultiple.symbols
+++ b/tests/baselines/reference/isolatedModulesNoExternalModuleMultiple.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/file1.ts ===
+var x;
+>x : Symbol(x, Decl(file1.ts, 0, 3))
+
+=== tests/cases/compiler/file2.ts ===
+var y;
+>y : Symbol(y, Decl(file2.ts, 0, 3))
+
+=== tests/cases/compiler/file3.ts ===
+var z;
+>z : Symbol(z, Decl(file3.ts, 0, 3))
+

--- a/tests/baselines/reference/isolatedModulesNoExternalModuleMultiple.types
+++ b/tests/baselines/reference/isolatedModulesNoExternalModuleMultiple.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/file1.ts ===
+var x;
+>x : any
+
+=== tests/cases/compiler/file2.ts ===
+var y;
+>y : any
+
+=== tests/cases/compiler/file3.ts ===
+var z;
+>z : any
+

--- a/tests/cases/compiler/isolatedModulesExternalModuleForced.ts
+++ b/tests/cases/compiler/isolatedModulesExternalModuleForced.ts
@@ -1,0 +1,6 @@
+// @isolatedModules: true
+// @target: es6
+// @moduleDetection: force
+
+// @filename: file1.ts
+var x;

--- a/tests/cases/compiler/isolatedModulesNoExternalModuleMultiple.ts
+++ b/tests/cases/compiler/isolatedModulesNoExternalModuleMultiple.ts
@@ -1,0 +1,11 @@
+// @isolatedModules: true
+// @target: es6
+
+// @filename: file1.ts
+var x;
+
+// @filename: file2.ts
+var y;
+
+// @filename: file3.ts
+var z;


### PR DESCRIPTION
Fixes #49995

Previously, many files could be considered global scripts during a compile with `isolatedModules`, but only one TS1208 error would be generated.

Now, there is one TS1208 error raised per file.

This is a simple change to loop over each file and emit TS1208 if necessary. A new test was added to confirm that multiple TS1208 errors are generated. The test failed prior to this change.
