### PR TITLE
Remove error message in node16

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -45755,7 +45755,7 @@ namespace ts {
             }
 
             const nodeArguments = node.arguments;
-            if (moduleKind !== ModuleKind.ESNext && moduleKind !== ModuleKind.NodeNext) {
+            if (moduleKind !== ModuleKind.ESNext && moduleKind !== ModuleKind.NodeNext && moduleKind !== ModuleKind.Node16) {
                 // We are allowed trailing comma after proposal-import-assertions.
                 checkGrammarForDisallowedTrailingComma(nodeArguments);
 

--- a/tests/baselines/reference/nodeModulesImportAssertions(module=node16).errors.txt
+++ b/tests/baselines/reference/nodeModulesImportAssertions(module=node16).errors.txt
@@ -1,19 +1,16 @@
 tests/cases/conformance/node/index.ts(1,35): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext' or 'nodenext'.
 tests/cases/conformance/node/otherc.cts(1,35): error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext' or 'nodenext'.
-tests/cases/conformance/node/otherc.cts(2,40): error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', or 'nodenext'.
 
 
 ==== tests/cases/conformance/node/index.ts (1 errors) ====
     import json from "./package.json" assert { type: "json" };
                                       ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext' or 'nodenext'.
-==== tests/cases/conformance/node/otherc.cts (2 errors) ====
+==== tests/cases/conformance/node/otherc.cts (1 errors) ====
     import json from "./package.json" assert { type: "json" }; // should error, cjs mode imports don't support assertions
                                       ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2821: Import assertions are only supported when the '--module' option is set to 'esnext' or 'nodenext'.
     const json2 = import("./package.json", { assert: { type: "json" } }); // should be fine
-                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1324: Dynamic imports only support a second argument when the '--module' option is set to 'esnext', 'node16', or 'nodenext'.
 ==== tests/cases/conformance/node/package.json (0 errors) ====
     {
         "name": "pkg",


### PR DESCRIPTION
The diagnostic message got updated to include `node16` when we updated `node12` to `node16`, but the offending condition in the code to trigger the diagnostic never got updated to account for `node16`.

Fixes #50653
