### PR TITLE
fix(49993): The add missing enum member quick fix shouldn't add new member to the enum if it's dotting off of a value whose type is enum

### DIFF
--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -257,7 +257,7 @@ namespace ts.codefix {
         }
 
         const enumDeclaration = find(symbol.declarations, isEnumDeclaration);
-        if (enumDeclaration && !isPrivateIdentifier(token) && !isSourceFileFromLibrary(program, enumDeclaration.getSourceFile())) {
+        if (enumDeclaration && !(leftExpressionType.flags & TypeFlags.EnumLike) && !isPrivateIdentifier(token) && !isSourceFileFromLibrary(program, enumDeclaration.getSourceFile())) {
             return { kind: InfoKind.Enum, token, parentDeclaration: enumDeclaration };
         }
 

--- a/tests/cases/fourslash/codeFixAddMissingEnumMember13.ts
+++ b/tests/cases/fourslash/codeFixAddMissingEnumMember13.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////enum E { A, B }
+////declare var a: E;
+////a.C;
+
+verify.not.codeFixAvailable("fixMissingMember");


### PR DESCRIPTION
Fixes #49993