### PR TITLE
mark Intl.LocalesArgument as readonly

### DIFF
--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -83,7 +83,7 @@ declare namespace Intl {
      *
      * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument).
      */
-    type LocalesArgument = UnicodeBCP47LocaleIdentifier | Locale | (UnicodeBCP47LocaleIdentifier | Locale)[] | undefined;
+    type LocalesArgument = UnicodeBCP47LocaleIdentifier | Locale | readonly (UnicodeBCP47LocaleIdentifier | Locale)[] | undefined;
 
     /**
      * An object with some or all of properties of `options` parameter


### PR DESCRIPTION
This PR changes `Intl.LocalesArgument` to accept a readonly array, since typescript currently considers this to be unacceptable code:

```js
new Date().toLocaleDateString(navigator.languages)
```

```
Argument of type 'readonly string[]' is not assignable to parameter of type 'string | string[] | undefined'.
  The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.(2345)
```

([playground link](https://www.typescriptlang.org/play?#code/HYUw7gBAIghgLiAFASgHRwPYBkMGMYA2IsCAynAE4CWwA5osDAG5W3wYWoEx0CuMtEAGdkAbiA))

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

