### PR TITLE
fix(50717): tsc crashes when it sees a JSDoc tag inside an @override annotation

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -734,6 +734,7 @@ namespace ts {
         [SyntaxKind.JSDocProtectedTag]: forEachChildInJSDocTag,
         [SyntaxKind.JSDocReadonlyTag]: forEachChildInJSDocTag,
         [SyntaxKind.JSDocDeprecatedTag]: forEachChildInJSDocTag,
+        [SyntaxKind.JSDocOverrideTag]: forEachChildInJSDocTag,
         [SyntaxKind.PartiallyEmittedExpression]: forEachChildInPartiallyEmittedExpression,
     };
 
@@ -815,10 +816,10 @@ namespace ts {
     }
 
     function forEachChildInJSDocLinkCodeOrPlain<T>(node: JSDocLink | JSDocLinkCode | JSDocLinkPlain, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-            return visitNode(cbNode, node.name);
+        return visitNode(cbNode, node.name);
     }
 
-    function forEachChildInJSDocTag<T>(node: JSDocUnknownTag | JSDocClassTag | JSDocPublicTag | JSDocPrivateTag | JSDocProtectedTag | JSDocReadonlyTag | JSDocDeprecatedTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    function forEachChildInJSDocTag<T>(node: JSDocUnknownTag | JSDocClassTag | JSDocPublicTag | JSDocPrivateTag | JSDocProtectedTag | JSDocReadonlyTag | JSDocDeprecatedTag | JSDocOverrideTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.tagName)
             || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -931,6 +931,7 @@ namespace ts {
         | JSDocProtectedTag
         | JSDocReadonlyTag
         | JSDocDeprecatedTag
+        | JSDocOverrideTag
         ;
 
     /* @internal */

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -16,7 +16,7 @@ namespace ts.GoToDefinition {
         const { parent } = node;
         const typeChecker = program.getTypeChecker();
 
-        if (node.kind === SyntaxKind.OverrideKeyword || (isJSDocOverrideTag(node) && rangeContainsPosition(node.tagName, position))) {
+        if (node.kind === SyntaxKind.OverrideKeyword || (isIdentifier(node) && isJSDocOverrideTag(parent) && parent.tagName === node)) {
             return getDefinitionFromOverriddenMember(typeChecker, node) || emptyArray;
         }
 

--- a/tests/baselines/reference/jsdocLinkTag6.js
+++ b/tests/baselines/reference/jsdocLinkTag6.js
@@ -1,0 +1,45 @@
+//// [a.ts]
+class A {
+    foo() {}
+}
+class B extends A {
+    /**
+     * @override {@link A.foo}
+     */
+    foo() {}
+}
+
+
+//// [a.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var A = /** @class */ (function () {
+    function A() {
+    }
+    A.prototype.foo = function () { };
+    return A;
+}());
+var B = /** @class */ (function (_super) {
+    __extends(B, _super);
+    function B() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    /**
+     * @override {@link A.foo}
+     */
+    B.prototype.foo = function () { };
+    return B;
+}(A));

--- a/tests/baselines/reference/jsdocLinkTag6.symbols
+++ b/tests/baselines/reference/jsdocLinkTag6.symbols
@@ -1,0 +1,18 @@
+=== /a.ts ===
+class A {
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+    foo() {}
+>foo : Symbol(A.foo, Decl(a.ts, 0, 9))
+}
+class B extends A {
+>B : Symbol(B, Decl(a.ts, 2, 1))
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+    /**
+     * @override {@link A.foo}
+     */
+    foo() {}
+>foo : Symbol(B.foo, Decl(a.ts, 3, 19))
+}
+

--- a/tests/baselines/reference/jsdocLinkTag6.types
+++ b/tests/baselines/reference/jsdocLinkTag6.types
@@ -1,0 +1,18 @@
+=== /a.ts ===
+class A {
+>A : A
+
+    foo() {}
+>foo : () => void
+}
+class B extends A {
+>B : B
+>A : A
+
+    /**
+     * @override {@link A.foo}
+     */
+    foo() {}
+>foo : () => void
+}
+

--- a/tests/cases/conformance/jsdoc/jsdocLinkTag6.ts
+++ b/tests/cases/conformance/jsdoc/jsdocLinkTag6.ts
@@ -1,0 +1,10 @@
+// @filename: /a.ts
+class A {
+    foo() {}
+}
+class B extends A {
+    /**
+     * @override {@link A.foo}
+     */
+    foo() {}
+}

--- a/tests/cases/fourslash/goToDefinitionOverriddenMember11.ts
+++ b/tests/cases/fourslash/goToDefinitionOverriddenMember11.ts
@@ -10,7 +10,7 @@
 ////    /*Foo_m*/m() {}
 ////}
 ////class Bar extends Foo {
-////    /** [|@over{|"name": "1"|}ride[| se{|"name": "2"|}e {@li{|"name": "3"|}nk https://test.c{|"name": "4"|}om} {|"name": "5"|}description |]|]*/
+////    /** @[|over{|"name": "1"|}ride|][| se{|"name": "2"|}e {@li{|"name": "3"|}nk https://test.c{|"name": "4"|}om} {|"name": "5"|}description |]*/
 ////    m() {}
 ////}
 


### PR DESCRIPTION
Fixes #50717