### PR TITLE
fix(50075): JS declaration emit does not capture undefined-ness of function class properties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8070,7 +8070,7 @@ namespace ts {
                                 factory.createModifiersFromModifierFlags((isReadonlySymbol(p) ? ModifierFlags.Readonly : 0) | flag),
                                 name,
                                 p.flags & SymbolFlags.Optional ? factory.createToken(SyntaxKind.QuestionToken) : undefined,
-                                isPrivate ? undefined : serializeTypeForDeclaration(context, getTypeOfSymbol(p), p, enclosingDeclaration, includePrivateSymbol, bundled),
+                                isPrivate ? undefined : serializeTypeForDeclaration(context, getWriteTypeOfSymbol(p), p, enclosingDeclaration, includePrivateSymbol, bundled),
                                 // TODO: https://github.com/microsoft/TypeScript/pull/32372#discussion_r328386357
                                 // interface members can't have initializers, however class members _can_
                                 /*initializer*/ undefined

--- a/tests/baselines/reference/jsdocFunctionClassPropertiesDeclaration.js
+++ b/tests/baselines/reference/jsdocFunctionClassPropertiesDeclaration.js
@@ -1,0 +1,47 @@
+//// [a.js]
+/**
+ * @param {number | undefined} x
+ * @param {number | undefined} y
+ */
+export function Foo(x, y) {
+    if (!(this instanceof Foo)) {
+        return new Foo(x, y);
+    }
+    this.x = x;
+    this.y = y;
+}
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+exports.Foo = void 0;
+/**
+ * @param {number | undefined} x
+ * @param {number | undefined} y
+ */
+function Foo(x, y) {
+    if (!(this instanceof Foo)) {
+        return new Foo(x, y);
+    }
+    this.x = x;
+    this.y = y;
+}
+exports.Foo = Foo;
+
+
+//// [a.d.ts]
+/**
+ * @param {number | undefined} x
+ * @param {number | undefined} y
+ */
+export function Foo(x: number | undefined, y: number | undefined): Foo;
+export class Foo {
+    /**
+     * @param {number | undefined} x
+     * @param {number | undefined} y
+     */
+    constructor(x: number | undefined, y: number | undefined);
+    x: number | undefined;
+    y: number | undefined;
+}

--- a/tests/baselines/reference/jsdocFunctionClassPropertiesDeclaration.symbols
+++ b/tests/baselines/reference/jsdocFunctionClassPropertiesDeclaration.symbols
@@ -1,0 +1,32 @@
+=== /a.js ===
+/**
+ * @param {number | undefined} x
+ * @param {number | undefined} y
+ */
+export function Foo(x, y) {
+>Foo : Symbol(Foo, Decl(a.js, 0, 0))
+>x : Symbol(x, Decl(a.js, 4, 20))
+>y : Symbol(y, Decl(a.js, 4, 22))
+
+    if (!(this instanceof Foo)) {
+>this : Symbol(Foo, Decl(a.js, 0, 0))
+>Foo : Symbol(Foo, Decl(a.js, 0, 0))
+
+        return new Foo(x, y);
+>Foo : Symbol(Foo, Decl(a.js, 0, 0))
+>x : Symbol(x, Decl(a.js, 4, 20))
+>y : Symbol(y, Decl(a.js, 4, 22))
+    }
+    this.x = x;
+>this.x : Symbol(Foo.x, Decl(a.js, 7, 5))
+>this : Symbol(Foo, Decl(a.js, 0, 0))
+>x : Symbol(Foo.x, Decl(a.js, 7, 5))
+>x : Symbol(x, Decl(a.js, 4, 20))
+
+    this.y = y;
+>this.y : Symbol(Foo.y, Decl(a.js, 8, 15))
+>this : Symbol(Foo, Decl(a.js, 0, 0))
+>y : Symbol(Foo.y, Decl(a.js, 8, 15))
+>y : Symbol(y, Decl(a.js, 4, 22))
+}
+

--- a/tests/baselines/reference/jsdocFunctionClassPropertiesDeclaration.types
+++ b/tests/baselines/reference/jsdocFunctionClassPropertiesDeclaration.types
@@ -1,0 +1,38 @@
+=== /a.js ===
+/**
+ * @param {number | undefined} x
+ * @param {number | undefined} y
+ */
+export function Foo(x, y) {
+>Foo : typeof Foo
+>x : number | undefined
+>y : number | undefined
+
+    if (!(this instanceof Foo)) {
+>!(this instanceof Foo) : boolean
+>(this instanceof Foo) : boolean
+>this instanceof Foo : boolean
+>this : this
+>Foo : typeof Foo
+
+        return new Foo(x, y);
+>new Foo(x, y) : Foo
+>Foo : typeof Foo
+>x : number | undefined
+>y : number | undefined
+    }
+    this.x = x;
+>this.x = x : number | undefined
+>this.x : any
+>this : this
+>x : any
+>x : number | undefined
+
+    this.y = y;
+>this.y = y : number | undefined
+>this.y : any
+>this : this
+>y : any
+>y : number | undefined
+}
+

--- a/tests/cases/compiler/jsdocFunctionClassPropertiesDeclaration.ts
+++ b/tests/cases/compiler/jsdocFunctionClassPropertiesDeclaration.ts
@@ -1,0 +1,18 @@
+// @allowJs: true
+// @checkJs: true
+// @strict: true
+// @declaration: true
+// @outDir: ./out
+// @filename: /a.js
+
+/**
+ * @param {number | undefined} x
+ * @param {number | undefined} y
+ */
+export function Foo(x, y) {
+    if (!(this instanceof Foo)) {
+        return new Foo(x, y);
+    }
+    this.x = x;
+    this.y = y;
+}


### PR DESCRIPTION
Fixes #50075