### PR TITLE
Split CI linting/playwright out into separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - release-*
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     strategy:
@@ -24,8 +24,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 5
     - name: Use node version ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
@@ -33,18 +31,37 @@ jobs:
         check-latest: true
     - run:  npm ci
 
-    # Re: https://github.com/actions/setup-node/pull/125
-    - name: Register Problem Matcher for TSC
-      run: echo "##[add-matcher].github/tsc.json"
-
     - name: Tests
       run:  npm test -- --no-lint
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        check-latest: true
+    - run:  npm ci
 
     - name: Linter
       run:  npm run lint:ci
 
+  browser-integration:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        check-latest: true
+    - run:  npm ci
+
     - name: Adding playwright
       run: npm install --no-save --no-package-lock playwright
+
+    - name: Build local
+      run: gulp local
 
     - name: Validate the browser can import TypeScript
       run: gulp test-browser-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
+        node-version: "*"
         check-latest: true
     - run:  npm ci
 
@@ -54,6 +55,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
+        node-version: "*"
         check-latest: true
     - run:  npm ci
 


### PR DESCRIPTION
Linting and playwright are unaffected by the node version; split these out into separate jobs, which should speed things up.

While I'm here, remove the tsc matcher; the PR linked in the comment was merged almost a year ago and is already active in setup-node.

Also unset `fetch-depth`, which then defaults us to a shallow clone. As far as I can tell, this has been set to `5` since #34614 (the PR that added GHA), but there's no rationale as to why 5 commits was chosen. At the time, the `travis.yml` file was [also a shallow clone](https://github.com/microsoft/TypeScript/blob/eb08ee6848125ccaabcf0ebb34d2e44081df7f1b/.travis.yml#L28). This workflow doesn't care about the git history at all, unlike some other workflows like the bisecter.