### PR TITLE
Improve binding element type inference using `CheckMode` 

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9700,7 +9700,7 @@ namespace ts {
                 // For a contextually typed parameter it is possible that a type has already
                 // been assigned (in assignTypeToParameterAndFixTypeParameters), and we want
                 // to preserve this type.
-                if (!links.type && !(checkMode && checkMode & ~CheckMode.Normal)) {
+                if (!links.type && !(checkMode && checkMode !== CheckMode.Normal)) {
                     links.type = result;
                 }
             }

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment3.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment3.types
@@ -1,15 +1,15 @@
 === tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment3.ts ===
 const [a, b = a] = [1]; // ok
->a : any
->b : any
->a : any
+>a : number
+>b : number
+>a : number
 >[1] : [number]
 >1 : 1
 
 const [c, d = c, e = e] = [1]; // error for e = e
->c : any
->d : any
->c : any
+>c : number
+>d : number
+>c : number
 >e : any
 >e : any
 >[1] : [number]

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.js
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.js
@@ -1,0 +1,36 @@
+//// [destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts]
+// To be inferred as `number`
+function f1() {
+    const [a1, b1 = a1] = [1];
+    const [a2, b2 = 1 + a2] = [1];
+}
+
+// To be inferred as `string`
+function f2() {
+    const [a1, b1 = a1] = ['hi'];
+    const [a2, b2 = a2 + '!'] = ['hi'];
+}
+
+// To be inferred as `string | number`
+function f3() {
+    const [a1, b1 = a1] = ['hi', 1];
+    const [a2, b2 = a2 + '!'] = ['hi', 1];
+}
+
+
+//// [destructuringArrayBindingPatternAndAssignment5SiblingInitializer.js]
+// To be inferred as `number`
+function f1() {
+    var _a = [1], a1 = _a[0], _b = _a[1], b1 = _b === void 0 ? a1 : _b;
+    var _c = [1], a2 = _c[0], _d = _c[1], b2 = _d === void 0 ? 1 + a2 : _d;
+}
+// To be inferred as `string`
+function f2() {
+    var _a = ['hi'], a1 = _a[0], _b = _a[1], b1 = _b === void 0 ? a1 : _b;
+    var _c = ['hi'], a2 = _c[0], _d = _c[1], b2 = _d === void 0 ? a2 + '!' : _d;
+}
+// To be inferred as `string | number`
+function f3() {
+    var _a = ['hi', 1], a1 = _a[0], _b = _a[1], b1 = _b === void 0 ? a1 : _b;
+    var _c = ['hi', 1], a2 = _c[0], _d = _c[1], b2 = _d === void 0 ? a2 + '!' : _d;
+}

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.symbols
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.symbols
@@ -1,0 +1,46 @@
+=== tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts ===
+// To be inferred as `number`
+function f1() {
+>f1 : Symbol(f1, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 0, 0))
+
+    const [a1, b1 = a1] = [1];
+>a1 : Symbol(a1, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 2, 11))
+>b1 : Symbol(b1, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 2, 14))
+>a1 : Symbol(a1, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 2, 11))
+
+    const [a2, b2 = 1 + a2] = [1];
+>a2 : Symbol(a2, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 3, 11))
+>b2 : Symbol(b2, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 3, 14))
+>a2 : Symbol(a2, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 3, 11))
+}
+
+// To be inferred as `string`
+function f2() {
+>f2 : Symbol(f2, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 4, 1))
+
+    const [a1, b1 = a1] = ['hi'];
+>a1 : Symbol(a1, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 8, 11))
+>b1 : Symbol(b1, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 8, 14))
+>a1 : Symbol(a1, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 8, 11))
+
+    const [a2, b2 = a2 + '!'] = ['hi'];
+>a2 : Symbol(a2, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 9, 11))
+>b2 : Symbol(b2, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 9, 14))
+>a2 : Symbol(a2, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 9, 11))
+}
+
+// To be inferred as `string | number`
+function f3() {
+>f3 : Symbol(f3, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 10, 1))
+
+    const [a1, b1 = a1] = ['hi', 1];
+>a1 : Symbol(a1, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 14, 11))
+>b1 : Symbol(b1, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 14, 14))
+>a1 : Symbol(a1, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 14, 11))
+
+    const [a2, b2 = a2 + '!'] = ['hi', 1];
+>a2 : Symbol(a2, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 15, 11))
+>b2 : Symbol(b2, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 15, 14))
+>a2 : Symbol(a2, Decl(destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts, 15, 11))
+}
+

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.types
@@ -1,0 +1,66 @@
+=== tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts ===
+// To be inferred as `number`
+function f1() {
+>f1 : () => void
+
+    const [a1, b1 = a1] = [1];
+>a1 : number
+>b1 : number
+>a1 : number
+>[1] : [number]
+>1 : 1
+
+    const [a2, b2 = 1 + a2] = [1];
+>a2 : number
+>b2 : number
+>1 + a2 : number
+>1 : 1
+>a2 : number
+>[1] : [number]
+>1 : 1
+}
+
+// To be inferred as `string`
+function f2() {
+>f2 : () => void
+
+    const [a1, b1 = a1] = ['hi'];
+>a1 : string
+>b1 : string
+>a1 : string
+>['hi'] : [string]
+>'hi' : "hi"
+
+    const [a2, b2 = a2 + '!'] = ['hi'];
+>a2 : string
+>b2 : string
+>a2 + '!' : string
+>a2 : string
+>'!' : "!"
+>['hi'] : [string]
+>'hi' : "hi"
+}
+
+// To be inferred as `string | number`
+function f3() {
+>f3 : () => void
+
+    const [a1, b1 = a1] = ['hi', 1];
+>a1 : string
+>b1 : string | number
+>a1 : string
+>['hi', 1] : [string, number]
+>'hi' : "hi"
+>1 : 1
+
+    const [a2, b2 = a2 + '!'] = ['hi', 1];
+>a2 : string
+>b2 : string | number
+>a2 + '!' : string
+>a2 : string
+>'!' : "!"
+>['hi', 1] : [string, number]
+>'hi' : "hi"
+>1 : 1
+}
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.js
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.js
@@ -1,0 +1,36 @@
+//// [destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts]
+// To be inferred as `number`
+function f1() {
+    const { a1, b1 = a1 } = { a1: 1 };
+    const { a2, b2 = 1 + a2 } = { a2: 1 };
+}
+
+// To be inferred as `string`
+function f2() {
+    const { a1, b1 = a1 } = { a1: 'hi' };
+    const { a2, b2 = a2 + '!' } = { a2: 'hi' };
+}
+
+// To be inferred as `string | number`
+function f3() {
+    const { a1, b1 = a1 } = { a1: 'hi', b1: 1 };
+    const { a2, b2 = a2 + '!' } = { a2: 'hi', b2: 1 };
+}
+
+
+//// [destructuringObjectBindingPatternAndAssignment9SiblingInitializer.js]
+// To be inferred as `number`
+function f1() {
+    var _a = { a1: 1 }, a1 = _a.a1, _b = _a.b1, b1 = _b === void 0 ? a1 : _b;
+    var _c = { a2: 1 }, a2 = _c.a2, _d = _c.b2, b2 = _d === void 0 ? 1 + a2 : _d;
+}
+// To be inferred as `string`
+function f2() {
+    var _a = { a1: 'hi' }, a1 = _a.a1, _b = _a.b1, b1 = _b === void 0 ? a1 : _b;
+    var _c = { a2: 'hi' }, a2 = _c.a2, _d = _c.b2, b2 = _d === void 0 ? a2 + '!' : _d;
+}
+// To be inferred as `string | number`
+function f3() {
+    var _a = { a1: 'hi', b1: 1 }, a1 = _a.a1, _b = _a.b1, b1 = _b === void 0 ? a1 : _b;
+    var _c = { a2: 'hi', b2: 1 }, a2 = _c.a2, _d = _c.b2, b2 = _d === void 0 ? a2 + '!' : _d;
+}

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.symbols
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.symbols
@@ -1,0 +1,54 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts ===
+// To be inferred as `number`
+function f1() {
+>f1 : Symbol(f1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 0, 0))
+
+    const { a1, b1 = a1 } = { a1: 1 };
+>a1 : Symbol(a1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 2, 11))
+>b1 : Symbol(b1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 2, 15))
+>a1 : Symbol(a1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 2, 11))
+>a1 : Symbol(a1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 2, 29))
+
+    const { a2, b2 = 1 + a2 } = { a2: 1 };
+>a2 : Symbol(a2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 3, 11))
+>b2 : Symbol(b2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 3, 15))
+>a2 : Symbol(a2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 3, 11))
+>a2 : Symbol(a2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 3, 33))
+}
+
+// To be inferred as `string`
+function f2() {
+>f2 : Symbol(f2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 4, 1))
+
+    const { a1, b1 = a1 } = { a1: 'hi' };
+>a1 : Symbol(a1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 8, 11))
+>b1 : Symbol(b1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 8, 15))
+>a1 : Symbol(a1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 8, 11))
+>a1 : Symbol(a1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 8, 29))
+
+    const { a2, b2 = a2 + '!' } = { a2: 'hi' };
+>a2 : Symbol(a2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 9, 11))
+>b2 : Symbol(b2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 9, 15))
+>a2 : Symbol(a2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 9, 11))
+>a2 : Symbol(a2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 9, 35))
+}
+
+// To be inferred as `string | number`
+function f3() {
+>f3 : Symbol(f3, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 10, 1))
+
+    const { a1, b1 = a1 } = { a1: 'hi', b1: 1 };
+>a1 : Symbol(a1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 14, 11))
+>b1 : Symbol(b1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 14, 15))
+>a1 : Symbol(a1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 14, 11))
+>a1 : Symbol(a1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 14, 29))
+>b1 : Symbol(b1, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 14, 39))
+
+    const { a2, b2 = a2 + '!' } = { a2: 'hi', b2: 1 };
+>a2 : Symbol(a2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 15, 11))
+>b2 : Symbol(b2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 15, 15))
+>a2 : Symbol(a2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 15, 11))
+>a2 : Symbol(a2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 15, 35))
+>b2 : Symbol(b2, Decl(destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts, 15, 45))
+}
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.types
@@ -1,0 +1,74 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts ===
+// To be inferred as `number`
+function f1() {
+>f1 : () => void
+
+    const { a1, b1 = a1 } = { a1: 1 };
+>a1 : number
+>b1 : number
+>a1 : number
+>{ a1: 1 } : { a1: number; b1?: number; }
+>a1 : number
+>1 : 1
+
+    const { a2, b2 = 1 + a2 } = { a2: 1 };
+>a2 : number
+>b2 : number
+>1 + a2 : number
+>1 : 1
+>a2 : number
+>{ a2: 1 } : { a2: number; b2?: number; }
+>a2 : number
+>1 : 1
+}
+
+// To be inferred as `string`
+function f2() {
+>f2 : () => void
+
+    const { a1, b1 = a1 } = { a1: 'hi' };
+>a1 : string
+>b1 : string
+>a1 : string
+>{ a1: 'hi' } : { a1: string; b1?: string; }
+>a1 : string
+>'hi' : "hi"
+
+    const { a2, b2 = a2 + '!' } = { a2: 'hi' };
+>a2 : string
+>b2 : string
+>a2 + '!' : string
+>a2 : string
+>'!' : "!"
+>{ a2: 'hi' } : { a2: string; b2?: string; }
+>a2 : string
+>'hi' : "hi"
+}
+
+// To be inferred as `string | number`
+function f3() {
+>f3 : () => void
+
+    const { a1, b1 = a1 } = { a1: 'hi', b1: 1 };
+>a1 : string
+>b1 : string | number
+>a1 : string
+>{ a1: 'hi', b1: 1 } : { a1: string; b1?: number; }
+>a1 : string
+>'hi' : "hi"
+>b1 : number
+>1 : 1
+
+    const { a2, b2 = a2 + '!' } = { a2: 'hi', b2: 1 };
+>a2 : string
+>b2 : string | number
+>a2 + '!' : string
+>a2 : string
+>'!' : "!"
+>{ a2: 'hi', b2: 1 } : { a2: string; b2?: number; }
+>a2 : string
+>'hi' : "hi"
+>b2 : number
+>1 : 1
+}
+

--- a/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts
@@ -1,0 +1,19 @@
+// @noImplicitAny: true
+
+// To be inferred as `number`
+function f1() {
+    const [a1, b1 = a1] = [1];
+    const [a2, b2 = 1 + a2] = [1];
+}
+
+// To be inferred as `string`
+function f2() {
+    const [a1, b1 = a1] = ['hi'];
+    const [a2, b2 = a2 + '!'] = ['hi'];
+}
+
+// To be inferred as `string | number`
+function f3() {
+    const [a1, b1 = a1] = ['hi', 1];
+    const [a2, b2 = a2 + '!'] = ['hi', 1];
+}

--- a/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment9SiblingInitializer.ts
@@ -1,0 +1,19 @@
+// @noImplicitAny: true
+
+// To be inferred as `number`
+function f1() {
+    const { a1, b1 = a1 } = { a1: 1 };
+    const { a2, b2 = 1 + a2 } = { a2: 1 };
+}
+
+// To be inferred as `string`
+function f2() {
+    const { a1, b1 = a1 } = { a1: 'hi' };
+    const { a2, b2 = a2 + '!' } = { a2: 'hi' };
+}
+
+// To be inferred as `string | number`
+function f3() {
+    const { a1, b1 = a1 } = { a1: 'hi', b1: 1 };
+    const { a2, b2 = a2 + '!' } = { a2: 'hi', b2: 1 };
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #49989 
Alternative to PR #50241.

Here, to prevent false circular-relationship on binding elements initialized with their siblings (like the code segment below), we've utilized `CheckMode` values other than `Normal` as an indicator of suppressing type-checking errors.

```ts
const [a, b = a] = [0];
// or
const [a, b = a + 1] = [0];
```

~One gotcha in this PR was to revert the updated links (i.e., `links.type`) of a symbol. Because once a circular relationship error was encountered the type of the symbol is inferred to be `any` and then somewhere in the call stack, the symbol's associated `links.type` would be assigned to that returned `any` type. So, in cases other than `CheckMode.Normal` we'd replace back the `links.type` old value.~ **(Sorry, that was not up-to-date)**

The gotcha is that I had to suppress updating the symbol's `links.type` (to `any` type) for other than `CheckMode.Normal` cases, because that would block further efforts to find the correct type for the symbol. Now, I'm thinking maybe it's better to also check if the returned type is `any` and then do the suppression. I didn't find any better approach than this, so let me know if there's one:

```ts
function getTypeOfVariableOrParameterOrProperty(symbol: Symbol, checkMode?: CheckMode): Type {
    const links = getSymbolLinks(symbol);
    let result = links.type;
    if (!result) {
        result = getTypeOfVariableOrParameterOrPropertyWorker(symbol, checkMode);
        // For a contextually typed parameter it is possible that a type has already
        // been assigned (in assignTypeToParameterAndFixTypeParameters), and we want
        // to preserve this type.
        if (!links.type && !(checkMode && checkMode !== CheckMode.Normal)) {
            links.type = result;
        }
    }
    return result;
}
```

## Further issues

Although this PR resolves common cases like the one above, but in cases like below false errors still occur. I didn't dig more to fix such issues because handling them would, in my opinion, clutter the type-checker without significant value in return due to the rarity of such usages. Please correct me if I'm wrong.

```ts
const [a, b = (() => 1 + a)()] = [0];
```



