### PR TITLE
fix: crashes under es6 build

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27022,7 +27022,9 @@ namespace ts {
                 case AssignmentDeclarationKind.ExportsProperty:
                 case AssignmentDeclarationKind.Prototype:
                 case AssignmentDeclarationKind.PrototypeProperty:
-                    let valueDeclaration = binaryExpression.left.symbol?.valueDeclaration;
+                    // TODO: this crashes in ES6
+                    // eslint-disable-next-line no-var
+                    var valueDeclaration = binaryExpression.left.symbol?.valueDeclaration;
                     // falls through
                 case AssignmentDeclarationKind.ModuleExports:
                     valueDeclaration ||= binaryExpression.symbol?.valueDeclaration;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1374,7 +1374,9 @@ namespace ts {
             // the program points to old source files that have been invalidated because of
             // incremental parsing.
 
-            const documentRegistryBucketKey = documentRegistry.getKeyForCompilationSettings(newSettings);
+            // TODO: this crashes in ES6
+            // eslint-disable-next-line no-var
+            var documentRegistryBucketKey = documentRegistry.getKeyForCompilationSettings(newSettings);
             const options: CreateProgramOptions = {
                 rootNames: rootFileNames,
                 options: newSettings,


### PR DESCRIPTION
I'm building tsc in ES6 for a better debugging experience, but it crashes with TDZ. This is a workaround.