### PR TITLE
Remove 'async' dependency, used only in errorCheck.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
             },
             "devDependencies": {
                 "@octokit/rest": "latest",
-                "@types/async": "latest",
                 "@types/chai": "latest",
                 "@types/fs-extra": "^9.0.13",
                 "@types/glob": "latest",
@@ -36,7 +35,6 @@
                 "@typescript-eslint/eslint-plugin": "^5.33.1",
                 "@typescript-eslint/parser": "^5.33.1",
                 "@typescript-eslint/utils": "^5.33.1",
-                "async": "latest",
                 "azure-devops-node-api": "^11.2.0",
                 "chai": "latest",
                 "chalk": "^4.1.2",
@@ -410,12 +408,6 @@
             "dependencies": {
                 "@octokit/openapi-types": "^13.6.0"
             }
-        },
-        "node_modules/@types/async": {
-            "version": "3.2.15",
-            "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
-            "integrity": "sha512-PAmPfzvFA31mRoqZyTVsgJMsvbynR429UTTxhmfsUCrWGh3/fxOrzqBtaTPJsn4UtzTv4Vb0+/O7CARWb69N4g==",
-            "dev": true
         },
         "node_modules/@types/chai": {
             "version": "4.3.3",
@@ -1209,12 +1201,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/async": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-            "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-            "dev": true
         },
         "node_modules/async-done": {
             "version": "1.3.2",
@@ -8794,12 +8780,6 @@
                 "@octokit/openapi-types": "^13.6.0"
             }
         },
-        "@types/async": {
-            "version": "3.2.15",
-            "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.15.tgz",
-            "integrity": "sha512-PAmPfzvFA31mRoqZyTVsgJMsvbynR429UTTxhmfsUCrWGh3/fxOrzqBtaTPJsn4UtzTv4Vb0+/O7CARWb69N4g==",
-            "dev": true
-        },
         "@types/chai": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
@@ -9400,12 +9380,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
             "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
-            "dev": true
-        },
-        "async": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-            "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
             "dev": true
         },
         "async-done": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     ],
     "devDependencies": {
         "@octokit/rest": "latest",
-        "@types/async": "latest",
         "@types/chai": "latest",
         "@types/fs-extra": "^9.0.13",
         "@types/glob": "latest",
@@ -62,7 +61,6 @@
         "@typescript-eslint/eslint-plugin": "^5.33.1",
         "@typescript-eslint/parser": "^5.33.1",
         "@typescript-eslint/utils": "^5.33.1",
-        "async": "latest",
         "azure-devops-node-api": "^11.2.0",
         "chai": "latest",
         "chalk": "^4.1.2",

--- a/scripts/errorCheck.ts
+++ b/scripts/errorCheck.ts
@@ -1,5 +1,4 @@
 import * as fs from "fs";
-import * as async from "async";
 import * as glob from "glob";
 
 fs.readFile("src/compiler/diagnosticMessages.json", "utf-8", (err, data) => {
@@ -20,8 +19,8 @@ fs.readFile("src/compiler/diagnosticMessages.json", "utf-8", (err, data) => {
 
     fs.readdir(baseDir, (err, files) => {
         files = files.filter(f => f.indexOf(".errors.txt") > 0);
-        const tasks: ((callback: () => void) => void)[] = [];
-        files.forEach(f => tasks.push(done => {
+
+        files.forEach(f => {
             fs.readFile(baseDir + f, "utf-8", (err, baseline) => {
                 if (err) throw err;
 
@@ -31,22 +30,18 @@ fs.readFile("src/compiler/diagnosticMessages.json", "utf-8", (err, data) => {
                     const msg = keys.filter(k => messages[k].code === errCode)[0];
                     messages[msg].seen = true;
                 }
-
-                done();
             });
-        }));
-
-        async.parallelLimit(tasks, 25, done => {
-            console.log("== List of errors not present in baselines ==");
-            let count = 0;
-            for (const k of keys) {
-                if (messages[k].seen !== true) {
-                    console.log(k);
-                    count++;
-                }
-            }
-            console.log(count + " of " + keys.length + " errors are not in baselines");
         });
+
+        console.log("== List of errors not present in baselines ==");
+        let count = 0;
+        for (const k of keys) {
+            if (messages[k].seen !== true) {
+                console.log(k);
+                count++;
+            }
+        }
+        console.log(count + " of " + keys.length + " errors are not in baselines");
     });
 });
 


### PR DESCRIPTION
The "async" library is only used in this file; it was used to do multiple things concurrently, but in my testing on Windows and Linux, it provides no speedup. Just remove it, which lets us drop the dep.