### PR TITLE
Contextual type of methods only in noImplicitAny or JS

### DIFF
--- a/tests/baselines/reference/quickInfoJsDocTags5.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags5.baseline
@@ -58,7 +58,7 @@
           "kind": "space"
         },
         {
-          "text": "any",
+          "text": "number",
           "kind": "keyword"
         },
         {
@@ -82,7 +82,7 @@
           "kind": "space"
         },
         {
-          "text": "any",
+          "text": "number",
           "kind": "keyword"
         },
         {

--- a/tests/baselines/reference/quickInfoJsDocTags6.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags6.baseline
@@ -58,7 +58,7 @@
           "kind": "space"
         },
         {
-          "text": "any",
+          "text": "number",
           "kind": "keyword"
         },
         {
@@ -82,7 +82,7 @@
           "kind": "space"
         },
         {
-          "text": "any",
+          "text": "number",
           "kind": "keyword"
         },
         {


### PR DESCRIPTION
Fixes #23911, maybe
