### PR TITLE
Run ESLint over our JS files, fix all lints

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@
 /tests/**
 /lib/**
 /src/lib/*.generated.d.ts
+/scripts/*.js
+/scripts/eslint/built/**

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,9 +16,12 @@
     "overrides": [
         // By default, the ESLint CLI only looks at .js files. But, it will also look at
         // any files which are referenced in an override config. Most users of typescript-eslint
-        // get this behavior by defauly by extending the recommended TS config, which happens
-        // to override some core ESLint rules for TS files. We don't extend from the recommended
-        // config, so explicitly include TS files here.
+        // get this behavior by default by extending a recommended typescript-eslint config, which 
+        // just so happens to override some core ESLint rules. We don't extend from any config, so
+        // explicitly reference TS files here so the CLI picks them up.
+        //
+        // ESLint in VS Code will lint any opened file (so long as it's not eslintignore'd), so
+        // that will work regardless of the below.
         { "files": ["*.ts"] }
     ],
     "rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,14 @@
     "plugins": [
         "@typescript-eslint", "jsdoc", "no-null", "import"
     ],
+    "overrides": [
+        // By default, the ESLint CLI only looks at .js files. But, it will also look at
+        // any files which are referenced in an override config. Most users of typescript-eslint
+        // get this behavior by defauly by extending the recommended TS config, which happens
+        // to override some core ESLint rules for TS files. We don't extend from the recommended
+        // config, so explicitly include TS files here.
+        { "files": ["*.ts"] }
+    ],
     "rules": {
         "@typescript-eslint/adjacent-overload-signatures": "error",
         "@typescript-eslint/array-type": "error",

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -6,7 +6,6 @@
     ],
     "eslint.options": {
         "rulePaths": ["./scripts/eslint/built/rules/"],
-        "extensions": [".ts"]
     },
     // To use the last-known-good (LKG) compiler version:
     // "typescript.tsdk": "lib"

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -364,7 +364,6 @@ const eslint = (folder) => async () => {
         "--cache-location", `${folder}/.eslintcache`,
         "--format", formatter,
         "--rulesdir", "scripts/eslint/built/rules",
-        "--ext", ".ts",
     ];
 
     if (cmdLineOptions.fix) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
                 "typescript": "^4.5.5",
                 "vinyl": "latest",
                 "vinyl-sourcemaps-apply": "latest",
+                "which": "^2.0.2",
                 "xml2js": "^0.4.23"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "typescript": "^4.5.5",
         "vinyl": "latest",
         "vinyl-sourcemaps-apply": "latest",
+        "which": "^2.0.2",
         "xml2js": "^0.4.23"
     },
     "overrides": {

--- a/scripts/build/options.js
+++ b/scripts/build/options.js
@@ -7,6 +7,7 @@ module.exports = minimist(process.argv.slice(2), {
     boolean: ["dirty", "light", "colors", "lint", "lkg", "soft", "fix", "failed", "keepFailed", "force", "built"],
     string: ["browser", "tests", "break", "host", "reporter", "stackTraceLimit", "timeout", "shards", "shardId"],
     alias: {
+        /* eslint-disable quote-props */
         "b": "browser",
         "i": ["inspect", "inspect-brk", "break", "debug", "debug-brk"],
         "t": ["tests", "test"],
@@ -16,6 +17,7 @@ module.exports = minimist(process.argv.slice(2), {
         "skippercent": "skipPercent",
         "w": "workers",
         "f": "fix"
+        /* eslint-enable quote-props */
     },
     default: {
         soft: false,

--- a/scripts/build/prepend.js
+++ b/scripts/build/prepend.js
@@ -1,6 +1,5 @@
 // @ts-check
 const stream = require("stream");
-const Vinyl = require("vinyl");
 const ts = require("../../lib/typescript");
 const fs = require("fs");
 const { base64VLQFormatEncode } = require("./sourcemaps");
@@ -43,13 +42,14 @@ function prepend(data) {
                         sourcesContent: input.sourcesContent
                     };
                 }
+                // eslint-disable-next-line boolean-trivia, no-null/no-null
                 return cb(null, output);
             }
             catch (e) {
                 return cb(e);
             }
         }
-    })
+    });
 }
 exports.prepend = prepend;
 
@@ -59,6 +59,6 @@ exports.prepend = prepend;
 function prependFile(file) {
     const data = typeof file === "string" ? fs.readFileSync(file, "utf8") :
         vinyl => fs.readFileSync(file(vinyl), "utf8");
-    return prepend(data)
+    return prepend(data);
 }
 exports.prependFile = prependFile;

--- a/scripts/build/projects.js
+++ b/scripts/build/projects.js
@@ -35,7 +35,7 @@ class ProjectQueue {
     }
 }
 
-const execTsc = (lkg, ...args) =>
+const execTsc = (/** @type {boolean} */ lkg, /** @type {string[]} */ ...args) =>
     exec(process.execPath,
          [resolve(findUpRoot(), lkg ? "./lib/tsc" : "./built/local/tsc"),
           "-b", ...args],
@@ -45,7 +45,7 @@ const projectBuilder = new ProjectQueue((projects, lkg, force) => execTsc(lkg, .
 
 /**
  * @param {string} project
- * @param {object} [options]
+ * @param {object} options
  * @param {boolean} [options.lkg=true]
  * @param {boolean} [options.force=false]
  */
@@ -58,11 +58,11 @@ const projectCleaner = new ProjectQueue((projects, lkg) => execTsc(lkg, "--clean
  */
 exports.cleanProject = (project) => projectCleaner.enqueue(project);
 
-const projectWatcher = new ProjectQueue((projects) => execTsc(true, "--watch", ...projects));
+const projectWatcher = new ProjectQueue((projects) => execTsc(/*lkg*/ true, "--watch", ...projects));
 
 /**
  * @param {string} project
- * @param {object} [options]
+ * @param {object} options
  * @param {boolean} [options.lkg=true]
  */
 exports.watchProject = (project, { lkg } = {}) => projectWatcher.enqueue(project, { lkg });

--- a/scripts/build/sourcemaps.js
+++ b/scripts/build/sourcemaps.js
@@ -46,3 +46,5 @@ function base64VLQFormatEncode(value) {
     return result;
 }
 exports.base64VLQFormatEncode = base64VLQFormatEncode;
+
+/** @typedef {object} RawSourceMap */

--- a/scripts/build/tests.js
+++ b/scripts/build/tests.js
@@ -27,7 +27,7 @@ exports.localTest262Baseline = "internal/baselines/test262/local";
  */
 async function runConsoleTests(runJs, defaultReporter, runInParallel, watchMode, cancelToken = CancellationToken.none) {
     let testTimeout = cmdLineOptions.timeout;
-    let tests = cmdLineOptions.tests;
+    const tests = cmdLineOptions.tests;
     const inspect = cmdLineOptions.break || cmdLineOptions.inspect;
     const runners = cmdLineOptions.runners;
     const light = cmdLineOptions.light;
@@ -72,7 +72,7 @@ async function runConsoleTests(runJs, defaultReporter, runInParallel, watchMode,
     const reporter = cmdLineOptions.reporter || defaultReporter;
 
     /** @type {string[]} */
-    let args = [];
+    const args = [];
 
     // timeout normally isn't necessary but Travis-CI has been timing out on compiler baselines occasionally
     // default timeout is 2sec which really should be enough, but maybe we just need a small amount longer
@@ -101,7 +101,7 @@ async function runConsoleTests(runJs, defaultReporter, runInParallel, watchMode,
             args.push("--no-colors");
         }
         if (inspect !== undefined) {
-            args.unshift((inspect == "" || inspect === true) ? "--inspect-brk" : "--inspect-brk="+inspect);
+            args.unshift((inspect === "" || inspect === true) ? "--inspect-brk" : "--inspect-brk="+inspect);
             args.push("-t", "0");
         }
         else {
@@ -160,7 +160,7 @@ async function runConsoleTests(runJs, defaultReporter, runInParallel, watchMode,
 exports.runConsoleTests = runConsoleTests;
 
 async function cleanTestDirs() {
-    await del([exports.localBaseline, exports.localRwcBaseline])
+    await del([exports.localBaseline, exports.localRwcBaseline]);
     mkdirP.sync(exports.localRwcBaseline);
     mkdirP.sync(exports.localBaseline);
 }
@@ -214,5 +214,5 @@ function deleteTemporaryProjectOutput() {
 }
 
 function regExpEscape(text) {
-    return text.replace(/[.*+?^${}()|\[\]\\]/g, '\\$&');
+    return text.replace(/[.*+?^${}()|\[\]\\]/g, "\\$&");
 }

--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -1,4 +1,7 @@
 // @ts-check
+
+/* eslint-disable no-restricted-globals */
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../types/ambient.d.ts" />
 
 const fs = require("fs");
@@ -128,6 +131,7 @@ function streamFromBuffer(buffer) {
     return new Readable({
         read() {
             this.push(buffer);
+            // eslint-disable-next-line no-null/no-null
             this.push(null);
         }
     });
@@ -249,7 +253,7 @@ function flatten(projectSpec, flattenedProjectSpec, options = {}) {
     const files = [];
     const resolvedOutputSpec = path.resolve(cwd, flattenedProjectSpec);
     const resolvedOutputDirectory = path.dirname(resolvedOutputSpec);
-    const resolvedProjectSpec = resolveProjectSpec(projectSpec, cwd, undefined);
+    const resolvedProjectSpec = resolveProjectSpec(projectSpec, cwd, /*referrer*/ undefined);
     const project = readJson(resolvedProjectSpec);
     const skipProjects = /**@type {Set<string>}*/(new Set());
     const skipFiles = new Set(options && options.exclude && options.exclude.map(file => normalizeSlashes(path.resolve(cwd, file))));
@@ -310,7 +314,7 @@ function normalizeSlashes(file) {
  * @returns {string}
  */
 function resolveProjectSpec(projectSpec, cwd, referrer) {
-    let projectPath = normalizeSlashes(path.resolve(cwd, referrer ? path.dirname(referrer) : "", projectSpec));
+    const projectPath = normalizeSlashes(path.resolve(cwd, referrer ? path.dirname(referrer) : "", projectSpec));
     const stats = fs.statSync(projectPath);
     if (stats.isFile()) return normalizeSlashes(projectPath);
     return normalizeSlashes(path.resolve(cwd, projectPath, "tsconfig.json"));
@@ -321,7 +325,10 @@ function resolveProjectSpec(projectSpec, cwd, referrer) {
  * @param {{ cwd?: string }} [opts]
  */
 function rm(dest, opts) {
-    if (dest && typeof dest === "object") opts = dest, dest = undefined;
+    if (dest && typeof dest === "object") {
+        opts = dest;
+        dest = undefined;
+    }
     let failed = false;
 
     const cwd = path.resolve(opts && opts.cwd || process.cwd());
@@ -369,6 +376,7 @@ function rm(dest, opts) {
             pending.push(entry);
         },
         final(cb) {
+            // eslint-disable-next-line no-null/no-null
             const endThenCb = () => (duplex.push(null), cb()); // signal end of read queue
             processDeleted();
             if (pending.length) {


### PR DESCRIPTION
In prep for adding copyright headers to all of our source files, make our lint task run ESLint on our JS files too (which will need the headers, and I want ESLint to enforce that).

Our `.eslintignore` already covers ignoring the js files we don't care about, e.g. build artifacts and baselines.