### PR TITLE
Fix deprecatedCompat create/updateConstructorDeclaration functions

### DIFF
--- a/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
+++ b/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
@@ -535,7 +535,7 @@ namespace ts {
                     (decorators === undefined || !some(decorators, isModifier)) &&
                     (modifiers === undefined || !some(modifiers, isParameter)) &&
                     (parameters === undefined || isArray(parameters)) &&
-                    (body === undefined || !isBlock(body)),
+                    (body === undefined || isBlock(body)),
             })
             .deprecate({
                 1: DISALLOW_DECORATORS
@@ -563,7 +563,7 @@ namespace ts {
                     (decorators === undefined || !some(decorators, isModifier)) &&
                     (modifiers === undefined || !some(modifiers, isParameter)) &&
                     (parameters === undefined || isArray(parameters)) &&
-                    (body === undefined || !isBlock(body)),
+                    (body === undefined || isBlock(body)),
             })
             .deprecate({
                 1: DISALLOW_DECORATORS

--- a/src/testRunner/unittests/factory.ts
+++ b/src/testRunner/unittests/factory.ts
@@ -81,5 +81,28 @@ namespace ts {
                 checkRhs(SyntaxKind.QuestionQuestionEqualsToken, /*expectParens*/ false);
             });
         });
+
+        describe("deprecatedCompat/mergeDecoratorsAndModifiers", () => {
+            it("supports deprecated createConstructorDeclaration/updateConstructorDeclaration functions", () => {
+                const body = factory.createBlock([]);
+                const ctor = factory.createConstructorDeclaration(
+                    /*decorators*/ undefined,
+                    /*modifiers*/ undefined,
+                    /*parameters*/ [],
+                    /*body*/ body,
+                );
+
+                const newBody = factory.createBlock([]);
+                const updatedCtor = factory.updateConstructorDeclaration(
+                    ctor,
+                    /*decorators*/ ctor.decorators,
+                    /*modifiers*/ ctor.modifiers?.filter(isModifier),
+                    /*parameters*/ ctor.parameters,
+                    /*body*/ newBody,
+                );
+
+                assert.strictEqual(updatedCtor.body, newBody);
+            });
+        });
     });
 }


### PR DESCRIPTION
Fix an incorrect check for the `body` parameter of the deprecated overloads for create/updateConstructorDeclaration, which made them throw a type error at runtime.

Fixes #50259