### PR TITLE
Replace eslint rulesdir with eslint-plugin-local, convert eslint rules to JS

### DIFF
--- a/.eslintplugin.js
+++ b/.eslintplugin.js
@@ -5,6 +5,8 @@ const rulesDir = path.join(__dirname, "scripts", "eslint", "rules");
 const ext = ".js";
 const ruleFiles = fs.readdirSync(rulesDir).filter((p) => p.endsWith(ext));
 
-module.exports = Object.fromEntries(ruleFiles.map((p) => {
-    return [p.slice(0, -ext.length), require(path.join(rulesDir, p))];
-}));
+module.exports = {
+    rules: Object.fromEntries(ruleFiles.map((p) => {
+        return [p.slice(0, -ext.length), require(path.join(rulesDir, p))];
+    })),
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
         "es6": true
     },
     "plugins": [
-        "@typescript-eslint", "jsdoc", "no-null", "import"
+        "@typescript-eslint", "jsdoc", "no-null", "import", "eslint-plugin-local-rules"
     ],
     "overrides": [
         // By default, the ESLint CLI only looks at .js files. But, it will also look at
@@ -81,20 +81,20 @@
         "@typescript-eslint/unified-signatures": "error",
 
         // scripts/eslint/rules
-        "object-literal-surrounding-space": "error",
-        "no-type-assertion-whitespace": "error",
-        "type-operator-spacing": "error",
-        "only-arrow-functions": ["error", {
+        "local-rules/object-literal-surrounding-space": "error",
+        "local-rules/no-type-assertion-whitespace": "error",
+        "local-rules/type-operator-spacing": "error",
+        "local-rules/only-arrow-functions": ["error", {
             "allowNamedFunctions": true ,
             "allowDeclarations": true
         }],
-        "no-double-space": "error",
-        "boolean-trivia": "error",
-        "no-in-operator": "error",
-        "simple-indent": "error",
-        "debug-assert": "error",
-        "no-keywords": "error",
-        "one-namespace-per-file": "error",
+        "local-rules/no-double-space": "error",
+        "local-rules/boolean-trivia": "error",
+        "local-rules/no-in-operator": "error",
+        "local-rules/simple-indent": "error",
+        "local-rules/debug-assert": "error",
+        "local-rules/no-keywords": "error",
+        "local-rules/one-namespace-per-file": "error",
 
         // eslint-plugin-import
         "import/no-extraneous-dependencies": ["error", { "optionalDependencies": false }],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
         "es6": true
     },
     "plugins": [
-        "@typescript-eslint", "jsdoc", "no-null", "import", "eslint-plugin-local-rules"
+        "@typescript-eslint", "jsdoc", "no-null", "import", "eslint-plugin-local"
     ],
     "overrides": [
         // By default, the ESLint CLI only looks at .js files. But, it will also look at
@@ -81,20 +81,20 @@
         "@typescript-eslint/unified-signatures": "error",
 
         // scripts/eslint/rules
-        "local-rules/object-literal-surrounding-space": "error",
-        "local-rules/no-type-assertion-whitespace": "error",
-        "local-rules/type-operator-spacing": "error",
-        "local-rules/only-arrow-functions": ["error", {
+        "local/object-literal-surrounding-space": "error",
+        "local/no-type-assertion-whitespace": "error",
+        "local/type-operator-spacing": "error",
+        "local/only-arrow-functions": ["error", {
             "allowNamedFunctions": true ,
             "allowDeclarations": true
         }],
-        "local-rules/no-double-space": "error",
-        "local-rules/boolean-trivia": "error",
-        "local-rules/no-in-operator": "error",
-        "local-rules/simple-indent": "error",
-        "local-rules/debug-assert": "error",
-        "local-rules/no-keywords": "error",
-        "local-rules/one-namespace-per-file": "error",
+        "local/no-double-space": "error",
+        "local/boolean-trivia": "error",
+        "local/no-in-operator": "error",
+        "local/simple-indent": "error",
+        "local/debug-assert": "error",
+        "local/no-keywords": "error",
+        "local/one-namespace-per-file": "error",
 
         // eslint-plugin-import
         "import/no-extraneous-dependencies": ["error", { "optionalDependencies": false }],

--- a/.npmignore
+++ b/.npmignore
@@ -37,5 +37,5 @@ Dockerfile
 .eslintrc.json
 .yarnrc
 tmp
-eslint-local-rules.js
+.eslintplugin.js
 .eslintcache

--- a/.npmignore
+++ b/.npmignore
@@ -37,3 +37,5 @@ Dockerfile
 .eslintrc.json
 .yarnrc
 tmp
+eslint-local-rules.js
+.eslintcache

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -1,12 +1,6 @@
 // Rename this file 'settings.json' or merge its
 // contents into your existing settings.
 {
-    "eslint.validate": [
-        "typescript"
-    ],
-    "eslint.options": {
-        "rulePaths": ["./scripts/eslint/built/rules/"],
-    },
     // To use the last-known-good (LKG) compiler version:
     // "typescript.tsdk": "lib"
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -356,7 +356,6 @@ const eslint = (folder) => async () => {
         "--cache",
         "--cache-location", `${folder}/.eslintcache`,
         "--format", formatter,
-        "--rulesdir", "scripts/eslint/built/rules",
     ];
 
     if (cmdLineOptions.fix) {
@@ -369,10 +368,7 @@ const eslint = (folder) => async () => {
     return exec(process.execPath, args);
 };
 
-const lintRoot = eslint(".");
-lintRoot.displayName = "lint";
-
-const lint = series([buildEslintRules, lintRoot]);
+const lint = eslint(".");
 lint.displayName = "lint";
 task("lint", lint);
 task("lint").description = "Runs eslint on the compiler and scripts sources.";
@@ -431,7 +427,7 @@ task("watch-local").flags = {
 const preTest = parallel(buildTsc, buildTests, buildServices, buildLssl);
 preTest.displayName = "preTest";
 
-const postTest = (done) => cmdLineOptions.lint ? lint(done) : done();
+const postTest = (done) => cmdLineOptions.lint ? lint() : done();
 
 const runTests = () => runConsoleTests("built/local/run.js", "mocha-fivemat-progress-reporter", /*runInParallel*/ false, /*watchMode*/ false);
 task("runtests", series(preBuild, preTest, runTests, postTest));

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -2,9 +2,9 @@ const fs = require("fs");
 const path = require("path");
 
 const rulesDir = path.join(__dirname, "scripts", "eslint", "rules");
-const ruleFiles = fs.readdirSync(rulesDir).filter(p => p !== "utils.js");
+const ext = ".js";
+const ruleFiles = fs.readdirSync(rulesDir).filter((p) => p.endsWith(ext));
 
 module.exports = Object.fromEntries(ruleFiles.map((p) => {
-    const name = path.parse(p).name;
-    return [name, require(path.join(rulesDir, p))];
+    return [p.slice(0, -ext.length), require(path.join(rulesDir, p))];
 }));

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const path = require("path");
+
+const rulesDir = path.join(__dirname, "scripts", "eslint", "rules");
+const ruleFiles = fs.readdirSync(rulesDir).filter(p => p !== "utils.js");
+
+module.exports = Object.fromEntries(ruleFiles.map((p) => {
+    const name = path.parse(p).name;
+    return [name, require(path.join(rulesDir, p))];
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
                 "eslint-formatter-autolinkable-stylish": "^1.2.0",
                 "eslint-plugin-import": "^2.26.0",
                 "eslint-plugin-jsdoc": "^39.3.6",
-                "eslint-plugin-local-rules": "^1.3.1",
+                "eslint-plugin-local": "^1.0.0",
                 "eslint-plugin-no-null": "^1.0.2",
                 "fancy-log": "latest",
                 "fs-extra": "^9.1.0",
@@ -2524,10 +2524,10 @@
                 "eslint": "^7.0.0 || ^8.0.0"
             }
         },
-        "node_modules/eslint-plugin-local-rules": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.3.1.tgz",
-            "integrity": "sha512-ezuHRUXzRwFY3jFaX9vz8vxLLdLLIrbXBnVM6rip71/zjnIBaExY2vsm316temX+P3tasjQ2ciadWOTnnOUCgA==",
+        "node_modules/eslint-plugin-local": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-local/-/eslint-plugin-local-1.0.0.tgz",
+            "integrity": "sha512-bcwcQnKL/Iw5Vi/F2lG1he5oKD2OGjhsLmrcctkWrWq5TujgiaYb0cj3pZgr3XI54inNVnneOFdAx1daLoYLJQ==",
             "dev": true
         },
         "node_modules/eslint-plugin-no-null": {
@@ -10566,10 +10566,10 @@
                 "spdx-expression-parse": "^3.0.1"
             }
         },
-        "eslint-plugin-local-rules": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.3.1.tgz",
-            "integrity": "sha512-ezuHRUXzRwFY3jFaX9vz8vxLLdLLIrbXBnVM6rip71/zjnIBaExY2vsm316temX+P3tasjQ2ciadWOTnnOUCgA==",
+        "eslint-plugin-local": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-local/-/eslint-plugin-local-1.0.0.tgz",
+            "integrity": "sha512-bcwcQnKL/Iw5Vi/F2lG1he5oKD2OGjhsLmrcctkWrWq5TujgiaYb0cj3pZgr3XI54inNVnneOFdAx1daLoYLJQ==",
             "dev": true
         },
         "eslint-plugin-no-null": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
                 "eslint-formatter-autolinkable-stylish": "^1.2.0",
                 "eslint-plugin-import": "^2.26.0",
                 "eslint-plugin-jsdoc": "^39.3.6",
+                "eslint-plugin-local-rules": "^1.3.1",
                 "eslint-plugin-no-null": "^1.0.2",
                 "fancy-log": "latest",
                 "fs-extra": "^9.1.0",
@@ -2522,6 +2523,12 @@
             "peerDependencies": {
                 "eslint": "^7.0.0 || ^8.0.0"
             }
+        },
+        "node_modules/eslint-plugin-local-rules": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.3.1.tgz",
+            "integrity": "sha512-ezuHRUXzRwFY3jFaX9vz8vxLLdLLIrbXBnVM6rip71/zjnIBaExY2vsm316temX+P3tasjQ2ciadWOTnnOUCgA==",
+            "dev": true
         },
         "node_modules/eslint-plugin-no-null": {
             "version": "1.0.2",
@@ -10558,6 +10565,12 @@
                 "semver": "^7.3.7",
                 "spdx-expression-parse": "^3.0.1"
             }
+        },
+        "eslint-plugin-local-rules": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.3.1.tgz",
+            "integrity": "sha512-ezuHRUXzRwFY3jFaX9vz8vxLLdLLIrbXBnVM6rip71/zjnIBaExY2vsm316temX+P3tasjQ2ciadWOTnnOUCgA==",
+            "dev": true
         },
         "eslint-plugin-no-null": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "eslint-formatter-autolinkable-stylish": "^1.2.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsdoc": "^39.3.6",
-        "eslint-plugin-local-rules": "^1.3.1",
+        "eslint-plugin-local": "^1.0.0",
         "eslint-plugin-no-null": "^1.0.2",
         "fancy-log": "latest",
         "fs-extra": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "eslint-formatter-autolinkable-stylish": "^1.2.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsdoc": "^39.3.6",
+        "eslint-plugin-local-rules": "^1.3.1",
         "eslint-plugin-no-null": "^1.0.2",
         "fancy-log": "latest",
         "fs-extra": "^9.1.0",
@@ -90,7 +91,6 @@
         "es5-ext": "0.10.53"
     },
     "scripts": {
-        "prepare": "gulp build-eslint-rules",
         "pretest": "gulp tests",
         "test": "gulp runtests-parallel --light=false",
         "test:eslint-rules": "gulp run-eslint-rules-tests",

--- a/scripts/build/prepend.js
+++ b/scripts/build/prepend.js
@@ -42,7 +42,7 @@ function prepend(data) {
                         sourcesContent: input.sourcesContent
                     };
                 }
-                // eslint-disable-next-line boolean-trivia, no-null/no-null
+                // eslint-disable-next-line local-rules/boolean-trivia, no-null/no-null
                 return cb(null, output);
             }
             catch (e) {

--- a/scripts/build/prepend.js
+++ b/scripts/build/prepend.js
@@ -42,7 +42,7 @@ function prepend(data) {
                         sourcesContent: input.sourcesContent
                     };
                 }
-                // eslint-disable-next-line local-rules/boolean-trivia, no-null/no-null
+                // eslint-disable-next-line local/boolean-trivia, no-null/no-null
                 return cb(null, output);
             }
             catch (e) {

--- a/scripts/eslint/rules/boolean-trivia.js
+++ b/scripts/eslint/rules/boolean-trivia.js
@@ -1,7 +1,7 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { AST_NODE_TYPES, TSESTree } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-export = createRule({
+module.exports = createRule({
     name: "boolean-trivia",
     meta: {
         docs: {
@@ -21,8 +21,10 @@ export = createRule({
         const sourceCode = context.getSourceCode();
         const sourceCodeText = sourceCode.getText();
 
-        const isSetOrAssert = (name: string): boolean => name.startsWith("set") || name.startsWith("assert");
-        const isTrivia = (node: TSESTree.Node): boolean => {
+        /** @type {(name: string) => boolean} */
+        const isSetOrAssert = (name) => name.startsWith("set") || name.startsWith("assert");
+        /** @type {(node: TSESTree.Node) => boolean} */
+        const isTrivia = (node) => {
             if (node.type === AST_NODE_TYPES.Identifier) {
                 return node.name === "undefined";
             }
@@ -35,7 +37,8 @@ export = createRule({
             return false;
         };
 
-        const shouldIgnoreCalledExpression = (node: TSESTree.CallExpression): boolean => {
+        /** @type {(node: TSESTree.CallExpression) => boolean} */
+        const shouldIgnoreCalledExpression = (node) => {
             if (node.callee && node.callee.type === AST_NODE_TYPES.MemberExpression) {
                 const methodName = node.callee.property.type === AST_NODE_TYPES.Identifier
                     ? node.callee.property.name
@@ -68,7 +71,8 @@ export = createRule({
             return false;
         };
 
-        const checkArg = (node: TSESTree.Node): void => {
+        /** @type {(node: TSESTree.Node) => void} */
+        const checkArg = (node) => {
             if (!isTrivia(node)) {
                 return;
             }
@@ -88,7 +92,8 @@ export = createRule({
             }
         };
 
-        const checkBooleanTrivia = (node: TSESTree.CallExpression) => {
+        /** @type {(node: TSESTree.CallExpression) => void} */
+        const checkBooleanTrivia = (node) => {
             if (shouldIgnoreCalledExpression(node)) {
                 return;
             }

--- a/scripts/eslint/rules/debug-assert.js
+++ b/scripts/eslint/rules/debug-assert.js
@@ -1,7 +1,7 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { AST_NODE_TYPES, TSESTree } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-export = createRule({
+module.exports = createRule({
     name: "debug-assert",
     meta: {
         docs: {
@@ -18,19 +18,23 @@ export = createRule({
     defaultOptions: [],
 
     create(context) {
-        const isArrowFunction = (node: TSESTree.Node) => node.type === AST_NODE_TYPES.ArrowFunctionExpression;
-        const isStringLiteral = (node: TSESTree.Node): boolean => (
+        /** @type {(node: TSESTree.Node) => boolean} */
+        const isArrowFunction = (node) => node.type === AST_NODE_TYPES.ArrowFunctionExpression;
+        /** @type {(node: TSESTree.Node) => boolean} */
+        const isStringLiteral = (node) => (
             (node.type === AST_NODE_TYPES.Literal && typeof node.value === "string") || node.type === AST_NODE_TYPES.TemplateLiteral
         );
 
-        const isDebugAssert = (node: TSESTree.MemberExpression): boolean => (
+        /** @type {(node: TSESTree.MemberExpression) => boolean} */
+        const isDebugAssert = (node) => (
             node.object.type === AST_NODE_TYPES.Identifier
                 && node.object.name === "Debug"
                 && node.property.type === AST_NODE_TYPES.Identifier
                 && node.property.name === "assert"
         );
 
-        const checkDebugAssert = (node: TSESTree.CallExpression) => {
+        /** @type {(node: TSESTree.CallExpression) => void} */
+        const checkDebugAssert = (node) => {
             const args = node.arguments;
             const argsLen = args.length;
             if (!(node.callee.type === AST_NODE_TYPES.MemberExpression && isDebugAssert(node.callee)) || argsLen < 2) {

--- a/scripts/eslint/rules/no-double-space.js
+++ b/scripts/eslint/rules/no-double-space.js
@@ -1,7 +1,7 @@
-import { TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { TSESTree, AST_NODE_TYPES } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-export = createRule({
+module.exports = createRule({
     name: "no-double-space",
     meta: {
         docs: {
@@ -20,7 +20,8 @@ export = createRule({
         const sourceCode = context.getSourceCode();
         const lines = sourceCode.getLines();
 
-        const isStringLiteral = (node: TSESTree.Node | null): boolean => {
+        /** @type {(node: TSESTree.Node | null) => boolean} */
+        const isStringLiteral = (node) => {
             return !!(node && (
                 (node.type === AST_NODE_TYPES.TemplateElement) ||
                 (node.type === AST_NODE_TYPES.TemplateLiteral && node.quasis) ||
@@ -28,11 +29,13 @@ export = createRule({
             ));
         };
 
-        const isRegexLiteral = (node: TSESTree.Node | null): boolean => {
+        /** @type {(node: TSESTree.Node | null) => boolean} */
+        const isRegexLiteral = (node) => {
             return !!(node && node.type === AST_NODE_TYPES.Literal && Object.prototype.hasOwnProperty.call(node, "regex"));
         };
 
-        const checkDoubleSpace = (node: TSESTree.Node) => {
+        /** @type {(node: TSESTree.Node) => void} */
+        const checkDoubleSpace = (node) => {
             lines.forEach((line, index) => {
                 const firstNonSpace = /\S/.exec(line);
                 if (!firstNonSpace || line.includes("@param")) {

--- a/scripts/eslint/rules/no-in-operator.js
+++ b/scripts/eslint/rules/no-in-operator.js
@@ -1,7 +1,7 @@
-import { TSESTree } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { TSESTree } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-export = createRule({
+module.exports = createRule({
     name: "no-in-operator",
     meta: {
         docs: {
@@ -18,7 +18,8 @@ export = createRule({
 
     create(context) {
         const IN_OPERATOR = "in";
-        const checkInOperator = (node: TSESTree.BinaryExpression) => {
+        /** @type {(node: TSESTree.BinaryExpression) => void} */
+        const checkInOperator = (node) => {
             if (node.operator === IN_OPERATOR) {
                 context.report({ messageId: "noInOperatorError", node });
             }

--- a/scripts/eslint/rules/no-keywords.js
+++ b/scripts/eslint/rules/no-keywords.js
@@ -1,7 +1,7 @@
-import { TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { TSESTree, AST_NODE_TYPES } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-export = createRule({
+module.exports = createRule({
     name: "no-keywords",
     meta: {
         docs: {
@@ -35,13 +35,16 @@ export = createRule({
             "any",
         ];
 
-        const isKeyword = (name: string) => keywords.includes(name);
+        /** @type {(name: string) => boolean} */
+        const isKeyword = (name) => keywords.includes(name);
 
-        const report = (node: TSESTree.Identifier) => {
+        /** @type {(node: TSESTree.Identifier) => void} */
+        const report = (node) => {
             context.report({ messageId: "noKeywordsError", data: { name: node.name }, node });
         };
 
-        const checkProperties = (node: TSESTree.ObjectPattern): void => {
+        /** @type {(node: TSESTree.ObjectPattern) => void} */
+        const checkProperties = (node) => {
             node.properties.forEach(property => {
                 if (
                     property &&
@@ -54,7 +57,8 @@ export = createRule({
             });
         };
 
-        const checkElements = (node: TSESTree.ArrayPattern): void => {
+        /** @type {(node: TSESTree.ArrayPattern) => void} */
+        const checkElements = (node) => {
             node.elements.forEach(element => {
                 if (
                     element &&
@@ -66,14 +70,8 @@ export = createRule({
             });
         };
 
-        const checkParams = (
-            node:
-                | TSESTree.ArrowFunctionExpression
-                | TSESTree.FunctionDeclaration
-                | TSESTree.FunctionExpression
-                | TSESTree.TSMethodSignature
-                | TSESTree.TSFunctionType
-        ): void => {
+        /** @type {(node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionDeclaration | TSESTree.FunctionExpression | TSESTree.TSMethodSignature | TSESTree.TSFunctionType) => void} */
+        const checkParams = (node) => {
             if (!node || !node.params || !node.params.length) {
                 return;
             }

--- a/scripts/eslint/rules/no-type-assertion-whitespace.js
+++ b/scripts/eslint/rules/no-type-assertion-whitespace.js
@@ -1,7 +1,7 @@
-import { TSESTree } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { TSESTree } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-export = createRule({
+module.exports = createRule({
     name: "no-type-assertion-whitespace",
     meta: {
         docs: {
@@ -18,7 +18,8 @@ export = createRule({
 
     create(context) {
         const sourceCode = context.getSourceCode();
-        const checkTypeAssertionWhitespace = (node: TSESTree.TSTypeAssertion) => {
+        /** @type {(node: TSESTree.TSTypeAssertion) => void} */
+        const checkTypeAssertionWhitespace = (node) => {
             const leftToken = sourceCode.getLastToken(node.typeAnnotation);
             const rightToken = sourceCode.getFirstToken(node.expression);
 

--- a/scripts/eslint/rules/object-literal-surrounding-space.js
+++ b/scripts/eslint/rules/object-literal-surrounding-space.js
@@ -1,7 +1,7 @@
-import { TSESTree } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { TSESTree } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-export = createRule({
+module.exports = createRule({
     name: "object-literal-surrounding-space",
     meta: {
         docs: {
@@ -26,11 +26,13 @@ export = createRule({
         const CLOSE_SYMBOL = "}";
         const OPEN_SYMBOL = "{";
 
-        const manySpaces = (text: string, startIndex: number): boolean => (
+        /** @type {(text: string, startIndex: number) => boolean} */
+        const manySpaces = (text, startIndex) => (
             [startIndex, startIndex + 1].every(i => text.charAt(i) === SPACE_SYMBOL)
         );
 
-        const checkObjectLiteralSurroundingSpace = (node: TSESTree.ObjectExpression) => {
+        /** @type {(node: TSESTree.ObjectExpression) => void} */
+        const checkObjectLiteralSurroundingSpace = (node) => {
             const text = sourceCode.getText(node);
             const startLine = node.loc.start.line;
             const endLine = node.loc.end.line;

--- a/scripts/eslint/rules/one-namespace-per-file.js
+++ b/scripts/eslint/rules/one-namespace-per-file.js
@@ -1,7 +1,7 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { AST_NODE_TYPES, TSESTree } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-export = createRule({
+module.exports = createRule({
     name: "one-namespace-per-file",
     meta: {
         docs: {
@@ -17,9 +17,11 @@ export = createRule({
     defaultOptions: [],
 
     create(context) {
-        const isNamespaceDeclaration = (node: TSESTree.Node): node is TSESTree.TSModuleDeclaration => node.type === AST_NODE_TYPES.TSModuleDeclaration;
+        /** @type {(node: TSESTree.Node) => node is TSESTree.TSModuleDeclaration} */
+        const isNamespaceDeclaration = (node) => node.type === AST_NODE_TYPES.TSModuleDeclaration;
 
-        const checkSourceFile = (node: TSESTree.Program) => {
+        /** @type {(node: TSESTree.Program) => void} */
+        const checkSourceFile = (node) => {
             if (context.getFilename().endsWith(".d.ts")) {
                 return;
             }

--- a/scripts/eslint/rules/only-arrow-functions.js
+++ b/scripts/eslint/rules/only-arrow-functions.js
@@ -1,13 +1,7 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { AST_NODE_TYPES, TSESTree } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-type MessageId = "onlyArrowFunctionsError";
-type Options = [{
-    allowNamedFunctions?: boolean;
-    allowDeclarations?: boolean;
-}];
-
-export = createRule<Options, MessageId>({
+module.exports = createRule({
     name: "only-arrow-functions",
     meta: {
         docs: {
@@ -34,11 +28,11 @@ export = createRule<Options, MessageId>({
 
     create(context, [{ allowNamedFunctions, allowDeclarations }]) {
 
-        const isThisParameter = (node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpression) => (
-            node.params.length && !!node.params.find(param => param.type === AST_NODE_TYPES.Identifier && param.name === "this")
-        );
+        /** @type {(node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpression) => boolean} */
+        const isThisParameter = (node) => !!node.params.length && !!node.params.find(param => param.type === AST_NODE_TYPES.Identifier && param.name === "this");
 
-        const isMethodType = (node: TSESTree.Node) => {
+        /** @type {(node: TSESTree.Node) => boolean} */
+        const isMethodType = (node) => {
             const types = [
                 AST_NODE_TYPES.MethodDefinition,
                 AST_NODE_TYPES.Property,
@@ -52,7 +46,8 @@ export = createRule<Options, MessageId>({
             return node.type === AST_NODE_TYPES.FunctionExpression && types.includes(parent.type);
         };
 
-        const stack: boolean[] = [];
+        /** @type {boolean[]} */
+        const stack = [];
         const enterFunction = () => {
             stack.push(false);
         };
@@ -63,7 +58,8 @@ export = createRule<Options, MessageId>({
             }
         };
 
-        const exitFunction = (node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpression) => {
+        /** @type {(node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpression) => void} */
+        const exitFunction = (node) => {
             const methodUsesThis = stack.pop();
 
             if (node.type === AST_NODE_TYPES.FunctionDeclaration && allowDeclarations) {

--- a/scripts/eslint/rules/only-arrow-functions.js
+++ b/scripts/eslint/rules/only-arrow-functions.js
@@ -21,6 +21,7 @@ module.exports = createRule({
         }],
         type: "suggestion",
     },
+    /** @type {[{ allowNamedFunctions?: boolean; allowDeclarations?: boolean }]} */
     defaultOptions: [{
         allowNamedFunctions: false,
         allowDeclarations: false,

--- a/scripts/eslint/rules/simple-indent.js
+++ b/scripts/eslint/rules/simple-indent.js
@@ -1,7 +1,7 @@
-import { TSESTree } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { TSESTree } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-export = createRule({
+module.exports = createRule({
     name: "simple-indent",
     meta: {
         docs: {
@@ -22,7 +22,8 @@ export = createRule({
         const sourceCode = context.getSourceCode();
         const linebreaks = sourceCode.getText().match(/\r\n|[\r\n\u2028\u2029]/gu);
 
-        const checkIndent = (node: TSESTree.Program) => {
+        /** @type {(node: TSESTree.Program) => void} */
+        const checkIndent = (node) => {
             const lines = sourceCode.getLines();
             const linesLen = lines.length;
 

--- a/scripts/eslint/rules/type-operator-spacing.js
+++ b/scripts/eslint/rules/type-operator-spacing.js
@@ -1,7 +1,7 @@
-import { TSESTree, AST_TOKEN_TYPES } from "@typescript-eslint/utils";
-import { createRule } from "./utils";
+const { TSESTree, AST_TOKEN_TYPES } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils");
 
-export = createRule({
+module.exports = createRule({
     name: "type-operator-spacing",
     meta: {
         docs: {
@@ -21,7 +21,8 @@ export = createRule({
         const tokens = ["|", "&"];
         const text = sourceCode.getText();
 
-        const checkTypeOperatorSpacing = (node: TSESTree.TSIntersectionType | TSESTree.TSUnionType) => {
+        /** @type {(node: TSESTree.TSIntersectionType | TSESTree.TSUnionType) => void} */
+        const checkTypeOperatorSpacing = (node) => {
             node.types.forEach(node => {
                 const token = sourceCode.getTokenBefore(node);
 

--- a/scripts/eslint/rules/utils.js
+++ b/scripts/eslint/rules/utils.js
@@ -1,0 +1,2 @@
+const { ESLintUtils } = require("@typescript-eslint/utils");
+module.exports.createRule = ESLintUtils.RuleCreator(() => "");

--- a/scripts/eslint/rules/utils.ts
+++ b/scripts/eslint/rules/utils.ts
@@ -1,2 +1,0 @@
-import { ESLintUtils } from "@typescript-eslint/utils";
-export const createRule = ESLintUtils.RuleCreator(() => "");

--- a/scripts/eslint/tsconfig.json
+++ b/scripts/eslint/tsconfig.json
@@ -1,23 +1,25 @@
 {
     "compilerOptions": {
-        "forceConsistentCasingInFileNames": true,
-        "suppressImplicitAnyIndexErrors":  true,
-        "experimentalDecorators": true,
-        "noImplicitReturns": true,
-        "resolveJsonModule": true,
-        "moduleResolution": "node",
-        "esModuleInterop": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": true,
-        "noImplicitAny": true,
-        "skipLibCheck": true,
-        "declaration": false,
-        "noResolve": false,
-        "strict": true,
+        "lib": [
+            "es6"
+        ],
         "module": "commonjs",
         "target": "es6",
         "outDir": "./built",
-        "lib": ["es2015", "es2016"]
+        "declaration": false,
+
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "moduleResolution": "node",
+        "allowUnusedLabels": false,
+        "noImplicitOverride": true,
+        "noImplicitReturns": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "checkJs": true
     },
 
     "include": [

--- a/scripts/eslint/tsconfig.json
+++ b/scripts/eslint/tsconfig.json
@@ -19,6 +19,7 @@
         "noPropertyAccessFromIndexSignature": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
+        "allowJs": true,
         "checkJs": true
     },
 

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -17,7 +17,7 @@
                 "@typescript-eslint/unified-signatures": "off",
 
                 // scripts/eslint/rules
-                "no-keywords": "off",
+                "local-rules/no-keywords": "off",
 
                 // eslint
                 "no-var": "off"

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -17,7 +17,7 @@
                 "@typescript-eslint/unified-signatures": "off",
 
                 // scripts/eslint/rules
-                "local-rules/no-keywords": "off",
+                "local/no-keywords": "off",
 
                 // eslint
                 "no-var": "off"

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1206,10 +1206,10 @@ namespace ts {
                 }
                 // Issue errors globally
                 const file = getSourceFileOfNode(location);
-                addErrorOrSuggestion(isError, "message" in message ? createFileDiagnostic(file, 0, 0, message, arg0, arg1, arg2, arg3) : createDiagnosticForFileFromMessageChain(file, message)); // eslint-disable-line local-rules/no-in-operator
+                addErrorOrSuggestion(isError, "message" in message ? createFileDiagnostic(file, 0, 0, message, arg0, arg1, arg2, arg3) : createDiagnosticForFileFromMessageChain(file, message)); // eslint-disable-line local/no-in-operator
                 return;
             }
-            addErrorOrSuggestion(isError, "message" in message ? createDiagnosticForNode(location, message, arg0, arg1, arg2, arg3) : createDiagnosticForNodeFromMessageChain(location, message)); // eslint-disable-line local-rules/no-in-operator
+            addErrorOrSuggestion(isError, "message" in message ? createDiagnosticForNode(location, message, arg0, arg1, arg2, arg3) : createDiagnosticForNodeFromMessageChain(location, message)); // eslint-disable-line local/no-in-operator
         }
 
         function errorAndMaybeSuggestAwait(

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1206,10 +1206,10 @@ namespace ts {
                 }
                 // Issue errors globally
                 const file = getSourceFileOfNode(location);
-                addErrorOrSuggestion(isError, "message" in message ? createFileDiagnostic(file, 0, 0, message, arg0, arg1, arg2, arg3) : createDiagnosticForFileFromMessageChain(file, message)); // eslint-disable-line no-in-operator
+                addErrorOrSuggestion(isError, "message" in message ? createFileDiagnostic(file, 0, 0, message, arg0, arg1, arg2, arg3) : createDiagnosticForFileFromMessageChain(file, message)); // eslint-disable-line local-rules/no-in-operator
                 return;
             }
-            addErrorOrSuggestion(isError, "message" in message ? createDiagnosticForNode(location, message, arg0, arg1, arg2, arg3) : createDiagnosticForNodeFromMessageChain(location, message)); // eslint-disable-line no-in-operator
+            addErrorOrSuggestion(isError, "message" in message ? createDiagnosticForNode(location, message, arg0, arg1, arg2, arg3) : createDiagnosticForNodeFromMessageChain(location, message)); // eslint-disable-line local-rules/no-in-operator
         }
 
         function errorAndMaybeSuggestAwait(

--- a/src/compiler/corePublic.ts
+++ b/src/compiler/corePublic.ts
@@ -127,7 +127,7 @@ namespace ts {
         export function tryGetNativeMap(): MapConstructor {
             // Internet Explorer's Map doesn't support iteration, so don't use it.
             const gMap = globals?.Map;
-            // eslint-disable-next-line local-rules/no-in-operator
+            // eslint-disable-next-line local/no-in-operator
             const constructor = typeof gMap !== "undefined" && "entries" in gMap.prototype && new gMap([[0, 0]]).size === 1 ? gMap : undefined;
             if (!constructor) {
                 throw new Error("No compatible Map implementation found.");
@@ -141,7 +141,7 @@ namespace ts {
         export function tryGetNativeSet(): SetConstructor {
             // Internet Explorer's Set doesn't support iteration, so don't use it.
             const gSet = globals?.Set;
-            // eslint-disable-next-line local-rules/no-in-operator
+            // eslint-disable-next-line local/no-in-operator
             const constructor = typeof gSet !== "undefined" && "entries" in gSet.prototype && new gSet([0]).size === 1 ? gSet : undefined;
             if (!constructor) {
                 throw new Error("No compatible Set implementation found.");

--- a/src/compiler/corePublic.ts
+++ b/src/compiler/corePublic.ts
@@ -127,7 +127,7 @@ namespace ts {
         export function tryGetNativeMap(): MapConstructor {
             // Internet Explorer's Map doesn't support iteration, so don't use it.
             const gMap = globals?.Map;
-            // eslint-disable-next-line no-in-operator
+            // eslint-disable-next-line local-rules/no-in-operator
             const constructor = typeof gMap !== "undefined" && "entries" in gMap.prototype && new gMap([[0, 0]]).size === 1 ? gMap : undefined;
             if (!constructor) {
                 throw new Error("No compatible Map implementation found.");
@@ -141,7 +141,7 @@ namespace ts {
         export function tryGetNativeSet(): SetConstructor {
             // Internet Explorer's Set doesn't support iteration, so don't use it.
             const gSet = globals?.Set;
-            // eslint-disable-next-line no-in-operator
+            // eslint-disable-next-line local-rules/no-in-operator
             const constructor = typeof gSet !== "undefined" && "entries" in gSet.prototype && new gSet([0]).size === 1 ? gSet : undefined;
             if (!constructor) {
                 throw new Error("No compatible Set implementation found.");

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -439,7 +439,7 @@ namespace ts {
         let flowNodeProto: FlowNodeBase | undefined;
 
         function attachFlowNodeDebugInfoWorker(flowNode: FlowNodeBase) {
-            if (!("__debugFlowFlags" in flowNode)) { // eslint-disable-line no-in-operator
+            if (!("__debugFlowFlags" in flowNode)) { // eslint-disable-line local-rules/no-in-operator
                 Object.defineProperties(flowNode, {
                     // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
                     __tsDebuggerDisplay: {
@@ -488,7 +488,7 @@ namespace ts {
         let nodeArrayProto: NodeArray<Node> | undefined;
 
         function attachNodeArrayDebugInfoWorker(array: NodeArray<Node>) {
-            if (!("__tsDebuggerDisplay" in array)) { // eslint-disable-line no-in-operator
+            if (!("__tsDebuggerDisplay" in array)) { // eslint-disable-line local-rules/no-in-operator
                 Object.defineProperties(array, {
                     __tsDebuggerDisplay: {
                         value(this: NodeArray<Node>, defaultValue: string) {

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -439,7 +439,7 @@ namespace ts {
         let flowNodeProto: FlowNodeBase | undefined;
 
         function attachFlowNodeDebugInfoWorker(flowNode: FlowNodeBase) {
-            if (!("__debugFlowFlags" in flowNode)) { // eslint-disable-line local-rules/no-in-operator
+            if (!("__debugFlowFlags" in flowNode)) { // eslint-disable-line local/no-in-operator
                 Object.defineProperties(flowNode, {
                     // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
                     __tsDebuggerDisplay: {
@@ -488,7 +488,7 @@ namespace ts {
         let nodeArrayProto: NodeArray<Node> | undefined;
 
         function attachNodeArrayDebugInfoWorker(array: NodeArray<Node>) {
-            if (!("__tsDebuggerDisplay" in array)) { // eslint-disable-line local-rules/no-in-operator
+            if (!("__tsDebuggerDisplay" in array)) { // eslint-disable-line local/no-in-operator
                 Object.defineProperties(array, {
                     __tsDebuggerDisplay: {
                         value(this: NodeArray<Node>, defaultValue: string) {

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -69,7 +69,7 @@ namespace ts {
             return sourceIndex;
         }
 
-        /* eslint-disable local-rules/boolean-trivia, no-null/no-null */
+        /* eslint-disable local/boolean-trivia, no-null/no-null */
         function setSourceContent(sourceIndex: number, content: string | null) {
             enter();
             if (content !== null) {
@@ -81,7 +81,7 @@ namespace ts {
             }
             exit();
         }
-        /* eslint-enable local-rules/boolean-trivia, no-null/no-null */
+        /* eslint-enable local/boolean-trivia, no-null/no-null */
 
         function addName(name: string) {
             enter();

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -69,7 +69,7 @@ namespace ts {
             return sourceIndex;
         }
 
-        /* eslint-disable boolean-trivia, no-null/no-null */
+        /* eslint-disable local-rules/boolean-trivia, no-null/no-null */
         function setSourceContent(sourceIndex: number, content: string | null) {
             enter();
             if (content !== null) {
@@ -81,7 +81,7 @@ namespace ts {
             }
             exit();
         }
-        /* eslint-enable boolean-trivia, no-null/no-null */
+        /* eslint-enable local-rules/boolean-trivia, no-null/no-null */
 
         function addName(name: string) {
             enter();

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -1,13 +1,13 @@
 /* Tracing events for the compiler. */
 
 /*@internal*/
-namespace ts { // eslint-disable-line local-rules/one-namespace-per-file
+namespace ts { // eslint-disable-line local/one-namespace-per-file
     // should be used as tracing?.___
     export let tracing: typeof tracingEnabled | undefined;
     // enable the above using startTracing()
 
     // `tracingEnabled` should never be used directly, only through the above
-    namespace tracingEnabled { // eslint-disable-line local-rules/one-namespace-per-file
+    namespace tracingEnabled { // eslint-disable-line local/one-namespace-per-file
         type Mode = "project" | "build" | "server";
 
         let fs: typeof import("fs");

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -1,13 +1,13 @@
 /* Tracing events for the compiler. */
 
 /*@internal*/
-namespace ts { // eslint-disable-line one-namespace-per-file
+namespace ts { // eslint-disable-line local-rules/one-namespace-per-file
     // should be used as tracing?.___
     export let tracing: typeof tracingEnabled | undefined;
     // enable the above using startTracing()
 
     // `tracingEnabled` should never be used directly, only through the above
-    namespace tracingEnabled { // eslint-disable-line one-namespace-per-file
+    namespace tracingEnabled { // eslint-disable-line local-rules/one-namespace-per-file
         type Mode = "project" | "build" | "server";
 
         let fs: typeof import("fs");

--- a/src/deprecatedCompat/4.0/nodeFactoryTopLevelExports.ts
+++ b/src/deprecatedCompat/4.0/nodeFactoryTopLevelExports.ts
@@ -965,7 +965,7 @@ namespace ts {
         if (typeof value === "number") {
             return factory.createNumericLiteral(value);
         }
-        // eslint-disable-next-line local-rules/no-in-operator
+        // eslint-disable-next-line local/no-in-operator
         if (typeof value === "object" && "base10Value" in value) { // PseudoBigInt
             return factory.createBigIntLiteral(value);
         }

--- a/src/deprecatedCompat/4.0/nodeFactoryTopLevelExports.ts
+++ b/src/deprecatedCompat/4.0/nodeFactoryTopLevelExports.ts
@@ -965,7 +965,7 @@ namespace ts {
         if (typeof value === "number") {
             return factory.createNumericLiteral(value);
         }
-        // eslint-disable-next-line no-in-operator
+        // eslint-disable-next-line local-rules/no-in-operator
         if (typeof value === "object" && "base10Value" in value) { // PseudoBigInt
             return factory.createBigIntLiteral(value);
         }

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1452,7 +1452,7 @@ namespace FourSlash {
                 const sort = (locations: readonly ts.RenameLocation[] | undefined) =>
                     locations && ts.sort(locations, (r1, r2) => ts.compareStringsCaseSensitive(r1.fileName, r2.fileName) || r1.textSpan.start - r2.textSpan.start);
                 assert.deepEqual(sort(references), sort(ranges.map((rangeOrOptions): ts.RenameLocation => {
-                    const { range, ...prefixSuffixText } = "range" in rangeOrOptions ? rangeOrOptions : { range: rangeOrOptions }; // eslint-disable-line no-in-operator
+                    const { range, ...prefixSuffixText } = "range" in rangeOrOptions ? rangeOrOptions : { range: rangeOrOptions }; // eslint-disable-line local-rules/no-in-operator
                     const { contextRangeIndex, contextRangeDelta, contextRangeId } = (range.marker && range.marker.data || {}) as RangeMarkerData;
                     let contextSpan: ts.TextSpan | undefined;
                     if (contextRangeDelta !== undefined) {
@@ -3923,7 +3923,7 @@ namespace FourSlash {
             return this.getApplicableRefactorsWorker(this.getSelection(), this.activeFile.fileName, preferences, triggerReason, kind);
         }
         private getApplicableRefactors(rangeOrMarker: Range | Marker, preferences = ts.emptyOptions, triggerReason: ts.RefactorTriggerReason = "implicit", kind?: string): readonly ts.ApplicableRefactorInfo[] {
-            return this.getApplicableRefactorsWorker("position" in rangeOrMarker ? rangeOrMarker.position : rangeOrMarker, rangeOrMarker.fileName, preferences, triggerReason, kind); // eslint-disable-line no-in-operator
+            return this.getApplicableRefactorsWorker("position" in rangeOrMarker ? rangeOrMarker.position : rangeOrMarker, rangeOrMarker.fileName, preferences, triggerReason, kind); // eslint-disable-line local-rules/no-in-operator
         }
         private getApplicableRefactorsWorker(positionOrRange: number | ts.TextRange, fileName: string, preferences = ts.emptyOptions, triggerReason: ts.RefactorTriggerReason, kind?: string): readonly ts.ApplicableRefactorInfo[] {
             return this.languageService.getApplicableRefactors(fileName, positionOrRange, preferences, triggerReason, kind) || ts.emptyArray;

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1452,7 +1452,7 @@ namespace FourSlash {
                 const sort = (locations: readonly ts.RenameLocation[] | undefined) =>
                     locations && ts.sort(locations, (r1, r2) => ts.compareStringsCaseSensitive(r1.fileName, r2.fileName) || r1.textSpan.start - r2.textSpan.start);
                 assert.deepEqual(sort(references), sort(ranges.map((rangeOrOptions): ts.RenameLocation => {
-                    const { range, ...prefixSuffixText } = "range" in rangeOrOptions ? rangeOrOptions : { range: rangeOrOptions }; // eslint-disable-line local-rules/no-in-operator
+                    const { range, ...prefixSuffixText } = "range" in rangeOrOptions ? rangeOrOptions : { range: rangeOrOptions }; // eslint-disable-line local/no-in-operator
                     const { contextRangeIndex, contextRangeDelta, contextRangeId } = (range.marker && range.marker.data || {}) as RangeMarkerData;
                     let contextSpan: ts.TextSpan | undefined;
                     if (contextRangeDelta !== undefined) {
@@ -3923,7 +3923,7 @@ namespace FourSlash {
             return this.getApplicableRefactorsWorker(this.getSelection(), this.activeFile.fileName, preferences, triggerReason, kind);
         }
         private getApplicableRefactors(rangeOrMarker: Range | Marker, preferences = ts.emptyOptions, triggerReason: ts.RefactorTriggerReason = "implicit", kind?: string): readonly ts.ApplicableRefactorInfo[] {
-            return this.getApplicableRefactorsWorker("position" in rangeOrMarker ? rangeOrMarker.position : rangeOrMarker, rangeOrMarker.fileName, preferences, triggerReason, kind); // eslint-disable-line local-rules/no-in-operator
+            return this.getApplicableRefactorsWorker("position" in rangeOrMarker ? rangeOrMarker.position : rangeOrMarker, rangeOrMarker.fileName, preferences, triggerReason, kind); // eslint-disable-line local/no-in-operator
         }
         private getApplicableRefactorsWorker(positionOrRange: number | ts.TextRange, fileName: string, preferences = ts.emptyOptions, triggerReason: ts.RefactorTriggerReason, kind?: string): readonly ts.ApplicableRefactorInfo[] {
             return this.languageService.getApplicableRefactors(fileName, positionOrRange, preferences, triggerReason, kind) || ts.emptyArray;

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -4,7 +4,7 @@ namespace Harness.LanguageService {
         const proxy = Object.create(/*prototype*/ null); // eslint-disable-line no-null/no-null
         const langSvc: any = info.languageService;
         for (const k of Object.keys(langSvc)) {
-            // eslint-disable-next-line only-arrow-functions
+            // eslint-disable-next-line local-rules/only-arrow-functions
             proxy[k] = function () {
                 return langSvc[k].apply(langSvc, arguments);
             };
@@ -886,7 +886,7 @@ namespace Harness.LanguageService {
                             create(info: ts.server.PluginCreateInfo) {
                                 const proxy = makeDefaultProxy(info);
                                 const langSvc: any = info.languageService;
-                                // eslint-disable-next-line only-arrow-functions
+                                // eslint-disable-next-line local-rules/only-arrow-functions
                                 proxy.getQuickInfoAtPosition = function () {
                                     const parts = langSvc.getQuickInfoAtPosition.apply(langSvc, arguments);
                                     if (parts.displayParts.length > 0) {

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -4,7 +4,7 @@ namespace Harness.LanguageService {
         const proxy = Object.create(/*prototype*/ null); // eslint-disable-line no-null/no-null
         const langSvc: any = info.languageService;
         for (const k of Object.keys(langSvc)) {
-            // eslint-disable-next-line local-rules/only-arrow-functions
+            // eslint-disable-next-line local/only-arrow-functions
             proxy[k] = function () {
                 return langSvc[k].apply(langSvc, arguments);
             };
@@ -886,7 +886,7 @@ namespace Harness.LanguageService {
                             create(info: ts.server.PluginCreateInfo) {
                                 const proxy = makeDefaultProxy(info);
                                 const langSvc: any = info.languageService;
-                                // eslint-disable-next-line local-rules/only-arrow-functions
+                                // eslint-disable-next-line local/only-arrow-functions
                                 proxy.getQuickInfoAtPosition = function () {
                                     const parts = langSvc.getQuickInfoAtPosition.apply(langSvc, arguments);
                                     if (parts.displayParts.length > 0) {

--- a/src/loggedIO/loggedIO.ts
+++ b/src/loggedIO/loggedIO.ts
@@ -1,4 +1,4 @@
-namespace Playback { // eslint-disable-line one-namespace-per-file
+namespace Playback { // eslint-disable-line local-rules/one-namespace-per-file
     interface FileInformation {
         contents?: string;
         contentsPath?: string;
@@ -361,7 +361,7 @@ namespace Playback { // eslint-disable-line one-namespace-per-file
 
     function recordReplay<T extends ts.AnyFunction>(original: T, underlying: any) {
         function createWrapper(record: T, replay: T): T {
-            // eslint-disable-next-line only-arrow-functions
+            // eslint-disable-next-line local-rules/only-arrow-functions
             return (function () {
                 if (replayLog !== undefined) {
                     return replay.apply(undefined, arguments);
@@ -447,5 +447,5 @@ namespace Playback { // eslint-disable-line one-namespace-per-file
 }
 
 // empty modules for the module migration script
-namespace ts.server { } // eslint-disable-line one-namespace-per-file
-namespace Harness { } // eslint-disable-line one-namespace-per-file
+namespace ts.server { } // eslint-disable-line local-rules/one-namespace-per-file
+namespace Harness { } // eslint-disable-line local-rules/one-namespace-per-file

--- a/src/loggedIO/loggedIO.ts
+++ b/src/loggedIO/loggedIO.ts
@@ -1,4 +1,4 @@
-namespace Playback { // eslint-disable-line local-rules/one-namespace-per-file
+namespace Playback { // eslint-disable-line local/one-namespace-per-file
     interface FileInformation {
         contents?: string;
         contentsPath?: string;
@@ -361,7 +361,7 @@ namespace Playback { // eslint-disable-line local-rules/one-namespace-per-file
 
     function recordReplay<T extends ts.AnyFunction>(original: T, underlying: any) {
         function createWrapper(record: T, replay: T): T {
-            // eslint-disable-next-line local-rules/only-arrow-functions
+            // eslint-disable-next-line local/only-arrow-functions
             return (function () {
                 if (replayLog !== undefined) {
                     return replay.apply(undefined, arguments);
@@ -447,5 +447,5 @@ namespace Playback { // eslint-disable-line local-rules/one-namespace-per-file
 }
 
 // empty modules for the module migration script
-namespace ts.server { } // eslint-disable-line local-rules/one-namespace-per-file
-namespace Harness { } // eslint-disable-line local-rules/one-namespace-per-file
+namespace ts.server { } // eslint-disable-line local/one-namespace-per-file
+namespace Harness { } // eslint-disable-line local/one-namespace-per-file

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1721,7 +1721,7 @@ namespace ts.server {
                 const pluginModule = pluginModuleFactory({ typescript: ts });
                 const newLS = pluginModule.create(info);
                 for (const k of Object.keys(this.languageService)) {
-                    // eslint-disable-next-line no-in-operator
+                    // eslint-disable-next-line local-rules/no-in-operator
                     if (!(k in newLS)) {
                         this.projectService.logger.info(`Plugin activation warning: Missing proxied method ${k} in created LS. Patching.`);
                         (newLS as any)[k] = (this.languageService as any)[k];

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1721,7 +1721,7 @@ namespace ts.server {
                 const pluginModule = pluginModuleFactory({ typescript: ts });
                 const newLS = pluginModule.create(info);
                 for (const k of Object.keys(this.languageService)) {
-                    // eslint-disable-next-line local-rules/no-in-operator
+                    // eslint-disable-next-line local/no-in-operator
                     if (!(k in newLS)) {
                         this.projectService.logger.info(`Plugin activation warning: Missing proxied method ${k} in created LS. Patching.`);
                         (newLS as any)[k] = (this.languageService as any)[k];

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -819,7 +819,7 @@ namespace ts {
             // defined in `ts.commentPragmas` would be excessive, but we can avoid
             // some obvious false positives (e.g. in XML-like doc comments) by
             // checking the element name.
-            // eslint-disable-next-line no-in-operator
+            // eslint-disable-next-line local-rules/no-in-operator
             if (!match[3] || !(match[3] in commentPragmas)) {
                 return false;
             }

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -819,7 +819,7 @@ namespace ts {
             // defined in `ts.commentPragmas` would be excessive, but we can avoid
             // some obvious false positives (e.g. in XML-like doc comments) by
             // checking the element name.
-            // eslint-disable-next-line local-rules/no-in-operator
+            // eslint-disable-next-line local/no-in-operator
             if (!match[3] || !(match[3] in commentPragmas)) {
                 return false;
             }

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -754,7 +754,7 @@ namespace ts.codefix {
         }
 
         // return undefined argName when arg is null or undefined
-        // eslint-disable-next-line no-in-operator
+        // eslint-disable-next-line local-rules/no-in-operator
         if (!name || "identifier" in name && name.identifier.text === "undefined") {
             return undefined;
         }

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -754,7 +754,7 @@ namespace ts.codefix {
         }
 
         // return undefined argName when arg is null or undefined
-        // eslint-disable-next-line local-rules/no-in-operator
+        // eslint-disable-next-line local/no-in-operator
         if (!name || "identifier" in name && name.identifier.text === "undefined") {
             return undefined;
         }

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1725,7 +1725,7 @@ namespace ts.FindAllReferences {
         }
 
         function addReference(referenceLocation: Node, relatedSymbol: Symbol | RelatedSymbol, state: State): void {
-            const { kind, symbol } = "kind" in relatedSymbol ? relatedSymbol : { kind: undefined, symbol: relatedSymbol }; // eslint-disable-line no-in-operator
+            const { kind, symbol } = "kind" in relatedSymbol ? relatedSymbol : { kind: undefined, symbol: relatedSymbol }; // eslint-disable-line local-rules/no-in-operator
 
             // if rename symbol from default export anonymous function, for example `export default function() {}`, we do not need to add reference
             if (state.options.use === FindReferencesUse.Rename && referenceLocation.kind === SyntaxKind.DefaultKeyword) {

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1725,7 +1725,7 @@ namespace ts.FindAllReferences {
         }
 
         function addReference(referenceLocation: Node, relatedSymbol: Symbol | RelatedSymbol, state: State): void {
-            const { kind, symbol } = "kind" in relatedSymbol ? relatedSymbol : { kind: undefined, symbol: relatedSymbol }; // eslint-disable-line local-rules/no-in-operator
+            const { kind, symbol } = "kind" in relatedSymbol ? relatedSymbol : { kind: undefined, symbol: relatedSymbol }; // eslint-disable-line local/no-in-operator
 
             // if rename symbol from default export anonymous function, for example `export default function() {}`, we do not need to add reference
             if (state.options.use === FindReferencesUse.Rename && referenceLocation.kind === SyntaxKind.DefaultKeyword) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -36,7 +36,7 @@ namespace ts {
         }
 
         private assertHasRealPosition(message?: string) {
-            // eslint-disable-next-line local-rules/debug-assert
+            // eslint-disable-next-line local/debug-assert
             Debug.assert(!positionIsSynthesized(this.pos) && !positionIsSynthesized(this.end), message || "Node must have a real position for this operation");
         }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -36,7 +36,7 @@ namespace ts {
         }
 
         private assertHasRealPosition(message?: string) {
-            // eslint-disable-next-line debug-assert
+            // eslint-disable-next-line local-rules/debug-assert
             Debug.assert(!positionIsSynthesized(this.pos) && !positionIsSynthesized(this.end), message || "Node must have a real position for this operation");
         }
 

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -19,7 +19,7 @@ let debugObjectHost: { CollectGarbage(): void } = (function (this: any) { // esl
 })();
 
 // We need to use 'null' to interface with the managed side.
-/* eslint-disable no-in-operator */
+/* eslint-disable local-rules/no-in-operator */
 
 /* @internal */
 namespace ts {
@@ -1357,4 +1357,4 @@ namespace ts {
     }
 }
 
-/* eslint-enable no-in-operator */
+/* eslint-enable local-rules/no-in-operator */

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -19,7 +19,7 @@ let debugObjectHost: { CollectGarbage(): void } = (function (this: any) { // esl
 })();
 
 // We need to use 'null' to interface with the managed side.
-/* eslint-disable local-rules/no-in-operator */
+/* eslint-disable local/no-in-operator */
 
 /* @internal */
 namespace ts {
@@ -1357,4 +1357,4 @@ namespace ts {
     }
 }
 
-/* eslint-enable local-rules/no-in-operator */
+/* eslint-enable local/no-in-operator */

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -407,11 +407,11 @@ namespace ts.SignatureHelp {
         //          not enough to put us in the substitution expression; we should consider ourselves part of
         //          the *next* span's expression by offsetting the index (argIndex = (spanIndex + 1) + 1).
         //
-        /* eslint-disable no-double-space */
+        /* eslint-disable local-rules/no-double-space */
         // Example: f  `# abcd $#{#  1 + 1#  }# efghi ${ #"#hello"#  }  #  `
         //              ^       ^ ^       ^   ^          ^ ^      ^     ^
         // Case:        1       1 3       2   1          3 2      2     1
-        /* eslint-enable no-double-space */
+        /* eslint-enable local-rules/no-double-space */
         Debug.assert(position >= node.getStart(), "Assumed 'position' could not occur before node.");
         if (isTemplateLiteralToken(node)) {
             if (isInsideTemplateLiteral(node, position, sourceFile)) {

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -407,11 +407,11 @@ namespace ts.SignatureHelp {
         //          not enough to put us in the substitution expression; we should consider ourselves part of
         //          the *next* span's expression by offsetting the index (argIndex = (spanIndex + 1) + 1).
         //
-        /* eslint-disable local-rules/no-double-space */
+        /* eslint-disable local/no-double-space */
         // Example: f  `# abcd $#{#  1 + 1#  }# efghi ${ #"#hello"#  }  #  `
         //              ^       ^ ^       ^   ^          ^ ^      ^     ^
         // Case:        1       1 3       2   1          3 2      2     1
-        /* eslint-enable local-rules/no-double-space */
+        /* eslint-enable local/no-double-space */
         Debug.assert(position >= node.getStart(), "Assumed 'position' could not occur before node.");
         if (isTemplateLiteralToken(node)) {
             if (isInsideTemplateLiteral(node, position, sourceFile)) {

--- a/src/testRunner/parallel/host.ts
+++ b/src/testRunner/parallel/host.ts
@@ -45,7 +45,7 @@ namespace Harness.Parallel.Host {
             constructor(info: ErrorInfo | TestInfo) {
                 super(info.name[info.name.length - 1]);
                 this.info = info;
-                this.state = "error" in info ? "failed" : "passed"; // eslint-disable-line no-in-operator
+                this.state = "error" in info ? "failed" : "passed"; // eslint-disable-line local-rules/no-in-operator
                 this.pending = false;
             }
         }
@@ -512,7 +512,7 @@ namespace Harness.Parallel.Host {
                 function replayTest(runner: Mocha.Runner, test: RemoteTest) {
                     runner.emit("test", test);
                     if (test.isFailed()) {
-                        runner.emit("fail", test, "error" in test.info ? rebuildError(test.info) : new Error("Unknown error")); // eslint-disable-line no-in-operator
+                        runner.emit("fail", test, "error" in test.info ? rebuildError(test.info) : new Error("Unknown error")); // eslint-disable-line local-rules/no-in-operator
                     }
                     else {
                         runner.emit("pass", test);

--- a/src/testRunner/parallel/host.ts
+++ b/src/testRunner/parallel/host.ts
@@ -45,7 +45,7 @@ namespace Harness.Parallel.Host {
             constructor(info: ErrorInfo | TestInfo) {
                 super(info.name[info.name.length - 1]);
                 this.info = info;
-                this.state = "error" in info ? "failed" : "passed"; // eslint-disable-line local-rules/no-in-operator
+                this.state = "error" in info ? "failed" : "passed"; // eslint-disable-line local/no-in-operator
                 this.pending = false;
             }
         }
@@ -512,7 +512,7 @@ namespace Harness.Parallel.Host {
                 function replayTest(runner: Mocha.Runner, test: RemoteTest) {
                     runner.emit("test", test);
                     if (test.isFailed()) {
-                        runner.emit("fail", test, "error" in test.info ? rebuildError(test.info) : new Error("Unknown error")); // eslint-disable-line local-rules/no-in-operator
+                        runner.emit("fail", test, "error" in test.info ? rebuildError(test.info) : new Error("Unknown error")); // eslint-disable-line local/no-in-operator
                     }
                     else {
                         runner.emit("pass", test);

--- a/src/testRunner/unittests/services/textChanges.ts
+++ b/src/testRunner/unittests/services/textChanges.ts
@@ -550,7 +550,7 @@ import {
     x
 } from "bar"`;
             runSingleFileTest("insertNodeInListAfter12", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line boolean-trivia
+                // eslint-disable-next-line local-rules/boolean-trivia
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier("a")));
             });
         }
@@ -560,7 +560,7 @@ import {
     x // this is x
 } from "bar"`;
             runSingleFileTest("insertNodeInListAfter13", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line boolean-trivia
+                // eslint-disable-next-line local-rules/boolean-trivia
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier("a")));
             });
         }
@@ -591,7 +591,7 @@ import {
     x
 } from "bar"`;
             runSingleFileTest("insertNodeInListAfter16", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line boolean-trivia
+                // eslint-disable-next-line local-rules/boolean-trivia
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier("a")));
             });
         }
@@ -602,7 +602,7 @@ import {
     x // this is x
 } from "bar"`;
             runSingleFileTest("insertNodeInListAfter17", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line boolean-trivia
+                // eslint-disable-next-line local-rules/boolean-trivia
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier("a")));
             });
         }
@@ -612,14 +612,14 @@ import {
     x0, x
 } from "bar"`;
             runSingleFileTest("insertNodeInListAfter18", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line boolean-trivia
+                // eslint-disable-next-line local-rules/boolean-trivia
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier("a")));
             });
         }
         {
             const runTest = (name: string, text: string) => runSingleFileTest(name, /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
                 for (const specifier of ["x3", "x4", "x5"]) {
-                    // eslint-disable-next-line boolean-trivia
+                    // eslint-disable-next-line local-rules/boolean-trivia
                     changeTracker.insertNodeInListAfter(sourceFile, findChild("x2", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier(specifier)));
                 }
             });
@@ -639,7 +639,7 @@ class A {
                 const newNodes = [];
                 for (let i = 0; i < 11 /*error doesn't occur with fewer nodes*/; ++i) {
                     newNodes.push(
-                        // eslint-disable-next-line boolean-trivia
+                        // eslint-disable-next-line local-rules/boolean-trivia
                         factory.createPropertyDeclaration(undefined, i + "", undefined, undefined, undefined));
                 }
                 const insertAfter = findChild("x", sourceFile);
@@ -655,7 +655,7 @@ class A {
 }
 `;
             runSingleFileTest("insertNodeAfterInClass1", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line boolean-trivia
+                // eslint-disable-next-line local-rules/boolean-trivia
                 changeTracker.insertNodeAfter(sourceFile, findChild("x", sourceFile), factory.createPropertyDeclaration(undefined, "a", undefined, factory.createKeywordTypeNode(SyntaxKind.BooleanKeyword), undefined));
             });
         }
@@ -666,7 +666,7 @@ class A {
 }
 `;
             runSingleFileTest("insertNodeAfterInClass2", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line boolean-trivia
+                // eslint-disable-next-line local-rules/boolean-trivia
                 changeTracker.insertNodeAfter(sourceFile, findChild("x", sourceFile), factory.createPropertyDeclaration(undefined, "a", undefined, factory.createKeywordTypeNode(SyntaxKind.BooleanKeyword), undefined));
             });
         }

--- a/src/testRunner/unittests/services/textChanges.ts
+++ b/src/testRunner/unittests/services/textChanges.ts
@@ -550,7 +550,7 @@ import {
     x
 } from "bar"`;
             runSingleFileTest("insertNodeInListAfter12", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line local-rules/boolean-trivia
+                // eslint-disable-next-line local/boolean-trivia
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier("a")));
             });
         }
@@ -560,7 +560,7 @@ import {
     x // this is x
 } from "bar"`;
             runSingleFileTest("insertNodeInListAfter13", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line local-rules/boolean-trivia
+                // eslint-disable-next-line local/boolean-trivia
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier("a")));
             });
         }
@@ -591,7 +591,7 @@ import {
     x
 } from "bar"`;
             runSingleFileTest("insertNodeInListAfter16", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line local-rules/boolean-trivia
+                // eslint-disable-next-line local/boolean-trivia
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier("a")));
             });
         }
@@ -602,7 +602,7 @@ import {
     x // this is x
 } from "bar"`;
             runSingleFileTest("insertNodeInListAfter17", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line local-rules/boolean-trivia
+                // eslint-disable-next-line local/boolean-trivia
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier("a")));
             });
         }
@@ -612,14 +612,14 @@ import {
     x0, x
 } from "bar"`;
             runSingleFileTest("insertNodeInListAfter18", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line local-rules/boolean-trivia
+                // eslint-disable-next-line local/boolean-trivia
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier("a")));
             });
         }
         {
             const runTest = (name: string, text: string) => runSingleFileTest(name, /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
                 for (const specifier of ["x3", "x4", "x5"]) {
-                    // eslint-disable-next-line local-rules/boolean-trivia
+                    // eslint-disable-next-line local/boolean-trivia
                     changeTracker.insertNodeInListAfter(sourceFile, findChild("x2", sourceFile), factory.createImportSpecifier(/*isTypeOnly*/ false, undefined, factory.createIdentifier(specifier)));
                 }
             });
@@ -639,7 +639,7 @@ class A {
                 const newNodes = [];
                 for (let i = 0; i < 11 /*error doesn't occur with fewer nodes*/; ++i) {
                     newNodes.push(
-                        // eslint-disable-next-line local-rules/boolean-trivia
+                        // eslint-disable-next-line local/boolean-trivia
                         factory.createPropertyDeclaration(undefined, i + "", undefined, undefined, undefined));
                 }
                 const insertAfter = findChild("x", sourceFile);
@@ -655,7 +655,7 @@ class A {
 }
 `;
             runSingleFileTest("insertNodeAfterInClass1", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line local-rules/boolean-trivia
+                // eslint-disable-next-line local/boolean-trivia
                 changeTracker.insertNodeAfter(sourceFile, findChild("x", sourceFile), factory.createPropertyDeclaration(undefined, "a", undefined, factory.createKeywordTypeNode(SyntaxKind.BooleanKeyword), undefined));
             });
         }
@@ -666,7 +666,7 @@ class A {
 }
 `;
             runSingleFileTest("insertNodeAfterInClass2", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
-                // eslint-disable-next-line local-rules/boolean-trivia
+                // eslint-disable-next-line local/boolean-trivia
                 changeTracker.insertNodeAfter(sourceFile, findChild("x", sourceFile), factory.createPropertyDeclaration(undefined, "a", undefined, factory.createKeywordTypeNode(SyntaxKind.BooleanKeyword), undefined));
             });
         }

--- a/src/testRunner/unittests/tsserver/helpers.ts
+++ b/src/testRunner/unittests/tsserver/helpers.ts
@@ -695,7 +695,7 @@ namespace ts.projectSystem {
     export function openFilesForSession(files: readonly (File | { readonly file: File | string, readonly projectRootPath: string, content?: string })[], session: server.Session): void {
         for (const file of files) {
             session.executeCommand(makeSessionRequest<protocol.OpenRequestArgs>(CommandNames.Open,
-                "projectRootPath" in file ? { file: typeof file.file === "string" ? file.file : file.file.path, projectRootPath: file.projectRootPath } : { file: file.path })); // eslint-disable-line no-in-operator
+                "projectRootPath" in file ? { file: typeof file.file === "string" ? file.file : file.file.path, projectRootPath: file.projectRootPath } : { file: file.path })); // eslint-disable-line local-rules/no-in-operator
         }
     }
 

--- a/src/testRunner/unittests/tsserver/helpers.ts
+++ b/src/testRunner/unittests/tsserver/helpers.ts
@@ -695,7 +695,7 @@ namespace ts.projectSystem {
     export function openFilesForSession(files: readonly (File | { readonly file: File | string, readonly projectRootPath: string, content?: string })[], session: server.Session): void {
         for (const file of files) {
             session.executeCommand(makeSessionRequest<protocol.OpenRequestArgs>(CommandNames.Open,
-                "projectRootPath" in file ? { file: typeof file.file === "string" ? file.file : file.file.path, projectRootPath: file.projectRootPath } : { file: file.path })); // eslint-disable-line local-rules/no-in-operator
+                "projectRootPath" in file ? { file: typeof file.file === "string" ? file.file : file.file.path, projectRootPath: file.projectRootPath } : { file: file.path })); // eslint-disable-line local/no-in-operator
         }
     }
 

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -1560,7 +1560,7 @@ const b: B = new B();`
                 });
             }
 
-            /* eslint-disable local-rules/boolean-trivia */
+            /* eslint-disable local/boolean-trivia */
 
             // Pre-loaded = A file from project B is already open when FAR is invoked
             // dRPL = Project A has disableReferencedProjectLoad
@@ -1587,7 +1587,7 @@ const b: B = new B();`
             baselineDisableReferencedProjectLoad(false,       false,   false,   true);  // Loaded     | Via redirect | index.ts, helper.ts |
             baselineDisableReferencedProjectLoad(false,       false,   false,   false); // Loaded     | Via redirect | index.ts, helper.ts |
 
-            /* eslint-enable local-rules/boolean-trivia */
+            /* eslint-enable local/boolean-trivia */
         });
     });
 }

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -1560,7 +1560,7 @@ const b: B = new B();`
                 });
             }
 
-            /* eslint-disable boolean-trivia */
+            /* eslint-disable local-rules/boolean-trivia */
 
             // Pre-loaded = A file from project B is already open when FAR is invoked
             // dRPL = Project A has disableReferencedProjectLoad
@@ -1587,7 +1587,7 @@ const b: B = new B();`
             baselineDisableReferencedProjectLoad(false,       false,   false,   true);  // Loaded     | Via redirect | index.ts, helper.ts |
             baselineDisableReferencedProjectLoad(false,       false,   false,   false); // Loaded     | Via redirect | index.ts, helper.ts |
 
-            /* eslint-enable boolean-trivia */
+            /* eslint-enable local-rules/boolean-trivia */
         });
     });
 }

--- a/src/testRunner/unittests/tsserver/webServer.ts
+++ b/src/testRunner/unittests/tsserver/webServer.ts
@@ -1,4 +1,4 @@
-/* eslint-disable local-rules/boolean-trivia */
+/* eslint-disable local/boolean-trivia */
 namespace ts.projectSystem {
     describe("unittests:: tsserver:: webServer", () => {
         class TestWorkerSession extends server.WorkerSession {

--- a/src/testRunner/unittests/tsserver/webServer.ts
+++ b/src/testRunner/unittests/tsserver/webServer.ts
@@ -1,4 +1,4 @@
-/* eslint-disable boolean-trivia */
+/* eslint-disable local-rules/boolean-trivia */
 namespace ts.projectSystem {
     describe("unittests:: tsserver:: webServer", () => {
         class TestWorkerSession extends server.WorkerSession {


### PR DESCRIPTION
`--rulesdir` is deprecated in favor of plugins. Although there's no official support for a local plugin, `eslint-plugin-local` can do what we need. This, combined with converting our rules to JS, means that we don't need any configuration in VS Code or to run the CLI, nor do we need a build step to run after clone or branch changes (leaving the diagnostics as the only remaining build step on clone/branch change).