### PR TITLE
Disable JS size limit by default

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1153,7 +1153,7 @@ namespace ts {
             affectsProgramStructure: true,
             category: Diagnostics.Editor_Support,
             description: Diagnostics.Remove_the_20mb_cap_on_total_source_code_size_for_JavaScript_files_in_the_TypeScript_language_server,
-            defaultValueDescription: false,
+            defaultValueDescription: true,
         },
         {
             name: "disableSourceOfProjectReferenceRedirect",

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1959,7 +1959,8 @@ namespace ts.server {
 
         /** Get a filename if the language service exceeds the maximum allowed program size; otherwise returns undefined. */
         private getFilenameForExceededTotalSizeLimitForNonTsFiles<T>(name: string, options: CompilerOptions | undefined, fileNames: T[], propertyReader: FilePropertyReader<T>): string | undefined {
-            if (options && options.disableSizeLimit || !this.host.getFileSize) {
+            // Size limit is disabled if option is not specified
+            if (options?.disableSizeLimit !== false || !this.host.getFileSize) {
                 return;
             }
 

--- a/src/testRunner/unittests/tsserver/configuredProjects.ts
+++ b/src/testRunner/unittests/tsserver/configuredProjects.ts
@@ -717,7 +717,7 @@ namespace ts.projectSystem {
             };
             const config = {
                 path: "/a/jsconfig.json",
-                content: "{}"
+                content: `{ "compilerOptions": { "disableSizeLimit": false } }`
             };
             const host = createServerHost([f1, f2, config]);
             const originalGetFileSize = host.getFileSize;

--- a/src/testRunner/unittests/tsserver/events/projectLanguageServiceState.ts
+++ b/src/testRunner/unittests/tsserver/events/projectLanguageServiceState.ts
@@ -11,7 +11,7 @@ namespace ts.projectSystem {
             };
             const config = {
                 path: "/a/jsconfig.json",
-                content: "{}"
+                content: `{ "compilerOptions": { "disableSizeLimit": false } }`
             };
             const configWithExclude = {
                 path: config.path,
@@ -65,7 +65,7 @@ namespace ts.projectSystem {
             };
             const config = {
                 path: "/a/jsconfig.json",
-                content: "{}"
+                content: `{ "compilerOptions": { "disableSizeLimit": false } }`
             };
             const host = createServerHost([f1, f2, f3, libFile, config]);
             const service = createProjectService(host, { logger: createLoggerWithInMemoryLogs() });

--- a/src/testRunner/unittests/tsserver/externalProjects.ts
+++ b/src/testRunner/unittests/tsserver/externalProjects.ts
@@ -470,11 +470,12 @@ namespace ts.projectSystem {
 
             const service = createProjectService(host);
             const projectFileName = "/a/proj.csproj";
+            const options = { disableSizeLimit: false };
 
             service.openExternalProject({
                 projectFileName,
                 rootFiles: toExternalFiles([f1.path, f2.path]),
-                options: {}
+                options,
             });
             service.checkNumberOfProjects({ externalProjects: 1 });
             assert.isFalse(service.externalProjects[0].languageServiceEnabled, "language service should be disabled - 1");
@@ -482,7 +483,7 @@ namespace ts.projectSystem {
             service.openExternalProject({
                 projectFileName,
                 rootFiles: toExternalFiles([f1.path]),
-                options: {}
+                options,
             });
             service.checkNumberOfProjects({ externalProjects: 1 });
             assert.isTrue(service.externalProjects[0].languageServiceEnabled, "language service should be enabled");
@@ -490,7 +491,7 @@ namespace ts.projectSystem {
             service.openExternalProject({
                 projectFileName,
                 rootFiles: toExternalFiles([f1.path, f2.path]),
-                options: {}
+                options,
             });
             service.checkNumberOfProjects({ externalProjects: 1 });
             assert.isFalse(service.externalProjects[0].languageServiceEnabled, "language service should be disabled - 2");

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -77,15 +77,17 @@ namespace ts.projectSystem {
             const host = createServerHost([file1, file2, file3]);
             const projectService = createProjectService(host);
 
-            projectService.openExternalProject({ rootFiles: toExternalFiles([file1.path]), options: {}, projectFileName: proj1name });
+            const options = { disableSizeLimit: false };
+
+            projectService.openExternalProject({ rootFiles: toExternalFiles([file1.path]), options, projectFileName: proj1name });
             const proj1 = projectService.findProject(proj1name)!;
             assert.isTrue(proj1.languageServiceEnabled);
 
-            projectService.openExternalProject({ rootFiles: toExternalFiles([file2.path]), options: {}, projectFileName: proj2name });
+            projectService.openExternalProject({ rootFiles: toExternalFiles([file2.path]), options, projectFileName: proj2name });
             const proj2 = projectService.findProject(proj2name)!;
             assert.isTrue(proj2.languageServiceEnabled);
 
-            projectService.openExternalProject({ rootFiles: toExternalFiles([file3.path]), options: {}, projectFileName: proj3name });
+            projectService.openExternalProject({ rootFiles: toExternalFiles([file3.path]), options, projectFileName: proj3name });
             const proj3 = projectService.findProject(proj3name)!;
             assert.isFalse(proj3.languageServiceEnabled);
         });
@@ -107,7 +109,7 @@ namespace ts.projectSystem {
             const host = createServerHost([file1, file2]);
             const projectService = createProjectService(host, { useSingleInferredProject: true, eventHandler: noop });
 
-            projectService.openExternalProject({ rootFiles: toExternalFiles([file1.path, file2.path]), options: {}, projectFileName: projName });
+            projectService.openExternalProject({ rootFiles: toExternalFiles([file1.path, file2.path]), options: { disableSizeLimit: false }, projectFileName: projName });
             const proj1 = projectService.findProject(projName)!;
             assert.isFalse(proj1.languageServiceEnabled);
 

--- a/src/testRunner/unittests/tsserver/telemetry.ts
+++ b/src/testRunner/unittests/tsserver/telemetry.ts
@@ -233,7 +233,7 @@ namespace ts.projectSystem {
 
         it("detects whether language service was disabled", () => {
             const file = makeFile("/a.js");
-            const tsconfig = makeFile("/jsconfig.json", {});
+            const tsconfig = makeFile("/jsconfig.json", { compilerOptions: { disableSizeLimit: false } });
             const et = new TestServerEventManager([tsconfig, file]);
             const fileSize = server.maxProgramSizeForNonTsFiles + 1;
             et.host.getFileSize = () => fileSize;
@@ -241,7 +241,7 @@ namespace ts.projectSystem {
             et.getEvent<server.ProjectLanguageServiceStateEvent>(server.ProjectLanguageServiceStateEvent);
             et.assertProjectInfoTelemetryEvent({
                 fileStats: fileStats({ js: 1, jsSize: fileSize }),
-                compilerOptions: autoJsCompilerOptions,
+                compilerOptions: { ...autoJsCompilerOptions, disableSizeLimit: false },
                 configFileName: "jsconfig.json",
                 typeAcquisition: {
                     enable: true,

--- a/tests/baselines/reference/tsserver/projectLanguageServiceStateEvent/large-file-size-is-determined-correctly.js
+++ b/tests/baselines/reference/tsserver/projectLanguageServiceStateEvent/large-file-size-is-determined-correctly.js
@@ -16,6 +16,7 @@ Config: /a/jsconfig.json : {
   "allowSyntheticDefaultImports": true,
   "skipLibCheck": true,
   "noEmit": true,
+  "disableSizeLimit": false,
   "configFilePath": "/a/jsconfig.json"
  }
 }


### PR DESCRIPTION
Now that VS and VS Code both ship with 64-bit node, it seems a little arbitrary.

You can still enable it with `disableSizeLimit: false` but it's not obvious why someone would want to do that explicitly.  We kept the option mostly so that specifying it wouldn't be an error.