### PR TITLE
Run tests against VS Code as node process

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@
 /scripts/eslint/built/**
 /internal/**
 /coverage/**
+/scripts/electron-node/.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Use node version ${{ matrix.node-version }}
-      if: ${{ matrix.node-version != "vscode" }}
+      if: ${{ matrix.node-version != 'vscode' }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         check-latest: true
 
     - name: Use VS Code as node
-      if: ${{ matrix.node-version == "vscode" }}
+      if: ${{ matrix.node-version == 'vscode' }}
       run: |
         node ./scripts/electron-node/download.js
         echo "$PWD/scripts/electron-node/.bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         check-latest: true
 
-    - name: Use vscode as node
+    - name: Use VS Code as node
       if: ${{ matrix.node-version == "vscode" }}
       run: |
         node ./scripts/electron-node/download.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,24 @@ jobs:
           - "*"
           - lts/*
           - lts/-1
+          - vscode
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Use node version ${{ matrix.node-version }}
+      if: ${{ matrix.node-version != "vscode" }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         check-latest: true
+
+    - name: Use vscode as node
+      if: ${{ matrix.node-version == "vscode" }}
+      run: |
+        node ./scripts/electron-node/download.js
+        echo "$PWD/scripts/electron-node/.bin" >> $GITHUB_PATH
+
     - run:  npm ci
 
     - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       if: ${{ matrix.node-version == 'vscode' }}
       run: |
         node ./scripts/electron-node/download.js
+        ./scripts/electron-node/.bin/node -e "console.log(process.versions)"
         echo "$PWD/scripts/electron-node/.bin" >> $GITHUB_PATH
 
     - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
         node-version: ${{ matrix.node-version }}
         check-latest: true
 
+    - run:  npm ci
+
     - name: Use VS Code as node
       if: ${{ matrix.node-version == 'vscode' }}
       run: |
         node ./scripts/electron-node/download.js
         echo "$PWD/scripts/electron-node/.bin" >> $GITHUB_PATH
-
-    - run:  npm ci
 
     - name: Tests
       run:  npm test -- --no-lint

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ tests/cases/user/puppeteer/puppeteer
 tests/cases/user/axios-src/axios-src
 tests/cases/user/prettier/prettier
 .eslintcache
+scripts/electron-node/.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
                 "@typescript-eslint/eslint-plugin": "^5.33.1",
                 "@typescript-eslint/parser": "^5.33.1",
                 "@typescript-eslint/utils": "^5.33.1",
+                "@vscode/test-electron": "^2.1.5",
                 "async": "latest",
                 "azure-devops-node-api": "^11.2.0",
                 "chai": "latest",
@@ -439,6 +440,15 @@
             "dev": true,
             "dependencies": {
                 "@octokit/openapi-types": "^13.4.0"
+            }
+        },
+        "node_modules/@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/@types/async": {
@@ -859,6 +869,21 @@
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
         },
+        "node_modules/@vscode/test-electron": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
+            "integrity": "sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==",
+            "dev": true,
+            "dependencies": {
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "rimraf": "^3.0.2",
+                "unzipper": "^0.10.11"
+            },
+            "engines": {
+                "node": ">=8.9.3"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.8.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
@@ -878,6 +903,18 @@
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
             }
         },
         "node_modules/aggregate-error": {
@@ -1377,6 +1414,28 @@
             "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
             "dev": true
         },
+        "node_modules/big-integer": {
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+            "dev": true,
+            "dependencies": {
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1395,6 +1454,12 @@
             "dependencies": {
                 "file-uri-to-path": "1.0.0"
             }
+        },
+        "node_modules/bluebird": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -1438,6 +1503,24 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
+        },
+        "node_modules/buffer-indexof-polyfill": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.2.0"
+            }
         },
         "node_modules/cache-base": {
             "version": "1.0.1",
@@ -1506,6 +1589,18 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+            "dev": true,
+            "dependencies": {
+                "traverse": ">=0.3.0 <0.4"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/chalk": {
@@ -2138,6 +2233,15 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "^2.0.2"
             }
         },
         "node_modules/duplexify": {
@@ -3403,6 +3507,65 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
+        "node_modules/fstream": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            },
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/fstream/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/fstream/node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/fstream/node_modules/rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4382,6 +4545,33 @@
             "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
             "dev": true
         },
+        "node_modules/http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/ignore": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -5122,6 +5312,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/listenercount": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
         },
         "node_modules/load-json-file": {
             "version": "1.1.0",
@@ -7119,6 +7315,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
+        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7900,6 +8102,15 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true
         },
+        "node_modules/traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/tsconfig-paths": {
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -8181,6 +8392,24 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/unzipper": {
+            "version": "0.10.11",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "dev": true,
+            "dependencies": {
+                "big-integer": "^1.6.17",
+                "binary": "~0.3.0",
+                "bluebird": "~3.4.1",
+                "buffer-indexof-polyfill": "~1.0.0",
+                "duplexer2": "~0.1.4",
+                "fstream": "^1.0.12",
+                "graceful-fs": "^4.2.2",
+                "listenercount": "~1.0.1",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "~1.0.4"
             }
         },
         "node_modules/upath": {
@@ -8878,6 +9107,12 @@
                 "@octokit/openapi-types": "^13.4.0"
             }
         },
+        "@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true
+        },
         "@types/async": {
             "version": "3.2.15",
             "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
@@ -9207,6 +9442,18 @@
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
         },
+        "@vscode/test-electron": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
+            "integrity": "sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==",
+            "dev": true,
+            "requires": {
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "rimraf": "^3.0.2",
+                "unzipper": "^0.10.11"
+            }
+        },
         "acorn": {
             "version": "8.8.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
@@ -9219,6 +9466,15 @@
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "requires": {}
+        },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "requires": {
+                "debug": "4"
+            }
         },
         "aggregate-error": {
             "version": "3.1.0",
@@ -9601,6 +9857,22 @@
             "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
             "dev": true
         },
+        "big-integer": {
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "dev": true
+        },
+        "binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+            "dev": true,
+            "requires": {
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
+            }
+        },
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -9616,6 +9888,12 @@
             "requires": {
                 "file-uri-to-path": "1.0.0"
             }
+        },
+        "bluebird": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -9652,6 +9930,18 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
+        },
+        "buffer-indexof-polyfill": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true
+        },
+        "buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
             "dev": true
         },
         "cache-base": {
@@ -9706,6 +9996,15 @@
                 "loupe": "^2.3.1",
                 "pathval": "^1.1.1",
                 "type-detect": "^4.0.5"
+            }
+        },
+        "chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+            "dev": true,
+            "requires": {
+                "traverse": ">=0.3.0 <0.4"
             }
         },
         "chalk": {
@@ -10205,6 +10504,15 @@
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2"
+            }
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
             }
         },
         "duplexify": {
@@ -11244,6 +11552,52 @@
             "dev": true,
             "optional": true
         },
+        "fstream": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.2.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.1.1",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.6",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+                    "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.6"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
+            }
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -12025,6 +12379,27 @@
             "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
             "dev": true
         },
+        "http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
+            "requires": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
         "ignore": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -12575,6 +12950,12 @@
                     }
                 }
             }
+        },
+        "listenercount": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
         },
         "load-json-file": {
             "version": "1.1.0",
@@ -14090,6 +14471,12 @@
                 }
             }
         },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
+        },
         "shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -14738,6 +15125,12 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true
         },
+        "traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+            "dev": true
+        },
         "tsconfig-paths": {
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -14963,6 +15356,24 @@
                     "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
                     "dev": true
                 }
+            }
+        },
+        "unzipper": {
+            "version": "0.10.11",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "dev": true,
+            "requires": {
+                "big-integer": "^1.6.17",
+                "binary": "~0.3.0",
+                "bluebird": "~3.4.1",
+                "buffer-indexof-polyfill": "~1.0.0",
+                "duplexer2": "~0.1.4",
+                "fstream": "^1.0.12",
+                "graceful-fs": "^4.2.2",
+                "listenercount": "~1.0.1",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "~1.0.4"
             }
         },
         "upath": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "@typescript-eslint/eslint-plugin": "^5.33.1",
         "@typescript-eslint/parser": "^5.33.1",
         "@typescript-eslint/utils": "^5.33.1",
+        "@vscode/test-electron": "^2.1.5",
         "async": "latest",
         "azure-devops-node-api": "^11.2.0",
         "chai": "latest",

--- a/scripts/build/projects.js
+++ b/scripts/build/projects.js
@@ -37,7 +37,7 @@ class ProjectQueue {
 
 const execTsc = (/** @type {boolean} */ lkg, /** @type {string[]} */ ...args) =>
     exec(process.execPath,
-         [resolve(findUpRoot(), lkg ? "./lib/tsc" : "./built/local/tsc"),
+         [...process.execArgv, resolve(findUpRoot(), lkg ? "./lib/tsc" : "./built/local/tsc"),
           "-b", ...args],
          { hidePrompt: true });
 

--- a/scripts/build/tests.js
+++ b/scripts/build/tests.js
@@ -7,7 +7,7 @@ const mkdirP = require("mkdirp");
 const log = require("fancy-log");
 const cmdLineOptions = require("./options");
 const { CancellationToken } = require("prex");
-const { exec } = require("./utils");
+const { exec, execNode } = require("./utils");
 const { findUpFile } = require("./findUpDir");
 
 const mochaJs = require.resolve("mocha/bin/_mocha");
@@ -121,7 +121,7 @@ async function runConsoleTests(runJs, defaultReporter, runInParallel, watchMode,
 
     try {
         setNodeEnvToDevelopment();
-        const { exitCode } = await exec(process.execPath, args, {
+        const { exitCode } = await execNode(args, {
             cancelToken,
         });
         if (exitCode !== 0) {

--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -49,7 +49,7 @@ async function exec(cmd, args, options = {}) {
                     resolve({ exitCode });
                 }
                 else {
-                    reject(new Error(`${JSON.stringify({ cmd, args, options })}\nProcess exited with code: ${exitCode}`));
+                    reject(new Error(`Process exited with code: ${exitCode}`));
                 }
             });
             proc.on("error", error => {

--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -49,7 +49,7 @@ async function exec(cmd, args, options = {}) {
                     resolve({ exitCode });
                 }
                 else {
-                    reject(new Error(`Process exited with code: ${exitCode}`));
+                    reject(new Error(`${JSON.stringify({ cmd, args, options })}\nProcess exited with code: ${exitCode}`));
                 }
             });
             proc.on("error", error => {
@@ -65,6 +65,11 @@ async function exec(cmd, args, options = {}) {
     }));
 }
 exports.exec = exec;
+
+async function execNode(args, options = {}) {
+    return exec(process.execPath, [...process.execArgv, ...args], options);
+}
+exports.execNode = execNode;
 
 /**
  * @param {ts.Diagnostic[]} diagnostics

--- a/scripts/electron-node/download.js
+++ b/scripts/electron-node/download.js
@@ -1,0 +1,47 @@
+// @ts-check
+const path = require("path");
+const fs = require("fs");
+const { download } = require("@vscode/test-electron");
+
+async function main() {
+    const codePath = await download({ cachePath: path.join(__dirname, ".vscode-test") });
+    const requireHook = path.resolve(__dirname, "requireHook.js");
+
+    /** @type {string} */
+    let binName;
+    /** @type {string} */
+    let contents;
+
+    if (process.platform !== "win32") {
+        binName = "node";
+        contents = `
+#!/usr/bin/bash
+export ELECTRON_RUN_AS_NODE=1
+export ELECTRON_NO_ASAR=1
+exec ${codePath} --ms-enable-electron-run-as-node --require=${requireHook} $@
+        `;
+    }
+    else {
+        binName = "node.cmd";
+        contents = `
+@echo off
+setlocal
+set ELECTRON_RUN_AS_NODE=1
+set ELECTRON_NO_ASAR=1
+"${codePath}" --ms-enable-electron-run-as-node --require=${requireHook} %*
+endlocal
+        `;
+    }
+
+    const newLine = process.platform === "win32" ? "\r\n" : "\n";
+    contents = contents.trim().replace(/\r?\n/, newLine) + newLine;
+
+    const binDir = path.resolve(__dirname, ".bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    const binPath = path.join(binDir, binName);
+    fs.writeFileSync(binPath, contents, { mode: 0o755 });
+
+    console.log(`Electron-based node shim created; add ${binDir} to your $PATH`);
+}
+
+void main();

--- a/scripts/electron-node/requireHook.js
+++ b/scripts/electron-node/requireHook.js
@@ -1,0 +1,5 @@
+const flag = "--ms-enable-electron-run-as-node";
+
+if (!process.execArgv.includes(flag)) {
+    process.execArgv = [...process.execArgv, flag];
+}


### PR DESCRIPTION
This is a goofy idea I thought of in https://github.com/microsoft/TypeScript/pull/50382#issuecomment-1226021013; VS Code runs typescript via `ELECTRON_RUN_IN_NODE`; with some trickery, we can create a shim which calls VS Code and pretends to be node.

This way, we can (hopefully) be told if we introduce a problem that only affects our use in electron's node, e.g. if pointer compression is enabled and we overflow an integer or something.