### PR TITLE
Don't remove space before dot if in property access on numeric literal

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -59,7 +59,7 @@ namespace ts.formatting {
             // in other cases there should be no space between '?' and next token
             rule("NoSpaceAfterQuestionMark", SyntaxKind.QuestionToken, anyToken, [isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
 
-            rule("NoSpaceBeforeDot", anyToken, [SyntaxKind.DotToken, SyntaxKind.QuestionDotToken], [isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
+            rule("NoSpaceBeforeDot", anyToken, [SyntaxKind.DotToken, SyntaxKind.QuestionDotToken], [isNonJsxSameLineTokenContext, isNotPropertyAccessOnNumericLiteral], RuleAction.DeleteSpace),
             rule("NoSpaceAfterDot", [SyntaxKind.DotToken, SyntaxKind.QuestionDotToken], anyToken, [isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
 
             rule("NoSpaceBetweenImportParenInImportType", SyntaxKind.ImportKeyword, SyntaxKind.OpenParenToken, [isNonJsxSameLineTokenContext, isImportTypeContext], RuleAction.DeleteSpace),
@@ -892,5 +892,9 @@ namespace ts.formatting {
 
     function isSemicolonInsertionContext(context: FormattingContext): boolean {
         return positionIsASICandidate(context.currentTokenSpan.end, context.currentTokenParent, context.sourceFile);
+    }
+
+    function isNotPropertyAccessOnNumericLiteral(context: FormattingContext): boolean {
+        return !isPropertyAccessExpression(context.contextNode) || !isNumericLiteral(context.contextNode.expression);
     }
 }

--- a/tests/cases/fourslash/formatDotAfterNumber.ts
+++ b/tests/cases/fourslash/formatDotAfterNumber.ts
@@ -1,0 +1,7 @@
+/// <reference path='fourslash.ts' />
+
+////1+ 2 .toString() +3/**/
+
+format.document();
+goTo.marker("");
+verify.currentLineContentIs("1 + 2 .toString() + 3");


### PR DESCRIPTION
Fixes #50686

Funnily I fixed this bug once in Python too...

I opted for the "do nothing" approach, rather than prettier's approach of adding parens, which might be better, but more complicated.