### PR TITLE
Fix eslint not looking at certain scripts, fix lints

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,7 +3,20 @@
 /tests/**
 /lib/**
 /src/lib/*.generated.d.ts
+# Ignore all compiled script outputs
 /scripts/*.js
+# But, not the ones that are hand-written.
+# TODO: remove once scripts are pure JS
+!/scripts/browserIntegrationTest.js
+!/scripts/createPlaygroundBuild.js
+!/scripts/failed-tests.js
+!/scripts/find-unused-diagnostic-messages.js
+!/scripts/lint-hooks.js
+!/scripts/perf-result-post.js
+!/scripts/post-vsts-artifact-comment.js
+!/scripts/regenerate-unicode-identifier-parts.js
+!/scripts/run-sequence.js
+!/scripts/update-experimental-branches.js
 /scripts/eslint/built/**
 /internal/**
 /coverage/**

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
         //
         // ESLint in VS Code will lint any opened file (so long as it's not eslintignore'd), so
         // that will work regardless of the below.
-        { "files": ["*.ts"] }
+        { "files": ["*.ts", "*.mts", "*.cts", "*.mjs", "*.cjs"] }
     ],
     "rules": {
         "@typescript-eslint/adjacent-overload-signatures": "error",

--- a/scripts/failed-tests.js
+++ b/scripts/failed-tests.js
@@ -45,7 +45,7 @@ class FailedTestsReporter extends Mocha.reporters.Base {
                 }
             }
 
-            const newOptions = Object.assign({}, options, { reporterOptions: reporterOptions.reporterOptions || {} });
+            const newOptions = { ...options, reporterOptions: reporterOptions.reporterOptions || {} };
             if (reporterOptions.reporter === "xunit") {
                 newOptions.reporterOptions.output = "TEST-results.xml";
             }

--- a/scripts/find-unused-diganostic-messages.mjs
+++ b/scripts/find-unused-diganostic-messages.mjs
@@ -17,7 +17,8 @@ startOfDiags.split(EOL).forEach(line => {
     try {
         execSync(`grep -rnw 'src' -e 'Diagnostics.${diagName}'`).toString();
         process.stdout.write(".");
-    } catch (error) {
+    }
+    catch (error) {
         missingNames.push(diagName);
         process.stdout.write("x");
     }

--- a/scripts/post-vsts-artifact-comment.js
+++ b/scripts/post-vsts-artifact-comment.js
@@ -48,7 +48,7 @@ and then running \`npm install\`.
 
     // Temporarily disable until we get access controls set up right
     // Send a ping to https://github.com/microsoft/typescript-make-monaco-builds#pull-request-builds
-    await gh.request("POST /repos/microsoft/typescript-make-monaco-builds/dispatches", { event_type: process.env.SOURCE_ISSUE, headers: { Accept: "application/vnd.github.everest-preview+json" }});
+    await gh.request("POST /repos/microsoft/typescript-make-monaco-builds/dispatches", { event_type: process.env.SOURCE_ISSUE, headers: { Accept: "application/vnd.github.everest-preview+json" } });
 }
 
 main().catch(async e => {

--- a/scripts/run-sequence.js
+++ b/scripts/run-sequence.js
@@ -1,7 +1,6 @@
 // @ts-check
 const cp = require("child_process");
 /**
- * 
  * @param {[string, string[]][]} tasks
  * @param {cp.SpawnSyncOptions} opts
  */

--- a/scripts/update-experimental-branches.js
+++ b/scripts/update-experimental-branches.js
@@ -10,7 +10,7 @@ const triggeredPR = process.env.SOURCE_ISSUE || process.env.SYSTEM_PULLREQUEST_P
  * This program should be invoked as `node ./scripts/update-experimental-branches <GithubAccessToken>`
  * TODO: the following is racey - if two experiment-enlisted PRs trigger simultaneously and witness one another in an unupdated state, they'll both produce
  * a new experimental branch, but each will be missing a change from the other. There's no _great_ way to fix this beyond setting the maximum concurrency
- * of this task to 1 (so only one job is allowed to update experiments at a time). 
+ * of this task to 1 (so only one job is allowed to update experiments at a time).
  */
 async function main() {
     const gh = new Octokit({


### PR DESCRIPTION
Noticed this when working on other branches for formatting / script conversion to JS; eslint doesn't scan `mjs`, `cjs`, `mts`, `cts` by default, so we were missing a bunch of files. We also ignored scripts for linting unintentionally, if they were already in JS.