### PR TITLE
Fixes for `decorators` property deprecations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -44015,7 +44015,7 @@ namespace ts {
         }
 
         function checkGrammarDecorators(node: Node): boolean {
-            if (canHaveIllegalDecorators(node) && some(node.decorators)) {
+            if (canHaveIllegalDecorators(node) && some(node._decorators)) {
                 return grammarErrorOnFirstToken(node, Diagnostics.Decorators_are_not_valid_here);
             }
             if (!canHaveDecorators(node) || !hasDecorators(node)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -44015,7 +44015,7 @@ namespace ts {
         }
 
         function checkGrammarDecorators(node: Node): boolean {
-            if (canHaveIllegalDecorators(node) && some(node._decorators)) {
+            if (canHaveIllegalDecorators(node) && some(node.illegalDecorators)) {
                 return grammarErrorOnFirstToken(node, Diagnostics.Decorators_are_not_valid_here);
             }
             if (!canHaveDecorators(node) || !hasDecorators(node)) {

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -30,6 +30,7 @@ namespace ts {
         export let currentLogLevel = LogLevel.Warning;
         export let isDebugging = false;
         export let loggingHost: LoggingHost | undefined;
+        export let enableDeprecationWarnings = true;
         /* eslint-enable prefer-const */
 
         type AssertionKeys = MatchingKeys<typeof Debug, AnyFunction>;
@@ -732,7 +733,7 @@ namespace ts {
         function createWarningDeprecation(name: string, errorAfter: Version | undefined, since: Version | undefined, message: string | undefined) {
             let hasWrittenDeprecation = false;
             return () => {
-                if (!hasWrittenDeprecation) {
+                if (enableDeprecationWarnings && !hasWrittenDeprecation) {
                     log.warn(formatDeprecationMessage(name, /*error*/ false, errorAfter, since, message));
                     hasWrittenDeprecation = true;
                 }

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -1435,7 +1435,7 @@ namespace ts {
             node.transformFlags = propagateChildFlags(body) | TransformFlags.ContainsClassFields;
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             node.modifiers = undefined;
             return node;
         }
@@ -1452,7 +1452,7 @@ namespace ts {
 
         function finishUpdateClassStaticBlockDeclaration(updated: Mutable<ClassStaticBlockDeclaration>, original: ClassStaticBlockDeclaration) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
                 updated.modifiers = original.modifiers;
             }
             return update(updated, original);
@@ -1476,7 +1476,7 @@ namespace ts {
             node.transformFlags |= TransformFlags.ContainsES2015;
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             node.typeParameters = undefined;
             node.type = undefined;
             return node;
@@ -1498,7 +1498,7 @@ namespace ts {
 
         function finishUpdateConstructorDeclaration(updated: Mutable<ConstructorDeclaration>, original: ConstructorDeclaration) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
                 updated.typeParameters = original.typeParameters;
                 updated.type = original.type;
             }
@@ -3657,7 +3657,7 @@ namespace ts {
             }
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             return node;
         }
 
@@ -3686,7 +3686,7 @@ namespace ts {
         function finishUpdateFunctionDeclaration(updated: Mutable<FunctionDeclaration>, original: FunctionDeclaration) {
             if (updated !== original) {
                 // copy children used only for error reporting
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
             }
             return finishUpdateBaseSignatureDeclaration(updated, original);
         }
@@ -3756,7 +3756,7 @@ namespace ts {
             node.transformFlags = TransformFlags.ContainsTypeScript;
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             return node;
         }
 
@@ -3780,7 +3780,7 @@ namespace ts {
 
         function finishUpdateInterfaceDeclaration(updated: Mutable<InterfaceDeclaration>, original: InterfaceDeclaration) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
             }
             return update(updated, original);
         }
@@ -3802,7 +3802,7 @@ namespace ts {
             node.transformFlags = TransformFlags.ContainsTypeScript;
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             return node;
         }
 
@@ -3824,7 +3824,7 @@ namespace ts {
 
         function finishUpdateTypeAliasDeclaration(updated: Mutable<TypeAliasDeclaration>, original: TypeAliasDeclaration) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
             }
             return update(updated, original);
         }
@@ -3847,7 +3847,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // Enum declarations cannot contain `await`
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             return node;
         }
 
@@ -3866,7 +3866,7 @@ namespace ts {
 
         function finishUpdateEnumDeclaration(updated: Mutable<EnumDeclaration>, original: EnumDeclaration) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
             }
             return update(updated, original);
         }
@@ -3896,7 +3896,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // Module declarations cannot contain `await`.
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             return node;
         }
 
@@ -3916,7 +3916,7 @@ namespace ts {
 
         function finishUpdateModuleDeclaration(updated: Mutable<ModuleDeclaration>, original: ModuleDeclaration) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
             }
             return update(updated, original);
         }
@@ -3961,7 +3961,7 @@ namespace ts {
             node.transformFlags = TransformFlags.ContainsTypeScript;
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             node.modifiers = undefined;
             return node;
         }
@@ -3975,7 +3975,7 @@ namespace ts {
 
         function finishUpdateNamespaceExportDeclaration(updated: Mutable<NamespaceExportDeclaration>, original: NamespaceExportDeclaration) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
                 updated.modifiers = original.modifiers;
             }
             return update(updated, original);
@@ -4000,7 +4000,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // Import= declaration is always parsed in an Await context
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             return node;
         }
 
@@ -4022,7 +4022,7 @@ namespace ts {
 
         function finishUpdateImportEqualsDeclaration(updated: Mutable<ImportEqualsDeclaration>, original: ImportEqualsDeclaration) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
             }
             return update(updated, original);
         }
@@ -4045,7 +4045,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             return node;
         }
 
@@ -4067,7 +4067,7 @@ namespace ts {
 
         function finishUpdateImportDeclaration(updated: Mutable<ImportDeclaration>, original: ImportDeclaration) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
             }
             return update(updated, original);
         }
@@ -4235,7 +4235,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             return node;
         }
 
@@ -4253,7 +4253,7 @@ namespace ts {
 
         function finishUpdateExportAssignment(updated: Mutable<ExportAssignment>, original: ExportAssignment) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
             }
             return update(updated, original);
         }
@@ -4279,7 +4279,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             return node;
         }
 
@@ -4303,7 +4303,7 @@ namespace ts {
 
         function finishUpdateExportDeclaration(updated: Mutable<ExportDeclaration>, original: ExportDeclaration) {
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
             }
             return update(updated, original);
         }
@@ -5162,7 +5162,7 @@ namespace ts {
                 propagateChildFlags(node.initializer);
 
             // The following properties are used only to report grammar errors
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             node.modifiers = undefined;
             node.questionToken = undefined;
             node.exclamationToken = undefined;
@@ -5180,7 +5180,7 @@ namespace ts {
         function finishUpdatePropertyAssignment(updated: Mutable<PropertyAssignment>, original: PropertyAssignment) {
             // copy children used only for error reporting
             if (updated !== original) {
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
                 updated.modifiers = original.modifiers;
                 updated.questionToken = original.questionToken;
                 updated.exclamationToken = original.exclamationToken;
@@ -5202,7 +5202,7 @@ namespace ts {
 
             // The following properties are used only to report grammar errors
             node.equalsToken = undefined;
-            node._decorators = undefined;
+            node.illegalDecorators = undefined;
             node.modifiers = undefined;
             node.questionToken = undefined;
             node.exclamationToken = undefined;
@@ -5221,7 +5221,7 @@ namespace ts {
             if (updated !== original) {
                 // copy children used only for error reporting
                 updated.equalsToken = original.equalsToken;
-                updated._decorators = original._decorators;
+                updated.illegalDecorators = original.illegalDecorators;
                 updated.modifiers = original.modifiers;
                 updated.questionToken = original.questionToken;
                 updated.exclamationToken = original.exclamationToken;

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -1435,7 +1435,7 @@ namespace ts {
             node.transformFlags = propagateChildFlags(body) | TransformFlags.ContainsClassFields;
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             node.modifiers = undefined;
             return node;
         }
@@ -1452,7 +1452,7 @@ namespace ts {
 
         function finishUpdateClassStaticBlockDeclaration(updated: Mutable<ClassStaticBlockDeclaration>, original: ClassStaticBlockDeclaration) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
                 updated.modifiers = original.modifiers;
             }
             return update(updated, original);
@@ -1476,7 +1476,7 @@ namespace ts {
             node.transformFlags |= TransformFlags.ContainsES2015;
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             node.typeParameters = undefined;
             node.type = undefined;
             return node;
@@ -1498,7 +1498,7 @@ namespace ts {
 
         function finishUpdateConstructorDeclaration(updated: Mutable<ConstructorDeclaration>, original: ConstructorDeclaration) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
                 updated.typeParameters = original.typeParameters;
                 updated.type = original.type;
             }
@@ -3657,7 +3657,7 @@ namespace ts {
             }
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             return node;
         }
 
@@ -3686,7 +3686,7 @@ namespace ts {
         function finishUpdateFunctionDeclaration(updated: Mutable<FunctionDeclaration>, original: FunctionDeclaration) {
             if (updated !== original) {
                 // copy children used only for error reporting
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
             }
             return finishUpdateBaseSignatureDeclaration(updated, original);
         }
@@ -3756,7 +3756,7 @@ namespace ts {
             node.transformFlags = TransformFlags.ContainsTypeScript;
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             return node;
         }
 
@@ -3780,7 +3780,7 @@ namespace ts {
 
         function finishUpdateInterfaceDeclaration(updated: Mutable<InterfaceDeclaration>, original: InterfaceDeclaration) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
             }
             return update(updated, original);
         }
@@ -3802,7 +3802,7 @@ namespace ts {
             node.transformFlags = TransformFlags.ContainsTypeScript;
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             return node;
         }
 
@@ -3824,7 +3824,7 @@ namespace ts {
 
         function finishUpdateTypeAliasDeclaration(updated: Mutable<TypeAliasDeclaration>, original: TypeAliasDeclaration) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
             }
             return update(updated, original);
         }
@@ -3847,7 +3847,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // Enum declarations cannot contain `await`
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             return node;
         }
 
@@ -3866,7 +3866,7 @@ namespace ts {
 
         function finishUpdateEnumDeclaration(updated: Mutable<EnumDeclaration>, original: EnumDeclaration) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
             }
             return update(updated, original);
         }
@@ -3896,7 +3896,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // Module declarations cannot contain `await`.
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             return node;
         }
 
@@ -3916,7 +3916,7 @@ namespace ts {
 
         function finishUpdateModuleDeclaration(updated: Mutable<ModuleDeclaration>, original: ModuleDeclaration) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
             }
             return update(updated, original);
         }
@@ -3961,7 +3961,7 @@ namespace ts {
             node.transformFlags = TransformFlags.ContainsTypeScript;
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             node.modifiers = undefined;
             return node;
         }
@@ -3975,7 +3975,7 @@ namespace ts {
 
         function finishUpdateNamespaceExportDeclaration(updated: Mutable<NamespaceExportDeclaration>, original: NamespaceExportDeclaration) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
                 updated.modifiers = original.modifiers;
             }
             return update(updated, original);
@@ -4000,7 +4000,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // Import= declaration is always parsed in an Await context
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             return node;
         }
 
@@ -4022,7 +4022,7 @@ namespace ts {
 
         function finishUpdateImportEqualsDeclaration(updated: Mutable<ImportEqualsDeclaration>, original: ImportEqualsDeclaration) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
             }
             return update(updated, original);
         }
@@ -4045,7 +4045,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             return node;
         }
 
@@ -4067,7 +4067,7 @@ namespace ts {
 
         function finishUpdateImportDeclaration(updated: Mutable<ImportDeclaration>, original: ImportDeclaration) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
             }
             return update(updated, original);
         }
@@ -4235,7 +4235,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             return node;
         }
 
@@ -4253,7 +4253,7 @@ namespace ts {
 
         function finishUpdateExportAssignment(updated: Mutable<ExportAssignment>, original: ExportAssignment) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
             }
             return update(updated, original);
         }
@@ -4279,7 +4279,7 @@ namespace ts {
             node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             return node;
         }
 
@@ -4303,7 +4303,7 @@ namespace ts {
 
         function finishUpdateExportDeclaration(updated: Mutable<ExportDeclaration>, original: ExportDeclaration) {
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
             }
             return update(updated, original);
         }
@@ -5162,7 +5162,7 @@ namespace ts {
                 propagateChildFlags(node.initializer);
 
             // The following properties are used only to report grammar errors
-            node.decorators = undefined;
+            node._decorators = undefined;
             node.modifiers = undefined;
             node.questionToken = undefined;
             node.exclamationToken = undefined;
@@ -5180,7 +5180,7 @@ namespace ts {
         function finishUpdatePropertyAssignment(updated: Mutable<PropertyAssignment>, original: PropertyAssignment) {
             // copy children used only for error reporting
             if (updated !== original) {
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
                 updated.modifiers = original.modifiers;
                 updated.questionToken = original.questionToken;
                 updated.exclamationToken = original.exclamationToken;
@@ -5202,7 +5202,7 @@ namespace ts {
 
             // The following properties are used only to report grammar errors
             node.equalsToken = undefined;
-            node.decorators = undefined;
+            node._decorators = undefined;
             node.modifiers = undefined;
             node.questionToken = undefined;
             node.exclamationToken = undefined;
@@ -5221,7 +5221,7 @@ namespace ts {
             if (updated !== original) {
                 // copy children used only for error reporting
                 updated.equalsToken = original.equalsToken;
-                updated.decorators = original.decorators;
+                updated._decorators = original._decorators;
                 updated.modifiers = original.modifiers;
                 updated.questionToken = original.questionToken;
                 updated.exclamationToken = original.exclamationToken;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -123,7 +123,7 @@ namespace ts {
                     visitNode(cbNode, (node as TypeParameterDeclaration).default) ||
                     visitNode(cbNode, (node as TypeParameterDeclaration).expression);
             case SyntaxKind.ShorthandPropertyAssignment:
-                return visitNodes(cbNode, cbNodes, (node as ShorthandPropertyAssignment).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ShorthandPropertyAssignment)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as ShorthandPropertyAssignment).modifiers) ||
                     visitNode(cbNode, (node as ShorthandPropertyAssignment).name) ||
                     visitNode(cbNode, (node as ShorthandPropertyAssignment).questionToken) ||
@@ -153,7 +153,7 @@ namespace ts {
                     visitNode(cbNode, (node as PropertySignature).type) ||
                     visitNode(cbNode, (node as PropertySignature).initializer);
             case SyntaxKind.PropertyAssignment:
-                return visitNodes(cbNode, cbNodes, (node as PropertyAssignment).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as PropertyAssignment)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as PropertyAssignment).modifiers) ||
                     visitNode(cbNode, (node as PropertyAssignment).name) ||
                     visitNode(cbNode, (node as PropertyAssignment).questionToken) ||
@@ -170,7 +170,7 @@ namespace ts {
                     visitNode(cbNode, (node as BindingElement).name) ||
                     visitNode(cbNode, (node as BindingElement).initializer);
             case SyntaxKind.IndexSignature:
-                return visitNodes(cbNode, cbNodes, (node as IndexSignatureDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as IndexSignatureDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as IndexSignatureDeclaration).modifiers) ||
                     visitNodes(cbNode, cbNodes, (node as IndexSignatureDeclaration).typeParameters) ||
                     visitNodes(cbNode, cbNodes, (node as IndexSignatureDeclaration).parameters) ||
@@ -208,7 +208,7 @@ namespace ts {
                     visitNodes(cbNode, cbNodes, (node as MethodSignature).parameters) ||
                     visitNode(cbNode, (node as MethodSignature).type);
             case SyntaxKind.Constructor:
-                return visitNodes(cbNode, cbNodes, (node as ConstructorDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ConstructorDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as ConstructorDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ConstructorDeclaration).name) ||
                     visitNodes(cbNode, cbNodes, (node as ConstructorDeclaration).typeParameters) ||
@@ -230,7 +230,7 @@ namespace ts {
                     visitNode(cbNode, (node as SetAccessorDeclaration).type) ||
                     visitNode(cbNode, (node as SetAccessorDeclaration).body);
             case SyntaxKind.FunctionDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as FunctionDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as FunctionDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as FunctionDeclaration).modifiers) ||
                     visitNode(cbNode, (node as FunctionDeclaration).asteriskToken) ||
                     visitNode(cbNode, (node as FunctionDeclaration).name) ||
@@ -254,7 +254,7 @@ namespace ts {
                     visitNode(cbNode, (node as ArrowFunction).equalsGreaterThanToken) ||
                     visitNode(cbNode, (node as ArrowFunction).body);
             case SyntaxKind.ClassStaticBlockDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as ClassStaticBlockDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ClassStaticBlockDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as ClassStaticBlockDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ClassStaticBlockDeclaration).body);
             case SyntaxKind.TypeReference:
@@ -382,7 +382,7 @@ namespace ts {
                 return visitNodes(cbNode, cbNodes, (node as SourceFile).statements) ||
                     visitNode(cbNode, (node as SourceFile).endOfFileToken);
             case SyntaxKind.VariableStatement:
-                return visitNodes(cbNode, cbNodes, (node as VariableStatement).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as VariableStatement)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as VariableStatement).modifiers) ||
                     visitNode(cbNode, (node as VariableStatement).declarationList);
             case SyntaxKind.VariableDeclarationList:
@@ -453,20 +453,20 @@ namespace ts {
                     visitNodes(cbNode, cbNodes, (node as ClassLikeDeclaration).heritageClauses) ||
                     visitNodes(cbNode, cbNodes, (node as ClassLikeDeclaration).members);
             case SyntaxKind.InterfaceDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as InterfaceDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as InterfaceDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as InterfaceDeclaration).modifiers) ||
                     visitNode(cbNode, (node as InterfaceDeclaration).name) ||
                     visitNodes(cbNode, cbNodes, (node as InterfaceDeclaration).typeParameters) ||
                     visitNodes(cbNode, cbNodes, (node as ClassDeclaration).heritageClauses) ||
                     visitNodes(cbNode, cbNodes, (node as InterfaceDeclaration).members);
             case SyntaxKind.TypeAliasDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as TypeAliasDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as TypeAliasDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as TypeAliasDeclaration).modifiers) ||
                     visitNode(cbNode, (node as TypeAliasDeclaration).name) ||
                     visitNodes(cbNode, cbNodes, (node as TypeAliasDeclaration).typeParameters) ||
                     visitNode(cbNode, (node as TypeAliasDeclaration).type);
             case SyntaxKind.EnumDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as EnumDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as EnumDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as EnumDeclaration).modifiers) ||
                     visitNode(cbNode, (node as EnumDeclaration).name) ||
                     visitNodes(cbNode, cbNodes, (node as EnumDeclaration).members);
@@ -474,17 +474,17 @@ namespace ts {
                 return visitNode(cbNode, (node as EnumMember).name) ||
                     visitNode(cbNode, (node as EnumMember).initializer);
             case SyntaxKind.ModuleDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as ModuleDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ModuleDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as ModuleDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ModuleDeclaration).name) ||
                     visitNode(cbNode, (node as ModuleDeclaration).body);
             case SyntaxKind.ImportEqualsDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as ImportEqualsDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ImportEqualsDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as ImportEqualsDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ImportEqualsDeclaration).name) ||
                     visitNode(cbNode, (node as ImportEqualsDeclaration).moduleReference);
             case SyntaxKind.ImportDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as ImportDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ImportDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as ImportDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ImportDeclaration).importClause) ||
                     visitNode(cbNode, (node as ImportDeclaration).moduleSpecifier) ||
@@ -498,7 +498,7 @@ namespace ts {
                 return visitNode(cbNode, (node as AssertEntry).name) ||
                     visitNode(cbNode, (node as AssertEntry).value);
             case SyntaxKind.NamespaceExportDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as NamespaceExportDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as NamespaceExportDeclaration)._decorators) ||
                     visitNode(cbNode, (node as NamespaceExportDeclaration).name);
             case SyntaxKind.NamespaceImport:
                 return visitNode(cbNode, (node as NamespaceImport).name);
@@ -508,7 +508,7 @@ namespace ts {
             case SyntaxKind.NamedExports:
                 return visitNodes(cbNode, cbNodes, (node as NamedImportsOrExports).elements);
             case SyntaxKind.ExportDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as ExportDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ExportDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as ExportDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ExportDeclaration).exportClause) ||
                     visitNode(cbNode, (node as ExportDeclaration).moduleSpecifier) ||
@@ -518,7 +518,7 @@ namespace ts {
                 return visitNode(cbNode, (node as ImportOrExportSpecifier).propertyName) ||
                     visitNode(cbNode, (node as ImportOrExportSpecifier).name);
             case SyntaxKind.ExportAssignment:
-                return visitNodes(cbNode, cbNodes, (node as ExportAssignment).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ExportAssignment)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as ExportAssignment).modifiers) ||
                     visitNode(cbNode, (node as ExportAssignment).expression);
             case SyntaxKind.TemplateExpression:
@@ -543,7 +543,7 @@ namespace ts {
             case SyntaxKind.ExternalModuleReference:
                 return visitNode(cbNode, (node as ExternalModuleReference).expression);
             case SyntaxKind.MissingDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as MissingDeclaration).decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as MissingDeclaration)._decorators) ||
                     visitNodes(cbNode, cbNodes, (node as MissingDeclaration).modifiers);
             case SyntaxKind.CommaListExpression:
                 return visitNodes(cbNode, cbNodes, (node as CommaListExpression).elements);
@@ -3560,7 +3560,7 @@ namespace ts {
             const type = parseTypeAnnotation();
             parseTypeMemberSemicolon();
             const node = factory.createIndexSignature(modifiers, parameters, type);
-            (node as Mutable<IndexSignatureDeclaration>).decorators = decorators;
+            (node as Mutable<IndexSignatureDeclaration>)._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -5974,7 +5974,7 @@ namespace ts {
                 node = factory.createPropertyAssignment(name, initializer);
             }
             // Decorators, Modifiers, questionToken, and exclamationToken are not supported by property assignments and are reported in the grammar checker
-            node.decorators = decorators;
+            node._decorators = decorators;
             node.modifiers = modifiers;
             node.questionToken = questionToken;
             node.exclamationToken = exclamationToken;
@@ -6694,7 +6694,7 @@ namespace ts {
                         // would follow. For recovery and error reporting purposes, return an incomplete declaration.
                         const missing = createMissingNode<MissingDeclaration>(SyntaxKind.MissingDeclaration, /*reportAtCurrentPosition*/ true, Diagnostics.Declaration_expected);
                         setTextRangePos(missing, pos);
-                        missing.decorators = decorators;
+                        missing._decorators = decorators;
                         missing.modifiers = modifiers;
                         return missing;
                     }
@@ -6858,7 +6858,7 @@ namespace ts {
             parseSemicolon();
             const node = factory.createVariableStatement(modifiers, declarationList);
             // Decorators are not allowed on a variable statement, so we keep track of them to report them in the grammar checker.
-            node.decorators = decorators;
+            node._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -6879,7 +6879,7 @@ namespace ts {
             const body = parseFunctionBlockOrSemicolon(isGenerator | isAsync, Diagnostics.or_expected);
             setAwaitContext(savedAwaitContext);
             const node = factory.createFunctionDeclaration(modifiers, asteriskToken, name, typeParameters, parameters, type, body);
-            (node as Mutable<FunctionDeclaration>).decorators = decorators;
+            (node as Mutable<FunctionDeclaration>)._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -6905,7 +6905,7 @@ namespace ts {
                     const node = factory.createConstructorDeclaration(modifiers, parameters, body);
 
                     // Attach invalid nodes if they exist so that we can report them in the grammar checker.
-                    (node as Mutable<ConstructorDeclaration>).decorators = decorators;
+                    (node as Mutable<ConstructorDeclaration>)._decorators = decorators;
                     (node as Mutable<ConstructorDeclaration>).typeParameters = typeParameters;
                     (node as Mutable<ConstructorDeclaration>).type = type;
                     return withJSDoc(finishNode(node, pos), hasJSDoc);
@@ -7072,7 +7072,7 @@ namespace ts {
             parseExpectedToken(SyntaxKind.StaticKeyword);
             const body = parseClassStaticBlockBody();
             const node = withJSDoc(finishNode(factory.createClassStaticBlockDeclaration(body), pos), hasJSDoc);
-            (node as Mutable<ClassStaticBlockDeclaration>).decorators = decorators;
+            (node as Mutable<ClassStaticBlockDeclaration>)._decorators = decorators;
             (node as Mutable<ClassStaticBlockDeclaration>).modifiers = modifiers;
             return node;
         }
@@ -7347,7 +7347,7 @@ namespace ts {
             const heritageClauses = parseHeritageClauses();
             const members = parseObjectTypeMembers();
             const node = factory.createInterfaceDeclaration(modifiers, name, typeParameters, heritageClauses, members);
-            (node as Mutable<InterfaceDeclaration>).decorators = decorators;
+            (node as Mutable<InterfaceDeclaration>)._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7359,7 +7359,7 @@ namespace ts {
             const type = token() === SyntaxKind.IntrinsicKeyword && tryParse(parseKeywordAndNoDot) || parseType();
             parseSemicolon();
             const node = factory.createTypeAliasDeclaration(modifiers, name, typeParameters, type);
-            (node as Mutable<TypeAliasDeclaration>).decorators = decorators;
+            (node as Mutable<TypeAliasDeclaration>)._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7387,7 +7387,7 @@ namespace ts {
                 members = createMissingList<EnumMember>();
             }
             const node = factory.createEnumDeclaration(modifiers, name, members);
-            (node as Mutable<EnumDeclaration>).decorators = decorators;
+            (node as Mutable<EnumDeclaration>)._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7413,7 +7413,7 @@ namespace ts {
                 ? parseModuleOrNamespaceDeclaration(getNodePos(), /*hasJSDoc*/ false, /*decorators*/ undefined, /*modifiers*/ undefined, NodeFlags.NestedNamespace | namespaceFlag) as NamespaceDeclaration
                 : parseModuleBlock();
             const node = factory.createModuleDeclaration(modifiers, name, body, flags);
-            (node as Mutable<ModuleDeclaration>).decorators = decorators;
+            (node as Mutable<ModuleDeclaration>)._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7437,7 +7437,7 @@ namespace ts {
                 parseSemicolon();
             }
             const node = factory.createModuleDeclaration(modifiers, name, body, flags);
-            (node as Mutable<ModuleDeclaration>).decorators = decorators;
+            (node as Mutable<ModuleDeclaration>)._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7483,7 +7483,7 @@ namespace ts {
             parseSemicolon();
             const node = factory.createNamespaceExportDeclaration(name);
             // NamespaceExportDeclaration nodes cannot have decorators or modifiers, so we attach them here so we can report them in the grammar checker
-            (node as Mutable<NamespaceExportDeclaration>).decorators = decorators;
+            (node as Mutable<NamespaceExportDeclaration>)._decorators = decorators;
             (node as Mutable<NamespaceExportDeclaration>).modifiers = modifiers;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
@@ -7532,7 +7532,7 @@ namespace ts {
 
             parseSemicolon();
             const node = factory.createImportDeclaration(modifiers, importClause, moduleSpecifier, assertClause);
-            (node as Mutable<ImportDeclaration>).decorators = decorators;
+            (node as Mutable<ImportDeclaration>)._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7585,7 +7585,7 @@ namespace ts {
             const moduleReference = parseModuleReference();
             parseSemicolon();
             const node = factory.createImportEqualsDeclaration(modifiers, isTypeOnly, identifier, moduleReference);
-            (node as Mutable<ImportEqualsDeclaration>).decorators = decorators;
+            (node as Mutable<ImportEqualsDeclaration>)._decorators = decorators;
             const finished = withJSDoc(finishNode(node, pos), hasJSDoc);
             return finished;
         }
@@ -7794,7 +7794,7 @@ namespace ts {
             parseSemicolon();
             setAwaitContext(savedAwaitContext);
             const node = factory.createExportDeclaration(modifiers, isTypeOnly, exportClause, moduleSpecifier, assertClause);
-            (node as Mutable<ExportDeclaration>).decorators = decorators;
+            (node as Mutable<ExportDeclaration>)._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7812,7 +7812,7 @@ namespace ts {
             parseSemicolon();
             setAwaitContext(savedAwaitContext);
             const node = factory.createExportAssignment(modifiers, isExportEquals, expression);
-            (node as Mutable<ExportAssignment>).decorators = decorators;
+            (node as Mutable<ExportAssignment>)._decorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -123,7 +123,7 @@ namespace ts {
                     visitNode(cbNode, (node as TypeParameterDeclaration).default) ||
                     visitNode(cbNode, (node as TypeParameterDeclaration).expression);
             case SyntaxKind.ShorthandPropertyAssignment:
-                return visitNodes(cbNode, cbNodes, (node as ShorthandPropertyAssignment)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ShorthandPropertyAssignment).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as ShorthandPropertyAssignment).modifiers) ||
                     visitNode(cbNode, (node as ShorthandPropertyAssignment).name) ||
                     visitNode(cbNode, (node as ShorthandPropertyAssignment).questionToken) ||
@@ -153,7 +153,7 @@ namespace ts {
                     visitNode(cbNode, (node as PropertySignature).type) ||
                     visitNode(cbNode, (node as PropertySignature).initializer);
             case SyntaxKind.PropertyAssignment:
-                return visitNodes(cbNode, cbNodes, (node as PropertyAssignment)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as PropertyAssignment).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as PropertyAssignment).modifiers) ||
                     visitNode(cbNode, (node as PropertyAssignment).name) ||
                     visitNode(cbNode, (node as PropertyAssignment).questionToken) ||
@@ -170,7 +170,7 @@ namespace ts {
                     visitNode(cbNode, (node as BindingElement).name) ||
                     visitNode(cbNode, (node as BindingElement).initializer);
             case SyntaxKind.IndexSignature:
-                return visitNodes(cbNode, cbNodes, (node as IndexSignatureDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as IndexSignatureDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as IndexSignatureDeclaration).modifiers) ||
                     visitNodes(cbNode, cbNodes, (node as IndexSignatureDeclaration).typeParameters) ||
                     visitNodes(cbNode, cbNodes, (node as IndexSignatureDeclaration).parameters) ||
@@ -208,7 +208,7 @@ namespace ts {
                     visitNodes(cbNode, cbNodes, (node as MethodSignature).parameters) ||
                     visitNode(cbNode, (node as MethodSignature).type);
             case SyntaxKind.Constructor:
-                return visitNodes(cbNode, cbNodes, (node as ConstructorDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ConstructorDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as ConstructorDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ConstructorDeclaration).name) ||
                     visitNodes(cbNode, cbNodes, (node as ConstructorDeclaration).typeParameters) ||
@@ -230,7 +230,7 @@ namespace ts {
                     visitNode(cbNode, (node as SetAccessorDeclaration).type) ||
                     visitNode(cbNode, (node as SetAccessorDeclaration).body);
             case SyntaxKind.FunctionDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as FunctionDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as FunctionDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as FunctionDeclaration).modifiers) ||
                     visitNode(cbNode, (node as FunctionDeclaration).asteriskToken) ||
                     visitNode(cbNode, (node as FunctionDeclaration).name) ||
@@ -254,7 +254,7 @@ namespace ts {
                     visitNode(cbNode, (node as ArrowFunction).equalsGreaterThanToken) ||
                     visitNode(cbNode, (node as ArrowFunction).body);
             case SyntaxKind.ClassStaticBlockDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as ClassStaticBlockDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ClassStaticBlockDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as ClassStaticBlockDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ClassStaticBlockDeclaration).body);
             case SyntaxKind.TypeReference:
@@ -382,7 +382,7 @@ namespace ts {
                 return visitNodes(cbNode, cbNodes, (node as SourceFile).statements) ||
                     visitNode(cbNode, (node as SourceFile).endOfFileToken);
             case SyntaxKind.VariableStatement:
-                return visitNodes(cbNode, cbNodes, (node as VariableStatement)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as VariableStatement).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as VariableStatement).modifiers) ||
                     visitNode(cbNode, (node as VariableStatement).declarationList);
             case SyntaxKind.VariableDeclarationList:
@@ -453,20 +453,20 @@ namespace ts {
                     visitNodes(cbNode, cbNodes, (node as ClassLikeDeclaration).heritageClauses) ||
                     visitNodes(cbNode, cbNodes, (node as ClassLikeDeclaration).members);
             case SyntaxKind.InterfaceDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as InterfaceDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as InterfaceDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as InterfaceDeclaration).modifiers) ||
                     visitNode(cbNode, (node as InterfaceDeclaration).name) ||
                     visitNodes(cbNode, cbNodes, (node as InterfaceDeclaration).typeParameters) ||
                     visitNodes(cbNode, cbNodes, (node as ClassDeclaration).heritageClauses) ||
                     visitNodes(cbNode, cbNodes, (node as InterfaceDeclaration).members);
             case SyntaxKind.TypeAliasDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as TypeAliasDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as TypeAliasDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as TypeAliasDeclaration).modifiers) ||
                     visitNode(cbNode, (node as TypeAliasDeclaration).name) ||
                     visitNodes(cbNode, cbNodes, (node as TypeAliasDeclaration).typeParameters) ||
                     visitNode(cbNode, (node as TypeAliasDeclaration).type);
             case SyntaxKind.EnumDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as EnumDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as EnumDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as EnumDeclaration).modifiers) ||
                     visitNode(cbNode, (node as EnumDeclaration).name) ||
                     visitNodes(cbNode, cbNodes, (node as EnumDeclaration).members);
@@ -474,17 +474,17 @@ namespace ts {
                 return visitNode(cbNode, (node as EnumMember).name) ||
                     visitNode(cbNode, (node as EnumMember).initializer);
             case SyntaxKind.ModuleDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as ModuleDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ModuleDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as ModuleDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ModuleDeclaration).name) ||
                     visitNode(cbNode, (node as ModuleDeclaration).body);
             case SyntaxKind.ImportEqualsDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as ImportEqualsDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ImportEqualsDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as ImportEqualsDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ImportEqualsDeclaration).name) ||
                     visitNode(cbNode, (node as ImportEqualsDeclaration).moduleReference);
             case SyntaxKind.ImportDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as ImportDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ImportDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as ImportDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ImportDeclaration).importClause) ||
                     visitNode(cbNode, (node as ImportDeclaration).moduleSpecifier) ||
@@ -498,7 +498,7 @@ namespace ts {
                 return visitNode(cbNode, (node as AssertEntry).name) ||
                     visitNode(cbNode, (node as AssertEntry).value);
             case SyntaxKind.NamespaceExportDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as NamespaceExportDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as NamespaceExportDeclaration).illegalDecorators) ||
                     visitNode(cbNode, (node as NamespaceExportDeclaration).name);
             case SyntaxKind.NamespaceImport:
                 return visitNode(cbNode, (node as NamespaceImport).name);
@@ -508,7 +508,7 @@ namespace ts {
             case SyntaxKind.NamedExports:
                 return visitNodes(cbNode, cbNodes, (node as NamedImportsOrExports).elements);
             case SyntaxKind.ExportDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as ExportDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ExportDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as ExportDeclaration).modifiers) ||
                     visitNode(cbNode, (node as ExportDeclaration).exportClause) ||
                     visitNode(cbNode, (node as ExportDeclaration).moduleSpecifier) ||
@@ -518,7 +518,7 @@ namespace ts {
                 return visitNode(cbNode, (node as ImportOrExportSpecifier).propertyName) ||
                     visitNode(cbNode, (node as ImportOrExportSpecifier).name);
             case SyntaxKind.ExportAssignment:
-                return visitNodes(cbNode, cbNodes, (node as ExportAssignment)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as ExportAssignment).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as ExportAssignment).modifiers) ||
                     visitNode(cbNode, (node as ExportAssignment).expression);
             case SyntaxKind.TemplateExpression:
@@ -543,7 +543,7 @@ namespace ts {
             case SyntaxKind.ExternalModuleReference:
                 return visitNode(cbNode, (node as ExternalModuleReference).expression);
             case SyntaxKind.MissingDeclaration:
-                return visitNodes(cbNode, cbNodes, (node as MissingDeclaration)._decorators) ||
+                return visitNodes(cbNode, cbNodes, (node as MissingDeclaration).illegalDecorators) ||
                     visitNodes(cbNode, cbNodes, (node as MissingDeclaration).modifiers);
             case SyntaxKind.CommaListExpression:
                 return visitNodes(cbNode, cbNodes, (node as CommaListExpression).elements);
@@ -3560,7 +3560,7 @@ namespace ts {
             const type = parseTypeAnnotation();
             parseTypeMemberSemicolon();
             const node = factory.createIndexSignature(modifiers, parameters, type);
-            (node as Mutable<IndexSignatureDeclaration>)._decorators = decorators;
+            (node as Mutable<IndexSignatureDeclaration>).illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -5974,7 +5974,7 @@ namespace ts {
                 node = factory.createPropertyAssignment(name, initializer);
             }
             // Decorators, Modifiers, questionToken, and exclamationToken are not supported by property assignments and are reported in the grammar checker
-            node._decorators = decorators;
+            node.illegalDecorators = decorators;
             node.modifiers = modifiers;
             node.questionToken = questionToken;
             node.exclamationToken = exclamationToken;
@@ -6694,7 +6694,7 @@ namespace ts {
                         // would follow. For recovery and error reporting purposes, return an incomplete declaration.
                         const missing = createMissingNode<MissingDeclaration>(SyntaxKind.MissingDeclaration, /*reportAtCurrentPosition*/ true, Diagnostics.Declaration_expected);
                         setTextRangePos(missing, pos);
-                        missing._decorators = decorators;
+                        missing.illegalDecorators = decorators;
                         missing.modifiers = modifiers;
                         return missing;
                     }
@@ -6858,7 +6858,7 @@ namespace ts {
             parseSemicolon();
             const node = factory.createVariableStatement(modifiers, declarationList);
             // Decorators are not allowed on a variable statement, so we keep track of them to report them in the grammar checker.
-            node._decorators = decorators;
+            node.illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -6879,7 +6879,7 @@ namespace ts {
             const body = parseFunctionBlockOrSemicolon(isGenerator | isAsync, Diagnostics.or_expected);
             setAwaitContext(savedAwaitContext);
             const node = factory.createFunctionDeclaration(modifiers, asteriskToken, name, typeParameters, parameters, type, body);
-            (node as Mutable<FunctionDeclaration>)._decorators = decorators;
+            (node as Mutable<FunctionDeclaration>).illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -6905,7 +6905,7 @@ namespace ts {
                     const node = factory.createConstructorDeclaration(modifiers, parameters, body);
 
                     // Attach invalid nodes if they exist so that we can report them in the grammar checker.
-                    (node as Mutable<ConstructorDeclaration>)._decorators = decorators;
+                    (node as Mutable<ConstructorDeclaration>).illegalDecorators = decorators;
                     (node as Mutable<ConstructorDeclaration>).typeParameters = typeParameters;
                     (node as Mutable<ConstructorDeclaration>).type = type;
                     return withJSDoc(finishNode(node, pos), hasJSDoc);
@@ -7072,7 +7072,7 @@ namespace ts {
             parseExpectedToken(SyntaxKind.StaticKeyword);
             const body = parseClassStaticBlockBody();
             const node = withJSDoc(finishNode(factory.createClassStaticBlockDeclaration(body), pos), hasJSDoc);
-            (node as Mutable<ClassStaticBlockDeclaration>)._decorators = decorators;
+            (node as Mutable<ClassStaticBlockDeclaration>).illegalDecorators = decorators;
             (node as Mutable<ClassStaticBlockDeclaration>).modifiers = modifiers;
             return node;
         }
@@ -7347,7 +7347,7 @@ namespace ts {
             const heritageClauses = parseHeritageClauses();
             const members = parseObjectTypeMembers();
             const node = factory.createInterfaceDeclaration(modifiers, name, typeParameters, heritageClauses, members);
-            (node as Mutable<InterfaceDeclaration>)._decorators = decorators;
+            (node as Mutable<InterfaceDeclaration>).illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7359,7 +7359,7 @@ namespace ts {
             const type = token() === SyntaxKind.IntrinsicKeyword && tryParse(parseKeywordAndNoDot) || parseType();
             parseSemicolon();
             const node = factory.createTypeAliasDeclaration(modifiers, name, typeParameters, type);
-            (node as Mutable<TypeAliasDeclaration>)._decorators = decorators;
+            (node as Mutable<TypeAliasDeclaration>).illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7387,7 +7387,7 @@ namespace ts {
                 members = createMissingList<EnumMember>();
             }
             const node = factory.createEnumDeclaration(modifiers, name, members);
-            (node as Mutable<EnumDeclaration>)._decorators = decorators;
+            (node as Mutable<EnumDeclaration>).illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7413,7 +7413,7 @@ namespace ts {
                 ? parseModuleOrNamespaceDeclaration(getNodePos(), /*hasJSDoc*/ false, /*decorators*/ undefined, /*modifiers*/ undefined, NodeFlags.NestedNamespace | namespaceFlag) as NamespaceDeclaration
                 : parseModuleBlock();
             const node = factory.createModuleDeclaration(modifiers, name, body, flags);
-            (node as Mutable<ModuleDeclaration>)._decorators = decorators;
+            (node as Mutable<ModuleDeclaration>).illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7437,7 +7437,7 @@ namespace ts {
                 parseSemicolon();
             }
             const node = factory.createModuleDeclaration(modifiers, name, body, flags);
-            (node as Mutable<ModuleDeclaration>)._decorators = decorators;
+            (node as Mutable<ModuleDeclaration>).illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7483,7 +7483,7 @@ namespace ts {
             parseSemicolon();
             const node = factory.createNamespaceExportDeclaration(name);
             // NamespaceExportDeclaration nodes cannot have decorators or modifiers, so we attach them here so we can report them in the grammar checker
-            (node as Mutable<NamespaceExportDeclaration>)._decorators = decorators;
+            (node as Mutable<NamespaceExportDeclaration>).illegalDecorators = decorators;
             (node as Mutable<NamespaceExportDeclaration>).modifiers = modifiers;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
@@ -7532,7 +7532,7 @@ namespace ts {
 
             parseSemicolon();
             const node = factory.createImportDeclaration(modifiers, importClause, moduleSpecifier, assertClause);
-            (node as Mutable<ImportDeclaration>)._decorators = decorators;
+            (node as Mutable<ImportDeclaration>).illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7585,7 +7585,7 @@ namespace ts {
             const moduleReference = parseModuleReference();
             parseSemicolon();
             const node = factory.createImportEqualsDeclaration(modifiers, isTypeOnly, identifier, moduleReference);
-            (node as Mutable<ImportEqualsDeclaration>)._decorators = decorators;
+            (node as Mutable<ImportEqualsDeclaration>).illegalDecorators = decorators;
             const finished = withJSDoc(finishNode(node, pos), hasJSDoc);
             return finished;
         }
@@ -7794,7 +7794,7 @@ namespace ts {
             parseSemicolon();
             setAwaitContext(savedAwaitContext);
             const node = factory.createExportDeclaration(modifiers, isTypeOnly, exportClause, moduleSpecifier, assertClause);
-            (node as Mutable<ExportDeclaration>)._decorators = decorators;
+            (node as Mutable<ExportDeclaration>).illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 
@@ -7812,7 +7812,7 @@ namespace ts {
             parseSemicolon();
             setAwaitContext(savedAwaitContext);
             const node = factory.createExportAssignment(modifiers, isExportEquals, expression);
-            (node as Mutable<ExportAssignment>)._decorators = decorators;
+            (node as Mutable<ExportAssignment>).illegalDecorators = decorators;
             return withJSDoc(finishNode(node, pos), hasJSDoc);
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1484,7 +1484,7 @@ namespace ts {
         readonly initializer: Expression;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined; // property assignment cannot have decorators
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined; // property assignment cannot have decorators
         /* @internal */ readonly modifiers?: NodeArray<Modifier> | undefined; // property assignment cannot have modifiers
         /* @internal */ readonly questionToken?: QuestionToken | undefined; // property assignment cannot have a question token
         /* @internal */ readonly exclamationToken?: ExclamationToken | undefined; // property assignment cannot have an exclamation token
@@ -1500,7 +1500,7 @@ namespace ts {
         readonly objectAssignmentInitializer?: Expression;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined; // shorthand property assignment cannot have decorators
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined; // shorthand property assignment cannot have decorators
         /* @internal */ readonly modifiers?: NodeArray<Modifier> | undefined; // shorthand property assignment cannot have modifiers
         /* @internal */ readonly questionToken?: QuestionToken | undefined; // shorthand property assignment cannot have a question token
         /* @internal */ readonly exclamationToken?: ExclamationToken | undefined; // shorthand property assignment cannot have an exclamation token
@@ -1582,7 +1582,7 @@ namespace ts {
         readonly body?: FunctionBody;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined; // functions cannot have decorators
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined; // functions cannot have decorators
     }
 
     export interface MethodSignature extends SignatureDeclarationBase, TypeElement {
@@ -1619,7 +1619,7 @@ namespace ts {
         readonly body?: FunctionBody | undefined;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined; // A constructor cannot have decorators
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined; // A constructor cannot have decorators
         /* @internal */ readonly typeParameters?: NodeArray<TypeParameterDeclaration>; // A constructor cannot have type parameters
         /* @internal */ readonly type?: TypeNode; // A constructor cannot have a return type annotation
     }
@@ -1666,7 +1666,7 @@ namespace ts {
         readonly type: TypeNode;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface ClassStaticBlockDeclaration extends ClassElement, JSDocContainer {
@@ -1678,7 +1678,7 @@ namespace ts {
         /* @internal */ returnFlowNode?: FlowNode;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
         /* @internal */ readonly modifiers?: NodeArray<Modifier> | undefined;
     }
 
@@ -2828,7 +2828,7 @@ namespace ts {
         readonly name?: Identifier;
 
         // The following properties are used only to report grammar errors
-        /*@internal*/ decorators?: NodeArray<Decorator> | undefined;
+        /*@internal*/ _decorators?: NodeArray<Decorator> | undefined;
         /*@internal*/ modifiers?: NodeArray<Modifier> | undefined;
     }
 
@@ -2851,7 +2851,7 @@ namespace ts {
         readonly declarationList: VariableDeclarationList;
 
         // The following properties are used only to report grammar errors
-        /* @internal*/ decorators?: NodeArray<Decorator> | undefined;
+        /* @internal*/ _decorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface ExpressionStatement extends Statement {
@@ -3065,7 +3065,7 @@ namespace ts {
         readonly members: NodeArray<TypeElement>;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface HeritageClause extends Node {
@@ -3083,7 +3083,7 @@ namespace ts {
         readonly type: TypeNode;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface EnumMember extends NamedDeclaration, JSDocContainer {
@@ -3102,7 +3102,7 @@ namespace ts {
         readonly members: NodeArray<EnumMember>;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
     }
 
     export type ModuleName =
@@ -3128,7 +3128,7 @@ namespace ts {
         readonly body?: ModuleBody | JSDocNamespaceDeclaration;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
     }
 
     export type NamespaceBody =
@@ -3179,7 +3179,7 @@ namespace ts {
         readonly moduleReference: ModuleReference;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface ExternalModuleReference extends Node {
@@ -3202,7 +3202,7 @@ namespace ts {
         readonly assertClause?: AssertClause;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
     }
 
     export type NamedImportBindings =
@@ -3262,7 +3262,7 @@ namespace ts {
         readonly name: Identifier;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
         /* @internal */ readonly modifiers?: NodeArray<Modifier> | undefined;
     }
 
@@ -3278,7 +3278,7 @@ namespace ts {
         readonly assertClause?: AssertClause;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface NamedImports extends Node {
@@ -3343,7 +3343,7 @@ namespace ts {
         readonly expression: Expression;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface FileReference extends TextRange {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1484,7 +1484,7 @@ namespace ts {
         readonly initializer: Expression;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined; // property assignment cannot have decorators
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined; // property assignment cannot have decorators
         /* @internal */ readonly modifiers?: NodeArray<Modifier> | undefined; // property assignment cannot have modifiers
         /* @internal */ readonly questionToken?: QuestionToken | undefined; // property assignment cannot have a question token
         /* @internal */ readonly exclamationToken?: ExclamationToken | undefined; // property assignment cannot have an exclamation token
@@ -1500,7 +1500,7 @@ namespace ts {
         readonly objectAssignmentInitializer?: Expression;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined; // shorthand property assignment cannot have decorators
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined; // shorthand property assignment cannot have decorators
         /* @internal */ readonly modifiers?: NodeArray<Modifier> | undefined; // shorthand property assignment cannot have modifiers
         /* @internal */ readonly questionToken?: QuestionToken | undefined; // shorthand property assignment cannot have a question token
         /* @internal */ readonly exclamationToken?: ExclamationToken | undefined; // shorthand property assignment cannot have an exclamation token
@@ -1582,7 +1582,7 @@ namespace ts {
         readonly body?: FunctionBody;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined; // functions cannot have decorators
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined; // functions cannot have decorators
     }
 
     export interface MethodSignature extends SignatureDeclarationBase, TypeElement {
@@ -1619,7 +1619,7 @@ namespace ts {
         readonly body?: FunctionBody | undefined;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined; // A constructor cannot have decorators
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined; // A constructor cannot have decorators
         /* @internal */ readonly typeParameters?: NodeArray<TypeParameterDeclaration>; // A constructor cannot have type parameters
         /* @internal */ readonly type?: TypeNode; // A constructor cannot have a return type annotation
     }
@@ -1666,7 +1666,7 @@ namespace ts {
         readonly type: TypeNode;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface ClassStaticBlockDeclaration extends ClassElement, JSDocContainer {
@@ -1678,7 +1678,7 @@ namespace ts {
         /* @internal */ returnFlowNode?: FlowNode;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
         /* @internal */ readonly modifiers?: NodeArray<Modifier> | undefined;
     }
 
@@ -2828,7 +2828,7 @@ namespace ts {
         readonly name?: Identifier;
 
         // The following properties are used only to report grammar errors
-        /*@internal*/ _decorators?: NodeArray<Decorator> | undefined;
+        /*@internal*/ illegalDecorators?: NodeArray<Decorator> | undefined;
         /*@internal*/ modifiers?: NodeArray<Modifier> | undefined;
     }
 
@@ -2851,7 +2851,7 @@ namespace ts {
         readonly declarationList: VariableDeclarationList;
 
         // The following properties are used only to report grammar errors
-        /* @internal*/ _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal*/ illegalDecorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface ExpressionStatement extends Statement {
@@ -3065,7 +3065,7 @@ namespace ts {
         readonly members: NodeArray<TypeElement>;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface HeritageClause extends Node {
@@ -3083,7 +3083,7 @@ namespace ts {
         readonly type: TypeNode;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface EnumMember extends NamedDeclaration, JSDocContainer {
@@ -3102,7 +3102,7 @@ namespace ts {
         readonly members: NodeArray<EnumMember>;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
     }
 
     export type ModuleName =
@@ -3128,7 +3128,7 @@ namespace ts {
         readonly body?: ModuleBody | JSDocNamespaceDeclaration;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
     }
 
     export type NamespaceBody =
@@ -3179,7 +3179,7 @@ namespace ts {
         readonly moduleReference: ModuleReference;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface ExternalModuleReference extends Node {
@@ -3202,7 +3202,7 @@ namespace ts {
         readonly assertClause?: AssertClause;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
     }
 
     export type NamedImportBindings =
@@ -3262,7 +3262,7 @@ namespace ts {
         readonly name: Identifier;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
         /* @internal */ readonly modifiers?: NodeArray<Modifier> | undefined;
     }
 
@@ -3278,7 +3278,7 @@ namespace ts {
         readonly assertClause?: AssertClause;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface NamedImports extends Node {
@@ -3343,7 +3343,7 @@ namespace ts {
         readonly expression: Expression;
 
         // The following properties are used only to report grammar errors
-        /* @internal */ readonly _decorators?: NodeArray<Decorator> | undefined;
+        /* @internal */ readonly illegalDecorators?: NodeArray<Decorator> | undefined;
     }
 
     export interface FileReference extends TextRange {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7542,7 +7542,7 @@ namespace ts {
             case SyntaxKind.Decorator: {
                 const { parent } = node as Decorator;
                 return canHaveDecorators(parent) ? parent.modifiers :
-                    canHaveIllegalDecorators(parent) ? parent._decorators :
+                    canHaveIllegalDecorators(parent) ? parent.illegalDecorators :
                     undefined;
             }
             case SyntaxKind.HeritageClause:

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7542,7 +7542,7 @@ namespace ts {
             case SyntaxKind.Decorator: {
                 const { parent } = node as Decorator;
                 return canHaveDecorators(parent) ? parent.modifiers :
-                    canHaveIllegalDecorators(parent) ? parent.decorators :
+                    canHaveIllegalDecorators(parent) ? parent._decorators :
                     undefined;
             }
             case SyntaxKind.HeritageClause:

--- a/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
+++ b/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
@@ -15,7 +15,7 @@ namespace ts {
          * const decorators = ts.canHaveDecorators(node) ? ts.getDecorators(node) : undefined;
          * ```
          */
-        readonly decorators: never;
+        readonly decorators?: undefined;
 
         /**
          * @deprecated `modifiers` has been removed from `Node` and moved to the `Node` subtypes that support them.

--- a/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
+++ b/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
@@ -477,7 +477,7 @@ namespace ts {
                     (decorators === undefined || !some(decorators, isModifier)) &&
                     (modifiers === undefined || !some(modifiers, isParameter)) &&
                     (parameters === undefined || isArray(parameters)) &&
-                    (body === undefined || !isBlock(body)),
+                    (body === undefined || isBlock(body)),
             })
             .deprecate({
                 1: DISALLOW_DECORATORS
@@ -505,7 +505,7 @@ namespace ts {
                     (decorators === undefined || !some(decorators, isModifier)) &&
                     (modifiers === undefined || !some(modifiers, isParameter)) &&
                     (parameters === undefined || isArray(parameters)) &&
-                    (body === undefined || !isBlock(body)),
+                    (body === undefined || isBlock(body)),
             })
             .deprecate({
                 1: DISALLOW_DECORATORS

--- a/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
+++ b/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
@@ -6,9 +6,9 @@
 namespace ts {
     export interface Node {
         /**
-         * @deprecated `decorators` has been merged with `modifiers` on the declarations that support decorators.
-         * To test whether a `Node` can legally have decorators, use the `ts.canHaveDecorators()` function. To read the
-         * decorators of a `Node` that can legally have decorators, use the `ts.getDecorators()` function.
+         * @deprecated `decorators` has been removed from `Node` and merged with `modifiers` on the `Node` subtypes that support them.
+         * Use `ts.canHaveDecorators()` to test whether a `Node` can have decorators.
+         * Use `ts.getDecorators()` to get the decorators of a `Node`.
          *
          * For example:
          * ```ts
@@ -18,9 +18,9 @@ namespace ts {
         readonly decorators: never;
 
         /**
-         * @deprecated `modifiers` has been removed from `Node` and moved to the specific `Node` subtypes that support them.
-         * To test whether a `Node` can legally have modifiers, use the `ts.canHaveModifiers()` function. To read the modifiers
-         * of a `Node` that can legally have modifiers, use the `ts.getModifiers()` function.
+         * @deprecated `modifiers` has been removed from `Node` and moved to the `Node` subtypes that support them.
+         * Use `ts.canHaveModifiers()` to test whether a `Node` can have modifiers.
+         * Use `ts.getModifiers()` to get the modifiers of a `Node`.
          *
          * For example:
          * ```ts
@@ -212,7 +212,6 @@ namespace ts {
          * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateExportDeclaration(node: ExportDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, exportClause: NamedExportBindings | undefined, moduleSpecifier: Expression | undefined, assertClause: AssertClause | undefined): ExportDeclaration;
-
     }
 
     const MUST_MERGE: DeprecationOptions = { since: "4.8", warnAfter: "4.9.0-0", message: "Decorators have been combined with modifiers. Callers should switch to an overload that does not accept a 'decorators' parameter." };

--- a/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
+++ b/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
@@ -5,10 +5,28 @@
 //     - error: 5.0
 namespace ts {
     export interface Node {
-        /** @deprecated `decorators` has been merged with `modifiers` on the declarations that support decorators. */
-        readonly decorators?: NodeArray<Decorator> | undefined;
+        /**
+         * @deprecated `decorators` has been merged with `modifiers` on the declarations that support decorators.
+         * To test whether a `Node` can legally have decorators, use the `ts.canHaveDecorators()` function. To read the
+         * decorators of a `Node` that can legally have decorators, use the `ts.getDecorators()` function.
+         *
+         * For example:
+         * ```ts
+         * const decorators = ts.canHaveDecorators(node) ? ts.getDecorators(node) : undefined;
+         * ```
+         */
+        readonly decorators: never;
 
-        /** @deprecated `modifiers` has been removed from `Node` and moved to the specific `Node` subtypes that support them. */
+        /**
+         * @deprecated `modifiers` has been removed from `Node` and moved to the specific `Node` subtypes that support them.
+         * To test whether a `Node` can legally have modifiers, use the `ts.canHaveModifiers()` function. To read the modifiers
+         * of a `Node` that can legally have modifiers, use the `ts.getModifiers()` function.
+         *
+         * For example:
+         * ```ts
+         * const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+         * ```
+         */
         readonly modifiers?: NodeArray<ModifierLike> | undefined;
     }
 
@@ -43,239 +61,163 @@ namespace ts {
 
     export interface NodeFactory {
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createParameterDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateParameterDeclaration(node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): ParameterDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createPropertyDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, questionOrExclamationToken: QuestionToken | ExclamationToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): PropertyDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updatePropertyDeclaration(node: PropertyDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, questionOrExclamationToken: QuestionToken | ExclamationToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): PropertyDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createMethodDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: string | PropertyName, questionToken: QuestionToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): MethodDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateMethodDeclaration(node: MethodDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: PropertyName, questionToken: QuestionToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): MethodDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated This node does not support Decorators. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createConstructorDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], body: Block | undefined): ConstructorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated This node does not support Decorators. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateConstructorDeclaration(node: ConstructorDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], body: Block | undefined): ConstructorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createGetAccessorDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): GetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateGetAccessorDeclaration(node: GetAccessorDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: PropertyName, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): GetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createSetAccessorDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, parameters: readonly ParameterDeclaration[], body: Block | undefined): SetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateSetAccessorDeclaration(node: SetAccessorDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: PropertyName, parameters: readonly ParameterDeclaration[], body: Block | undefined): SetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createIndexSignature(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode): IndexSignatureDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators and modifiers are no longer supported for this function. Callers should use an overload that does not accept the `decorators` and `modifiers` parameters.
          */
         updateIndexSignature(node: IndexSignatureDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode): IndexSignatureDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators and modifiers are no longer supported for this function. Callers should use an overload that does not accept the `decorators` and `modifiers` parameters.
          */
         createClassStaticBlockDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, body: Block): ClassStaticBlockDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateClassStaticBlockDeclaration(node: ClassStaticBlockDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, body: Block): ClassStaticBlockDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createClassExpression(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassExpression;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateClassExpression(node: ClassExpression, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassExpression;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createFunctionDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: string | Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): FunctionDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateFunctionDeclaration(node: FunctionDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): FunctionDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createClassDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateClassDeclaration(node: ClassDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createInterfaceDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly TypeElement[]): InterfaceDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateInterfaceDeclaration(node: InterfaceDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly TypeElement[]): InterfaceDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createTypeAliasDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, type: TypeNode): TypeAliasDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateTypeAliasDeclaration(node: TypeAliasDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, type: TypeNode): TypeAliasDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createEnumDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier, members: readonly EnumMember[]): EnumDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateEnumDeclaration(node: EnumDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier, members: readonly EnumMember[]): EnumDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createModuleDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: ModuleName, body: ModuleBody | undefined, flags?: NodeFlags): ModuleDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateModuleDeclaration(node: ModuleDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: ModuleName, body: ModuleBody | undefined): ModuleDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createImportEqualsDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, name: string | Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateImportEqualsDeclaration(node: ImportEqualsDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, name: Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createImportDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression, assertClause?: AssertClause): ImportDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateImportDeclaration(node: ImportDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression, assertClause: AssertClause | undefined): ImportDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createExportAssignment(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isExportEquals: boolean | undefined, expression: Expression): ExportAssignment;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateExportAssignment(node: ExportAssignment, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, expression: Expression): ExportAssignment;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createExportDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, exportClause: NamedExportBindings | undefined, moduleSpecifier?: Expression, assertClause?: AssertClause): ExportDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateExportDeclaration(node: ExportDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, exportClause: NamedExportBindings | undefined, moduleSpecifier: Expression | undefined, assertClause: AssertClause | undefined): ExportDeclaration;
 
     }
 
-    const MUST_MERGE: DeprecationOptions = { since: "4.8", warnAfter: "4.9.0-0", message: "Decorators have been combined with modifiers. Callers should switch to an overload without a 'decorators' parameter." };
-    const DISALLOW_DECORATORS: DeprecationOptions = { since: "4.8", warnAfter: "4.9.0-0", message: `Decorators are no longer supported for this function. Callers should switch to an overload without a 'decorators' parameter.` };
-    const DISALLOW_DECORATORS_AND_MODIFIERS: DeprecationOptions = { since: "4.8", warnAfter: "4.9.0-0", message: `Decorators and modifiers are no longer supported for this function. Callers should switch to an overload without the 'decorators' or 'modifiers' parameters.` };
+    const MUST_MERGE: DeprecationOptions = { since: "4.8", warnAfter: "4.9.0-0", message: "Decorators have been combined with modifiers. Callers should switch to an overload that does not accept a 'decorators' parameter." };
+    const DISALLOW_DECORATORS: DeprecationOptions = { since: "4.8", warnAfter: "4.9.0-0", message: `Decorators are no longer supported for this function. Callers should switch to an overload that does not accept a 'decorators' parameter.` };
+    const DISALLOW_DECORATORS_AND_MODIFIERS: DeprecationOptions = { since: "4.8", warnAfter: "4.9.0-0", message: `Decorators and modifiers are no longer supported for this function. Callers should switch to an overload that does not accept the 'decorators' and 'modifiers' parameters.` };
 
     function patchNodeFactory(factory: NodeFactory) {
         const {

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -653,7 +653,7 @@ namespace ts.refactor.convertParamsToDestructuredObject {
     interface ValidParameterDeclaration extends ParameterDeclaration {
         name: Identifier;
         modifiers: undefined;
-        decorators: undefined;
+        _decorators: undefined;
     }
 
     interface GroupedReferences {

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -653,7 +653,7 @@ namespace ts.refactor.convertParamsToDestructuredObject {
     interface ValidParameterDeclaration extends ParameterDeclaration {
         name: Identifier;
         modifiers: undefined;
-        _decorators: undefined;
+        illegalDecorators: undefined;
     }
 
     interface GroupedReferences {

--- a/src/testRunner/unittests/factory.ts
+++ b/src/testRunner/unittests/factory.ts
@@ -81,5 +81,40 @@ namespace ts {
                 checkRhs(SyntaxKind.QuestionQuestionEqualsToken, /*expectParens*/ false);
             });
         });
+
+        describe("deprecations", () => {
+            beforeEach(() => {
+                Debug.enableDeprecationWarnings = false;
+            });
+
+            afterEach(() => {
+                Debug.enableDeprecationWarnings = true;
+            });
+
+            // https://github.com/microsoft/TypeScript/issues/50259
+            it("deprecated createConstructorDeclaration overload does not throw", () => {
+                const body = factory.createBlock([]);
+                assert.doesNotThrow(() => factory.createConstructorDeclaration(
+                    /*decorators*/ undefined,
+                    /*modifiers*/ undefined,
+                    /*parameters*/ [],
+                    body,
+                ));
+            });
+
+            // https://github.com/microsoft/TypeScript/issues/50259
+            it("deprecated updateConstructorDeclaration overload does not throw", () => {
+                const body = factory.createBlock([]);
+                const ctor = factory.createConstructorDeclaration(/*modifiers*/ undefined, [], body);
+                assert.doesNotThrow(() => factory.updateConstructorDeclaration(
+                    ctor,
+                    ctor.decorators,
+                    ctor.modifiers,
+                    ctor.parameters,
+                    ctor.body,
+                ));
+            });
+        });
+
     });
 }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -11781,20 +11781,20 @@ declare namespace ts {
 declare namespace ts {
     interface Node {
         /**
-         * @deprecated `decorators` has been merged with `modifiers` on the declarations that support decorators.
-         * To test whether a `Node` can legally have decorators, use the `ts.canHaveDecorators()` function. To read the
-         * decorators of a `Node` that can legally have decorators, use the `ts.getDecorators()` function.
+         * @deprecated `decorators` has been removed from `Node` and merged with `modifiers` on the `Node` subtypes that support them.
+         * Use `ts.canHaveDecorators()` to test whether a `Node` can have decorators.
+         * Use `ts.getDecorators()` to get the decorators of a `Node`.
          *
          * For example:
          * ```ts
          * const decorators = ts.canHaveDecorators(node) ? ts.getDecorators(node) : undefined;
          * ```
          */
-        readonly decorators: never;
+        readonly decorators?: undefined;
         /**
-         * @deprecated `modifiers` has been removed from `Node` and moved to the specific `Node` subtypes that support them.
-         * To test whether a `Node` can legally have modifiers, use the `ts.canHaveModifiers()` function. To read the modifiers
-         * of a `Node` that can legally have modifiers, use the `ts.getModifiers()` function.
+         * @deprecated `modifiers` has been removed from `Node` and moved to the `Node` subtypes that support them.
+         * Use `ts.canHaveModifiers()` to test whether a `Node` can have modifiers.
+         * Use `ts.getModifiers()` to get the modifiers of a `Node`.
          *
          * For example:
          * ```ts

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -11780,9 +11780,27 @@ declare namespace ts {
 }
 declare namespace ts {
     interface Node {
-        /** @deprecated `decorators` has been merged with `modifiers` on the declarations that support decorators. */
-        readonly decorators?: NodeArray<Decorator> | undefined;
-        /** @deprecated `modifiers` has been removed from `Node` and moved to the specific `Node` subtypes that support them. */
+        /**
+         * @deprecated `decorators` has been merged with `modifiers` on the declarations that support decorators.
+         * To test whether a `Node` can legally have decorators, use the `ts.canHaveDecorators()` function. To read the
+         * decorators of a `Node` that can legally have decorators, use the `ts.getDecorators()` function.
+         *
+         * For example:
+         * ```ts
+         * const decorators = ts.canHaveDecorators(node) ? ts.getDecorators(node) : undefined;
+         * ```
+         */
+        readonly decorators: never;
+        /**
+         * @deprecated `modifiers` has been removed from `Node` and moved to the specific `Node` subtypes that support them.
+         * To test whether a `Node` can legally have modifiers, use the `ts.canHaveModifiers()` function. To read the modifiers
+         * of a `Node` that can legally have modifiers, use the `ts.getModifiers()` function.
+         *
+         * For example:
+         * ```ts
+         * const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+         * ```
+         */
         readonly modifiers?: NodeArray<ModifierLike> | undefined;
     }
     interface PropertySignature {
@@ -11809,231 +11827,155 @@ declare namespace ts {
     }
     interface NodeFactory {
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createParameterDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateParameterDeclaration(node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): ParameterDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createPropertyDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, questionOrExclamationToken: QuestionToken | ExclamationToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): PropertyDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updatePropertyDeclaration(node: PropertyDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, questionOrExclamationToken: QuestionToken | ExclamationToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): PropertyDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createMethodDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: string | PropertyName, questionToken: QuestionToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): MethodDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateMethodDeclaration(node: MethodDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: PropertyName, questionToken: QuestionToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): MethodDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated This node does not support Decorators. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createConstructorDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], body: Block | undefined): ConstructorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated This node does not support Decorators. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateConstructorDeclaration(node: ConstructorDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], body: Block | undefined): ConstructorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createGetAccessorDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): GetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateGetAccessorDeclaration(node: GetAccessorDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: PropertyName, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): GetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createSetAccessorDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, parameters: readonly ParameterDeclaration[], body: Block | undefined): SetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateSetAccessorDeclaration(node: SetAccessorDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: PropertyName, parameters: readonly ParameterDeclaration[], body: Block | undefined): SetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createIndexSignature(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode): IndexSignatureDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators and modifiers are no longer supported for this function. Callers should use an overload that does not accept the `decorators` and `modifiers` parameters.
          */
         updateIndexSignature(node: IndexSignatureDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode): IndexSignatureDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators and modifiers are no longer supported for this function. Callers should use an overload that does not accept the `decorators` and `modifiers` parameters.
          */
         createClassStaticBlockDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, body: Block): ClassStaticBlockDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateClassStaticBlockDeclaration(node: ClassStaticBlockDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, body: Block): ClassStaticBlockDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createClassExpression(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassExpression;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateClassExpression(node: ClassExpression, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassExpression;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createFunctionDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: string | Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): FunctionDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateFunctionDeclaration(node: FunctionDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): FunctionDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createClassDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateClassDeclaration(node: ClassDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createInterfaceDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly TypeElement[]): InterfaceDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateInterfaceDeclaration(node: InterfaceDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly TypeElement[]): InterfaceDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createTypeAliasDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, type: TypeNode): TypeAliasDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateTypeAliasDeclaration(node: TypeAliasDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, type: TypeNode): TypeAliasDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createEnumDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier, members: readonly EnumMember[]): EnumDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateEnumDeclaration(node: EnumDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier, members: readonly EnumMember[]): EnumDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createModuleDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: ModuleName, body: ModuleBody | undefined, flags?: NodeFlags): ModuleDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateModuleDeclaration(node: ModuleDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: ModuleName, body: ModuleBody | undefined): ModuleDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createImportEqualsDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, name: string | Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateImportEqualsDeclaration(node: ImportEqualsDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, name: Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createImportDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression, assertClause?: AssertClause): ImportDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateImportDeclaration(node: ImportDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression, assertClause: AssertClause | undefined): ImportDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createExportAssignment(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isExportEquals: boolean | undefined, expression: Expression): ExportAssignment;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateExportAssignment(node: ExportAssignment, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, expression: Expression): ExportAssignment;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createExportDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, exportClause: NamedExportBindings | undefined, moduleSpecifier?: Expression, assertClause?: AssertClause): ExportDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateExportDeclaration(node: ExportDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, exportClause: NamedExportBindings | undefined, moduleSpecifier: Expression | undefined, assertClause: AssertClause | undefined): ExportDeclaration;
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -7913,20 +7913,20 @@ declare namespace ts {
 declare namespace ts {
     interface Node {
         /**
-         * @deprecated `decorators` has been merged with `modifiers` on the declarations that support decorators.
-         * To test whether a `Node` can legally have decorators, use the `ts.canHaveDecorators()` function. To read the
-         * decorators of a `Node` that can legally have decorators, use the `ts.getDecorators()` function.
+         * @deprecated `decorators` has been removed from `Node` and merged with `modifiers` on the `Node` subtypes that support them.
+         * Use `ts.canHaveDecorators()` to test whether a `Node` can have decorators.
+         * Use `ts.getDecorators()` to get the decorators of a `Node`.
          *
          * For example:
          * ```ts
          * const decorators = ts.canHaveDecorators(node) ? ts.getDecorators(node) : undefined;
          * ```
          */
-        readonly decorators: never;
+        readonly decorators?: undefined;
         /**
-         * @deprecated `modifiers` has been removed from `Node` and moved to the specific `Node` subtypes that support them.
-         * To test whether a `Node` can legally have modifiers, use the `ts.canHaveModifiers()` function. To read the modifiers
-         * of a `Node` that can legally have modifiers, use the `ts.getModifiers()` function.
+         * @deprecated `modifiers` has been removed from `Node` and moved to the `Node` subtypes that support them.
+         * Use `ts.canHaveModifiers()` to test whether a `Node` can have modifiers.
+         * Use `ts.getModifiers()` to get the modifiers of a `Node`.
          *
          * For example:
          * ```ts

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -7912,9 +7912,27 @@ declare namespace ts {
 }
 declare namespace ts {
     interface Node {
-        /** @deprecated `decorators` has been merged with `modifiers` on the declarations that support decorators. */
-        readonly decorators?: NodeArray<Decorator> | undefined;
-        /** @deprecated `modifiers` has been removed from `Node` and moved to the specific `Node` subtypes that support them. */
+        /**
+         * @deprecated `decorators` has been merged with `modifiers` on the declarations that support decorators.
+         * To test whether a `Node` can legally have decorators, use the `ts.canHaveDecorators()` function. To read the
+         * decorators of a `Node` that can legally have decorators, use the `ts.getDecorators()` function.
+         *
+         * For example:
+         * ```ts
+         * const decorators = ts.canHaveDecorators(node) ? ts.getDecorators(node) : undefined;
+         * ```
+         */
+        readonly decorators: never;
+        /**
+         * @deprecated `modifiers` has been removed from `Node` and moved to the specific `Node` subtypes that support them.
+         * To test whether a `Node` can legally have modifiers, use the `ts.canHaveModifiers()` function. To read the modifiers
+         * of a `Node` that can legally have modifiers, use the `ts.getModifiers()` function.
+         *
+         * For example:
+         * ```ts
+         * const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+         * ```
+         */
         readonly modifiers?: NodeArray<ModifierLike> | undefined;
     }
     interface PropertySignature {
@@ -7941,231 +7959,155 @@ declare namespace ts {
     }
     interface NodeFactory {
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createParameterDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken?: QuestionToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateParameterDeclaration(node: ParameterDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): ParameterDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createPropertyDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, questionOrExclamationToken: QuestionToken | ExclamationToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): PropertyDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updatePropertyDeclaration(node: PropertyDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, questionOrExclamationToken: QuestionToken | ExclamationToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined): PropertyDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createMethodDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: string | PropertyName, questionToken: QuestionToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): MethodDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateMethodDeclaration(node: MethodDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: PropertyName, questionToken: QuestionToken | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): MethodDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated This node does not support Decorators. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createConstructorDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], body: Block | undefined): ConstructorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated This node does not support Decorators. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateConstructorDeclaration(node: ConstructorDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], body: Block | undefined): ConstructorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createGetAccessorDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): GetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateGetAccessorDeclaration(node: GetAccessorDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: PropertyName, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): GetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createSetAccessorDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | PropertyName, parameters: readonly ParameterDeclaration[], body: Block | undefined): SetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateSetAccessorDeclaration(node: SetAccessorDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: PropertyName, parameters: readonly ParameterDeclaration[], body: Block | undefined): SetAccessorDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createIndexSignature(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode): IndexSignatureDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators and modifiers are no longer supported for this function. Callers should use an overload that does not accept the `decorators` and `modifiers` parameters.
          */
         updateIndexSignature(node: IndexSignatureDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode): IndexSignatureDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators and modifiers are no longer supported for this function. Callers should use an overload that does not accept the `decorators` and `modifiers` parameters.
          */
         createClassStaticBlockDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, body: Block): ClassStaticBlockDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateClassStaticBlockDeclaration(node: ClassStaticBlockDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, body: Block): ClassStaticBlockDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createClassExpression(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassExpression;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateClassExpression(node: ClassExpression, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassExpression;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createFunctionDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: string | Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): FunctionDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateFunctionDeclaration(node: FunctionDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, asteriskToken: AsteriskToken | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, parameters: readonly ParameterDeclaration[], type: TypeNode | undefined, body: Block | undefined): FunctionDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createClassDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators have been combined with modifiers. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateClassDeclaration(node: ClassDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier | undefined, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly ClassElement[]): ClassDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createInterfaceDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly TypeElement[]): InterfaceDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateInterfaceDeclaration(node: InterfaceDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, heritageClauses: readonly HeritageClause[] | undefined, members: readonly TypeElement[]): InterfaceDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createTypeAliasDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, type: TypeNode): TypeAliasDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateTypeAliasDeclaration(node: TypeAliasDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier, typeParameters: readonly TypeParameterDeclaration[] | undefined, type: TypeNode): TypeAliasDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createEnumDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: string | Identifier, members: readonly EnumMember[]): EnumDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateEnumDeclaration(node: EnumDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: Identifier, members: readonly EnumMember[]): EnumDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createModuleDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: ModuleName, body: ModuleBody | undefined, flags?: NodeFlags): ModuleDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateModuleDeclaration(node: ModuleDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, name: ModuleName, body: ModuleBody | undefined): ModuleDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createImportEqualsDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, name: string | Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateImportEqualsDeclaration(node: ImportEqualsDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, name: Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createImportDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression, assertClause?: AssertClause): ImportDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateImportDeclaration(node: ImportDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression, assertClause: AssertClause | undefined): ImportDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createExportAssignment(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isExportEquals: boolean | undefined, expression: Expression): ExportAssignment;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateExportAssignment(node: ExportAssignment, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, expression: Expression): ExportAssignment;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         createExportDeclaration(decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, exportClause: NamedExportBindings | undefined, moduleSpecifier?: Expression, assertClause?: AssertClause): ExportDeclaration;
         /**
-         * @deprecated Decorators have been combined with modifiers. Callers should pass
-         * `null` to the `decorators` parameter so that a future update can introduce
-         * an overload that removes the parameter entirely.
+         * @deprecated Decorators are no longer supported for this function. Callers should use an overload that does not accept a `decorators` parameter.
          */
         updateExportDeclaration(node: ExportDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, isTypeOnly: boolean, exportClause: NamedExportBindings | undefined, moduleSpecifier: Expression | undefined, assertClause: AssertClause | undefined): ExportDeclaration;
     }


### PR DESCRIPTION
This fixes two issues that occur in TS 4.8 related to the deprecation of the `decorators` property on `Node`:

First, the deprecated `decorators` property used a type that made it difficult to find runtime breaks since use of `decorators` would silently succeed rather than fail to compile. To address this, I've changed the typeof `decorators` from `NodeArray<Decorator> | undefined` to `undefined` to make these breaks more obvious. As a result of this change, I renamed the `decorators` property to `_decorators` internally for cases where we track invalid grammar nodes (such as decorators parsed on a constructor, etc.), otherwise I would have run into a conflict with the definition of the types.

Second, the `createConstructorDeclaration` and `updateConstructorDeclaration` functions of `NodeFactory` incorrectly rejected a valid value for `body` when using the deprecated overloads due to an incorrect negation of a test.


Fixes #50259
