### PR TITLE
Fix equality narrowing and comparable relation for intersections with {}

### DIFF
--- a/tests/baselines/reference/controlFlowOptionalChain.types
+++ b/tests/baselines/reference/controlFlowOptionalChain.types
@@ -1243,9 +1243,9 @@ function f15(o: Thing | undefined, value: number) {
     }
     else {
         o.foo;
->o.foo : number
+>o.foo : string | number
 >o : Thing
->foo : number
+>foo : string | number
     }
 }
 

--- a/tests/baselines/reference/intersectionNarrowing.types
+++ b/tests/baselines/reference/intersectionNarrowing.types
@@ -59,11 +59,11 @@ function f4<T>(x: T & 1 | T & 2) {
 
         case 1: x; break;  // T & 1
 >1 : 1
->x : (T & 1) | (T & 2)
+>x : T & 1
 
         case 2: x; break;  // T & 2
 >2 : 2
->x : (T & 1) | (T & 2)
+>x : T & 2
 
         default: x;  // Should narrow to never
 >x : never

--- a/tests/baselines/reference/unknownControlFlow.errors.txt
+++ b/tests/baselines/reference/unknownControlFlow.errors.txt
@@ -317,3 +317,104 @@ tests/cases/conformance/types/unknown/unknownControlFlow.ts(293,5): error TS2345
     
     type Bar<T extends NullableFoo> = NonNullable<T>[string];
     
+    // Generics and intersections with {}
+    
+    function fx0<T>(value: T & ({} | null)) {
+        if (value === 42) {
+            value;  // T & {}
+        }
+        else {
+            value;  // T & ({} | null)
+        }
+    }
+    
+    function fx1<T extends unknown>(value: T & ({} | null)) {
+        if (value === 42) {
+            value;  // T & {}
+        }
+        else {
+            value;  // T & ({} | null)
+        }
+    }
+    
+    function fx2<T extends {}>(value: T & ({} | null)) {
+        if (value === 42) {
+            value;  // T & {}
+        }
+        else {
+            value;  // T & ({} | null)
+        }
+    }
+    
+    function fx3<T extends {} | undefined>(value: T & ({} | null)) {
+        if (value === 42) {
+            value;  // T & {}
+        }
+        else {
+            value;  // T & ({} | null)
+        }
+    }
+    
+    function fx4<T extends {} | null>(value: T & ({} | null)) {
+        if (value === 42) {
+            value;  // T & {}
+        }
+        else {
+            value;  // T & ({} | null)
+        }
+    }
+    
+    function fx5<T extends {} | null | undefined>(value: T & ({} | null)) {
+        if (value === 42) {
+            value;  // T & {}
+        }
+        else {
+            value;  // T & ({} | null)
+        }
+    }
+    
+    // Double-equals narrowing
+    
+    function fx10(x: string | number, y: number) {
+        if (x == y) {
+            x;  // string | number
+        }
+        else {
+            x;  // string | number
+        }
+        if (x != y) {
+            x;  // string | number
+        }
+        else {
+            x;  // string | number
+        }
+    }
+    
+    // Repros from #50706
+    
+    function SendBlob(encoding: unknown) {
+        if (encoding !== undefined && encoding !== 'utf8') {
+            throw new Error('encoding');
+        }
+        encoding;
+    };
+    
+    function doSomething1<T extends unknown>(value: T): T {
+        if (value === undefined) {
+            return value;
+        }
+        if (value === 42) {
+            throw Error('Meaning of life value');
+        }
+        return value;
+    }
+    
+    function doSomething2(value: unknown): void {
+        if (value === undefined) {
+            return;
+        }
+        if (value === 42) {
+            value;
+        }
+    }
+    

--- a/tests/baselines/reference/unknownControlFlow.js
+++ b/tests/baselines/reference/unknownControlFlow.js
@@ -300,6 +300,107 @@ type NullableFoo = Foo | undefined;
 
 type Bar<T extends NullableFoo> = NonNullable<T>[string];
 
+// Generics and intersections with {}
+
+function fx0<T>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+function fx1<T extends unknown>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+function fx2<T extends {}>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+function fx3<T extends {} | undefined>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+function fx4<T extends {} | null>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+function fx5<T extends {} | null | undefined>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+// Double-equals narrowing
+
+function fx10(x: string | number, y: number) {
+    if (x == y) {
+        x;  // string | number
+    }
+    else {
+        x;  // string | number
+    }
+    if (x != y) {
+        x;  // string | number
+    }
+    else {
+        x;  // string | number
+    }
+}
+
+// Repros from #50706
+
+function SendBlob(encoding: unknown) {
+    if (encoding !== undefined && encoding !== 'utf8') {
+        throw new Error('encoding');
+    }
+    encoding;
+};
+
+function doSomething1<T extends unknown>(value: T): T {
+    if (value === undefined) {
+        return value;
+    }
+    if (value === 42) {
+        throw Error('Meaning of life value');
+    }
+    return value;
+}
+
+function doSomething2(value: unknown): void {
+    if (value === undefined) {
+        return;
+    }
+    if (value === 42) {
+        value;
+    }
+}
+
 
 //// [unknownControlFlow.js]
 "use strict";
@@ -552,6 +653,95 @@ ff1(null, 'foo'); // Error
 ff2(null, 'foo'); // Error
 ff3(null, 'foo');
 ff4(null, 'foo'); // Error
+// Generics and intersections with {}
+function fx0(value) {
+    if (value === 42) {
+        value; // T & {}
+    }
+    else {
+        value; // T & ({} | null)
+    }
+}
+function fx1(value) {
+    if (value === 42) {
+        value; // T & {}
+    }
+    else {
+        value; // T & ({} | null)
+    }
+}
+function fx2(value) {
+    if (value === 42) {
+        value; // T & {}
+    }
+    else {
+        value; // T & ({} | null)
+    }
+}
+function fx3(value) {
+    if (value === 42) {
+        value; // T & {}
+    }
+    else {
+        value; // T & ({} | null)
+    }
+}
+function fx4(value) {
+    if (value === 42) {
+        value; // T & {}
+    }
+    else {
+        value; // T & ({} | null)
+    }
+}
+function fx5(value) {
+    if (value === 42) {
+        value; // T & {}
+    }
+    else {
+        value; // T & ({} | null)
+    }
+}
+// Double-equals narrowing
+function fx10(x, y) {
+    if (x == y) {
+        x; // string | number
+    }
+    else {
+        x; // string | number
+    }
+    if (x != y) {
+        x; // string | number
+    }
+    else {
+        x; // string | number
+    }
+}
+// Repros from #50706
+function SendBlob(encoding) {
+    if (encoding !== undefined && encoding !== 'utf8') {
+        throw new Error('encoding');
+    }
+    encoding;
+}
+;
+function doSomething1(value) {
+    if (value === undefined) {
+        return value;
+    }
+    if (value === 42) {
+        throw Error('Meaning of life value');
+    }
+    return value;
+}
+function doSomething2(value) {
+    if (value === undefined) {
+        return;
+    }
+    if (value === 42) {
+        value;
+    }
+}
 
 
 //// [unknownControlFlow.d.ts]
@@ -601,3 +791,13 @@ type Foo = {
 };
 type NullableFoo = Foo | undefined;
 type Bar<T extends NullableFoo> = NonNullable<T>[string];
+declare function fx0<T>(value: T & ({} | null)): void;
+declare function fx1<T extends unknown>(value: T & ({} | null)): void;
+declare function fx2<T extends {}>(value: T & ({} | null)): void;
+declare function fx3<T extends {} | undefined>(value: T & ({} | null)): void;
+declare function fx4<T extends {} | null>(value: T & ({} | null)): void;
+declare function fx5<T extends {} | null | undefined>(value: T & ({} | null)): void;
+declare function fx10(x: string | number, y: number): void;
+declare function SendBlob(encoding: unknown): void;
+declare function doSomething1<T extends unknown>(value: T): T;
+declare function doSomething2(value: unknown): void;

--- a/tests/baselines/reference/unknownControlFlow.symbols
+++ b/tests/baselines/reference/unknownControlFlow.symbols
@@ -721,3 +721,205 @@ type Bar<T extends NullableFoo> = NonNullable<T>[string];
 >NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
 >T : Symbol(T, Decl(unknownControlFlow.ts, 299, 9))
 
+// Generics and intersections with {}
+
+function fx0<T>(value: T & ({} | null)) {
+>fx0 : Symbol(fx0, Decl(unknownControlFlow.ts, 299, 57))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 303, 13))
+>value : Symbol(value, Decl(unknownControlFlow.ts, 303, 16))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 303, 13))
+
+    if (value === 42) {
+>value : Symbol(value, Decl(unknownControlFlow.ts, 303, 16))
+
+        value;  // T & {}
+>value : Symbol(value, Decl(unknownControlFlow.ts, 303, 16))
+    }
+    else {
+        value;  // T & ({} | null)
+>value : Symbol(value, Decl(unknownControlFlow.ts, 303, 16))
+    }
+}
+
+function fx1<T extends unknown>(value: T & ({} | null)) {
+>fx1 : Symbol(fx1, Decl(unknownControlFlow.ts, 310, 1))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 312, 13))
+>value : Symbol(value, Decl(unknownControlFlow.ts, 312, 32))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 312, 13))
+
+    if (value === 42) {
+>value : Symbol(value, Decl(unknownControlFlow.ts, 312, 32))
+
+        value;  // T & {}
+>value : Symbol(value, Decl(unknownControlFlow.ts, 312, 32))
+    }
+    else {
+        value;  // T & ({} | null)
+>value : Symbol(value, Decl(unknownControlFlow.ts, 312, 32))
+    }
+}
+
+function fx2<T extends {}>(value: T & ({} | null)) {
+>fx2 : Symbol(fx2, Decl(unknownControlFlow.ts, 319, 1))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 321, 13))
+>value : Symbol(value, Decl(unknownControlFlow.ts, 321, 27))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 321, 13))
+
+    if (value === 42) {
+>value : Symbol(value, Decl(unknownControlFlow.ts, 321, 27))
+
+        value;  // T & {}
+>value : Symbol(value, Decl(unknownControlFlow.ts, 321, 27))
+    }
+    else {
+        value;  // T & ({} | null)
+>value : Symbol(value, Decl(unknownControlFlow.ts, 321, 27))
+    }
+}
+
+function fx3<T extends {} | undefined>(value: T & ({} | null)) {
+>fx3 : Symbol(fx3, Decl(unknownControlFlow.ts, 328, 1))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 330, 13))
+>value : Symbol(value, Decl(unknownControlFlow.ts, 330, 39))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 330, 13))
+
+    if (value === 42) {
+>value : Symbol(value, Decl(unknownControlFlow.ts, 330, 39))
+
+        value;  // T & {}
+>value : Symbol(value, Decl(unknownControlFlow.ts, 330, 39))
+    }
+    else {
+        value;  // T & ({} | null)
+>value : Symbol(value, Decl(unknownControlFlow.ts, 330, 39))
+    }
+}
+
+function fx4<T extends {} | null>(value: T & ({} | null)) {
+>fx4 : Symbol(fx4, Decl(unknownControlFlow.ts, 337, 1))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 339, 13))
+>value : Symbol(value, Decl(unknownControlFlow.ts, 339, 34))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 339, 13))
+
+    if (value === 42) {
+>value : Symbol(value, Decl(unknownControlFlow.ts, 339, 34))
+
+        value;  // T & {}
+>value : Symbol(value, Decl(unknownControlFlow.ts, 339, 34))
+    }
+    else {
+        value;  // T & ({} | null)
+>value : Symbol(value, Decl(unknownControlFlow.ts, 339, 34))
+    }
+}
+
+function fx5<T extends {} | null | undefined>(value: T & ({} | null)) {
+>fx5 : Symbol(fx5, Decl(unknownControlFlow.ts, 346, 1))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 348, 13))
+>value : Symbol(value, Decl(unknownControlFlow.ts, 348, 46))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 348, 13))
+
+    if (value === 42) {
+>value : Symbol(value, Decl(unknownControlFlow.ts, 348, 46))
+
+        value;  // T & {}
+>value : Symbol(value, Decl(unknownControlFlow.ts, 348, 46))
+    }
+    else {
+        value;  // T & ({} | null)
+>value : Symbol(value, Decl(unknownControlFlow.ts, 348, 46))
+    }
+}
+
+// Double-equals narrowing
+
+function fx10(x: string | number, y: number) {
+>fx10 : Symbol(fx10, Decl(unknownControlFlow.ts, 355, 1))
+>x : Symbol(x, Decl(unknownControlFlow.ts, 359, 14))
+>y : Symbol(y, Decl(unknownControlFlow.ts, 359, 33))
+
+    if (x == y) {
+>x : Symbol(x, Decl(unknownControlFlow.ts, 359, 14))
+>y : Symbol(y, Decl(unknownControlFlow.ts, 359, 33))
+
+        x;  // string | number
+>x : Symbol(x, Decl(unknownControlFlow.ts, 359, 14))
+    }
+    else {
+        x;  // string | number
+>x : Symbol(x, Decl(unknownControlFlow.ts, 359, 14))
+    }
+    if (x != y) {
+>x : Symbol(x, Decl(unknownControlFlow.ts, 359, 14))
+>y : Symbol(y, Decl(unknownControlFlow.ts, 359, 33))
+
+        x;  // string | number
+>x : Symbol(x, Decl(unknownControlFlow.ts, 359, 14))
+    }
+    else {
+        x;  // string | number
+>x : Symbol(x, Decl(unknownControlFlow.ts, 359, 14))
+    }
+}
+
+// Repros from #50706
+
+function SendBlob(encoding: unknown) {
+>SendBlob : Symbol(SendBlob, Decl(unknownControlFlow.ts, 372, 1))
+>encoding : Symbol(encoding, Decl(unknownControlFlow.ts, 376, 18))
+
+    if (encoding !== undefined && encoding !== 'utf8') {
+>encoding : Symbol(encoding, Decl(unknownControlFlow.ts, 376, 18))
+>undefined : Symbol(undefined)
+>encoding : Symbol(encoding, Decl(unknownControlFlow.ts, 376, 18))
+
+        throw new Error('encoding');
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+    }
+    encoding;
+>encoding : Symbol(encoding, Decl(unknownControlFlow.ts, 376, 18))
+
+};
+
+function doSomething1<T extends unknown>(value: T): T {
+>doSomething1 : Symbol(doSomething1, Decl(unknownControlFlow.ts, 381, 2))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 383, 22))
+>value : Symbol(value, Decl(unknownControlFlow.ts, 383, 41))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 383, 22))
+>T : Symbol(T, Decl(unknownControlFlow.ts, 383, 22))
+
+    if (value === undefined) {
+>value : Symbol(value, Decl(unknownControlFlow.ts, 383, 41))
+>undefined : Symbol(undefined)
+
+        return value;
+>value : Symbol(value, Decl(unknownControlFlow.ts, 383, 41))
+    }
+    if (value === 42) {
+>value : Symbol(value, Decl(unknownControlFlow.ts, 383, 41))
+
+        throw Error('Meaning of life value');
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+    }
+    return value;
+>value : Symbol(value, Decl(unknownControlFlow.ts, 383, 41))
+}
+
+function doSomething2(value: unknown): void {
+>doSomething2 : Symbol(doSomething2, Decl(unknownControlFlow.ts, 391, 1))
+>value : Symbol(value, Decl(unknownControlFlow.ts, 393, 22))
+
+    if (value === undefined) {
+>value : Symbol(value, Decl(unknownControlFlow.ts, 393, 22))
+>undefined : Symbol(undefined)
+
+        return;
+    }
+    if (value === 42) {
+>value : Symbol(value, Decl(unknownControlFlow.ts, 393, 22))
+
+        value;
+>value : Symbol(value, Decl(unknownControlFlow.ts, 393, 22))
+    }
+}
+

--- a/tests/baselines/reference/unknownControlFlow.types
+++ b/tests/baselines/reference/unknownControlFlow.types
@@ -802,3 +802,226 @@ type NullableFoo = Foo | undefined;
 type Bar<T extends NullableFoo> = NonNullable<T>[string];
 >Bar : Bar<T>
 
+// Generics and intersections with {}
+
+function fx0<T>(value: T & ({} | null)) {
+>fx0 : <T>(value: T & ({} | null)) => void
+>value : T & ({} | null)
+>null : null
+
+    if (value === 42) {
+>value === 42 : boolean
+>value : T & ({} | null)
+>42 : 42
+
+        value;  // T & {}
+>value : T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+>value : T & ({} | null)
+    }
+}
+
+function fx1<T extends unknown>(value: T & ({} | null)) {
+>fx1 : <T extends unknown>(value: T & ({} | null)) => void
+>value : T & ({} | null)
+>null : null
+
+    if (value === 42) {
+>value === 42 : boolean
+>value : T & ({} | null)
+>42 : 42
+
+        value;  // T & {}
+>value : T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+>value : T & ({} | null)
+    }
+}
+
+function fx2<T extends {}>(value: T & ({} | null)) {
+>fx2 : <T extends {}>(value: T & ({} | null)) => void
+>value : T & ({} | null)
+>null : null
+
+    if (value === 42) {
+>value === 42 : boolean
+>value : T & ({} | null)
+>42 : 42
+
+        value;  // T & {}
+>value : T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+>value : T & ({} | null)
+    }
+}
+
+function fx3<T extends {} | undefined>(value: T & ({} | null)) {
+>fx3 : <T extends {} | undefined>(value: T & ({} | null)) => void
+>value : T & ({} | null)
+>null : null
+
+    if (value === 42) {
+>value === 42 : boolean
+>value : T & ({} | null)
+>42 : 42
+
+        value;  // T & {}
+>value : T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+>value : T & ({} | null)
+    }
+}
+
+function fx4<T extends {} | null>(value: T & ({} | null)) {
+>fx4 : <T extends {} | null>(value: T & ({} | null)) => void
+>null : null
+>value : T & ({} | null)
+>null : null
+
+    if (value === 42) {
+>value === 42 : boolean
+>value : T & ({} | null)
+>42 : 42
+
+        value;  // T & {}
+>value : T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+>value : T & ({} | null)
+    }
+}
+
+function fx5<T extends {} | null | undefined>(value: T & ({} | null)) {
+>fx5 : <T extends {} | null | undefined>(value: T & ({} | null)) => void
+>null : null
+>value : T & ({} | null)
+>null : null
+
+    if (value === 42) {
+>value === 42 : boolean
+>value : T & ({} | null)
+>42 : 42
+
+        value;  // T & {}
+>value : T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+>value : T & ({} | null)
+    }
+}
+
+// Double-equals narrowing
+
+function fx10(x: string | number, y: number) {
+>fx10 : (x: string | number, y: number) => void
+>x : string | number
+>y : number
+
+    if (x == y) {
+>x == y : boolean
+>x : string | number
+>y : number
+
+        x;  // string | number
+>x : string | number
+    }
+    else {
+        x;  // string | number
+>x : string | number
+    }
+    if (x != y) {
+>x != y : boolean
+>x : string | number
+>y : number
+
+        x;  // string | number
+>x : string | number
+    }
+    else {
+        x;  // string | number
+>x : string | number
+    }
+}
+
+// Repros from #50706
+
+function SendBlob(encoding: unknown) {
+>SendBlob : (encoding: unknown) => void
+>encoding : unknown
+
+    if (encoding !== undefined && encoding !== 'utf8') {
+>encoding !== undefined && encoding !== 'utf8' : boolean
+>encoding !== undefined : boolean
+>encoding : unknown
+>undefined : undefined
+>encoding !== 'utf8' : boolean
+>encoding : {} | null
+>'utf8' : "utf8"
+
+        throw new Error('encoding');
+>new Error('encoding') : Error
+>Error : ErrorConstructor
+>'encoding' : "encoding"
+    }
+    encoding;
+>encoding : "utf8" | undefined
+
+};
+
+function doSomething1<T extends unknown>(value: T): T {
+>doSomething1 : <T extends unknown>(value: T) => T
+>value : T
+
+    if (value === undefined) {
+>value === undefined : boolean
+>value : T
+>undefined : undefined
+
+        return value;
+>value : T
+    }
+    if (value === 42) {
+>value === 42 : boolean
+>value : T & ({} | null)
+>42 : 42
+
+        throw Error('Meaning of life value');
+>Error('Meaning of life value') : Error
+>Error : ErrorConstructor
+>'Meaning of life value' : "Meaning of life value"
+    }
+    return value;
+>value : T & ({} | null)
+}
+
+function doSomething2(value: unknown): void {
+>doSomething2 : (value: unknown) => void
+>value : unknown
+
+    if (value === undefined) {
+>value === undefined : boolean
+>value : unknown
+>undefined : undefined
+
+        return;
+    }
+    if (value === 42) {
+>value === 42 : boolean
+>value : {} | null
+>42 : 42
+
+        value;
+>value : 42
+    }
+}
+

--- a/tests/cases/conformance/types/unknown/unknownControlFlow.ts
+++ b/tests/cases/conformance/types/unknown/unknownControlFlow.ts
@@ -301,3 +301,104 @@ type Foo = { [key: string]: unknown };
 type NullableFoo = Foo | undefined;
 
 type Bar<T extends NullableFoo> = NonNullable<T>[string];
+
+// Generics and intersections with {}
+
+function fx0<T>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+function fx1<T extends unknown>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+function fx2<T extends {}>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+function fx3<T extends {} | undefined>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+function fx4<T extends {} | null>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+function fx5<T extends {} | null | undefined>(value: T & ({} | null)) {
+    if (value === 42) {
+        value;  // T & {}
+    }
+    else {
+        value;  // T & ({} | null)
+    }
+}
+
+// Double-equals narrowing
+
+function fx10(x: string | number, y: number) {
+    if (x == y) {
+        x;  // string | number
+    }
+    else {
+        x;  // string | number
+    }
+    if (x != y) {
+        x;  // string | number
+    }
+    else {
+        x;  // string | number
+    }
+}
+
+// Repros from #50706
+
+function SendBlob(encoding: unknown) {
+    if (encoding !== undefined && encoding !== 'utf8') {
+        throw new Error('encoding');
+    }
+    encoding;
+};
+
+function doSomething1<T extends unknown>(value: T): T {
+    if (value === undefined) {
+        return value;
+    }
+    if (value === 42) {
+        throw Error('Meaning of life value');
+    }
+    return value;
+}
+
+function doSomething2(value: unknown): void {
+    if (value === undefined) {
+        return;
+    }
+    if (value === 42) {
+        value;
+    }
+}


### PR DESCRIPTION
This PR fixes both the original issue in #50706 and the issue reported [here](https://github.com/microsoft/TypeScript/issues/50706#issuecomment-1242366269). It also fixes an issue in control flow analysis of the false branch of `!=` (which should always yield the same result as the true branch of `==`, but didn't). Specifically, in [this test](https://github.com/microsoft/TypeScript/pull/50735/commits/a992a68deb6167edbffb036d764c20b46faac6ea#diff-e4e72b0b9fb71ec93b849c6a7f19ddeb711de8f9b061fee3997ba05b6916d5a8R363), `x` was wrongly narrowed to `number` in the last branch.

Fixes #50706.