### PR TITLE
Adjust constraint caluclation for T[U]

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12173,6 +12173,10 @@ namespace ts {
                 if (indexedAccess) {
                     return indexedAccess;
                 }
+                const bound = getBoundOfIndexedAccess(type.objectType, indexConstraint);
+                if (bound) {
+                    return bound;
+                }
             }
             const objectConstraint = getSimplifiedTypeOrConstraint(type.objectType);
             if (objectConstraint && objectConstraint !== type.objectType) {
@@ -12389,7 +12393,10 @@ namespace ts {
                     }
                     const baseObjectType = getBaseConstraint((t as IndexedAccessType).objectType);
                     const baseIndexType = getBaseConstraint((t as IndexedAccessType).indexType);
-                    const baseIndexedAccess = baseObjectType && baseIndexType && getIndexedAccessTypeOrUndefined(baseObjectType, baseIndexType, (t as IndexedAccessType).accessFlags);
+                    let baseIndexedAccess = baseObjectType && baseIndexType && getIndexedAccessTypeOrUndefined(baseObjectType, baseIndexType, (t as IndexedAccessType).accessFlags);
+                    if (!baseIndexedAccess && baseObjectType && baseIndexType) {
+                        return getBoundOfIndexedAccess(baseObjectType, baseIndexType);
+                    }
                     return baseIndexedAccess && getBaseConstraint(baseIndexedAccess);
                 }
                 if (t.flags & TypeFlags.Conditional) {
@@ -12401,6 +12408,30 @@ namespace ts {
                 }
                 return t;
             }
+        }
+
+        function getBoundOfIndexedAccess(objectType: Type, indexType: Type) {
+            // In `getIndexedAccessTypeOrUndefined`, given T[U], we only produce a result if `T` contains a match for `U` exactly. So if U = string,
+            // `T[string]` requires `T` have an index signature. This is quite strict. When relating types, we relate keys to index signatures and vice-versa.
+            // Similarly, here we allow ourselves to return concrete property types for index types which would normally require an index signature to match.
+            let types: Type[] | undefined;
+            const props = objectType.flags & TypeFlags.Intersection ? getPropertiesOfUnionOrIntersectionType(objectType as IntersectionType) : getPropertiesOfType(objectType);
+            for (const prop of props) {
+                // Skip over ignored JSX and symbol-named members
+                if (isApplicableIndexType(getLiteralTypeFromProperty(prop, TypeFlags.StringOrNumberLiteralOrUnique), indexType)) {
+                    const propType = getNonMissingTypeOfSymbol(prop);
+                    types = append(types, propType);
+                }
+            }
+            for (const info of getIndexInfosOfType(objectType)) {
+                if (isApplicableIndexType(info.keyType, indexType)) {
+                    types = append(types, info.type);
+                }
+            }
+            if (types) {
+                return getUnionType(types);
+            }
+            return undefined;
         }
 
         function getApparentTypeOfIntersectionType(type: IntersectionType) {

--- a/tests/baselines/reference/genericStringMappingInIndexedAccessKeyConstraint.js
+++ b/tests/baselines/reference/genericStringMappingInIndexedAccessKeyConstraint.js
@@ -1,0 +1,39 @@
+//// [genericStringMappingInIndexedAccessKeyConstraint.ts]
+export function childByTag<K extends Uppercase<keyof HTMLElementTagNameMap>>(
+    element: Element,
+    tagName: K,
+): HTMLElementTagNameMap[Lowercase<K>] | null; // this overload is rejected
+export function childByTag(element: Element, tagName: string): Element | null;
+export function childByTag(element: Element, tagName: string): Element | null {
+    for (let i = 0; i < element.childElementCount; i++) {
+        if (element.children[i].nodeName === tagName) {
+            return element.children[i];
+        }
+    }
+
+    return null;
+}
+
+const anchor = childByTag(document.documentElement, 'A');
+if (anchor) {
+    console.log(anchor.href); // Would be rejected without the first overload.
+};
+
+//// [genericStringMappingInIndexedAccessKeyConstraint.js]
+"use strict";
+exports.__esModule = true;
+exports.childByTag = void 0;
+function childByTag(element, tagName) {
+    for (var i = 0; i < element.childElementCount; i++) {
+        if (element.children[i].nodeName === tagName) {
+            return element.children[i];
+        }
+    }
+    return null;
+}
+exports.childByTag = childByTag;
+var anchor = childByTag(document.documentElement, 'A');
+if (anchor) {
+    console.log(anchor.href); // Would be rejected without the first overload.
+}
+;

--- a/tests/baselines/reference/genericStringMappingInIndexedAccessKeyConstraint.symbols
+++ b/tests/baselines/reference/genericStringMappingInIndexedAccessKeyConstraint.symbols
@@ -1,0 +1,81 @@
+=== tests/cases/compiler/genericStringMappingInIndexedAccessKeyConstraint.ts ===
+export function childByTag<K extends Uppercase<keyof HTMLElementTagNameMap>>(
+>childByTag : Symbol(childByTag, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 0, 0), Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 3, 46), Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 4, 78))
+>K : Symbol(K, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 0, 27))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+>HTMLElementTagNameMap : Symbol(HTMLElementTagNameMap, Decl(lib.dom.d.ts, --, --))
+
+    element: Element,
+>element : Symbol(element, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 0, 77))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    tagName: K,
+>tagName : Symbol(tagName, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 1, 21))
+>K : Symbol(K, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 0, 27))
+
+): HTMLElementTagNameMap[Lowercase<K>] | null; // this overload is rejected
+>HTMLElementTagNameMap : Symbol(HTMLElementTagNameMap, Decl(lib.dom.d.ts, --, --))
+>Lowercase : Symbol(Lowercase, Decl(lib.es5.d.ts, --, --))
+>K : Symbol(K, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 0, 27))
+
+export function childByTag(element: Element, tagName: string): Element | null;
+>childByTag : Symbol(childByTag, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 0, 0), Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 3, 46), Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 4, 78))
+>element : Symbol(element, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 4, 27))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 4, 44))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+export function childByTag(element: Element, tagName: string): Element | null {
+>childByTag : Symbol(childByTag, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 0, 0), Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 3, 46), Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 4, 78))
+>element : Symbol(element, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 5, 27))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 5, 44))
+>Element : Symbol(Element, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    for (let i = 0; i < element.childElementCount; i++) {
+>i : Symbol(i, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 6, 12))
+>i : Symbol(i, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 6, 12))
+>element.childElementCount : Symbol(ParentNode.childElementCount, Decl(lib.dom.d.ts, --, --))
+>element : Symbol(element, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 5, 27))
+>childElementCount : Symbol(ParentNode.childElementCount, Decl(lib.dom.d.ts, --, --))
+>i : Symbol(i, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 6, 12))
+
+        if (element.children[i].nodeName === tagName) {
+>element.children[i].nodeName : Symbol(Node.nodeName, Decl(lib.dom.d.ts, --, --))
+>element.children : Symbol(ParentNode.children, Decl(lib.dom.d.ts, --, --))
+>element : Symbol(element, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 5, 27))
+>children : Symbol(ParentNode.children, Decl(lib.dom.d.ts, --, --))
+>i : Symbol(i, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 6, 12))
+>nodeName : Symbol(Node.nodeName, Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 5, 44))
+
+            return element.children[i];
+>element.children : Symbol(ParentNode.children, Decl(lib.dom.d.ts, --, --))
+>element : Symbol(element, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 5, 27))
+>children : Symbol(ParentNode.children, Decl(lib.dom.d.ts, --, --))
+>i : Symbol(i, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 6, 12))
+        }
+    }
+
+    return null;
+}
+
+const anchor = childByTag(document.documentElement, 'A');
+>anchor : Symbol(anchor, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 15, 5))
+>childByTag : Symbol(childByTag, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 0, 0), Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 3, 46), Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 4, 78))
+>document.documentElement : Symbol(Document.documentElement, Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>documentElement : Symbol(Document.documentElement, Decl(lib.dom.d.ts, --, --))
+
+if (anchor) {
+>anchor : Symbol(anchor, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 15, 5))
+
+    console.log(anchor.href); // Would be rejected without the first overload.
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>anchor.href : Symbol(HTMLHyperlinkElementUtils.href, Decl(lib.dom.d.ts, --, --))
+>anchor : Symbol(anchor, Decl(genericStringMappingInIndexedAccessKeyConstraint.ts, 15, 5))
+>href : Symbol(HTMLHyperlinkElementUtils.href, Decl(lib.dom.d.ts, --, --))
+
+};

--- a/tests/baselines/reference/genericStringMappingInIndexedAccessKeyConstraint.types
+++ b/tests/baselines/reference/genericStringMappingInIndexedAccessKeyConstraint.types
@@ -1,0 +1,82 @@
+=== tests/cases/compiler/genericStringMappingInIndexedAccessKeyConstraint.ts ===
+export function childByTag<K extends Uppercase<keyof HTMLElementTagNameMap>>(
+>childByTag : { <K extends "OBJECT" | "A" | "ABBR" | "ADDRESS" | "AREA" | "ARTICLE" | "ASIDE" | "AUDIO" | "B" | "BASE" | "BDI" | "BDO" | "BLOCKQUOTE" | "BODY" | "BR" | "BUTTON" | "CANVAS" | "CAPTION" | "CITE" | "CODE" | "COL" | "COLGROUP" | "DATA" | "DATALIST" | "DD" | "DEL" | "DETAILS" | "DFN" | "DIALOG" | "DIV" | "DL" | "DT" | "EM" | "EMBED" | "FIELDSET" | "FIGCAPTION" | "FIGURE" | "FOOTER" | "FORM" | "H1" | "H2" | "H3" | "H4" | "H5" | "H6" | "HEAD" | "HEADER" | "HGROUP" | "HR" | "HTML" | "I" | "IFRAME" | "IMG" | "INPUT" | "INS" | "KBD" | "LABEL" | "LEGEND" | "LI" | "LINK" | "MAIN" | "MAP" | "MARK" | "MENU" | "META" | "METER" | "NAV" | "NOSCRIPT" | "OL" | "OPTGROUP" | "OPTION" | "OUTPUT" | "P" | "PICTURE" | "PRE" | "PROGRESS" | "Q" | "RP" | "RT" | "RUBY" | "S" | "SAMP" | "SCRIPT" | "SECTION" | "SELECT" | "SLOT" | "SMALL" | "SOURCE" | "SPAN" | "STRONG" | "STYLE" | "SUB" | "SUMMARY" | "SUP" | "TABLE" | "TBODY" | "TD" | "TEMPLATE" | "TEXTAREA" | "TFOOT" | "TH" | "THEAD" | "TIME" | "TITLE" | "TR" | "TRACK" | "U" | "UL" | "VAR" | "VIDEO" | "WBR">(element: Element, tagName: K): HTMLElementTagNameMap[Lowercase<K>] | null; (element: Element, tagName: string): Element; }
+
+    element: Element,
+>element : Element
+
+    tagName: K,
+>tagName : K
+
+): HTMLElementTagNameMap[Lowercase<K>] | null; // this overload is rejected
+>null : null
+
+export function childByTag(element: Element, tagName: string): Element | null;
+>childByTag : { <K extends "OBJECT" | "A" | "ABBR" | "ADDRESS" | "AREA" | "ARTICLE" | "ASIDE" | "AUDIO" | "B" | "BASE" | "BDI" | "BDO" | "BLOCKQUOTE" | "BODY" | "BR" | "BUTTON" | "CANVAS" | "CAPTION" | "CITE" | "CODE" | "COL" | "COLGROUP" | "DATA" | "DATALIST" | "DD" | "DEL" | "DETAILS" | "DFN" | "DIALOG" | "DIV" | "DL" | "DT" | "EM" | "EMBED" | "FIELDSET" | "FIGCAPTION" | "FIGURE" | "FOOTER" | "FORM" | "H1" | "H2" | "H3" | "H4" | "H5" | "H6" | "HEAD" | "HEADER" | "HGROUP" | "HR" | "HTML" | "I" | "IFRAME" | "IMG" | "INPUT" | "INS" | "KBD" | "LABEL" | "LEGEND" | "LI" | "LINK" | "MAIN" | "MAP" | "MARK" | "MENU" | "META" | "METER" | "NAV" | "NOSCRIPT" | "OL" | "OPTGROUP" | "OPTION" | "OUTPUT" | "P" | "PICTURE" | "PRE" | "PROGRESS" | "Q" | "RP" | "RT" | "RUBY" | "S" | "SAMP" | "SCRIPT" | "SECTION" | "SELECT" | "SLOT" | "SMALL" | "SOURCE" | "SPAN" | "STRONG" | "STYLE" | "SUB" | "SUMMARY" | "SUP" | "TABLE" | "TBODY" | "TD" | "TEMPLATE" | "TEXTAREA" | "TFOOT" | "TH" | "THEAD" | "TIME" | "TITLE" | "TR" | "TRACK" | "U" | "UL" | "VAR" | "VIDEO" | "WBR">(element: Element, tagName: K): HTMLElementTagNameMap[Lowercase<K>]; (element: Element, tagName: string): Element | null; }
+>element : Element
+>tagName : string
+>null : null
+
+export function childByTag(element: Element, tagName: string): Element | null {
+>childByTag : { <K extends "OBJECT" | "A" | "ABBR" | "ADDRESS" | "AREA" | "ARTICLE" | "ASIDE" | "AUDIO" | "B" | "BASE" | "BDI" | "BDO" | "BLOCKQUOTE" | "BODY" | "BR" | "BUTTON" | "CANVAS" | "CAPTION" | "CITE" | "CODE" | "COL" | "COLGROUP" | "DATA" | "DATALIST" | "DD" | "DEL" | "DETAILS" | "DFN" | "DIALOG" | "DIV" | "DL" | "DT" | "EM" | "EMBED" | "FIELDSET" | "FIGCAPTION" | "FIGURE" | "FOOTER" | "FORM" | "H1" | "H2" | "H3" | "H4" | "H5" | "H6" | "HEAD" | "HEADER" | "HGROUP" | "HR" | "HTML" | "I" | "IFRAME" | "IMG" | "INPUT" | "INS" | "KBD" | "LABEL" | "LEGEND" | "LI" | "LINK" | "MAIN" | "MAP" | "MARK" | "MENU" | "META" | "METER" | "NAV" | "NOSCRIPT" | "OL" | "OPTGROUP" | "OPTION" | "OUTPUT" | "P" | "PICTURE" | "PRE" | "PROGRESS" | "Q" | "RP" | "RT" | "RUBY" | "S" | "SAMP" | "SCRIPT" | "SECTION" | "SELECT" | "SLOT" | "SMALL" | "SOURCE" | "SPAN" | "STRONG" | "STYLE" | "SUB" | "SUMMARY" | "SUP" | "TABLE" | "TBODY" | "TD" | "TEMPLATE" | "TEXTAREA" | "TFOOT" | "TH" | "THEAD" | "TIME" | "TITLE" | "TR" | "TRACK" | "U" | "UL" | "VAR" | "VIDEO" | "WBR">(element: Element, tagName: K): HTMLElementTagNameMap[Lowercase<K>]; (element: Element, tagName: string): Element; }
+>element : Element
+>tagName : string
+>null : null
+
+    for (let i = 0; i < element.childElementCount; i++) {
+>i : number
+>0 : 0
+>i < element.childElementCount : boolean
+>i : number
+>element.childElementCount : number
+>element : Element
+>childElementCount : number
+>i++ : number
+>i : number
+
+        if (element.children[i].nodeName === tagName) {
+>element.children[i].nodeName === tagName : boolean
+>element.children[i].nodeName : string
+>element.children[i] : Element
+>element.children : HTMLCollection
+>element : Element
+>children : HTMLCollection
+>i : number
+>nodeName : string
+>tagName : string
+
+            return element.children[i];
+>element.children[i] : Element
+>element.children : HTMLCollection
+>element : Element
+>children : HTMLCollection
+>i : number
+        }
+    }
+
+    return null;
+>null : null
+}
+
+const anchor = childByTag(document.documentElement, 'A');
+>anchor : HTMLAnchorElement
+>childByTag(document.documentElement, 'A') : HTMLAnchorElement
+>childByTag : { <K extends "OBJECT" | "A" | "ABBR" | "ADDRESS" | "AREA" | "ARTICLE" | "ASIDE" | "AUDIO" | "B" | "BASE" | "BDI" | "BDO" | "BLOCKQUOTE" | "BODY" | "BR" | "BUTTON" | "CANVAS" | "CAPTION" | "CITE" | "CODE" | "COL" | "COLGROUP" | "DATA" | "DATALIST" | "DD" | "DEL" | "DETAILS" | "DFN" | "DIALOG" | "DIV" | "DL" | "DT" | "EM" | "EMBED" | "FIELDSET" | "FIGCAPTION" | "FIGURE" | "FOOTER" | "FORM" | "H1" | "H2" | "H3" | "H4" | "H5" | "H6" | "HEAD" | "HEADER" | "HGROUP" | "HR" | "HTML" | "I" | "IFRAME" | "IMG" | "INPUT" | "INS" | "KBD" | "LABEL" | "LEGEND" | "LI" | "LINK" | "MAIN" | "MAP" | "MARK" | "MENU" | "META" | "METER" | "NAV" | "NOSCRIPT" | "OL" | "OPTGROUP" | "OPTION" | "OUTPUT" | "P" | "PICTURE" | "PRE" | "PROGRESS" | "Q" | "RP" | "RT" | "RUBY" | "S" | "SAMP" | "SCRIPT" | "SECTION" | "SELECT" | "SLOT" | "SMALL" | "SOURCE" | "SPAN" | "STRONG" | "STYLE" | "SUB" | "SUMMARY" | "SUP" | "TABLE" | "TBODY" | "TD" | "TEMPLATE" | "TEXTAREA" | "TFOOT" | "TH" | "THEAD" | "TIME" | "TITLE" | "TR" | "TRACK" | "U" | "UL" | "VAR" | "VIDEO" | "WBR">(element: Element, tagName: K): HTMLElementTagNameMap[Lowercase<K>]; (element: Element, tagName: string): Element; }
+>document.documentElement : HTMLElement
+>document : Document
+>documentElement : HTMLElement
+>'A' : "A"
+
+if (anchor) {
+>anchor : HTMLAnchorElement
+
+    console.log(anchor.href); // Would be rejected without the first overload.
+>console.log(anchor.href) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>anchor.href : string
+>anchor : HTMLAnchorElement
+>href : string
+
+};

--- a/tests/baselines/reference/mappedTypeErrors2.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors2.errors.txt
@@ -1,12 +1,11 @@
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(9,30): error TS2536: Type 'K' cannot be used to index type 'T1<K>'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(13,30): error TS2536: Type 'K' cannot be used to index type 'T3'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(15,38): error TS2536: Type 'S' cannot be used to index type '{ [key in AB[S]]: true; }'.
-tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(15,47): error TS2322: Type 'AB[S]' is not assignable to type 'string | number | symbol'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(15,47): error TS2536: Type 'S' cannot be used to index type 'AB'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(17,49): error TS2536: Type 'L' cannot be used to index type '{ [key in AB[S]]: true; }'.
 
 
-==== tests/cases/conformance/types/mapped/mappedTypeErrors2.ts (6 errors) ====
+==== tests/cases/conformance/types/mapped/mappedTypeErrors2.ts (5 errors) ====
     // Repros from #17238
     
     type AB = {
@@ -28,8 +27,6 @@ tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(17,49): error TS2536: 
     type T5<S extends 'a'|'b'|'extra'> = {[key in AB[S]]: true}[S]; // Error
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2536: Type 'S' cannot be used to index type '{ [key in AB[S]]: true; }'.
-                                                  ~~~~~
-!!! error TS2322: Type 'AB[S]' is not assignable to type 'string | number | symbol'.
                                                   ~~~~~
 !!! error TS2536: Type 'S' cannot be used to index type 'AB'.
     

--- a/tests/cases/compiler/genericStringMappingInIndexedAccessKeyConstraint.ts
+++ b/tests/cases/compiler/genericStringMappingInIndexedAccessKeyConstraint.ts
@@ -1,0 +1,19 @@
+export function childByTag<K extends Uppercase<keyof HTMLElementTagNameMap>>(
+    element: Element,
+    tagName: K,
+): HTMLElementTagNameMap[Lowercase<K>] | null; // this overload is rejected
+export function childByTag(element: Element, tagName: string): Element | null;
+export function childByTag(element: Element, tagName: string): Element | null {
+    for (let i = 0; i < element.childElementCount; i++) {
+        if (element.children[i].nodeName === tagName) {
+            return element.children[i];
+        }
+    }
+
+    return null;
+}
+
+const anchor = childByTag(document.documentElement, 'A');
+if (anchor) {
+    console.log(anchor.href); // Would be rejected without the first overload.
+};


### PR DESCRIPTION
To return the type of all properties in `T` which are compatible with `U`, similar to how properties are related to index signatures, rather than only exact matches.

Fixes #50754
