### PR TITLE
fix: crashes when JSX.IntrinsicClassAttributes is an alias type close GH-50254

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27612,12 +27612,16 @@ namespace ts {
                 if (!isErrorType(intrinsicClassAttribs)) {
                     const typeParams = getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(intrinsicClassAttribs.symbol);
                     const hostClassType = getReturnTypeOfSignature(sig);
-                    apparentAttributesType = intersectTypes(
-                        typeParams
-                            ? createTypeReference(intrinsicClassAttribs as GenericType, fillMissingTypeArguments([hostClassType], typeParams, getMinTypeArgumentCount(typeParams), isInJSFile(context)))
-                            : intrinsicClassAttribs,
-                        apparentAttributesType
-                    );
+                    let libraryManagedAttributeType: Type | undefined;
+                    if (typeParams && typeParams.length === 1) {
+                        const inferredArgs = fillMissingTypeArguments([hostClassType], typeParams, getMinTypeArgumentCount(typeParams), isInJSFile(context));
+                        libraryManagedAttributeType = instantiateType(intrinsicClassAttribs, createTypeMapper(typeParams, inferredArgs));
+                    }
+                    else if (typeParams) libraryManagedAttributeType = undefined;
+                    else libraryManagedAttributeType = intrinsicClassAttribs;
+                    if (libraryManagedAttributeType) {
+                        apparentAttributesType = intersectTypes(libraryManagedAttributeType, apparentAttributesType);
+                    }
                 }
 
                 const intrinsicAttribs = getJsxType(JsxNames.IntrinsicAttributes, context);

--- a/tests/baselines/reference/jsxClassAttributeResolution.errors.txt
+++ b/tests/baselines/reference/jsxClassAttributeResolution.errors.txt
@@ -1,0 +1,28 @@
+tests/cases/compiler/file.tsx(2,19): error TS2741: Property 'ref' is missing in type '{}' but required in type 'IntrinsicClassAttributesAlias<T>'.
+
+
+==== tests/cases/compiler/file.tsx (1 errors) ====
+    class App {}
+    export const a = <App></App>;
+                      ~~~
+!!! error TS2741: Property 'ref' is missing in type '{}' but required in type 'IntrinsicClassAttributesAlias<T>'.
+!!! related TS2728 /.src/tests/cases/compiler/node_modules/@types/react/index.d.ts:2:5: 'ref' is declared here.
+==== tests/cases/compiler/node_modules/@types/react/package.json (0 errors) ====
+    {
+        "name": "@types/react",
+        "version": "0.0.1",
+        "main": "",
+        "types": "index.d.ts",
+    }
+==== tests/cases/compiler/node_modules/@types/react/index.d.ts (0 errors) ====
+    interface IntrinsicClassAttributesAlias<T> {
+        ref: T
+    }
+    declare namespace JSX {
+        type IntrinsicClassAttributes<T> = IntrinsicClassAttributesAlias<T>
+    }
+==== tests/cases/compiler/node_modules/@types/react/jsx-runtime.d.ts (0 errors) ====
+    import './';
+==== tests/cases/compiler/node_modules/@types/react/jsx-dev-runtime.d.ts (0 errors) ====
+    import './';
+    

--- a/tests/baselines/reference/jsxClassAttributeResolution.js
+++ b/tests/baselines/reference/jsxClassAttributeResolution.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/jsxClassAttributeResolution.tsx] ////
+
+//// [file.tsx]
+class App {}
+export const a = <App></App>;
+//// [package.json]
+{
+    "name": "@types/react",
+    "version": "0.0.1",
+    "main": "",
+    "types": "index.d.ts",
+}
+//// [index.d.ts]
+interface IntrinsicClassAttributesAlias<T> {
+    ref: T
+}
+declare namespace JSX {
+    type IntrinsicClassAttributes<T> = IntrinsicClassAttributesAlias<T>
+}
+//// [jsx-runtime.d.ts]
+import './';
+//// [jsx-dev-runtime.d.ts]
+import './';
+
+
+//// [file.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.a = void 0;
+const jsx_runtime_1 = require("react/jsx-runtime");
+class App {
+}
+exports.a = (0, jsx_runtime_1.jsx)(App, {});

--- a/tests/baselines/reference/jsxClassAttributeResolution.symbols
+++ b/tests/baselines/reference/jsxClassAttributeResolution.symbols
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/file.tsx ===
+class App {}
+>App : Symbol(App, Decl(file.tsx, 0, 0))
+
+export const a = <App></App>;
+>a : Symbol(a, Decl(file.tsx, 1, 12))
+>App : Symbol(App, Decl(file.tsx, 0, 0))
+>App : Symbol(App, Decl(file.tsx, 0, 0))
+
+=== tests/cases/compiler/node_modules/@types/react/index.d.ts ===
+interface IntrinsicClassAttributesAlias<T> {
+>IntrinsicClassAttributesAlias : Symbol(IntrinsicClassAttributesAlias, Decl(index.d.ts, 0, 0))
+>T : Symbol(T, Decl(index.d.ts, 0, 40))
+
+    ref: T
+>ref : Symbol(IntrinsicClassAttributesAlias.ref, Decl(index.d.ts, 0, 44))
+>T : Symbol(T, Decl(index.d.ts, 0, 40))
+}
+declare namespace JSX {
+>JSX : Symbol(JSX, Decl(index.d.ts, 2, 1))
+
+    type IntrinsicClassAttributes<T> = IntrinsicClassAttributesAlias<T>
+>IntrinsicClassAttributes : Symbol(IntrinsicClassAttributes, Decl(index.d.ts, 3, 23))
+>T : Symbol(T, Decl(index.d.ts, 4, 34))
+>IntrinsicClassAttributesAlias : Symbol(IntrinsicClassAttributesAlias, Decl(index.d.ts, 0, 0))
+>T : Symbol(T, Decl(index.d.ts, 4, 34))
+}
+=== tests/cases/compiler/node_modules/@types/react/jsx-runtime.d.ts ===
+import './';
+No type information for this code.=== tests/cases/compiler/node_modules/@types/react/jsx-dev-runtime.d.ts ===
+import './';
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/jsxClassAttributeResolution.types
+++ b/tests/baselines/reference/jsxClassAttributeResolution.types
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/file.tsx ===
+class App {}
+>App : App
+
+export const a = <App></App>;
+>a : any
+><App></App> : any
+>App : typeof App
+>App : typeof App
+
+=== tests/cases/compiler/node_modules/@types/react/index.d.ts ===
+interface IntrinsicClassAttributesAlias<T> {
+    ref: T
+>ref : T
+}
+declare namespace JSX {
+    type IntrinsicClassAttributes<T> = IntrinsicClassAttributesAlias<T>
+>IntrinsicClassAttributes : IntrinsicClassAttributes<T>
+}
+=== tests/cases/compiler/node_modules/@types/react/jsx-runtime.d.ts ===
+import './';
+No type information for this code.=== tests/cases/compiler/node_modules/@types/react/jsx-dev-runtime.d.ts ===
+import './';
+No type information for this code.
+No type information for this code.

--- a/tests/cases/compiler/jsxClassAttributeResolution.tsx
+++ b/tests/cases/compiler/jsxClassAttributeResolution.tsx
@@ -1,0 +1,23 @@
+// @jsx: react-jsx
+// @module: nodenext
+// @filename: file.tsx
+class App {}
+export const a = <App></App>;
+// @filename: node_modules/@types/react/package.json
+{
+    "name": "@types/react",
+    "version": "0.0.1",
+    "main": "",
+    "types": "index.d.ts",
+}
+// @filename: node_modules/@types/react/index.d.ts
+interface IntrinsicClassAttributesAlias<T> {
+    ref: T
+}
+declare namespace JSX {
+    type IntrinsicClassAttributes<T> = IntrinsicClassAttributesAlias<T>
+}
+// @filename: node_modules/@types/react/jsx-runtime.d.ts
+import './';
+// @filename: node_modules/@types/react/jsx-dev-runtime.d.ts
+import './';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #50254
