### PR TITLE
Forbid functions named `require` in JS

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37845,7 +37845,7 @@ namespace ts {
 
         function checkCollisionWithRequireExportsInGeneratedCode(node: Node, name: Identifier | undefined) {
             // No need to check for require or exports for ES6 modules and later
-            if (moduleKind >= ModuleKind.ES2015 && !(moduleKind >= ModuleKind.Node16 && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)) {
+            if (moduleKind >= ModuleKind.ES2015 && !isInJSFile(node) && !(moduleKind >= ModuleKind.Node16 && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)) {
                 return;
             }
 
@@ -37862,8 +37862,14 @@ namespace ts {
             const parent = getDeclarationContainer(node);
             if (parent.kind === SyntaxKind.SourceFile && isExternalOrCommonJsModule(parent as SourceFile)) {
                 // If the declaration happens to be in external module, report error that require and exports are reserved keywords
-                errorSkippedOn("noEmit", name, Diagnostics.Duplicate_identifier_0_Compiler_reserves_name_1_in_top_level_scope_of_a_module,
-                    declarationNameToString(name), declarationNameToString(name));
+                if (isInJSFile(node)) {
+                    error(name, Diagnostics.Duplicate_identifier_0_Compiler_reserves_name_1_in_top_level_scope_of_a_module,
+                        declarationNameToString(name), declarationNameToString(name));
+                }
+                else {
+                    errorSkippedOn("noEmit", name, Diagnostics.Duplicate_identifier_0_Compiler_reserves_name_1_in_top_level_scope_of_a_module,
+                        declarationNameToString(name), declarationNameToString(name));
+                }
             }
         }
 

--- a/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=node16).errors.txt
+++ b/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=node16).errors.txt
@@ -1,3 +1,5 @@
+tests/cases/conformance/node/allowJs/index.js(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
+tests/cases/conformance/node/allowJs/index.js(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
 tests/cases/conformance/node/allowJs/subfolder/index.js(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
 tests/cases/conformance/node/allowJs/subfolder/index.js(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
 tests/cases/conformance/node/allowJs/subfolder/index.js(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 with module Node16.
@@ -19,10 +21,14 @@ tests/cases/conformance/node/allowJs/subfolder/index.js(5,14): error TS1216: Ide
                  ~~~~~~~~~~
 !!! error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.
     export {require, exports, Object};
-==== tests/cases/conformance/node/allowJs/index.js (0 errors) ====
+==== tests/cases/conformance/node/allowJs/index.js (2 errors) ====
     // esm format file
     function require() {}
+             ~~~~~~~
+!!! error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
     const exports = {};
+          ~~~~~~~
+!!! error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
     class Object {}
     export const __esModule = false;
     export {require, exports, Object};

--- a/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=nodenext).errors.txt
+++ b/tests/baselines/reference/nodeModulesAllowJsGeneratedNameCollisions(module=nodenext).errors.txt
@@ -1,3 +1,5 @@
+tests/cases/conformance/node/allowJs/index.js(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
+tests/cases/conformance/node/allowJs/index.js(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
 tests/cases/conformance/node/allowJs/subfolder/index.js(2,10): error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
 tests/cases/conformance/node/allowJs/subfolder/index.js(3,7): error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
 tests/cases/conformance/node/allowJs/subfolder/index.js(4,7): error TS2725: Class name cannot be 'Object' when targeting ES5 with module NodeNext.
@@ -19,10 +21,14 @@ tests/cases/conformance/node/allowJs/subfolder/index.js(5,14): error TS1216: Ide
                  ~~~~~~~~~~
 !!! error TS1216: Identifier expected. '__esModule' is reserved as an exported marker when transforming ECMAScript modules.
     export {require, exports, Object};
-==== tests/cases/conformance/node/allowJs/index.js (0 errors) ====
+==== tests/cases/conformance/node/allowJs/index.js (2 errors) ====
     // esm format file
     function require() {}
+             ~~~~~~~
+!!! error TS2441: Duplicate identifier 'require'. Compiler reserves name 'require' in top level scope of a module.
     const exports = {};
+          ~~~~~~~
+!!! error TS2441: Duplicate identifier 'exports'. Compiler reserves name 'exports' in top level scope of a module.
     class Object {}
     export const __esModule = false;
     export {require, exports, Object};


### PR DESCRIPTION
Fixes #48726

This is a maximal version that forbids it everywhere. I want to see how much of the user tests will break.
