### PR TITLE
Ensure all scripts are checked, fix errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ scripts/produceLKG.js
 scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.js
 scripts/generateLocalizedDiagnosticMessages.js
 scripts/request-pr-review.js
+scripts/errorCheck.js
 scripts/*.js.map
 scripts/typings/
 coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
             },
             "devDependencies": {
                 "@octokit/rest": "latest",
+                "@types/async": "latest",
                 "@types/chai": "latest",
                 "@types/convert-source-map": "latest",
                 "@types/fs-extra": "^9.0.13",
@@ -434,6 +435,12 @@
             "dependencies": {
                 "@octokit/openapi-types": "^13.0.0"
             }
+        },
+        "node_modules/@types/async": {
+            "version": "3.2.15",
+            "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
+            "integrity": "sha512-PAmPfzvFA31mRoqZyTVsgJMsvbynR429UTTxhmfsUCrWGh3/fxOrzqBtaTPJsn4UtzTv4Vb0+/O7CARWb69N4g==",
+            "dev": true
         },
         "node_modules/@types/chai": {
             "version": "4.3.3",
@@ -8883,6 +8890,12 @@
             "requires": {
                 "@octokit/openapi-types": "^13.0.0"
             }
+        },
+        "@types/async": {
+            "version": "3.2.15",
+            "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
+            "integrity": "sha512-PAmPfzvFA31mRoqZyTVsgJMsvbynR429UTTxhmfsUCrWGh3/fxOrzqBtaTPJsn4UtzTv4Vb0+/O7CARWb69N4g==",
+            "dev": true
         },
         "@types/chai": {
             "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     },
     "devDependencies": {
         "@octokit/rest": "latest",
+        "@types/async": "latest",
         "@types/chai": "latest",
         "@types/convert-source-map": "latest",
         "@types/fs-extra": "^9.0.13",

--- a/scripts/authors.ts
+++ b/scripts/authors.ts
@@ -1,6 +1,6 @@
-import fs = require("fs");
-import path = require("path");
-import childProcess = require("child_process");
+import * as fs from "fs";
+import * as path from "path";
+import * as childProcess from "child_process";
 
 interface Author {
     displayNames: string[];
@@ -120,10 +120,10 @@ namespace Commands {
         const authors: { name: string, email: string, knownAuthor?: Author }[] = [];
         const {output: [error, stdout, stderr]} = childProcess.spawnSync(`git`, ["shortlog", "-se", ...specs], { cwd: path.resolve(__dirname, "../") });
         if (error) {
-            console.log(stderr.toString());
+            console.log(stderr!.toString());
         }
         else {
-            const output = stdout.toString();
+            const output = stdout!.toString();
             const lines = output.split("\n");
             lines.forEach(line => {
                 if (line) {

--- a/scripts/configureLanguageServiceBuild.ts
+++ b/scripts/configureLanguageServiceBuild.ts
@@ -1,7 +1,7 @@
 /// <reference types="node"/>
 import { normalize, dirname, join } from "path";
 import { readFileSync, writeFileSync, unlinkSync, existsSync } from "fs";
-import assert = require("assert");
+import * as assert from "assert";
 import { execSync } from "child_process";
 const args = process.argv.slice(2);
 
@@ -10,11 +10,11 @@ const args = process.argv.slice(2);
  */
 interface PackageJson {
     name: string;
-    bin: {};
+    bin?: {};
     main: string;
     scripts: {
-        prepare: string
-        postpublish: string
+        prepare?: string
+        postpublish?: string
     }
 }
 

--- a/scripts/configurePrerelease.ts
+++ b/scripts/configurePrerelease.ts
@@ -1,6 +1,6 @@
 /// <reference types="node"/>
 import { normalize, relative } from "path";
-import assert = require("assert");
+import * as assert from "assert";
 import { readFileSync, writeFileSync } from "fs";
 
 /**

--- a/scripts/errorCheck.ts
+++ b/scripts/errorCheck.ts
@@ -1,6 +1,6 @@
-const fs = require("fs");
-const async = require("async");
-const glob = require("glob");
+import * as fs from "fs";
+import * as async from "async";
+import * as glob from "glob";
 
 fs.readFile("src/compiler/diagnosticMessages.json", "utf-8", (err, data) => {
     if (err) {
@@ -25,7 +25,7 @@ fs.readFile("src/compiler/diagnosticMessages.json", "utf-8", (err, data) => {
             fs.readFile(baseDir + f, "utf-8", (err, baseline) => {
                 if (err) throw err;
 
-                let g: string[];
+                let g: RegExpExecArray | null;
                 while (g = errRegex.exec(baseline)) {
                     const errCode = +g[1];
                     const msg = keys.filter(k => messages[k].code === errCode)[0];
@@ -53,7 +53,7 @@ fs.readFile("src/compiler/diagnosticMessages.json", "utf-8", (err, data) => {
 fs.readFile("src/compiler/diagnosticInformationMap.generated.ts", "utf-8", (err, data) => {
     const errorRegexp = /\s(\w+): \{ code/g;
     const errorNames: string[] = [];
-    let errMatch: string[];
+    let errMatch: RegExpExecArray | null;
     while (errMatch = errorRegexp.exec(data)) {
         errorNames.push(errMatch[1]);
     }

--- a/scripts/failed-tests.d.ts
+++ b/scripts/failed-tests.d.ts
@@ -1,4 +1,4 @@
-import Mocha = require("mocha");
+import * as Mocha from "mocha";
 
 export = FailedTestsReporter;
 

--- a/scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.ts
+++ b/scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as childProcess from "child_process";
+import assert = require("assert");
 
 
 interface Map<T> {
@@ -46,7 +47,7 @@ function copyFileSync(source: string, destination: string) {
     fs.writeFileSync(destination, text);
 }
 
-function importDefinitelyTypedTest(tscPath: string, rwcTestPath: string, testCaseName: string, testFiles: string[], responseFile: string) {
+function importDefinitelyTypedTest(tscPath: string, rwcTestPath: string, testCaseName: string, testFiles: string[], responseFile: string | undefined) {
     let cmd = "node " + tscPath + " --module commonjs " + testFiles.join(" ");
     if (responseFile) {
         cmd += " @" + responseFile;
@@ -122,7 +123,7 @@ function importDefinitelyTypedTests(tscPath: string, rwcTestPath: string, defini
 
                     const tsFiles: string[] = [];
                     const testFiles: string[] = [];
-                    let paramFile: string;
+                    let paramFile: string | undefined;
 
                     for (const filePath of files.map(f => path.join(directoryPath, f))) {
                         if (filePathEndsWith(filePath, ".ts")) {

--- a/scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.ts
+++ b/scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as childProcess from "child_process";
-import assert = require("assert");
 
 
 interface Map<T> {

--- a/scripts/open-cherry-pick-pr.ts
+++ b/scripts/open-cherry-pick-pr.ts
@@ -3,9 +3,9 @@
 /// <reference types="node" />
 
 import { Octokit } from "@octokit/rest";
-const {runSequence} = require("./run-sequence");
-import fs = require("fs");
-import path = require("path");
+import { runSequence } from "./run-sequence";
+import * as fs from "fs";
+import * as path from "path";
 
 const userName = process.env.GH_USERNAME;
 const reviewers = process.env.REQUESTING_USER ? [process.env.REQUESTING_USER] : ["weswigham", "RyanCavanaugh"];

--- a/scripts/open-user-pr.ts
+++ b/scripts/open-user-pr.ts
@@ -2,7 +2,7 @@
 /// <reference lib="es2015.promise" />
 // Must reference esnext.asynciterable lib, since octokit uses AsyncIterable internally
 import { Octokit } from "@octokit/rest";
-const {runSequence} = require("./run-sequence");
+import { runSequence } from "./run-sequence";
 
 const userName = process.env.GH_USERNAME || "typescript-bot";
 const reviewers = process.env.REQUESTING_USER ? [process.env.REQUESTING_USER] : ["weswigham", "sandersn", "RyanCavanaugh"];
@@ -22,7 +22,7 @@ runSequence([
     ["node", ["./node_modules/gulp/bin/gulp.js", "baseline-accept"]], // accept baselines
     ["git", ["checkout", "-b", branchName]], // create a branch
     ["git", ["add", "."]], // Add all changes
-    ["git", ["commit", "-m", `"Update user baselines${+process.env.SOURCE_ISSUE === 33716 ? " +cc @sandersn" : ""}"`]], // Commit all changes (ping nathan if we would post to CI thread)
+    ["git", ["commit", "-m", `"Update user baselines${+process.env.SOURCE_ISSUE! === 33716 ? " +cc @sandersn" : ""}"`]], // Commit all changes (ping nathan if we would post to CI thread)
     ["git", ["push", "--set-upstream", "fork", branchName, "-f"]] // push the branch
 ]);
 

--- a/scripts/processDiagnosticMessages.ts
+++ b/scripts/processDiagnosticMessages.ts
@@ -1,5 +1,5 @@
-import path = require("path");
-import fs = require("fs");
+import * as path from "path";
+import * as fs from "fs";
 
 interface DiagnosticDetails {
     category: string;

--- a/scripts/produceLKG.ts
+++ b/scripts/produceLKG.ts
@@ -1,9 +1,9 @@
 /// <reference types="node" />
 
-import childProcess = require("child_process");
-import fs = require("fs-extra");
-import path = require("path");
-import glob = require("glob");
+import * as childProcess from "child_process";
+import * as fs from "fs-extra";
+import * as path from "path";
+import * as glob from "glob";
 
 const root = path.join(__dirname, "..");
 const source = path.join(root, "built/local");

--- a/scripts/request-pr-review.ts
+++ b/scripts/request-pr-review.ts
@@ -1,8 +1,7 @@
 /// <reference lib="esnext.asynciterable" />
 /// <reference lib="es2015.promise" />
-import octokit = require("@octokit/rest");
-import Octokit = octokit.Octokit;
-import minimist = require("minimist");
+import { Octokit } from "@octokit/rest";
+import * as minimist from "minimist";
 
 const options = minimist(process.argv.slice(2), {
     boolean: ["help"],

--- a/scripts/run-sequence.d.ts
+++ b/scripts/run-sequence.d.ts
@@ -1,0 +1,3 @@
+import { SpawnSyncOptions } from "child_process";
+
+export function runSequence(tasks: [string, string[]][], opts?: SpawnSyncOptions): string;

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -11,13 +11,5 @@
         "lib": ["es6", "scripthost"],
     },
 
-    "include": [
-        "generateLocalizedDiagnosticMessages.ts",
-        "processDiagnosticMessages.ts",
-        "configurePrerelease.ts",
-        "buildProtocol.ts",
-        "produceLKG.ts",
-        "word2md.ts",
-        "request-pr-review.ts"
-    ]
+    "include": ["*.ts"]
 }


### PR DESCRIPTION
While working on a new lint rule, I noticed that a lot of the scripts have errors when I open them in the editor for various reasons, be it improper imports, type errors, etc.

Fix everything up and ensure any .ts files are included in this project, so we see their errors at build time.

There are a couple of the scripts that are written in `js` directly, so have handwritten `d.ts` files for them. I don't like that, but I think there must be some external callers (I see VSTS mentioned) that rely on being able to run the project without being compiled, it seems, so I won't change the status quo there quite yet.