### PR TITLE
Move contributing related info out of README to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,32 @@ In general, things we find useful when reviewing suggestions are:
 5. Change to the TypeScript folder you made: `cd TypeScript`
 6. Install dependencies: `npm ci`
 7. Make sure everything builds and tests pass: `gulp runtests-parallel`
-8. Open the Typescript folder in your editor.
+8. Open the TypeScript folder in your editor.
 9. Follow the directions below to add and debug a test.
+
+## Helpful tasks
+
+Running `gulp --tasks --depth 1` provides the full listing, but here are a few common tasks you might use.
+
+```
+gulp local             # Build the compiler into built/local.
+gulp clean             # Delete the built compiler.
+gulp LKG               # Replace the last known good with the built one.
+                       # Bootstrapping step to be executed when the built compiler reaches a stable state.
+gulp tests             # Build the test infrastructure using the built compiler.
+gulp runtests          # Run tests using the built compiler and test infrastructure.
+                       # You can override the specific suite runner used or specify a test for this command.
+                       # Use --tests=<testPath> for a specific test and/or --runner=<runnerName> for a specific suite.
+                       # Valid runners include conformance, compiler, fourslash, project, user, and docker
+                       # The user and docker runners are extended test suite runners - the user runner
+                       # works on disk in the tests/cases/user directory, while the docker runner works in containers.
+                       # You'll need to have the docker executable in your system path for the docker runner to work.
+gulp runtests-parallel # Like runtests, but split across multiple threads. Uses a number of threads equal to the system
+                       # core count by default. Use --workers=<number> to adjust this.
+gulp baseline-accept   # This replaces the baseline test results with the results obtained from gulp runtests.
+gulp lint              # Runs eslint on the TypeScript source.
+gulp help              # List the above commands.
+```
 
 ## Tips
 

--- a/README.md
+++ b/README.md
@@ -46,59 +46,6 @@ with any additional questions or comments.
 *  [Programming handbook](https://www.typescriptlang.org/docs/handbook/intro.html)
 *  [Homepage](https://www.typescriptlang.org/)
 
-## Building
-
-In order to build the TypeScript compiler, ensure that you have [Git](https://git-scm.com/downloads) and [Node.js](https://nodejs.org/) installed.
-
-Clone a copy of the repo:
-
-```bash
-git clone https://github.com/microsoft/TypeScript.git
-```
-
-Change to the TypeScript directory:
-
-```bash
-cd TypeScript
-```
-
-Install [Gulp](https://gulpjs.com/) tools and dev dependencies:
-
-```bash
-npm install -g gulp
-npm ci
-```
-
-Use one of the following to build and test:
-
-```
-gulp local             # Build the compiler into built/local.
-gulp clean             # Delete the built compiler.
-gulp LKG               # Replace the last known good with the built one.
-                       # Bootstrapping step to be executed when the built compiler reaches a stable state.
-gulp tests             # Build the test infrastructure using the built compiler.
-gulp runtests          # Run tests using the built compiler and test infrastructure.
-                       # You can override the specific suite runner used or specify a test for this command.
-                       # Use --tests=<testPath> for a specific test and/or --runner=<runnerName> for a specific suite.
-                       # Valid runners include conformance, compiler, fourslash, project, user, and docker
-                       # The user and docker runners are extended test suite runners - the user runner
-                       # works on disk in the tests/cases/user directory, while the docker runner works in containers.
-                       # You'll need to have the docker executable in your system path for the docker runner to work.
-gulp runtests-parallel # Like runtests, but split across multiple threads. Uses a number of threads equal to the system
-                       # core count by default. Use --workers=<number> to adjust this.
-gulp baseline-accept   # This replaces the baseline test results with the results obtained from gulp runtests.
-gulp lint              # Runs eslint on the TypeScript source.
-gulp help              # List the above commands.
-```
-
-
-## Usage
-
-```bash
-node built/local/tsc.js hello.ts
-```
-
-
 ## Roadmap
 
 For details on our planned features and future direction please refer to our [roadmap](https://github.com/microsoft/TypeScript/wiki/Roadmap).


### PR DESCRIPTION
The README used in the repo is also the README that is uploaded to npm and is read by users. Right now, about 50% of the content (height-wise) is related to building/testing the TS project itself, but the average user is not going to need this info. See: https://www.npmjs.com/package/typescript#building

IMO, detailed contributing related information shouldn't be present in this file, and are better suited to CONTRIBUTING, which we already link to in a special "contribute" section.

(Potentially, the block I'm moving is redundant with other parts of CONTRIBUTING, but simplifying that file is a different PR.)