### PR TITLE
Fix export = error message to not have redundant language

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2819,7 +2819,7 @@ namespace ts {
                         if (exportAssignment) {
                             addRelatedInfo(err, createDiagnosticForNode(
                                 exportAssignment,
-                                Diagnostics.This_module_is_declared_with_using_export_and_can_only_be_used_with_a_default_import_when_using_the_0_flag,
+                                Diagnostics.This_module_is_declared_with_export_and_can_only_be_used_with_a_default_import_when_using_the_0_flag,
                                 compilerOptionName
                             ));
                         }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2677,7 +2677,7 @@
         "category": "Error",
         "code": 2593
     },
-    "This module is declared with using 'export =', and can only be used with a default import when using the '{0}' flag.": {
+    "This module is declared with 'export =', and can only be used with a default import when using the '{0}' flag.": {
         "category": "Error",
         "code": 2594
     },

--- a/tests/baselines/reference/allowSyntheticDefaultImports6.errors.txt
+++ b/tests/baselines/reference/allowSyntheticDefaultImports6.errors.txt
@@ -11,6 +11,6 @@ tests/cases/compiler/a.ts(1,8): error TS1259: Module '"tests/cases/compiler/b"' 
     import Foo from "./b";
            ~~~
 !!! error TS1259: Module '"tests/cases/compiler/b"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/b.d.ts:4:1: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/b.d.ts:4:1: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     export var x = new Foo();
     

--- a/tests/baselines/reference/es6ExportEqualsInterop.errors.txt
+++ b/tests/baselines/reference/es6ExportEqualsInterop.errors.txt
@@ -77,43 +77,43 @@ tests/cases/compiler/main.ts(106,15): error TS2498: Module '"class-module"' uses
     import x1 from "interface";
            ~~
 !!! error TS1259: Module '"interface"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/modules.d.ts:6:5: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/modules.d.ts:6:5: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     import x2 from "variable";
            ~~
 !!! error TS1259: Module '"variable"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/modules.d.ts:14:5: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/modules.d.ts:14:5: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     import x3 from "interface-variable";
            ~~
 !!! error TS1259: Module '"interface-variable"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/modules.d.ts:26:5: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/modules.d.ts:26:5: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     import x4 from "module";
            ~~
 !!! error TS1259: Module '"module"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/modules.d.ts:34:5: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/modules.d.ts:34:5: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     import x5 from "interface-module";
            ~~
 !!! error TS1259: Module '"interface-module"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/modules.d.ts:46:5: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/modules.d.ts:46:5: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     import x6 from "variable-module";
            ~~
 !!! error TS1259: Module '"variable-module"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/modules.d.ts:60:5: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/modules.d.ts:60:5: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     import x7 from "function";
            ~~
 !!! error TS1259: Module '"function"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/modules.d.ts:65:5: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/modules.d.ts:65:5: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     import x8 from "function-module";
            ~~
 !!! error TS1259: Module '"function-module"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/modules.d.ts:74:5: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/modules.d.ts:74:5: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     import x9 from "class";
            ~~
 !!! error TS1259: Module '"class"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/modules.d.ts:82:5: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/modules.d.ts:82:5: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     import x0 from "class-module";
            ~~
 !!! error TS1259: Module '"class-module"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/modules.d.ts:94:5: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/modules.d.ts:94:5: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     
     // namespace import
     import * as y1 from "interface";

--- a/tests/baselines/reference/es6ImportDefaultBindingInEs5.errors.txt
+++ b/tests/baselines/reference/es6ImportDefaultBindingInEs5.errors.txt
@@ -9,4 +9,4 @@ tests/cases/compiler/es6ImportDefaultBindingInEs5_1.ts(1,8): error TS1259: Modul
     import defaultBinding from "./es6ImportDefaultBindingInEs5_0";
            ~~~~~~~~~~~~~~
 !!! error TS1259: Module '"tests/cases/compiler/es6ImportDefaultBindingInEs5_0"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 tests/cases/compiler/es6ImportDefaultBindingInEs5_0.ts:2:1: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 tests/cases/compiler/es6ImportDefaultBindingInEs5_0.ts:2:1: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.

--- a/tests/baselines/reference/exportAssignmentWithoutAllowSyntheticDefaultImportsError.errors.txt
+++ b/tests/baselines/reference/exportAssignmentWithoutAllowSyntheticDefaultImportsError.errors.txt
@@ -12,4 +12,4 @@
     import bar from './bar';
            ~~~
 !!! error TS1259: Module '"/bar"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
-!!! related TS2594 /bar.ts:1:1: This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+!!! related TS2594 /bar.ts:1:1: This module is declared with 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.

--- a/tests/baselines/reference/javascriptImportDefaultBadExport.errors.txt
+++ b/tests/baselines/reference/javascriptImportDefaultBadExport.errors.txt
@@ -12,5 +12,5 @@
     import a from "./a";
            ~
 !!! error TS1259: Module '"/a"' can only be default-imported using the 'esModuleInterop' flag
-!!! related TS2594 /a.js:5:1: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+!!! related TS2594 /a.js:5:1: This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
     

--- a/tests/baselines/reference/tscWatch/watchApi/verify-that-module-resolution-with-json-extension-works-when-returned-without-extension.js
+++ b/tests/baselines/reference/tscWatch/watchApi/verify-that-module-resolution-with-json-extension-works-when-returned-without-extension.js
@@ -35,7 +35,7 @@ Output::
   [96msettings.json[0m:[93m1[0m:[93m1[0m
     [7m1[0m {"content":"Print this"}
     [7m [0m [96m~[0m
-    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+    This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
 
 [[90m12:00:26 AM[0m] Found 1 error. Watching for file changes.
 


### PR DESCRIPTION
I noticed this while working on a project this weekend; this message currently says:

> This module is declared with using 'export ='

"with using" is sorta like typoing "is is". I removed "using" so it's not duplicated, but that's just a wording taste.