### PR TITLE
Don't leave space for property access on non-integer literals

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -59,7 +59,7 @@ namespace ts.formatting {
             // in other cases there should be no space between '?' and next token
             rule("NoSpaceAfterQuestionMark", SyntaxKind.QuestionToken, anyToken, [isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
 
-            rule("NoSpaceBeforeDot", anyToken, [SyntaxKind.DotToken, SyntaxKind.QuestionDotToken], [isNonJsxSameLineTokenContext, isNotPropertyAccessOnNumericLiteral], RuleAction.DeleteSpace),
+            rule("NoSpaceBeforeDot", anyToken, [SyntaxKind.DotToken, SyntaxKind.QuestionDotToken], [isNonJsxSameLineTokenContext, isNotPropertyAccessOnIntegerLiteral], RuleAction.DeleteSpace),
             rule("NoSpaceAfterDot", [SyntaxKind.DotToken, SyntaxKind.QuestionDotToken], anyToken, [isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
 
             rule("NoSpaceBetweenImportParenInImportType", SyntaxKind.ImportKeyword, SyntaxKind.OpenParenToken, [isNonJsxSameLineTokenContext, isImportTypeContext], RuleAction.DeleteSpace),
@@ -894,7 +894,9 @@ namespace ts.formatting {
         return positionIsASICandidate(context.currentTokenSpan.end, context.currentTokenParent, context.sourceFile);
     }
 
-    function isNotPropertyAccessOnNumericLiteral(context: FormattingContext): boolean {
-        return !isPropertyAccessExpression(context.contextNode) || !isNumericLiteral(context.contextNode.expression);
+    function isNotPropertyAccessOnIntegerLiteral(context: FormattingContext): boolean {
+        return !isPropertyAccessExpression(context.contextNode)
+            || !isNumericLiteral(context.contextNode.expression)
+            || context.contextNode.expression.getText().indexOf(".") !== -1;
     }
 }

--- a/tests/cases/fourslash/formatDotAfterNumber.ts
+++ b/tests/cases/fourslash/formatDotAfterNumber.ts
@@ -1,7 +1,24 @@
 /// <reference path='fourslash.ts' />
 
-////1+ 2 .toString() +3/**/
+////1+ 2 .toString() +3/*1*/
+////1+ 2. .toString() +3/*2*/
+////1+ 2.0 .toString() +3/*3*/
+////1+ (2) .toString() +3/*4*/
+////1+ 2_000 .toString() +3/*5*/
 
 format.document();
-goTo.marker("");
+
+goTo.marker("1");
 verify.currentLineContentIs("1 + 2 .toString() + 3");
+
+goTo.marker("2");
+verify.currentLineContentIs("1 + 2..toString() + 3");
+
+goTo.marker("3");
+verify.currentLineContentIs("1 + 2.0.toString() + 3");
+
+goTo.marker("4");
+verify.currentLineContentIs("1 + (2).toString() + 3");
+
+goTo.marker("5");
+verify.currentLineContentIs("1 + 2_000 .toString() + 3");


### PR DESCRIPTION
For #50686

My fix was too overzealous; we shouldn't change our behavior when removing the space is still syntactically valid. My previous PR left the space in for an expression like `1.2.toString()`.

Whether or not that is nicely formatted code is debatable, but I didn't intend to introduce a space for that expression in #50695.