### PR TITLE
JSDoc comment parsing supports multiline backticks

### DIFF
--- a/tests/baselines/reference/jsdocParseMatchingBackticks.errors.txt
+++ b/tests/baselines/reference/jsdocParseMatchingBackticks.errors.txt
@@ -1,0 +1,31 @@
+tests/cases/conformance/jsdoc/jsdocParseMatchingBackticks.js(22,22): error TS7006: Parameter 'gamma' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/jsdoc/jsdocParseMatchingBackticks.js (1 errors) ====
+    /**
+     * `@param` initial at-param is OK in title comment
+     * @param {string} x hi there `@param`
+     * @param {string} y hi there @ * param
+     *                   this is the margin
+     *                   so we'll drop everything before it
+     `@param` @param {string} z hello???
+     * `@param` @param {string} alpha hello???
+     * `@ * param` @param {string} beta hello???
+     * @param {string} gamma
+     */
+    export function f(x, y, z, alpha, beta, gamma) {
+        return x + y + z + alpha + beta + gamma
+    }
+    /**
+     * Unmatched backticks keep going past newlines
+     * @param {string} y hi there `@ * param
+     *                   this is the margin
+     *                   so we'll drop everything before it
+     * @param {string} gamma
+     */
+    export function g(y, gamma) {
+                         ~~~~~
+!!! error TS7006: Parameter 'gamma' implicitly has an 'any' type.
+        return y + gamma
+    }
+    

--- a/tests/baselines/reference/jsdocParseMatchingBackticks.symbols
+++ b/tests/baselines/reference/jsdocParseMatchingBackticks.symbols
@@ -2,7 +2,7 @@
 /**
  * `@param` initial at-param is OK in title comment
  * @param {string} x hi there `@param`
- * @param {string} y hi there `@ * param
+ * @param {string} y hi there @ * param
  *                   this is the margin
  *                   so we'll drop everything before it
  `@param` @param {string} z hello???
@@ -26,5 +26,21 @@ export function f(x, y, z, alpha, beta, gamma) {
 >alpha : Symbol(alpha, Decl(jsdocParseMatchingBackticks.js, 11, 26))
 >beta : Symbol(beta, Decl(jsdocParseMatchingBackticks.js, 11, 33))
 >gamma : Symbol(gamma, Decl(jsdocParseMatchingBackticks.js, 11, 39))
+}
+/**
+ * Unmatched backticks keep going past newlines
+ * @param {string} y hi there `@ * param
+ *                   this is the margin
+ *                   so we'll drop everything before it
+ * @param {string} gamma
+ */
+export function g(y, gamma) {
+>g : Symbol(g, Decl(jsdocParseMatchingBackticks.js, 13, 1))
+>y : Symbol(y, Decl(jsdocParseMatchingBackticks.js, 21, 18))
+>gamma : Symbol(gamma, Decl(jsdocParseMatchingBackticks.js, 21, 20))
+
+    return y + gamma
+>y : Symbol(y, Decl(jsdocParseMatchingBackticks.js, 21, 18))
+>gamma : Symbol(gamma, Decl(jsdocParseMatchingBackticks.js, 21, 20))
 }
 

--- a/tests/baselines/reference/jsdocParseMatchingBackticks.types
+++ b/tests/baselines/reference/jsdocParseMatchingBackticks.types
@@ -2,7 +2,7 @@
 /**
  * `@param` initial at-param is OK in title comment
  * @param {string} x hi there `@param`
- * @param {string} y hi there `@ * param
+ * @param {string} y hi there @ * param
  *                   this is the margin
  *                   so we'll drop everything before it
  `@param` @param {string} z hello???
@@ -31,5 +31,22 @@ export function f(x, y, z, alpha, beta, gamma) {
 >alpha : string
 >beta : string
 >gamma : string
+}
+/**
+ * Unmatched backticks keep going past newlines
+ * @param {string} y hi there `@ * param
+ *                   this is the margin
+ *                   so we'll drop everything before it
+ * @param {string} gamma
+ */
+export function g(y, gamma) {
+>g : (y: string, gamma: any) => string
+>y : string
+>gamma : any
+
+    return y + gamma
+>y + gamma : string
+>y : string
+>gamma : any
 }
 

--- a/tests/cases/conformance/jsdoc/jsdocParseMatchingBackticks.ts
+++ b/tests/cases/conformance/jsdoc/jsdocParseMatchingBackticks.ts
@@ -7,7 +7,7 @@
 /**
  * `@param` initial at-param is OK in title comment
  * @param {string} x hi there `@param`
- * @param {string} y hi there `@ * param
+ * @param {string} y hi there @ * param
  *                   this is the margin
  *                   so we'll drop everything before it
  `@param` @param {string} z hello???
@@ -17,4 +17,14 @@
  */
 export function f(x, y, z, alpha, beta, gamma) {
     return x + y + z + alpha + beta + gamma
+}
+/**
+ * Unmatched backticks keep going past newlines
+ * @param {string} y hi there `@ * param
+ *                   this is the margin
+ *                   so we'll drop everything before it
+ * @param {string} gamma
+ */
+export function g(y, gamma) {
+    return y + gamma
 }

--- a/tests/cases/fourslash/quickInfoJSDocBackticks.ts
+++ b/tests/cases/fourslash/quickInfoJSDocBackticks.ts
@@ -11,15 +11,18 @@
 //// * @param {string} x hi there `@param`
 //// * @param {string} y hi there `@ * param
 //// *                   this is the margin
+//// * @param {string} z OOPS, unclosed backtick!
 //// */
-////export function f(x, y) {
-////    return x/*x*/ + y/*y*/
+////export function f(x, y, z) {
+////    return x/*x*/ + y/*y*/ + z/*z*/
 ////}
 ////f/*f*/
 
 goTo.marker("f");
-verify.quickInfoIs("function f(x: string, y: string): string", "`@param` initial at-param is OK in title comment");
+verify.quickInfoIs("function f(x: string, y: string, z: any): string", "`@param` initial at-param is OK in title comment");
 goTo.marker("x");
 verify.quickInfoIs("(parameter) x: string", "hi there `@param`");
 goTo.marker("y");
-verify.quickInfoIs("(parameter) y: string", "hi there `@ * param\nthis is the margin");
+verify.quickInfoIs("(parameter) y: string", "hi there `@ * param\nthis is the margin\n@param {string} z OOPS, unclosed backtick!");
+goTo.marker("z");
+verify.quickInfoIs("(parameter) z: any", undefined);


### PR DESCRIPTION
Previously, backticks in JSDoc ended at the end of a line. This PR changes that so that backticks continue parsing until another backtick. I'm not sure this is a good change, and I left the code a bit inelegant until we decide.

Note that triple backticks and single backticks are treated the same way: both have to be closed. The code change is already very clunky, and I haven't thought about how much clunkier it would be to track backtick history in the parser.

I would appreciate opinions on whether this is a sensible change in behaviour, as well as ideas on how hard it would be to distinguish triple from single backticks.

Fixes #47679
