### PR TITLE
Remove redundant pretest script

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
         "es5-ext": "0.10.53"
     },
     "scripts": {
-        "pretest": "gulp tests",
         "test": "gulp runtests-parallel --light=false",
         "test:eslint-rules": "gulp run-eslint-rules-tests",
         "build": "npm run build:compiler && npm run build:tests",


### PR DESCRIPTION
The "pretest" script builds the tests by running `gulp tests`, but `gulp runtests` and `gulp runtests-parallel` already do this themselves by explicitly declaring their dependency on the `tests` task in `Gulpfile.js`. We can safely remove this script, which saves a little time (and stops annoying me on my WIP module transform branch where I currently have no `tests` task).