### PR TITLE
Simplify normalizeSlashes

### DIFF
--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -452,12 +452,9 @@ namespace ts {
      * Normalize path separators, converting `\` into `/`.
      */
     export function normalizeSlashes(path: string): string {
-        const index = path.indexOf("\\");
-        if (index === -1) {
-            return path;
-        }
-        backslashRegExp.lastIndex = index; // prime regex with known position
-        return path.replace(backslashRegExp, directorySeparator);
+        return path.indexOf("\\") !== -1
+            ? path.replace(backslashRegExp, directorySeparator)
+            : path;
     }
 
     /**


### PR DESCRIPTION
It turns out that `replace` totally ignores `lastIndex`. It's faster to not set the property, and then (seemingly) a little faster still to use a conditional (it is at least consistent with other functions like this one).