### PR TITLE
Syntax operations also need to ensure project is present for the open script infos since update could be pending to make sure open script info has project

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1868,9 +1868,9 @@ namespace ts.server {
 
         private getFileAndLanguageServiceForSyntacticOperation(args: protocol.FileRequestArgs) {
             // Since this is syntactic operation, there should always be project for the file
-            // we wouldnt have to ensure project but rather throw if we dont get project
+            // throw if we dont get project
             const file = toNormalizedPath(args.file);
-            const project = this.getProject(args.projectFileName) || this.projectService.tryGetDefaultProjectForFile(file);
+            const project = this.getProject(args.projectFileName) || this.projectService.ensureDefaultProjectForFile(file);
             if (!project) {
                 return Errors.ThrowNoProject();
             }

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -1054,7 +1054,7 @@ namespace ts.projectSystem {
             assert.equal(options.outDir, "C:/a/b", "");
         });
 
-        it("files opened, closed affecting multiple projects", () => {
+        it("files opened and closed affecting multiple projects", () => {
             const file: File = {
                 path: "/a/b/projects/config/file.ts",
                 content: `import {a} from "../files/file1"; export let b = a;`
@@ -1074,7 +1074,7 @@ namespace ts.projectSystem {
 
             const files = [config, file, filesFile1, filesFile2, libFile];
             const host = createServerHost(files);
-            const session = createSession(host);
+            const session = createSession(host, { logger: createLoggerWithInMemoryLogs() });
             // Create configured project
             session.executeCommandSeq<protocol.OpenRequest>({
                 command: protocol.CommandTypes.Open,
@@ -1083,10 +1083,6 @@ namespace ts.projectSystem {
                 }
             });
 
-            const projectService = session.getProjectService();
-            const configuredProject = projectService.configuredProjects.get(config.path)!;
-            verifyConfiguredProject();
-
             // open files/file1 = should not create another project
             session.executeCommandSeq<protocol.OpenRequest>({
                 command: protocol.CommandTypes.Open,
@@ -1094,7 +1090,6 @@ namespace ts.projectSystem {
                     file: filesFile1.path
                 }
             });
-            verifyConfiguredProject();
 
             // Close the file = should still have project
             session.executeCommandSeq<protocol.CloseRequest>({
@@ -1103,7 +1098,6 @@ namespace ts.projectSystem {
                     file: file.path
                 }
             });
-            verifyConfiguredProject();
 
             // Open files/file2 - should create inferred project and close configured project
             session.executeCommandSeq<protocol.OpenRequest>({
@@ -1112,8 +1106,6 @@ namespace ts.projectSystem {
                     file: filesFile2.path
                 }
             });
-            checkNumberOfProjects(projectService, { inferredProjects: 1 });
-            checkProjectActualFiles(projectService.inferredProjects[0], [libFile.path, filesFile2.path]);
 
             // Actions on file1 would result in assert
             session.executeCommandSeq<protocol.OccurrencesRequest>({
@@ -1125,10 +1117,7 @@ namespace ts.projectSystem {
                 }
             });
 
-            function verifyConfiguredProject() {
-                checkNumberOfProjects(projectService, { configuredProjects: 1 });
-                checkProjectActualFiles(configuredProject, [file.path, filesFile1.path, libFile.path, config.path]);
-            }
+            baselineTsserverLogs("projects", "files opened and closed affecting multiple projects", session);
         });
 
         it("requests are done on file on pendingReload but has svc for previous version", () => {
@@ -1619,6 +1608,41 @@ namespace ts.projectSystem {
             checkProjectActualFiles(rootProject, [rootProjectPath, rootFilePath, nodeModulesFilePath1, nodeModulesFilePath2]);
 
             checkNumberOfInferredProjects(projectService, 0);
+        });
+
+        it("file opened is in configured project that will be removed", () => {
+            const testsConfig: File = {
+                path: `${tscWatch.projectRoot}/playground/tsconfig.json`,
+                content: "{}"
+            };
+            const testsFile: File = {
+                path: `${tscWatch.projectRoot}/playground/tests.ts`,
+                content: `export function foo() {}`
+            };
+            const innerFile: File = {
+                path: `${tscWatch.projectRoot}/playground/tsconfig-json/tests/spec.ts`,
+                content: `export function bar() { }`
+            };
+            const innerConfig: File = {
+                path: `${tscWatch.projectRoot}/playground/tsconfig-json/tsconfig.json`,
+                content: JSON.stringify({
+                    include: ["./src"]
+                })
+            };
+            const innerSrcFile: File = {
+                path: `${tscWatch.projectRoot}/playground/tsconfig-json/src/src.ts`,
+                content: `export function foobar() { }`
+            };
+            const host = createServerHost([testsConfig, testsFile, innerFile, innerConfig, innerSrcFile, libFile]);
+            const session = createSession(host, { logger: createLoggerWithInMemoryLogs() });
+            openFilesForSession([testsFile], session);
+            closeFilesForSession([testsFile], session);
+            openFilesForSession([innerFile], session);
+            session.executeCommandSeq<protocol.OutliningSpansRequest>({
+                command: protocol.CommandTypes.GetOutliningSpans,
+                arguments: { file: innerFile.path }
+            });
+            baselineTsserverLogs("projects", "file opened is in configured project that will be removed", session);
         });
     });
 }

--- a/tests/baselines/reference/tsserver/projects/file-opened-is-in-configured-project-that-will-be-removed.js
+++ b/tests/baselines/reference/tsserver/projects/file-opened-is-in-configured-project-that-will-be-removed.js
@@ -1,0 +1,186 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/playground/tests.ts"}}
+Search path: /user/username/projects/myproject/playground
+For info: /user/username/projects/myproject/playground/tests.ts :: Config file name: /user/username/projects/myproject/playground/tsconfig.json
+Creating configuration project /user/username/projects/myproject/playground/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/playground/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/playground/tests.ts",
+  "/user/username/projects/myproject/playground/tsconfig-json/src/src.ts",
+  "/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/playground/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground 1 undefined Config: /user/username/projects/myproject/playground/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground 1 undefined Config: /user/username/projects/myproject/playground/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/src/src.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts 500 undefined WatchType: Closed Script info
+Starting updateGraphWorker: Project: /user/username/projects/myproject/playground/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/playground/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/playground/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/playground/tests.ts
+	/user/username/projects/myproject/playground/tsconfig-json/src/src.ts
+	/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library for target 'es3'
+	tests.ts
+	  Matched by default include pattern '**/*'
+	tsconfig-json/src/src.ts
+	  Matched by default include pattern '**/*'
+	tsconfig-json/tests/spec.ts
+	  Matched by default include pattern '**/*'
+
+-----------------------------------------------
+Project '/user/username/projects/myproject/playground/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/playground/tests.ts ProjectRootPath: undefined
+		Projects: /user/username/projects/myproject/playground/tsconfig.json
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"close","arguments":{"file":"/user/username/projects/myproject/playground/tests.ts"}}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tests.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/playground/tsconfig.json' (Configured)
+	Files (4)
+
+-----------------------------------------------
+Open files: 
+response:{"responseRequired":false}
+request:{"seq":0,"type":"request","command":"open","arguments":{"file":"/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts"}}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts 500 undefined WatchType: Closed Script info
+Search path: /user/username/projects/myproject/playground/tsconfig-json/tests
+For info: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts :: Config file name: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json
+Creating configuration project /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Config file
+Config: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/playground/tsconfig-json/src/src.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/src 1 undefined Config: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/src 1 undefined Config: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json' (Configured)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/playground/tsconfig-json/src/src.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es3'
+	src/src.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+-----------------------------------------------
+`remove Project::
+Project '/user/username/projects/myproject/playground/tsconfig.json' (Configured)
+	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/playground/tests.ts
+	/user/username/projects/myproject/playground/tsconfig-json/src/src.ts
+	/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library for target 'es3'
+	tests.ts
+	  Matched by default include pattern '**/*'
+	tsconfig-json/src/src.ts
+	  Matched by default include pattern '**/*'
+	tsconfig-json/tests/spec.ts
+	  Matched by default include pattern '**/*'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground 1 undefined Config: /user/username/projects/myproject/playground/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground 1 undefined Config: /user/username/projects/myproject/playground/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground/tests.ts 500 undefined WatchType: Closed Script info
+Project '/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts ProjectRootPath: undefined
+		Projects: 
+response:{"responseRequired":false}
+request:{"command":"getOutliningSpans","arguments":{"file":"/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts"},"seq":1,"type":"request"}
+Before ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts ProjectRootPath: undefined
+		Projects: 
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	spec.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+After ensureProjectForOpenFiles:
+Project '/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json' (Configured)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"response":[{"textSpan":{"start":{"line":1,"offset":22},"end":{"line":1,"offset":26}},"hintSpan":{"start":{"line":1,"offset":1},"end":{"line":1,"offset":26}},"bannerText":"...","autoCollapse":true,"kind":"code"}],"responseRequired":true}

--- a/tests/baselines/reference/tsserver/projects/files-opened-and-closed-affecting-multiple-projects.js
+++ b/tests/baselines/reference/tsserver/projects/files-opened-and-closed-affecting-multiple-projects.js
@@ -1,0 +1,167 @@
+Provided types map file "/a/lib/typesMap.json" doesn't exist
+request:{"command":"open","arguments":{"file":"/a/b/projects/config/file.ts"},"seq":1,"type":"request"}
+Search path: /a/b/projects/config
+For info: /a/b/projects/config/file.ts :: Config file name: /a/b/projects/config/tsconfig.json
+Creating configuration project /a/b/projects/config/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/projects/config/tsconfig.json 2000 undefined Project: /a/b/projects/config/tsconfig.json WatchType: Config file
+Config: /a/b/projects/config/tsconfig.json : {
+ "rootNames": [
+  "/a/b/projects/config/file.ts"
+ ],
+ "options": {
+  "configFilePath": "/a/b/projects/config/tsconfig.json"
+ }
+}
+DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/config 1 undefined Config: /a/b/projects/config/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/config 1 undefined Config: /a/b/projects/config/tsconfig.json WatchType: Wild card directory
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /a/b/projects/config/tsconfig.json
+FileWatcher:: Added:: WatchInfo: /a/b/projects/files/file1.ts 500 undefined WatchType: Closed Script info
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/config/node_modules/@types 1 undefined Project: /a/b/projects/config/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/config/node_modules/@types 1 undefined Project: /a/b/projects/config/tsconfig.json WatchType: Type roots
+Finishing updateGraphWorker: Project: /a/b/projects/config/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/a/b/projects/config/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/a/b/projects/files/file1.ts
+	/a/b/projects/config/file.ts
+
+
+	../../../lib/lib.d.ts
+	  Default library for target 'es3'
+	../files/file1.ts
+	  Imported via "../files/file1" from file 'file.ts'
+	file.ts
+	  Matched by default include pattern '**/*'
+
+-----------------------------------------------
+Project '/a/b/projects/config/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/config/file.ts ProjectRootPath: undefined
+		Projects: /a/b/projects/config/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"open","arguments":{"file":"/a/b/projects/files/file1.ts"},"seq":2,"type":"request"}
+FileWatcher:: Close:: WatchInfo: /a/b/projects/files/file1.ts 500 undefined WatchType: Closed Script info
+Search path: /a/b/projects/files
+For info: /a/b/projects/files/file1.ts :: No config files found.
+Project '/a/b/projects/config/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/config/file.ts ProjectRootPath: undefined
+		Projects: /a/b/projects/config/tsconfig.json
+	FileName: /a/b/projects/files/file1.ts ProjectRootPath: undefined
+		Projects: /a/b/projects/config/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"close","arguments":{"file":"/a/b/projects/config/file.ts"},"seq":3,"type":"request"}
+FileWatcher:: Added:: WatchInfo: /a/b/projects/config/file.ts 500 undefined WatchType: Closed Script info
+Project '/a/b/projects/config/tsconfig.json' (Configured)
+	Files (3)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/files/file1.ts ProjectRootPath: undefined
+		Projects: /a/b/projects/config/tsconfig.json
+response:{"responseRequired":false}
+request:{"command":"open","arguments":{"file":"/a/b/projects/files/file2.ts"},"seq":4,"type":"request"}
+Search path: /a/b/projects/files
+For info: /a/b/projects/files/file2.ts :: No config files found.
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+FileWatcher:: Added:: WatchInfo: /a/b/projects/files/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+FileWatcher:: Added:: WatchInfo: /a/b/projects/files/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/files/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/files/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/projects/files/file2.ts
+
+
+	../../../lib/lib.d.ts
+	  Default library for target 'es5'
+	file2.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+`remove Project::
+Project '/a/b/projects/config/tsconfig.json' (Configured)
+	Files (3)
+	/a/lib/lib.d.ts
+	/a/b/projects/files/file1.ts
+	/a/b/projects/config/file.ts
+
+
+	../../../lib/lib.d.ts
+	  Default library for target 'es3'
+	../files/file1.ts
+	  Imported via "../files/file1" from file 'file.ts'
+	file.ts
+	  Matched by default include pattern '**/*'
+
+-----------------------------------------------
+DirectoryWatcher:: Close:: WatchInfo: /a/b/projects/config 1 undefined Config: /a/b/projects/config/tsconfig.json WatchType: Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a/b/projects/config 1 undefined Config: /a/b/projects/config/tsconfig.json WatchType: Wild card directory
+FileWatcher:: Close:: WatchInfo: /a/b/projects/config/tsconfig.json 2000 undefined Project: /a/b/projects/config/tsconfig.json WatchType: Config file
+DirectoryWatcher:: Close:: WatchInfo: /a/b/projects/config/node_modules/@types 1 undefined Project: /a/b/projects/config/tsconfig.json WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a/b/projects/config/node_modules/@types 1 undefined Project: /a/b/projects/config/tsconfig.json WatchType: Type roots
+FileWatcher:: Close:: WatchInfo: /a/b/projects/config/file.ts 500 undefined WatchType: Closed Script info
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/files/file1.ts ProjectRootPath: undefined
+		Projects: 
+	FileName: /a/b/projects/files/file2.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"responseRequired":false}
+request:{"command":"occurrences","arguments":{"file":"/a/b/projects/files/file1.ts","line":1,"offset":11},"seq":5,"type":"request"}
+Before ensureProjectForOpenFiles:
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/files/file1.ts ProjectRootPath: undefined
+		Projects: 
+	FileName: /a/b/projects/files/file2.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Starting updateGraphWorker: Project: /dev/null/inferredProject2*
+DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/files/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /a/b/projects/files/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+	/a/lib/lib.d.ts
+	/a/b/projects/files/file1.ts
+
+
+	../../../lib/lib.d.ts
+	  Default library for target 'es5'
+	file1.ts
+	  Root file specified for compilation
+
+-----------------------------------------------
+After ensureProjectForOpenFiles:
+Project '/dev/null/inferredProject1*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Project '/dev/null/inferredProject2*' (Inferred)
+	Files (2)
+
+-----------------------------------------------
+Open files: 
+	FileName: /a/b/projects/files/file1.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject2*
+	FileName: /a/b/projects/files/file2.ts ProjectRootPath: undefined
+		Projects: /dev/null/inferredProject1*
+response:{"response":[],"responseRequired":true}


### PR DESCRIPTION
Also convert one relevant test case to baseline
Fixes #50131
