### PR TITLE
Pull back esfx dependencies to fix error in gulpfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,19 +89,31 @@
                 "node": "^14 || ^16 || ^17 || ^18"
             }
         },
-        "node_modules/@esfx/cancelable": {
-            "version": "1.0.0-pre.33",
-            "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.33.tgz",
-            "integrity": "sha512-W5DCyDDkH8y4iaolrW7U1Rf+BrHZOoEwuThHY5A2EJwJ4PauTS4yFV2wKorYmJhfDC13lsw6rdzrh/DRwjrBIA==",
+        "node_modules/@esfx/internal-deprecate": {
+            "version": "1.0.0-pre.24",
+            "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.24.tgz",
+            "integrity": "sha512-TSU5k04+nuVQdyfYhaVXxyskdiwYQHgwN20J3cbyRrm/YFi2dOoFSLFvkMNh7LNOPGWSOg6pfAm3kd23ISR3Ow==",
+            "dev": true
+        },
+        "node_modules/@esfx/internal-guards": {
+            "version": "1.0.0-pre.34",
+            "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.34.tgz",
+            "integrity": "sha512-PYJWQ8rJ5Z/FJB3daAxduJjF54gDc/X00UaffX3jYjDryCq/jeXtH2kfj7SdioLGWluWoKtVhw0kRvBDmlBsqQ==",
             "dev": true,
             "dependencies": {
-                "@esfx/disposable": "^1.0.0-pre.33"
+                "@esfx/type-model": "^1.0.0-pre.34"
             }
         },
-        "node_modules/@esfx/disposable": {
-            "version": "1.0.0-pre.33",
-            "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.33.tgz",
-            "integrity": "sha512-esqBTgZAUY5P8BHNqOL8dTTAG2jLnX9iKKQiP6GI0DmVAOY9GHA86HGy6dabqbzLAaZh/KJgHXOu1krjx1O7Pw==",
+        "node_modules/@esfx/internal-tag": {
+            "version": "1.0.0-pre.19",
+            "resolved": "https://registry.npmjs.org/@esfx/internal-tag/-/internal-tag-1.0.0-pre.19.tgz",
+            "integrity": "sha512-/v1D5LfvBnbvHzL22Vh6yobrOTVCBhsW/l9M+/GRA51eqCN27yTmWGaYUSd1QXp2vxHwNr0sfckVoNtTzeaIqQ==",
+            "dev": true
+        },
+        "node_modules/@esfx/type-model": {
+            "version": "1.0.0-pre.34",
+            "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.34.tgz",
+            "integrity": "sha512-WnNJob3BZxdy/2+B58nx2P5FaT/GVEKEcsapcuKBqnghw1Z7XAtnAqgP+FrvjZqbuH9wgHbaocaLrl7npxBtkg==",
             "dev": true
         },
         "node_modules/@eslint/eslintrc": {
@@ -6531,6 +6543,24 @@
                 "@esfx/disposable": "^1.0.0-pre.13"
             }
         },
+        "node_modules/prex/node_modules/@esfx/cancelable": {
+            "version": "1.0.0-pre.30",
+            "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.30.tgz",
+            "integrity": "sha512-fo0+/D3tEcSOHdZ8HiCR7qOKl5Tkk6Nw6QJNNXSQ0ejlpP3HU4S2i0rb/tjHQ1EkUcWZfB3g2jzfL0ioQSEgGg==",
+            "dev": true,
+            "dependencies": {
+                "@esfx/disposable": "^1.0.0-pre.30",
+                "@esfx/internal-deprecate": "^1.0.0-pre.24",
+                "@esfx/internal-guards": "^1.0.0-pre.23",
+                "@esfx/internal-tag": "^1.0.0-pre.19"
+            }
+        },
+        "node_modules/prex/node_modules/@esfx/disposable": {
+            "version": "1.0.0-pre.30",
+            "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.30.tgz",
+            "integrity": "sha512-njBGIQO+HW+lMqqMjURC+MWn+55ufulgebPLXzlxbwVSz5hZkoCsv6n9sIBQbnvg/PYQmWK5Dk6gDSmFfihTUg==",
+            "dev": true
+        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -8572,19 +8602,31 @@
                 "jsdoc-type-pratt-parser": "~3.1.0"
             }
         },
-        "@esfx/cancelable": {
-            "version": "1.0.0-pre.33",
-            "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.33.tgz",
-            "integrity": "sha512-W5DCyDDkH8y4iaolrW7U1Rf+BrHZOoEwuThHY5A2EJwJ4PauTS4yFV2wKorYmJhfDC13lsw6rdzrh/DRwjrBIA==",
+        "@esfx/internal-deprecate": {
+            "version": "1.0.0-pre.24",
+            "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.24.tgz",
+            "integrity": "sha512-TSU5k04+nuVQdyfYhaVXxyskdiwYQHgwN20J3cbyRrm/YFi2dOoFSLFvkMNh7LNOPGWSOg6pfAm3kd23ISR3Ow==",
+            "dev": true
+        },
+        "@esfx/internal-guards": {
+            "version": "1.0.0-pre.34",
+            "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.34.tgz",
+            "integrity": "sha512-PYJWQ8rJ5Z/FJB3daAxduJjF54gDc/X00UaffX3jYjDryCq/jeXtH2kfj7SdioLGWluWoKtVhw0kRvBDmlBsqQ==",
             "dev": true,
             "requires": {
-                "@esfx/disposable": "^1.0.0-pre.33"
+                "@esfx/type-model": "^1.0.0-pre.34"
             }
         },
-        "@esfx/disposable": {
-            "version": "1.0.0-pre.33",
-            "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.33.tgz",
-            "integrity": "sha512-esqBTgZAUY5P8BHNqOL8dTTAG2jLnX9iKKQiP6GI0DmVAOY9GHA86HGy6dabqbzLAaZh/KJgHXOu1krjx1O7Pw==",
+        "@esfx/internal-tag": {
+            "version": "1.0.0-pre.19",
+            "resolved": "https://registry.npmjs.org/@esfx/internal-tag/-/internal-tag-1.0.0-pre.19.tgz",
+            "integrity": "sha512-/v1D5LfvBnbvHzL22Vh6yobrOTVCBhsW/l9M+/GRA51eqCN27yTmWGaYUSd1QXp2vxHwNr0sfckVoNtTzeaIqQ==",
+            "dev": true
+        },
+        "@esfx/type-model": {
+            "version": "1.0.0-pre.34",
+            "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.34.tgz",
+            "integrity": "sha512-WnNJob3BZxdy/2+B58nx2P5FaT/GVEKEcsapcuKBqnghw1Z7XAtnAqgP+FrvjZqbuH9wgHbaocaLrl7npxBtkg==",
             "dev": true
         },
         "@eslint/eslintrc": {
@@ -13612,8 +13654,28 @@
             "integrity": "sha512-ulhl3iyjmAW/GroRQJN4CG+pC6KJ+W+deNRBkEShQwe16wLP9k92+x6RmLJuLiVSGkbxhnAqHpGdJJCh3bRpUQ==",
             "dev": true,
             "requires": {
-                "@esfx/cancelable": "^1.0.0-pre.13",
-                "@esfx/disposable": "^1.0.0-pre.13"
+                "@esfx/cancelable": "1.0.0-pre.30",
+                "@esfx/disposable": "1.0.0-pre.30"
+            },
+            "dependencies": {
+                "@esfx/cancelable": {
+                    "version": "1.0.0-pre.30",
+                    "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.30.tgz",
+                    "integrity": "sha512-fo0+/D3tEcSOHdZ8HiCR7qOKl5Tkk6Nw6QJNNXSQ0ejlpP3HU4S2i0rb/tjHQ1EkUcWZfB3g2jzfL0ioQSEgGg==",
+                    "dev": true,
+                    "requires": {
+                        "@esfx/disposable": "1.0.0-pre.30",
+                        "@esfx/internal-deprecate": "^1.0.0-pre.24",
+                        "@esfx/internal-guards": "^1.0.0-pre.23",
+                        "@esfx/internal-tag": "^1.0.0-pre.19"
+                    }
+                },
+                "@esfx/disposable": {
+                    "version": "1.0.0-pre.30",
+                    "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.30.tgz",
+                    "integrity": "sha512-njBGIQO+HW+lMqqMjURC+MWn+55ufulgebPLXzlxbwVSz5hZkoCsv6n9sIBQbnvg/PYQmWK5Dk6gDSmFfihTUg==",
+                    "dev": true
+                }
             }
         },
         "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,9 @@
         "xml2js": "^0.4.23"
     },
     "overrides": {
-        "es5-ext": "0.10.53"
+        "es5-ext": "0.10.53",
+        "@esfx/cancelable": "1.0.0-pre.30",
+        "@esfx/disposable": "1.0.0-pre.30"
     },
     "scripts": {
         "test": "gulp runtests-parallel --light=false",


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/commit/66fbf058ece7882f2a964aeeda81bc352e4a6329 updated dependencies, which included esfx stuff, but it appears as though the packages are missing files as of https://github.com/esfx/esfx/commit/be78c9e54650d3e506d48da0630a788a2ba8b756.

Use overrides to temporarily pull these back to working versions.

We only use these via "prex", for cancellation during the build, but as far as I can tell, we never give anything a cancellation token, so potentially we could just remove cancellation altogether as a fix too.