### PR TITLE
fix(50117): Using @extends in JavaScript + JSDoc removes method documentations

### DIFF
--- a/tests/baselines/reference/jsdocOnInheritedMembers.baseline
+++ b/tests/baselines/reference/jsdocOnInheritedMembers.baseline
@@ -1,0 +1,73 @@
+[
+  {
+    "marker": {
+      "fileName": "/a.js",
+      "position": 175,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 169,
+        "length": 6
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "B",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "Method documentation.",
+          "kind": "text"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/jsdocOnInheritedMembers.ts
+++ b/tests/cases/fourslash/jsdocOnInheritedMembers.ts
@@ -1,0 +1,20 @@
+///<reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+// @filename: /a.js
+/////** @template T */
+////class A {
+////    /** Method documentation. */
+////    method() {}
+////}
+////
+/////** @extends {A<number>} */
+////class B extends A {
+////    method() {}
+////}
+////
+////const b = new B();
+////b.method/**/;
+
+verify.baselineQuickInfo();


### PR DESCRIPTION
Fixes #50117