### PR TITLE
Make RegExpMatchArray index and input field non-optional

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -907,8 +907,8 @@ interface DateConstructor {
 declare var Date: DateConstructor;
 
 interface RegExpMatchArray extends Array<string> {
-    index?: number;
-    input?: string;
+    index: number;
+    input: string;
 }
 
 interface RegExpExecArray extends Array<string> {


### PR DESCRIPTION
On MDN, I don't see documentation for any case where either of these could be `undefined`. This change dates all the way back to 2017 when @jedmao asked @DanielRosenwasser about it, but there was no response:

https://github.com/microsoft/TypeScript/commit/7bf846ab3dd620e182da2bb4dc6f85b23016aecf#diff-88c6092c5611bde0c0df8f538cb4334bcdc2860d73616190f1c3d3095ceda301R794

Either this is a mistake or there indeed is a case where either of these can be `undefined` but if that's the case, can anyone please educate me on that? I will update the MDN page to include information about this as well as add JSDoc description to the fields so that this information appears on hover, too.

The fields being optional is problematic because either one has to add a condition that will never be useful for anything or use the `!` operator. The problem with the latter is that it is not obvious why it needs to be there (circling back to the root of this issue) and that TypeScript is also used for type checking JavaScript with JSDoc and JavaScript has no `!`, so code like this won't work in JavaScript checked with TypeScript:

```javascript
for (const match of ''.matchAll(/something/g)) {
  results[match.index] = match[0];
}
```

In a case like this, the only solution is to use `@ts-ignore` and risk missing other erros on that line or to add the presumable useless condition for checking `index` is not `undefined`.

---

Please verify that:

* [ ] There is an associated issue in the `Backlog` milestone (**required**)
  Is TypeScript an open-source project of the barier for inclusion of a change
  is this high? In this particular case, am I expect to raise this issue, get a backlog
  item created for it (how does that work?), then go create the two-character PR
  refering to the backlog item and weeks later maybe get it fixed?
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
  Again, how does this make any sense as a general policy? GitHub has a web UI
  for contributing changes and there is a CI to run tests, why expect all contributors
  to check out TypeScript and figure out how to build it and run tests locally?
* [ ] There are new or updated unit tests validating the change
  I don't think this change will impact any tests, at most, if any have this
  condition to check for `undefined`s on these fields, it will become extraneous.
  Let's see what the CI says.

** Please don't send typo fixes! **
> Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

Seriously???