### PR TITLE
Make canHaveModifiers/Decorators public

### DIFF
--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -877,17 +877,6 @@ namespace ts {
             || kind === SyntaxKind.SetAccessor;
     }
 
-    export function canHaveDecorators(node: Node): node is HasDecorators {
-        const kind = node.kind;
-        return kind === SyntaxKind.Parameter
-            || kind === SyntaxKind.PropertyDeclaration
-            || kind === SyntaxKind.MethodDeclaration
-            || kind === SyntaxKind.GetAccessor
-            || kind === SyntaxKind.SetAccessor
-            || kind === SyntaxKind.ClassExpression
-            || kind === SyntaxKind.ClassDeclaration;
-    }
-
     export function canHaveIllegalDecorators(node: Node): node is HasIllegalDecorators {
         const kind = node.kind;
         return kind === SyntaxKind.PropertyAssignment
@@ -907,35 +896,6 @@ namespace ts {
             || kind === SyntaxKind.NamespaceExportDeclaration
             || kind === SyntaxKind.ExportDeclaration
             || kind === SyntaxKind.ExportAssignment;
-    }
-
-    export function canHaveModifiers(node: Node): node is HasModifiers {
-        const kind = node.kind;
-        return kind === SyntaxKind.TypeParameter
-            || kind === SyntaxKind.Parameter
-            || kind === SyntaxKind.PropertySignature
-            || kind === SyntaxKind.PropertyDeclaration
-            || kind === SyntaxKind.MethodSignature
-            || kind === SyntaxKind.MethodDeclaration
-            || kind === SyntaxKind.Constructor
-            || kind === SyntaxKind.GetAccessor
-            || kind === SyntaxKind.SetAccessor
-            || kind === SyntaxKind.IndexSignature
-            || kind === SyntaxKind.ConstructorType
-            || kind === SyntaxKind.FunctionExpression
-            || kind === SyntaxKind.ArrowFunction
-            || kind === SyntaxKind.ClassExpression
-            || kind === SyntaxKind.VariableStatement
-            || kind === SyntaxKind.FunctionDeclaration
-            || kind === SyntaxKind.ClassDeclaration
-            || kind === SyntaxKind.InterfaceDeclaration
-            || kind === SyntaxKind.TypeAliasDeclaration
-            || kind === SyntaxKind.EnumDeclaration
-            || kind === SyntaxKind.ModuleDeclaration
-            || kind === SyntaxKind.ImportEqualsDeclaration
-            || kind === SyntaxKind.ImportDeclaration
-            || kind === SyntaxKind.ExportAssignment
-            || kind === SyntaxKind.ExportDeclaration;
     }
 
     export function canHaveIllegalModifiers(node: Node): node is HasIllegalModifiers {

--- a/src/compiler/factory/utilitiesPublic.ts
+++ b/src/compiler/factory/utilitiesPublic.ts
@@ -2,4 +2,44 @@ namespace ts {
     export function setTextRange<T extends TextRange>(range: T, location: TextRange | undefined): T {
         return location ? setTextRangePosEnd(range, location.pos, location.end) : range;
     }
+
+    export function canHaveModifiers(node: Node): node is HasModifiers {
+        const kind = node.kind;
+        return kind === SyntaxKind.TypeParameter
+            || kind === SyntaxKind.Parameter
+            || kind === SyntaxKind.PropertySignature
+            || kind === SyntaxKind.PropertyDeclaration
+            || kind === SyntaxKind.MethodSignature
+            || kind === SyntaxKind.MethodDeclaration
+            || kind === SyntaxKind.Constructor
+            || kind === SyntaxKind.GetAccessor
+            || kind === SyntaxKind.SetAccessor
+            || kind === SyntaxKind.IndexSignature
+            || kind === SyntaxKind.ConstructorType
+            || kind === SyntaxKind.FunctionExpression
+            || kind === SyntaxKind.ArrowFunction
+            || kind === SyntaxKind.ClassExpression
+            || kind === SyntaxKind.VariableStatement
+            || kind === SyntaxKind.FunctionDeclaration
+            || kind === SyntaxKind.ClassDeclaration
+            || kind === SyntaxKind.InterfaceDeclaration
+            || kind === SyntaxKind.TypeAliasDeclaration
+            || kind === SyntaxKind.EnumDeclaration
+            || kind === SyntaxKind.ModuleDeclaration
+            || kind === SyntaxKind.ImportEqualsDeclaration
+            || kind === SyntaxKind.ImportDeclaration
+            || kind === SyntaxKind.ExportAssignment
+            || kind === SyntaxKind.ExportDeclaration;
+    }
+
+    export function canHaveDecorators(node: Node): node is HasDecorators {
+        const kind = node.kind;
+        return kind === SyntaxKind.Parameter
+            || kind === SyntaxKind.PropertyDeclaration
+            || kind === SyntaxKind.MethodDeclaration
+            || kind === SyntaxKind.GetAccessor
+            || kind === SyntaxKind.SetAccessor
+            || kind === SyntaxKind.ClassExpression
+            || kind === SyntaxKind.ClassDeclaration;
+    }
 }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4834,6 +4834,8 @@ declare namespace ts {
 }
 declare namespace ts {
     function setTextRange<T extends TextRange>(range: T, location: TextRange | undefined): T;
+    function canHaveModifiers(node: Node): node is HasModifiers;
+    function canHaveDecorators(node: Node): node is HasDecorators;
 }
 declare namespace ts {
     /**

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4834,6 +4834,8 @@ declare namespace ts {
 }
 declare namespace ts {
     function setTextRange<T extends TextRange>(range: T, location: TextRange | undefined): T;
+    function canHaveModifiers(node: Node): node is HasModifiers;
+    function canHaveDecorators(node: Node): node is HasDecorators;
 }
 declare namespace ts {
     /**


### PR DESCRIPTION
Makes `canHaveModifiers` and `canHaveDecorators` public.

Related #49939

@DanielRosenwasser If it's not too late we should probably take this for 4.8 as well.