### PR TITLE
Remove unused cancellation from build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
                 "mocha-fivemat-progress-reporter": "latest",
                 "ms": "^2.1.3",
                 "node-fetch": "^2.6.7",
-                "prex": "^0.4.7",
                 "source-map-support": "latest",
                 "typescript": "^4.8.2",
                 "vinyl": "latest",
@@ -88,21 +87,6 @@
             "engines": {
                 "node": "^14 || ^16 || ^17 || ^18"
             }
-        },
-        "node_modules/@esfx/cancelable": {
-            "version": "1.0.0-pre.33",
-            "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.33.tgz",
-            "integrity": "sha512-W5DCyDDkH8y4iaolrW7U1Rf+BrHZOoEwuThHY5A2EJwJ4PauTS4yFV2wKorYmJhfDC13lsw6rdzrh/DRwjrBIA==",
-            "dev": true,
-            "dependencies": {
-                "@esfx/disposable": "^1.0.0-pre.33"
-            }
-        },
-        "node_modules/@esfx/disposable": {
-            "version": "1.0.0-pre.33",
-            "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.33.tgz",
-            "integrity": "sha512-esqBTgZAUY5P8BHNqOL8dTTAG2jLnX9iKKQiP6GI0DmVAOY9GHA86HGy6dabqbzLAaZh/KJgHXOu1krjx1O7Pw==",
-            "dev": true
         },
         "node_modules/@eslint/eslintrc": {
             "version": "1.3.1",
@@ -6521,16 +6505,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/prex": {
-            "version": "0.4.7",
-            "resolved": "https://registry.npmjs.org/prex/-/prex-0.4.7.tgz",
-            "integrity": "sha512-ulhl3iyjmAW/GroRQJN4CG+pC6KJ+W+deNRBkEShQwe16wLP9k92+x6RmLJuLiVSGkbxhnAqHpGdJJCh3bRpUQ==",
-            "dev": true,
-            "dependencies": {
-                "@esfx/cancelable": "^1.0.0-pre.13",
-                "@esfx/disposable": "^1.0.0-pre.13"
-            }
-        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -8571,21 +8545,6 @@
                 "esquery": "^1.4.0",
                 "jsdoc-type-pratt-parser": "~3.1.0"
             }
-        },
-        "@esfx/cancelable": {
-            "version": "1.0.0-pre.33",
-            "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.33.tgz",
-            "integrity": "sha512-W5DCyDDkH8y4iaolrW7U1Rf+BrHZOoEwuThHY5A2EJwJ4PauTS4yFV2wKorYmJhfDC13lsw6rdzrh/DRwjrBIA==",
-            "dev": true,
-            "requires": {
-                "@esfx/disposable": "^1.0.0-pre.33"
-            }
-        },
-        "@esfx/disposable": {
-            "version": "1.0.0-pre.33",
-            "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.33.tgz",
-            "integrity": "sha512-esqBTgZAUY5P8BHNqOL8dTTAG2jLnX9iKKQiP6GI0DmVAOY9GHA86HGy6dabqbzLAaZh/KJgHXOu1krjx1O7Pw==",
-            "dev": true
         },
         "@eslint/eslintrc": {
             "version": "1.3.1",
@@ -13605,16 +13564,6 @@
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
             "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
             "dev": true
-        },
-        "prex": {
-            "version": "0.4.7",
-            "resolved": "https://registry.npmjs.org/prex/-/prex-0.4.7.tgz",
-            "integrity": "sha512-ulhl3iyjmAW/GroRQJN4CG+pC6KJ+W+deNRBkEShQwe16wLP9k92+x6RmLJuLiVSGkbxhnAqHpGdJJCh3bRpUQ==",
-            "dev": true,
-            "requires": {
-                "@esfx/cancelable": "^1.0.0-pre.13",
-                "@esfx/disposable": "^1.0.0-pre.13"
-            }
         },
         "process-nextick-args": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
         "mocha-fivemat-progress-reporter": "latest",
         "ms": "^2.1.3",
         "node-fetch": "^2.6.7",
-        "prex": "^0.4.7",
         "source-map-support": "latest",
         "typescript": "^4.8.2",
         "vinyl": "latest",


### PR DESCRIPTION
This is an alternative to #50656 to fix the build, by removing the dep entirely. From my looking, we don't pass a cancellation token into anything anymore, so we don't need the extra dep and supporting code.