### PR TITLE
Run eslint at root, rather than on src and scripts individually

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,9 @@
+**/node_modules/**
 /built/local/**
 /tests/**
 /lib/**
 /src/lib/*.generated.d.ts
 /scripts/*.js
 /scripts/eslint/built/**
+/internal/**
+/coverage/**

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -350,7 +350,6 @@ task("run-eslint-rules-tests").description = "Runs the eslint rule tests";
 
 /** @type { (folder: string) => { (): Promise<any>; displayName?: string } } */
 const eslint = (folder) => async () => {
-
     const formatter = cmdLineOptions.ci ? "stylish" : "autolinkable-stylish";
     const args = [
         "node_modules/eslint/bin/eslint",
@@ -370,21 +369,8 @@ const eslint = (folder) => async () => {
     return exec(process.execPath, args);
 };
 
-const lintScripts = eslint("scripts");
-lintScripts.displayName = "lint-scripts";
-task("lint-scripts", series([buildEslintRules, lintScripts]));
-task("lint-scripts").description = "Runs eslint on the scripts sources.";
-
-const lintCompiler = eslint("src");
-lintCompiler.displayName = "lint-compiler";
-task("lint-compiler", series([buildEslintRules, lintCompiler]));
-task("lint-compiler").description = "Runs eslint on the compiler sources.";
-task("lint-compiler").flags = {
-    "   --ci": "Runs eslint additional rules",
-};
-
 const lintRoot = eslint(".");
-lintRoot.displayName = "lint-root";
+lintRoot.displayName = "lint";
 
 const lint = series([buildEslintRules, lintRoot]);
 lint.displayName = "lint";

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -383,9 +383,12 @@ task("lint-compiler").flags = {
     "   --ci": "Runs eslint additional rules",
 };
 
-const lint = series([buildEslintRules, lintScripts, lintCompiler]);
+const lintRoot = eslint(".");
+lintRoot.displayName = "lint-root";
+
+const lint = series([buildEslintRules, lintRoot]);
 lint.displayName = "lint";
-task("lint", series([buildEslintRules, lint]));
+task("lint", lint);
 task("lint").description = "Runs eslint on the compiler and scripts sources.";
 task("lint").flags = {
     "   --ci": "Runs eslint additional rules",

--- a/package.json
+++ b/package.json
@@ -107,8 +107,8 @@
         "gulp": "gulp",
         "lint": "gulp lint",
         "lint:ci": "gulp lint --ci",
-        "lint:compiler": "gulp lint-compiler",
-        "lint:scripts": "gulp lint-scripts",
+        "lint:compiler": "gulp lint",
+        "lint:scripts": "gulp lint",
         "setup-hooks": "node scripts/link-hooks.js"
     },
     "browser": {

--- a/package.json
+++ b/package.json
@@ -107,8 +107,6 @@
         "gulp": "gulp",
         "lint": "gulp lint",
         "lint:ci": "gulp lint --ci",
-        "lint:compiler": "gulp lint-compiler",
-        "lint:scripts": "gulp lint-scripts",
         "setup-hooks": "node scripts/link-hooks.js"
     },
     "browser": {

--- a/package.json
+++ b/package.json
@@ -107,8 +107,8 @@
         "gulp": "gulp",
         "lint": "gulp lint",
         "lint:ci": "gulp lint --ci",
-        "lint:compiler": "gulp lint",
-        "lint:scripts": "gulp lint",
+        "lint:compiler": "gulp lint-compiler",
+        "lint:scripts": "gulp lint-scripts",
         "setup-hooks": "node scripts/link-hooks.js"
     },
     "browser": {


### PR DESCRIPTION
This is slightly faster (a few seconds) in my testing (average of 5 runs, without cache).

It'd probably be best to delete the individual tasks, but I don't know who depends on those directly besides our `package.json` scripts.