### PR TITLE
Fix backticks in our JSDoc comments

### DIFF
--- a/src/lib/es2015.proxy.d.ts
+++ b/src/lib/es2015.proxy.d.ts
@@ -78,7 +78,7 @@ interface ProxyHandler<T extends object> {
      * @param target The original object which is being proxied.
      * @param p The name or `Symbol` of the property to set.
      * @param receiver The object to which the assignment was originally directed.
-     * @returns `A `Boolean` indicating whether or not the property was set.
+     * @returns A `Boolean` indicating whether or not the property was set.
      */
     set?(target: T, p: string | symbol, newValue: any, receiver: any): boolean;
 

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -70,11 +70,11 @@ namespace ts.codefix {
          * `MappedIndirect.ax` and `MappedIndirect.ay` have no declaration node attached (due to their mapped-type
          * parent):
          *
-         * >>> ```ts
-         * >>> type Base = { ax: number; ay: string };
-         * >>> type BaseKeys = keyof Base;
-         * >>> type MappedIndirect = { [K in BaseKeys]: boolean };
-         * >>> ```
+         * ```ts
+         * type Base = { ax: number; ay: string };
+         * type BaseKeys = keyof Base;
+         * type MappedIndirect = { [K in BaseKeys]: boolean };
+         * ```
          *
          * In such cases, we assume the declaration to be a `PropertySignature`.
          */

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1214,7 +1214,7 @@ namespace ts {
         isGlobalCompletion: boolean;
         isMemberCompletion: boolean;
         /**
-         * In the absence of `CompletionEntry["replacementSpan"], the editor may choose whether to use
+         * In the absence of `CompletionEntry["replacementSpan"]`, the editor may choose whether to use
          * this span or its default one. If `CompletionEntry["replacementSpan"]` is defined, that span
          * must be used to commit that completion entry.
          */

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1659,7 +1659,7 @@ namespace ts {
     /**
      * Returns true if the cursor at position in sourceFile is within a comment.
      *
-     * @param tokenAtPosition Must equal `getTokenAtPosition(sourceFile, position)
+     * @param tokenAtPosition Must equal `getTokenAtPosition(sourceFile, position)`
      * @param predicate Additional predicate to test on the comment range.
      */
     export function isInComment(sourceFile: SourceFile, position: number, tokenAtPosition?: Node): CommentRange | undefined {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6547,7 +6547,7 @@ declare namespace ts {
         isGlobalCompletion: boolean;
         isMemberCompletion: boolean;
         /**
-         * In the absence of `CompletionEntry["replacementSpan"], the editor may choose whether to use
+         * In the absence of `CompletionEntry["replacementSpan"]`, the editor may choose whether to use
          * this span or its default one. If `CompletionEntry["replacementSpan"]` is defined, that span
          * must be used to commit that completion entry.
          */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6547,7 +6547,7 @@ declare namespace ts {
         isGlobalCompletion: boolean;
         isMemberCompletion: boolean;
         /**
-         * In the absence of `CompletionEntry["replacementSpan"], the editor may choose whether to use
+         * In the absence of `CompletionEntry["replacementSpan"]`, the editor may choose whether to use
          * this span or its default one. If `CompletionEntry["replacementSpan"]` is defined, that span
          * must be used to commit that completion entry.
          */


### PR DESCRIPTION
Found via `eslint-plugin-tsdoc`, split out from #50736.

These end up rendering very weird in VS Code tooltips.