### PR TITLE
Add stricter Object.fromEntries for constructing from const tuples

### DIFF
--- a/lib/lib.es2019.object.d.ts
+++ b/lib/lib.es2019.object.d.ts
@@ -25,6 +25,14 @@ interface ObjectConstructor {
      * Returns an object created by key-value entries for properties and methods
      * @param entries An iterable object that contains key-value entries for properties and methods.
      */
+    <KeyValue extends readonly [any, any]>(
+      entries: Iterable<KeyValue>,
+    ) => { [K in KeyValue[0]]: KeyValue extends readonly [K, infer V] ? V : never };
+
+    /**
+     * Returns an object created by key-value entries for properties and methods
+     * @param entries An iterable object that contains key-value entries for properties and methods.
+     */
     fromEntries<T = any>(entries: Iterable<readonly [PropertyKey, T]>): { [k: string]: T };
 
     /**

--- a/lib/lib.es2019.object.d.ts
+++ b/lib/lib.es2019.object.d.ts
@@ -25,11 +25,7 @@ interface ObjectConstructor {
      * Returns an object created by key-value entries for properties and methods
      * @param entries An iterable object that contains key-value entries for properties and methods.
      */
-    <KeyValue extends readonly [PropertyKey, any]>(
-      entries: Iterable<KeyValue>,
-    ) => [KeyValue] extends [[PropertyKey, any]]
-      ? { [k: string]: KeyValue[1] }
-      : { [K in KeyValue[0]]: KeyValue extends readonly [K, infer V] ? V : never };
+    fromEntries<T = any>(entries: Iterable<readonly [PropertyKey, T]>): { [k: string]: T };
 
     /**
      * Returns an object created by key-value entries for properties and methods

--- a/lib/lib.es2019.object.d.ts
+++ b/lib/lib.es2019.object.d.ts
@@ -25,15 +25,11 @@ interface ObjectConstructor {
      * Returns an object created by key-value entries for properties and methods
      * @param entries An iterable object that contains key-value entries for properties and methods.
      */
-    <KeyValue extends readonly [any, any]>(
+    <KeyValue extends readonly [PropertyKey, any]>(
       entries: Iterable<KeyValue>,
-    ) => { [K in KeyValue[0]]: KeyValue extends readonly [K, infer V] ? V : never };
-
-    /**
-     * Returns an object created by key-value entries for properties and methods
-     * @param entries An iterable object that contains key-value entries for properties and methods.
-     */
-    fromEntries<T = any>(entries: Iterable<readonly [PropertyKey, T]>): { [k: string]: T };
+    ) => [KeyValue] extends [[PropertyKey, any]]
+      ? { [k: string]: KeyValue[1] }
+      : { [K in KeyValue[0]]: KeyValue extends readonly [K, infer V] ? V : never };
 
     /**
      * Returns an object created by key-value entries for properties and methods

--- a/src/lib/es2019.object.d.ts
+++ b/src/lib/es2019.object.d.ts
@@ -5,7 +5,7 @@ interface ObjectConstructor {
      * Returns an object created by key-value entries for properties and methods
      * @param entries An iterable object that contains key-value entries for properties and methods.
      */
-    <KeyValue extends readonly [PropertyKey, any]>(
+    fromEntries<KeyValue extends readonly [PropertyKey, any]>(
       entries: Iterable<KeyValue>,
     ): [KeyValue] extends [[PropertyKey, any]]
       ? { [k: string]: KeyValue[1] }

--- a/src/lib/es2019.object.d.ts
+++ b/src/lib/es2019.object.d.ts
@@ -5,7 +5,11 @@ interface ObjectConstructor {
      * Returns an object created by key-value entries for properties and methods
      * @param entries An iterable object that contains key-value entries for properties and methods.
      */
-    fromEntries<T = any>(entries: Iterable<readonly [PropertyKey, T]>): { [k: string]: T };
+    <KeyValue extends readonly [PropertyKey, any]>(
+      entries: Iterable<KeyValue>,
+    ): [KeyValue] extends [[PropertyKey, any]]
+      ? { [k: string]: KeyValue[1] }
+      : { [K in KeyValue[0]]: KeyValue extends readonly [K, infer V] ? V : never };
 
     /**
      * Returns an object created by key-value entries for properties and methods


### PR DESCRIPTION
Related issue: #50379.

**UPDATE**: The version in this branch is unsound, but see the [last comment](https://github.com/microsoft/TypeScript/pull/50203#issuecomment-1221189259) here with a proposed solution that is sound.

-----

`Object.fromEntries` as is declared today results in a loss of key names and a unionization of all values, or a complete loss of information and type of `any`. 
This change makes it so that it is possible to create strict objects from const tuples.

```ts
const obj1 = Object.fromEntries([
  ['1', 2],
  ['3', 4],
] as const)

// now results in an object of type: {1: 2, 3: 4}, previously { [k: string]: 2 | 4 }

const obj2 = Object.fromEntries([
  ['1', 2],
  ['3', '4'],
] as const)

// now results in an object of type: {1: 2, 3: '4'}, previously any
```

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #35745, #49305, #43332
