### PR TITLE
Make `React` import fix not block component import fix

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1119,6 +1119,13 @@ namespace ts {
     }
 
     /**
+     * Returns the only element of an array if it contains only one element; throws otherwise.
+     */
+    export function single<T>(array: readonly T[]): T {
+        return Debug.checkDefined(singleOrUndefined(array));
+    }
+
+    /**
      * Returns the only element of an array if it contains only one element; otherwise, returns the
      * array.
      */

--- a/tests/cases/fourslash/importNameCodeFix_importType9.ts
+++ b/tests/cases/fourslash/importNameCodeFix_importType9.ts
@@ -1,0 +1,39 @@
+/// <reference path="fourslash.ts" />
+// @module: es2015
+// @esModuleInterop: true
+// @jsx: react
+
+// @Filename: /types.d.ts
+//// declare module "react" { var React: any; export = React; export as namespace React; }
+
+// @Filename: /component.tsx
+//// export function Component() { return <div />; }
+
+// @Filename: /a.tsx
+//// import type React from "react";
+//// import type { Component } from "./component";
+//// (<Component/**/ />)
+
+goTo.marker("");
+
+// It would be preferable for these fixes to be provided simultaneously, like the add-new-import fixes are,
+// but this is such a weird edge case that I don't know that it's worth it - the test mainly ensures that
+// both fixes are eventually offered without crashing and that they do what they say they're going to do.
+
+verify.codeFix({
+  index: 0,
+  description: [ts.Diagnostics.Remove_type_from_import_declaration_from_0.message, "react"],
+  applyChanges: true,
+  newFileContent: `import React from "react";
+import type { Component } from "./component";
+(<Component />)`
+});
+
+verify.codeFix({
+  index: 0,
+  description: [ts.Diagnostics.Remove_type_from_import_declaration_from_0.message, "./component"],
+  applyChanges: true,
+  newFileContent: `import React from "react";
+import { Component } from "./component";
+(<Component />)`
+});

--- a/tests/cases/fourslash/importNameCodeFix_jsx6.ts
+++ b/tests/cases/fourslash/importNameCodeFix_jsx6.ts
@@ -20,22 +20,23 @@
 ////<[|Text|]></Text>;
 
 goTo.file("/a.tsx");
+
 verify.codeFix({
     index: 0,
-    description: [ts.Diagnostics.Import_0_from_1.message, "React", "react"],
-    applyChanges: true,
+    description: [ts.Diagnostics.Add_import_from_0.message, "react-native"],
+    applyChanges: false,
     newFileContent:
-`import React from "react";
+`import { Text } from "react-native";
 
 <Text></Text>;`
 });
 
 verify.codeFix({
-    index: 0,
-    description: [ts.Diagnostics.Add_import_from_0.message, "react-native"],
-    newFileContent:
+  index: 1,
+  description: [ts.Diagnostics.Import_0_from_1.message, "React", "react"],
+  applyChanges: false,
+  newFileContent:
 `import React from "react";
-import { Text } from "react-native";
 
 <Text></Text>;`
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

“Fixes” #50192

There’s been a lot of confusion lately about whether an import of `React` is needed in JSX files under different JSX compilers, and how to configure TypeScript to recognize that requirement or lack thereof. Historically, if TypeScript thought that a `React` import was needed, auto-imports would _only_ offer to import `React` on JSX opening tags, even if the local component name _also_ needed to be imported.

Before:

```ts
(<Component />);
// Errors: Cannot find name 'Component', Cannot find name 'React'
// Fixes: Add import from "react"
```

After:

```ts
(<Component />);
// Errors: Cannot find name 'Component', Cannot find name 'React'
// Fixes: Add import from "./Component", Add import from "react"
```

Users should still configure TS to get rid of that error if it doesn’t apply to their build system, but hopefully making both auto-imports available will make the misconfiguration a bit less painful, especially for plain-JS VS Code users who are just getting default settings and don’t know where they’re coming from.