### PR TITLE
Ignore related info in diagnostic deduplication

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3944,7 +3944,7 @@ namespace ts {
                 diagnostics = nonFileDiagnostics;
             }
 
-            insertSorted(diagnostics, diagnostic, compareDiagnostics);
+            insertSorted(diagnostics, diagnostic, compareDiagnosticsSkipRelatedInformation);
         }
 
         function getGlobalDiagnostics(): Diagnostic[] {

--- a/tests/baselines/reference/jsxSpreadOverwritesAttributeStrict.errors.txt
+++ b/tests/baselines/reference/jsxSpreadOverwritesAttributeStrict.errors.txt
@@ -6,13 +6,12 @@ tests/cases/conformance/jsx/file.tsx(20,23): error TS2783: 'b' is specified more
 tests/cases/conformance/jsx/file.tsx(21,17): error TS2783: 'a' is specified more than once, so this usage will be overwritten.
 tests/cases/conformance/jsx/file.tsx(21,23): error TS2783: 'd' is specified more than once, so this usage will be overwritten.
 tests/cases/conformance/jsx/file.tsx(22,17): error TS2783: 'a' is specified more than once, so this usage will be overwritten.
-tests/cases/conformance/jsx/file.tsx(22,17): error TS2783: 'a' is specified more than once, so this usage will be overwritten.
 tests/cases/conformance/jsx/file.tsx(22,23): error TS2783: 'd' is specified more than once, so this usage will be overwritten.
 
 
 !!! error TS2318: Cannot find global type 'CallableFunction'.
 !!! error TS2318: Cannot find global type 'NewableFunction'.
-==== tests/cases/conformance/jsx/file.tsx (8 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (7 errors) ====
     import React = require('react');
     
     interface Props {
@@ -53,9 +52,6 @@ tests/cases/conformance/jsx/file.tsx(22,23): error TS2783: 'd' is specified more
                     ~~~~~
 !!! error TS2783: 'a' is specified more than once, so this usage will be overwritten.
 !!! related TS2785 tests/cases/conformance/jsx/file.tsx:22:29: This spread always overwrites this property.
-                    ~~~~~
-!!! error TS2783: 'a' is specified more than once, so this usage will be overwritten.
-!!! related TS2785 tests/cases/conformance/jsx/file.tsx:22:40: This spread always overwrites this property.
                           ~~~~~
 !!! error TS2783: 'd' is specified more than once, so this usage will be overwritten.
 !!! related TS2785 tests/cases/conformance/jsx/file.tsx:22:40: This spread always overwrites this property.

--- a/tests/baselines/reference/objectSpreadNegative.errors.txt
+++ b/tests/baselines/reference/objectSpreadNegative.errors.txt
@@ -10,7 +10,6 @@ tests/cases/conformance/types/spread/objectSpreadNegative.ts(28,36): error TS111
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(28,53): error TS1117: An object literal cannot have multiple properties with the same name.
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(32,7): error TS2783: 'b' is specified more than once, so this usage will be overwritten.
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(37,7): error TS2783: 'b' is specified more than once, so this usage will be overwritten.
-tests/cases/conformance/types/spread/objectSpreadNegative.ts(37,7): error TS2783: 'b' is specified more than once, so this usage will be overwritten.
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(39,14): error TS2783: 'b' is specified more than once, so this usage will be overwritten.
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(41,53): error TS2783: 'd' is specified more than once, so this usage will be overwritten.
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(43,7): error TS2783: 'a' is specified more than once, so this usage will be overwritten.
@@ -27,7 +26,7 @@ tests/cases/conformance/types/spread/objectSpreadNegative.ts(69,9): error TS2339
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(74,11): error TS2339: Property 'a' does not exist on type '{}'.
 
 
-==== tests/cases/conformance/types/spread/objectSpreadNegative.ts (23 errors) ====
+==== tests/cases/conformance/types/spread/objectSpreadNegative.ts (22 errors) ====
     let o = { a: 1, b: 'no' }
     
     /// private propagates
@@ -91,9 +90,6 @@ tests/cases/conformance/types/spread/objectSpreadNegative.ts(74,11): error TS233
           ~~~~~~~
 !!! error TS2783: 'b' is specified more than once, so this usage will be overwritten.
 !!! related TS2785 tests/cases/conformance/types/spread/objectSpreadNegative.ts:37:16: This spread always overwrites this property.
-          ~~~~~~~
-!!! error TS2783: 'b' is specified more than once, so this usage will be overwritten.
-!!! related TS2785 tests/cases/conformance/types/spread/objectSpreadNegative.ts:37:23: This spread always overwrites this property.
     let combinedMid: { a: number, b: string, c: boolean } =
         { ...o3, b: 'ok', ...o4 }
                  ~~~~~~~

--- a/tests/cases/fourslash/deduplicateErrors.ts
+++ b/tests/cases/fourslash/deduplicateErrors.ts
@@ -1,0 +1,8 @@
+/// <reference path="./fourslash.ts" />
+
+////let lololol = 123;
+////
+////lololo/**/
+
+verify.encodedSemanticClassificationsLength("2020", 3);
+verify.numberOfErrorsInCurrentFile(1);

--- a/tests/cases/fourslash/insertReturnStatementInDuplicateIdentifierFunction.ts
+++ b/tests/cases/fourslash/insertReturnStatementInDuplicateIdentifierFunction.ts
@@ -6,10 +6,10 @@
 goTo.marker();
 
 // Function with bodies can only merge with classes
-// Class declaration cannot implement overload list x 2
-verify.numberOfErrorsInCurrentFile(4);
+// Class declaration cannot implement overload list
+verify.numberOfErrorsInCurrentFile(2);
 
 // Shouldn't change the number of errors
 edit.insert('return null;');
-verify.numberOfErrorsInCurrentFile(4);
+verify.numberOfErrorsInCurrentFile(2);
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Probably fixes #50243 but I can’t reproduce it. I noticed this first in https://github.com/microsoft/TypeScript/pull/50088#pullrequestreview-1060854727 and worked around it. I think there may be more than one place we deduplicate diagnostics which makes this not noticeable on the CLI or in error baselines—the two baselines that changed actually had materially different related info, but I still think it’s better to deduplicate. In the fourslash test that changed, however, the language service actually had two identical copies
of each diagnostic.

Also fixes #49437