### PR TITLE
Fix auto import crash due to difference in `paths` handling

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1671,7 +1671,7 @@ namespace ts.Completions {
             }
             case "symbol": {
                 const { symbol, location, contextToken, origin, previousToken } = symbolCompletion;
-                const { codeActions, sourceDisplay } = getCompletionEntryCodeActionsAndSourceDisplay(name, location, contextToken, origin, symbol, program, host, compilerOptions, sourceFile, position, previousToken, formatContext, preferences, data, source);
+                const { codeActions, sourceDisplay } = getCompletionEntryCodeActionsAndSourceDisplay(name, location, contextToken, origin, symbol, program, host, compilerOptions, sourceFile, position, previousToken, formatContext, preferences, data, source, cancellationToken);
                 return createCompletionDetailsForSymbol(symbol, typeChecker, sourceFile, location, cancellationToken, codeActions, sourceDisplay); // TODO: GH#18217
             }
             case "literal": {
@@ -1722,6 +1722,7 @@ namespace ts.Completions {
         preferences: UserPreferences,
         data: CompletionEntryData | undefined,
         source: string | undefined,
+        cancellationToken: CancellationToken,
     ): CodeActionsAndSourceDisplay {
         if (data?.moduleSpecifier) {
             if (previousToken && getImportStatementCompletionInfo(contextToken || previousToken).replacementNode) {
@@ -1786,7 +1787,8 @@ namespace ts.Completions {
             program,
             formatContext,
             previousToken && isIdentifier(previousToken) ? previousToken.getStart(sourceFile) : position,
-            preferences);
+            preferences,
+            cancellationToken);
         Debug.assert(!data?.moduleSpecifier || moduleSpecifier === data.moduleSpecifier);
         return { sourceDisplay: [textPart(moduleSpecifier)], codeActions: [codeAction] };
     }

--- a/tests/cases/fourslash/completionsImportPathsConflict.ts
+++ b/tests/cases/fourslash/completionsImportPathsConflict.ts
@@ -1,0 +1,49 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "module": "esnext",
+////         "paths": {
+////           "@reduxjs/toolkit": ["src/index.ts"],
+////           "@internal/*": ["src/*"]
+////         }
+////     }
+//// }
+
+// @Filename: /src/index.ts
+//// export { configureStore } from "./configureStore";
+
+// @Filename: /src/configureStore.ts
+//// export function configureStore() {}
+
+// @Filename: /src/tests/createAsyncThunk.typetest.ts
+//// import {} from "@reduxjs/toolkit";
+//// /**/
+
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "configureStore",
+    source: "@reduxjs/toolkit",
+    sourceDisplay: "@reduxjs/toolkit",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }],
+  preferences: {
+    allowIncompleteCompletions: true,
+    includeCompletionsForModuleExports: true,
+  },
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "configureStore",
+  source: "@reduxjs/toolkit",
+  data: {
+    exportName: "configureStore",
+    fileName: "/src/configureStore.ts",
+    moduleSpecifier: "@reduxjs/toolkit",
+  },
+  description: `Update import from "@reduxjs/toolkit"`,
+  newFileContent: `import { configureStore } from "@reduxjs/toolkit";\n`,
+});

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -108,6 +108,7 @@ declare module ts {
         fileName?: string;
         ambientModuleName?: string;
         isPackageJsonImport?: true;
+        moduleSpecifier?: string;
         exportName: string;
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #50392

Auto-imports in completions does some work when you start typing for each item in the list (doing as little as possible for performance), and then does the rest of the work to compute the code change for an individual completion in a separate request when that item is highlighted. Synchronizing this two work streams to come up with the same answer has long been a source of bugs and crashes; #50392 is of this kind. This PR migrates the latter code path away from some very old code with some bad assumptions in favor of reusing the same `ExportInfoMap` cache structure that the former code path uses.
