### PR TITLE
fix: produceLKG does not work on Windows

### DIFF
--- a/scripts/produceLKG.ts
+++ b/scripts/produceLKG.ts
@@ -90,7 +90,7 @@ async function copyFromBuiltLocal(fileName: string) {
 }
 
 async function copyFilesWithGlob(pattern: string) {
-    const files = glob.sync(path.join(source, pattern)).map(f => path.basename(f));
+    const files = glob.sync(path.join(source, pattern).replace(/\\/g, "/")).map(f => path.basename(f));
     for (const f of files) {
         await copyFromBuiltLocal(f);
     }

--- a/scripts/produceLKG.ts
+++ b/scripts/produceLKG.ts
@@ -90,7 +90,7 @@ async function copyFromBuiltLocal(fileName: string) {
 }
 
 async function copyFilesWithGlob(pattern: string) {
-    const files = glob.sync(path.join(source, pattern).replace(/\\/g, "/")).map(f => path.basename(f));
+    const files = glob.sync(pattern, { cwd: source }).map(f => path.basename(f));
     for (const f of files) {
         await copyFromBuiltLocal(f);
     }


### PR DESCRIPTION
I'm publishing my own TypeScript version and I found the build script is not working on Windows.