### PR TITLE
Fix return value and error reporting for getIterationTypesOfMethod

### DIFF
--- a/tests/baselines/reference/for-of16.errors.txt
+++ b/tests/baselines/reference/for-of16.errors.txt
@@ -1,7 +1,8 @@
-tests/cases/conformance/es6/for-ofStatements/for-of16.ts(8,11): error TS2489: An iterator must have a 'next()' method.
+tests/cases/conformance/es6/for-ofStatements/for-of16.ts(8,11): error TS2488: Type 'StringIterator' must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/for-ofStatements/for-of16.ts(10,11): error TS2488: Type 'StringIterator' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
-==== tests/cases/conformance/es6/for-ofStatements/for-of16.ts (1 errors) ====
+==== tests/cases/conformance/es6/for-ofStatements/for-of16.ts (2 errors) ====
     class StringIterator {
         [Symbol.iterator]() {
             return this;
@@ -11,4 +12,10 @@ tests/cases/conformance/es6/for-ofStatements/for-of16.ts(8,11): error TS2489: An
     var v: string;
     for (v of new StringIterator) { } // Should fail
               ~~~~~~~~~~~~~~~~~~
-!!! error TS2489: An iterator must have a 'next()' method.
+!!! error TS2488: Type 'StringIterator' must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! related TS2489 tests/cases/conformance/es6/for-ofStatements/for-of16.ts:8:11: An iterator must have a 'next()' method.
+    
+    for (v of new StringIterator) { } // Should still fail (related errors should still be shown even though type is cached).
+              ~~~~~~~~~~~~~~~~~~
+!!! error TS2488: Type 'StringIterator' must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! related TS2489 tests/cases/conformance/es6/for-ofStatements/for-of16.ts:10:11: An iterator must have a 'next()' method.

--- a/tests/baselines/reference/for-of16.js
+++ b/tests/baselines/reference/for-of16.js
@@ -8,6 +8,8 @@ class StringIterator {
 var v: string;
 for (v of new StringIterator) { } // Should fail
 
+for (v of new StringIterator) { } // Should still fail (related errors should still be shown even though type is cached).
+
 //// [for-of16.js]
 class StringIterator {
     [Symbol.iterator]() {
@@ -16,3 +18,4 @@ class StringIterator {
 }
 var v;
 for (v of new StringIterator) { } // Should fail
+for (v of new StringIterator) { } // Should still fail (related errors should still be shown even though type is cached).

--- a/tests/baselines/reference/for-of16.symbols
+++ b/tests/baselines/reference/for-of16.symbols
@@ -20,3 +20,7 @@ for (v of new StringIterator) { } // Should fail
 >v : Symbol(v, Decl(for-of16.ts, 6, 3))
 >StringIterator : Symbol(StringIterator, Decl(for-of16.ts, 0, 0))
 
+for (v of new StringIterator) { } // Should still fail (related errors should still be shown even though type is cached).
+>v : Symbol(v, Decl(for-of16.ts, 6, 3))
+>StringIterator : Symbol(StringIterator, Decl(for-of16.ts, 0, 0))
+

--- a/tests/baselines/reference/for-of16.types
+++ b/tests/baselines/reference/for-of16.types
@@ -21,3 +21,8 @@ for (v of new StringIterator) { } // Should fail
 >new StringIterator : StringIterator
 >StringIterator : typeof StringIterator
 
+for (v of new StringIterator) { } // Should still fail (related errors should still be shown even though type is cached).
+>v : string
+>new StringIterator : StringIterator
+>StringIterator : typeof StringIterator
+

--- a/tests/baselines/reference/generatorTypeCheck31.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck31.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts(2,11): error TS2322: Type 'Generator<(x: any) => any, void, any>' is not assignable to type '() => Iterable<(x: string) => number>'.
-  Type 'Generator<(x: any) => any, void, any>' provides no match for the signature '(): Iterable<(x: string) => number>'.
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts(2,11): error TS2322: Type 'Generator<(x: any) => any, void, unknown>' is not assignable to type '() => Iterable<(x: string) => number>'.
+  Type 'Generator<(x: any) => any, void, unknown>' provides no match for the signature '(): Iterable<(x: string) => number>'.
 
 
 ==== tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts (1 errors) ====
@@ -10,6 +10,6 @@ tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts(2,11): erro
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         } ()
     ~~~~~~~~
-!!! error TS2322: Type 'Generator<(x: any) => any, void, any>' is not assignable to type '() => Iterable<(x: string) => number>'.
-!!! error TS2322:   Type 'Generator<(x: any) => any, void, any>' provides no match for the signature '(): Iterable<(x: string) => number>'.
+!!! error TS2322: Type 'Generator<(x: any) => any, void, unknown>' is not assignable to type '() => Iterable<(x: string) => number>'.
+!!! error TS2322:   Type 'Generator<(x: any) => any, void, unknown>' provides no match for the signature '(): Iterable<(x: string) => number>'.
     }

--- a/tests/baselines/reference/generatorTypeCheck31.types
+++ b/tests/baselines/reference/generatorTypeCheck31.types
@@ -5,8 +5,8 @@ function* g2(): Iterator<() => Iterable<(x: string) => number>> {
 
     yield function* () {
 >yield function* () {        yield x => x.length;    } () : undefined
->function* () {        yield x => x.length;    } () : Generator<(x: any) => any, void, any>
->function* () {        yield x => x.length;    } : () => Generator<(x: any) => any, void, any>
+>function* () {        yield x => x.length;    } () : Generator<(x: any) => any, void, unknown>
+>function* () {        yield x => x.length;    } : () => Generator<(x: any) => any, void, unknown>
 
         yield x => x.length;
 >yield x => x.length : any

--- a/tests/baselines/reference/generatorTypeCheck6.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck6.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck6.ts(1,17): error TS2322: Type 'Generator<any, any, any>' is not assignable to type 'number'.
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck6.ts(1,17): error TS2322: Type 'Generator<any, any, unknown>' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck6.ts (1 errors) ====
     function* g1(): number { }
                     ~~~~~~
-!!! error TS2322: Type 'Generator<any, any, any>' is not assignable to type 'number'.
+!!! error TS2322: Type 'Generator<any, any, unknown>' is not assignable to type 'number'.

--- a/tests/baselines/reference/iteratorSpreadInArray10.errors.txt
+++ b/tests/baselines/reference/iteratorSpreadInArray10.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/spread/iteratorSpreadInArray10.ts(7,17): error TS2489: An iterator must have a 'next()' method.
+tests/cases/conformance/es6/spread/iteratorSpreadInArray10.ts(7,17): error TS2488: Type 'SymbolIterator' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/spread/iteratorSpreadInArray10.ts (1 errors) ====
@@ -10,4 +10,5 @@ tests/cases/conformance/es6/spread/iteratorSpreadInArray10.ts(7,17): error TS248
     
     var array = [...new SymbolIterator];
                     ~~~~~~~~~~~~~~~~~~
-!!! error TS2489: An iterator must have a 'next()' method.
+!!! error TS2488: Type 'SymbolIterator' must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! related TS2489 tests/cases/conformance/es6/spread/iteratorSpreadInArray10.ts:7:17: An iterator must have a 'next()' method.

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
@@ -36,7 +36,7 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(59,12): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(62,12): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(64,42): error TS2741: Property '[Symbol.iterator]' is missing in type 'AsyncGenerator<number, any, undefined>' but required in type 'IterableIterator<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(67,42): error TS2741: Property '[Symbol.iterator]' is missing in type 'AsyncGenerator<any, any, any>' but required in type 'Iterable<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(67,42): error TS2741: Property '[Symbol.iterator]' is missing in type 'AsyncGenerator<any, any, unknown>' but required in type 'Iterable<number>'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(70,42): error TS2322: Type 'AsyncGenerator<number, any, undefined>' is not assignable to type 'Iterator<number, any, undefined>'.
   The types returned by 'next(...)' are incompatible between these types.
     Type 'Promise<IteratorResult<number, any>>' is not assignable to type 'IteratorResult<number, any>'.
@@ -173,7 +173,7 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
     }
     async function * explicitReturnType11(): Iterable<number> {
                                              ~~~~~~~~~~~~~~~~
-!!! error TS2741: Property '[Symbol.iterator]' is missing in type 'AsyncGenerator<any, any, any>' but required in type 'Iterable<number>'.
+!!! error TS2741: Property '[Symbol.iterator]' is missing in type 'AsyncGenerator<any, any, unknown>' but required in type 'Iterable<number>'.
 !!! related TS2728 /.ts/lib.es2015.iterable.d.ts:51:5: '[Symbol.iterator]' is declared here.
         yield 1;
     }

--- a/tests/cases/conformance/es6/for-ofStatements/for-of16.ts
+++ b/tests/cases/conformance/es6/for-ofStatements/for-of16.ts
@@ -7,3 +7,5 @@ class StringIterator {
 
 var v: string;
 for (v of new StringIterator) { } // Should fail
+
+for (v of new StringIterator) { } // Should still fail (related errors should still be shown even though type is cached).


### PR DESCRIPTION
This fixes `getIterationTypesOfMethod` to correctly return `undefined` when the iterator type does not have a valid `next` method. This also ensures related errors are still reported when we've already cached a `noIterationTypes` result.

Related #49736
