### PR TITLE
Partially revert #41044, restoring parameter destructurings in d.ts files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6116,29 +6116,19 @@ namespace ts {
                 return parameterNode;
 
                 function cloneBindingName(node: BindingName): BindingName {
-                    return elideInitializerAndPropertyRenamingAndSetEmitFlags(node) as BindingName;
-                    function elideInitializerAndPropertyRenamingAndSetEmitFlags(node: Node): Node {
+                    return elideInitializerAndSetEmitFlags(node) as BindingName;
+                    function elideInitializerAndSetEmitFlags(node: Node): Node {
                         if (context.tracker.trackSymbol && isComputedPropertyName(node) && isLateBindableName(node)) {
                             trackComputedName(node.expression, context.enclosingDeclaration, context);
                         }
-                        let visited = visitEachChild(node, elideInitializerAndPropertyRenamingAndSetEmitFlags, nullTransformationContext, /*nodesVisitor*/ undefined, elideInitializerAndPropertyRenamingAndSetEmitFlags)!;
+                        let visited = visitEachChild(node, elideInitializerAndSetEmitFlags, nullTransformationContext, /*nodesVisitor*/ undefined, elideInitializerAndSetEmitFlags)!;
                         if (isBindingElement(visited)) {
-                            if (visited.propertyName && isIdentifier(visited.propertyName) && isIdentifier(visited.name) && !isStringAKeyword(idText(visited.propertyName))) {
-                                visited = factory.updateBindingElement(
-                                    visited,
-                                    visited.dotDotDotToken,
-                                    /* propertyName*/ undefined,
-                                    visited.propertyName,
-                                    /*initializer*/ undefined);
-                            }
-                            else {
-                                visited = factory.updateBindingElement(
-                                    visited,
-                                    visited.dotDotDotToken,
-                                    visited.propertyName,
-                                    visited.name,
-                                    /*initializer*/ undefined);
-                            }
+                            visited = factory.updateBindingElement(
+                                visited,
+                                visited.dotDotDotToken,
+                                visited.propertyName,
+                                visited.name,
+                                /*initializer*/ undefined);
                         }
                         if (!nodeIsSynthesized(visited)) {
                             visited = factory.cloneNode(visited);

--- a/tests/baselines/reference/contextuallyTypedBindingInitializerNegative.types
+++ b/tests/baselines/reference/contextuallyTypedBindingInitializerNegative.types
@@ -5,7 +5,7 @@ interface Show {
 >x : number
 }
 function f({ show: showRename = v => v }: Show) {}
->f : ({ show }: Show) => void
+>f : ({ show: showRename }: Show) => void
 >show : any
 >showRename : (x: number) => string
 >v => v : (v: number) => number
@@ -32,7 +32,7 @@ interface Nested {
 >nested : Show
 }
 function ff({ nested: nestedRename = { show: v => v } }: Nested) {}
->ff : ({ nested }: Nested) => void
+>ff : ({ nested: nestedRename }: Nested) => void
 >nested : any
 >nestedRename : Show
 >{ show: v => v } : { show: (v: number) => number; }

--- a/tests/baselines/reference/declarationEmitBindingPatternWithReservedWord.js
+++ b/tests/baselines/reference/declarationEmitBindingPatternWithReservedWord.js
@@ -44,5 +44,5 @@ export interface GetLocalesOptions<T extends LocaleData> {
     config?: LocaleConfig<T> | undefined;
     name?: string;
 }
-export declare const getLocales: <T extends LocaleData>({ app, name, default: defaultLocalesConfig, config, }: GetLocalesOptions<T>) => ConvertLocaleConfig<T>;
+export declare const getLocales: <T extends LocaleData>({ app, name, default: defaultLocalesConfig, config: userLocalesConfig, }: GetLocalesOptions<T>) => ConvertLocaleConfig<T>;
 export {};

--- a/tests/baselines/reference/declarationEmitBindingPatternWithReservedWord.types
+++ b/tests/baselines/reference/declarationEmitBindingPatternWithReservedWord.types
@@ -26,8 +26,8 @@ export interface GetLocalesOptions<T extends LocaleData> {
 }
 
 export const getLocales = <T extends LocaleData>({
->getLocales : <T extends LocaleData>({ app, name, default: defaultLocalesConfig, config, }: GetLocalesOptions<T>) => ConvertLocaleConfig<T>
-><T extends LocaleData>({    app,    name,    default: defaultLocalesConfig,    config: userLocalesConfig = {},}: GetLocalesOptions<T>): ConvertLocaleConfig<T> => {    return defaultLocalesConfig;} : <T extends LocaleData>({ app, name, default: defaultLocalesConfig, config, }: GetLocalesOptions<T>) => ConvertLocaleConfig<T>
+>getLocales : <T extends LocaleData>({ app, name, default: defaultLocalesConfig, config: userLocalesConfig, }: GetLocalesOptions<T>) => ConvertLocaleConfig<T>
+><T extends LocaleData>({    app,    name,    default: defaultLocalesConfig,    config: userLocalesConfig = {},}: GetLocalesOptions<T>): ConvertLocaleConfig<T> => {    return defaultLocalesConfig;} : <T extends LocaleData>({ app, name, default: defaultLocalesConfig, config: userLocalesConfig, }: GetLocalesOptions<T>) => ConvertLocaleConfig<T>
 
     app,
 >app : unknown

--- a/tests/baselines/reference/declarationEmitBindingPatterns.js
+++ b/tests/baselines/reference/declarationEmitBindingPatterns.js
@@ -18,7 +18,7 @@ function f(_a, _b, _c) {
 
 
 //// [declarationEmitBindingPatterns.d.ts]
-declare const k: ({ x }: {
+declare const k: ({ x: z }: {
     x?: string;
 }) => void;
 declare var a: any;

--- a/tests/baselines/reference/declarationEmitBindingPatterns.types
+++ b/tests/baselines/reference/declarationEmitBindingPatterns.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/declarationEmitBindingPatterns.ts ===
 const k = ({x: z = 'y'}) => { }
->k : ({ x }: { x?: string; }) => void
->({x: z = 'y'}) => { } : ({ x }: { x?: string; }) => void
+>k : ({ x: z }: { x?: string; }) => void
+>({x: z = 'y'}) => { } : ({ x: z }: { x?: string; }) => void
 >x : any
 >z : string
 >'y' : "y"

--- a/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.js
+++ b/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.js
@@ -1,0 +1,46 @@
+//// [declarationEmitDuplicateParameterDestructuring.ts]
+export const fn1 = ({ prop: a, prop: b }: { prop: number }) => a + b;
+
+export const fn2 = ({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b;
+
+
+
+
+//// [declarationEmitDuplicateParameterDestructuring.d.ts]
+export declare const fn1: ({ prop, prop }: {
+    prop: number;
+}) => number;
+export declare const fn2: ({ prop }: {
+    prop: number;
+}, { prop }: {
+    prop: number;
+}) => number;
+
+
+//// [DtsFileErrors]
+
+
+tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.d.ts(1,30): error TS2300: Duplicate identifier 'prop'.
+tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.d.ts(1,36): error TS2300: Duplicate identifier 'prop'.
+tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.d.ts(4,30): error TS2300: Duplicate identifier 'prop'.
+tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.d.ts(6,6): error TS2300: Duplicate identifier 'prop'.
+
+
+==== tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.d.ts (4 errors) ====
+    export declare const fn1: ({ prop, prop }: {
+                                 ~~~~
+!!! error TS2300: Duplicate identifier 'prop'.
+                                       ~~~~
+!!! error TS2300: Duplicate identifier 'prop'.
+        prop: number;
+    }) => number;
+    export declare const fn2: ({ prop }: {
+                                 ~~~~
+!!! error TS2300: Duplicate identifier 'prop'.
+        prop: number;
+    }, { prop }: {
+         ~~~~
+!!! error TS2300: Duplicate identifier 'prop'.
+        prop: number;
+    }) => number;
+    

--- a/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.js
+++ b/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.js
@@ -7,40 +7,11 @@ export const fn2 = ({ prop: a }: { prop: number }, { prop: b }: { prop: number }
 
 
 //// [declarationEmitDuplicateParameterDestructuring.d.ts]
-export declare const fn1: ({ prop, prop }: {
+export declare const fn1: ({ prop: a, prop: b }: {
     prop: number;
 }) => number;
-export declare const fn2: ({ prop }: {
+export declare const fn2: ({ prop: a }: {
     prop: number;
-}, { prop }: {
+}, { prop: b }: {
     prop: number;
 }) => number;
-
-
-//// [DtsFileErrors]
-
-
-tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.d.ts(1,30): error TS2300: Duplicate identifier 'prop'.
-tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.d.ts(1,36): error TS2300: Duplicate identifier 'prop'.
-tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.d.ts(4,30): error TS2300: Duplicate identifier 'prop'.
-tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.d.ts(6,6): error TS2300: Duplicate identifier 'prop'.
-
-
-==== tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.d.ts (4 errors) ====
-    export declare const fn1: ({ prop, prop }: {
-                                 ~~~~
-!!! error TS2300: Duplicate identifier 'prop'.
-                                       ~~~~
-!!! error TS2300: Duplicate identifier 'prop'.
-        prop: number;
-    }) => number;
-    export declare const fn2: ({ prop }: {
-                                 ~~~~
-!!! error TS2300: Duplicate identifier 'prop'.
-        prop: number;
-    }, { prop }: {
-         ~~~~
-!!! error TS2300: Duplicate identifier 'prop'.
-        prop: number;
-    }) => number;
-    

--- a/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.symbols
+++ b/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.ts ===
+export const fn1 = ({ prop: a, prop: b }: { prop: number }) => a + b;
+>fn1 : Symbol(fn1, Decl(declarationEmitDuplicateParameterDestructuring.ts, 0, 12))
+>prop : Symbol(prop, Decl(declarationEmitDuplicateParameterDestructuring.ts, 0, 43))
+>a : Symbol(a, Decl(declarationEmitDuplicateParameterDestructuring.ts, 0, 21))
+>prop : Symbol(prop, Decl(declarationEmitDuplicateParameterDestructuring.ts, 0, 43))
+>b : Symbol(b, Decl(declarationEmitDuplicateParameterDestructuring.ts, 0, 30))
+>prop : Symbol(prop, Decl(declarationEmitDuplicateParameterDestructuring.ts, 0, 43))
+>a : Symbol(a, Decl(declarationEmitDuplicateParameterDestructuring.ts, 0, 21))
+>b : Symbol(b, Decl(declarationEmitDuplicateParameterDestructuring.ts, 0, 30))
+
+export const fn2 = ({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b;
+>fn2 : Symbol(fn2, Decl(declarationEmitDuplicateParameterDestructuring.ts, 2, 12))
+>prop : Symbol(prop, Decl(declarationEmitDuplicateParameterDestructuring.ts, 2, 34))
+>a : Symbol(a, Decl(declarationEmitDuplicateParameterDestructuring.ts, 2, 21))
+>prop : Symbol(prop, Decl(declarationEmitDuplicateParameterDestructuring.ts, 2, 34))
+>prop : Symbol(prop, Decl(declarationEmitDuplicateParameterDestructuring.ts, 2, 65))
+>b : Symbol(b, Decl(declarationEmitDuplicateParameterDestructuring.ts, 2, 52))
+>prop : Symbol(prop, Decl(declarationEmitDuplicateParameterDestructuring.ts, 2, 65))
+>a : Symbol(a, Decl(declarationEmitDuplicateParameterDestructuring.ts, 2, 21))
+>b : Symbol(b, Decl(declarationEmitDuplicateParameterDestructuring.ts, 2, 52))
+

--- a/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.types
+++ b/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.ts ===
 export const fn1 = ({ prop: a, prop: b }: { prop: number }) => a + b;
->fn1 : ({ prop, prop }: {    prop: number;}) => number
->({ prop: a, prop: b }: { prop: number }) => a + b : ({ prop, prop }: {    prop: number;}) => number
+>fn1 : ({ prop: a, prop: b }: {    prop: number;}) => number
+>({ prop: a, prop: b }: { prop: number }) => a + b : ({ prop: a, prop: b }: {    prop: number;}) => number
 >prop : any
 >a : number
 >prop : any
@@ -12,8 +12,8 @@ export const fn1 = ({ prop: a, prop: b }: { prop: number }) => a + b;
 >b : number
 
 export const fn2 = ({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b;
->fn2 : ({ prop }: {    prop: number;}, { prop }: {    prop: number;}) => number
->({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b : ({ prop }: {    prop: number;}, { prop }: {    prop: number;}) => number
+>fn2 : ({ prop: a }: {    prop: number;}, { prop: b }: {    prop: number;}) => number
+>({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b : ({ prop: a }: {    prop: number;}, { prop: b }: {    prop: number;}) => number
 >prop : any
 >a : number
 >prop : number

--- a/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.types
+++ b/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.types
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.ts ===
+export const fn1 = ({ prop: a, prop: b }: { prop: number }) => a + b;
+>fn1 : ({ prop, prop }: {    prop: number;}) => number
+>({ prop: a, prop: b }: { prop: number }) => a + b : ({ prop, prop }: {    prop: number;}) => number
+>prop : any
+>a : number
+>prop : any
+>b : number
+>prop : number
+>a + b : number
+>a : number
+>b : number
+
+export const fn2 = ({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b;
+>fn2 : ({ prop }: {    prop: number;}, { prop }: {    prop: number;}) => number
+>({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b : ({ prop }: {    prop: number;}, { prop }: {    prop: number;}) => number
+>prop : any
+>a : number
+>prop : number
+>prop : any
+>b : number
+>prop : number
+>a + b : number
+>a : number
+>b : number
+

--- a/tests/baselines/reference/declarationsAndAssignments.types
+++ b/tests/baselines/reference/declarationsAndAssignments.types
@@ -417,7 +417,7 @@ function f13() {
 }
 
 function f14([a = 1, [b = "hello", { x, y: c = false }]]) {
->f14 : ([a, [b, { x, y }]]: [number, [string, { x: any; y?: boolean; }]]) => void
+>f14 : ([a, [b, { x, y: c }]]: [number, [string, { x: any; y?: boolean; }]]) => void
 >a : number
 >1 : 1
 >b : string
@@ -438,7 +438,7 @@ function f14([a = 1, [b = "hello", { x, y: c = false }]]) {
 }
 f14([2, ["abc", { x: 0, y: true }]]);
 >f14([2, ["abc", { x: 0, y: true }]]) : void
->f14 : ([a, [b, { x, y }]]: [number, [string, { x: any; y?: boolean; }]]) => void
+>f14 : ([a, [b, { x, y: c }]]: [number, [string, { x: any; y?: boolean; }]]) => void
 >[2, ["abc", { x: 0, y: true }]] : [number, [string, { x: number; y: true; }]]
 >2 : 2
 >["abc", { x: 0, y: true }] : [string, { x: number; y: true; }]
@@ -451,7 +451,7 @@ f14([2, ["abc", { x: 0, y: true }]]);
 
 f14([2, ["abc", { x: 0 }]]);
 >f14([2, ["abc", { x: 0 }]]) : void
->f14 : ([a, [b, { x, y }]]: [number, [string, { x: any; y?: boolean; }]]) => void
+>f14 : ([a, [b, { x, y: c }]]: [number, [string, { x: any; y?: boolean; }]]) => void
 >[2, ["abc", { x: 0 }]] : [number, [string, { x: number; }]]
 >2 : 2
 >["abc", { x: 0 }] : [string, { x: number; }]
@@ -462,7 +462,7 @@ f14([2, ["abc", { x: 0 }]]);
 
 f14([2, ["abc", { y: false }]]);  // Error, no x
 >f14([2, ["abc", { y: false }]]) : void
->f14 : ([a, [b, { x, y }]]: [number, [string, { x: any; y?: boolean; }]]) => void
+>f14 : ([a, [b, { x, y: c }]]: [number, [string, { x: any; y?: boolean; }]]) => void
 >[2, ["abc", { y: false }]] : [number, [string, { y: false; }]]
 >2 : 2
 >["abc", { y: false }] : [string, { y: false; }]

--- a/tests/baselines/reference/destructuringInFunctionType.types
+++ b/tests/baselines/reference/destructuringInFunctionType.types
@@ -31,7 +31,7 @@ type T3 = ([{ a: b }, { b: a }]);
 >b : a
 
 type F3 = ([{ a: b }, { b: a }]) => void;
->F3 : ([{ a }, { b }]: [{ a: any; }, { b: any; }]) => void
+>F3 : ([{ a: b }, { b: a }]: [{ a: any; }, { b: any; }]) => void
 >a : any
 >b : any
 >b : any

--- a/tests/baselines/reference/destructuringParameterDeclaration1ES5.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration1ES5.types
@@ -402,7 +402,7 @@ d5();  // Parameter is optional as its declaration included an initializer
 // Type annotations must instead be written on the top- level parameter declaration
 
 function e1({x: number}) { }  // x has type any NOT number
->e1 : ({ x }: { x: any; }) => void
+>e1 : ({ x: number }: { x: any; }) => void
 >x : any
 >number : any
 

--- a/tests/baselines/reference/destructuringParameterDeclaration1ES5iterable.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration1ES5iterable.types
@@ -402,7 +402,7 @@ d5();  // Parameter is optional as its declaration included an initializer
 // Type annotations must instead be written on the top- level parameter declaration
 
 function e1({x: number}) { }  // x has type any NOT number
->e1 : ({ x }: { x: any; }) => void
+>e1 : ({ x: number }: { x: any; }) => void
 >x : any
 >number : any
 

--- a/tests/baselines/reference/destructuringParameterDeclaration1ES6.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration1ES6.types
@@ -376,7 +376,7 @@ d5();  // Parameter is optional as its declaration included an initializer
 // Type annotations must instead be written on the top- level parameter declaration
 
 function e1({x: number}) { }  // x has type any NOT number
->e1 : ({ x }: { x: any; }) => void
+>e1 : ({ x: number }: { x: any; }) => void
 >x : any
 >number : any
 

--- a/tests/baselines/reference/excessPropertyCheckWithSpread.types
+++ b/tests/baselines/reference/excessPropertyCheckWithSpread.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/excessPropertyCheckWithSpread.ts ===
 declare function f({ a: number }): void
->f : ({ a }: { a: any; }) => void
+>f : ({ a: number }: { a: any; }) => void
 >a : any
 >number : any
 
@@ -13,7 +13,7 @@ declare let i: I;
 
 f({ a: 1, ...i });
 >f({ a: 1, ...i }) : void
->f : ({ a }: { a: any; }) => void
+>f : ({ a: number }: { a: any; }) => void
 >{ a: 1, ...i } : { n: number; a: number; }
 >a : number
 >1 : 1
@@ -35,7 +35,7 @@ declare let r: R;
 
 f({ a: 1, ...l, ...r });
 >f({ a: 1, ...l, ...r }) : void
->f : ({ a }: { a: any; }) => void
+>f : ({ a: number }: { a: any; }) => void
 >{ a: 1, ...l, ...r } : { opt: string | number; a: number; }
 >a : number
 >1 : 1

--- a/tests/baselines/reference/objectRestParameter.types
+++ b/tests/baselines/reference/objectRestParameter.types
@@ -19,7 +19,7 @@ declare function suddenly(f: (a: { x: { z, ka }, y: string }) => void);
 suddenly(({ x: a, ...rest }) => rest.y);
 >suddenly(({ x: a, ...rest }) => rest.y) : any
 >suddenly : (f: (a: { x: { z: any; ka: any; }; y: string; }) => void) => any
->({ x: a, ...rest }) => rest.y : ({ x, ...rest }: { x: { z: any; ka: any; }; y: string; }) => string
+>({ x: a, ...rest }) => rest.y : ({ x: a, ...rest }: { x: { z: any; ka: any; }; y: string; }) => string
 >x : any
 >a : { z: any; ka: any; }
 >rest : { y: string; }

--- a/tests/baselines/reference/objectRestParameterES5.types
+++ b/tests/baselines/reference/objectRestParameterES5.types
@@ -19,7 +19,7 @@ declare function suddenly(f: (a: { x: { z, ka }, y: string }) => void);
 suddenly(({ x: a, ...rest }) => rest.y);
 >suddenly(({ x: a, ...rest }) => rest.y) : any
 >suddenly : (f: (a: { x: { z: any; ka: any; }; y: string; }) => void) => any
->({ x: a, ...rest }) => rest.y : ({ x, ...rest }: { x: { z: any; ka: any; }; y: string; }) => string
+>({ x: a, ...rest }) => rest.y : ({ x: a, ...rest }: { x: { z: any; ka: any; }; y: string; }) => string
 >x : any
 >a : { z: any; ka: any; }
 >rest : { y: string; }

--- a/tests/baselines/reference/renamingDestructuredPropertyInFunctionType.js
+++ b/tests/baselines/reference/renamingDestructuredPropertyInFunctionType.js
@@ -167,18 +167,18 @@ interface I {
     }): any;
 }
 declare function f1({ a }: O): void;
-declare const f2: ({ a }: O) => void;
-declare const f3: ({ a, b, c }: O) => void;
-declare const f4: ({ a }: O) => string;
-declare const f5: ({ a, b, c }: O) => string;
+declare const f2: ({ a: string }: O) => void;
+declare const f3: ({ a: string, b, c }: O) => void;
+declare const f4: ({ a: string }: O) => string;
+declare const f5: ({ a: string, b, c }: O) => string;
 declare const obj1: {
-    method({ a }: O): void;
+    method({ a: string }: O): void;
 };
 declare const obj2: {
-    method({ a }: O): string;
+    method({ a: string }: O): string;
 };
 declare function f6({ a }: O): void;
-declare const f7: ({ a, b, c }: O) => void;
+declare const f7: ({ a: string, b, c }: O) => void;
 declare const f8: ({ "a": string }: O) => void;
 declare function f9({ 2: string }: {
     2: any;

--- a/tests/baselines/reference/renamingDestructuredPropertyInFunctionType.types
+++ b/tests/baselines/reference/renamingDestructuredPropertyInFunctionType.types
@@ -12,37 +12,37 @@ type F1 = (arg: number) => any; // OK
 >arg : number
 
 type F2 = ({ a: string }: O) => any; // Error
->F2 : ({ a }: O) => any
+>F2 : ({ a: string }: O) => any
 >a : any
 >string : string
 
 type F3 = ({ a: string, b, c }: O) => any; // Error
->F3 : ({ a, b, c }: O) => any
+>F3 : ({ a: string, b, c }: O) => any
 >a : any
 >string : string
 >b : number
 >c : number
 
 type F4 = ({ a: string }: O) => any; // Error
->F4 : ({ a }: O) => any
+>F4 : ({ a: string }: O) => any
 >a : any
 >string : string
 
 type F5 = ({ a: string, b, c }: O) => any; // Error
->F5 : ({ a, b, c }: O) => any
+>F5 : ({ a: string, b, c }: O) => any
 >a : any
 >string : string
 >b : number
 >c : number
 
 type F6 = ({ a: string }) => typeof string; // OK
->F6 : ({ a }: { a: any; }) => any
+>F6 : ({ a: string }: { a: any; }) => any
 >a : any
 >string : any
 >string : any
 
 type F7 = ({ a: string, b: number }) => typeof number; // Error
->F7 : ({ a, b }: { a: any; b: any; }) => any
+>F7 : ({ a: string, b: number }: { a: any; b: any; }) => any
 >a : any
 >string : any
 >b : any
@@ -50,7 +50,7 @@ type F7 = ({ a: string, b: number }) => typeof number; // Error
 >number : any
 
 type F8 = ({ a, b: number }) => typeof number; // OK
->F8 : ({ a, b }: { a: any; b: any; }) => any
+>F8 : ({ a, b: number }: { a: any; b: any; }) => any
 >a : any
 >b : any
 >number : any
@@ -67,37 +67,37 @@ type G1 = new (arg: number) => any; // OK
 >arg : number
 
 type G2 = new ({ a: string }: O) => any; // Error
->G2 : new ({ a }: O) => any
+>G2 : new ({ a: string }: O) => any
 >a : any
 >string : string
 
 type G3 = new ({ a: string, b, c }: O) => any; // Error
->G3 : new ({ a, b, c }: O) => any
+>G3 : new ({ a: string, b, c }: O) => any
 >a : any
 >string : string
 >b : number
 >c : number
 
 type G4 = new ({ a: string }: O) => any; // Error
->G4 : new ({ a }: O) => any
+>G4 : new ({ a: string }: O) => any
 >a : any
 >string : string
 
 type G5 = new ({ a: string, b, c }: O) => any; // Error
->G5 : new ({ a, b, c }: O) => any
+>G5 : new ({ a: string, b, c }: O) => any
 >a : any
 >string : string
 >b : number
 >c : number
 
 type G6 = new ({ a: string }) => typeof string; // OK
->G6 : new ({ a }: { a: any; }) => any
+>G6 : new ({ a: string }: { a: any; }) => any
 >a : any
 >string : any
 >string : any
 
 type G7 = new ({ a: string, b: number }) => typeof number; // Error
->G7 : new ({ a, b }: { a: any; b: any; }) => any
+>G7 : new ({ a: string, b: number }: { a: any; b: any; }) => any
 >a : any
 >string : any
 >b : any
@@ -105,7 +105,7 @@ type G7 = new ({ a: string, b: number }) => typeof number; // Error
 >number : any
 
 type G8 = new ({ a, b: number }) => typeof number; // OK
->G8 : new ({ a, b }: { a: any; b: any; }) => any
+>G8 : new ({ a, b: number }: { a: any; b: any; }) => any
 >a : any
 >b : any
 >number : any
@@ -161,7 +161,7 @@ interface I {
 >arg : number
 
   method2({ a: string }): any; // Error
->method2 : ({ a }: { a: any; }) => any
+>method2 : ({ a: string }: { a: any; }) => any
 >a : any
 >string : any
 
@@ -182,35 +182,35 @@ interface I {
 
 // Below are OK but renaming should be removed from declaration emit
 function f1({ a: string }: O) { }
->f1 : ({ a }: O) => void
+>f1 : ({ a: string }: O) => void
 >a : any
 >string : string
 
 const f2 = function({ a: string }: O) { };
->f2 : ({ a }: O) => void
->function({ a: string }: O) { } : ({ a }: O) => void
+>f2 : ({ a: string }: O) => void
+>function({ a: string }: O) { } : ({ a: string }: O) => void
 >a : any
 >string : string
 
 const f3 = ({ a: string, b, c }: O) => { };
->f3 : ({ a, b, c }: O) => void
->({ a: string, b, c }: O) => { } : ({ a, b, c }: O) => void
+>f3 : ({ a: string, b, c }: O) => void
+>({ a: string, b, c }: O) => { } : ({ a: string, b, c }: O) => void
 >a : any
 >string : string
 >b : number
 >c : number
 
 const f4 = function({ a: string }: O): typeof string { return string; };
->f4 : ({ a }: O) => string
->function({ a: string }: O): typeof string { return string; } : ({ a }: O) => string
+>f4 : ({ a: string }: O) => string
+>function({ a: string }: O): typeof string { return string; } : ({ a: string }: O) => string
 >a : any
 >string : string
 >string : string
 >string : string
 
 const f5 = ({ a: string, b, c }: O): typeof string => '';
->f5 : ({ a, b, c }: O) => string
->({ a: string, b, c }: O): typeof string => '' : ({ a, b, c }: O) => string
+>f5 : ({ a: string, b, c }: O) => string
+>({ a: string, b, c }: O): typeof string => '' : ({ a: string, b, c }: O) => string
 >a : any
 >string : string
 >b : number
@@ -219,21 +219,21 @@ const f5 = ({ a: string, b, c }: O): typeof string => '';
 >'' : ""
 
 const obj1 = {
->obj1 : { method({ a }: O): void; }
->{  method({ a: string }: O) { }} : { method({ a }: O): void; }
+>obj1 : { method({ a: string }: O): void; }
+>{  method({ a: string }: O) { }} : { method({ a: string }: O): void; }
 
   method({ a: string }: O) { }
->method : ({ a }: O) => void
+>method : ({ a: string }: O) => void
 >a : any
 >string : string
 
 };
 const obj2 = {
->obj2 : { method({ a }: O): string; }
->{  method({ a: string }: O): typeof string { return string; }} : { method({ a }: O): string; }
+>obj2 : { method({ a: string }: O): string; }
+>{  method({ a: string }: O): typeof string { return string; }} : { method({ a: string }: O): string; }
 
   method({ a: string }: O): typeof string { return string; }
->method : ({ a }: O) => string
+>method : ({ a: string }: O) => string
 >a : any
 >string : string
 >string : string
@@ -241,14 +241,14 @@ const obj2 = {
 
 };
 function f6({ a: string = "" }: O) { }
->f6 : ({ a }: O) => void
+>f6 : ({ a: string }: O) => void
 >a : any
 >string : string
 >"" : ""
 
 const f7 = ({ a: string = "", b, c }: O) => { };
->f7 : ({ a, b, c }: O) => void
->({ a: string = "", b, c }: O) => { } : ({ a, b, c }: O) => void
+>f7 : ({ a: string, b, c }: O) => void
+>({ a: string = "", b, c }: O) => { } : ({ a: string, b, c }: O) => void
 >a : any
 >string : string
 >"" : ""
@@ -277,7 +277,7 @@ const f11 =  ({ [2]: string }) => { };
 
 // In below case `string` should be kept because it is used
 function f12({ a: string = "" }: O): typeof string { return "a"; }
->f12 : ({ a }: O) => typeof string
+>f12 : ({ a: string }: O) => typeof string
 >a : any
 >string : string
 >"" : ""

--- a/tests/baselines/reference/renamingDestructuredPropertyInFunctionType2.types
+++ b/tests/baselines/reference/renamingDestructuredPropertyInFunctionType2.types
@@ -10,37 +10,37 @@ type F1 = (arg: number) => any;
 >arg : number
 
 type F2 = ({ a: string }: O) => any; 
->F2 : ({ a }: O) => any
+>F2 : ({ a: string }: O) => any
 >a : any
 >string : string
 
 type F3 = ({ a: string, b, c }: O) => any; 
->F3 : ({ a, b, c }: O) => any
+>F3 : ({ a: string, b, c }: O) => any
 >a : any
 >string : string
 >b : number
 >c : number
 
 type F4 = ({ a: string }: O) => any; 
->F4 : ({ a }: O) => any
+>F4 : ({ a: string }: O) => any
 >a : any
 >string : string
 
 type F5 = ({ a: string, b, c }: O) => any; 
->F5 : ({ a, b, c }: O) => any
+>F5 : ({ a: string, b, c }: O) => any
 >a : any
 >string : string
 >b : number
 >c : number
 
 type F6 = ({ a: string }) => typeof string; 
->F6 : ({ a }: { a: any; }) => any
+>F6 : ({ a: string }: { a: any; }) => any
 >a : any
 >string : any
 >string : any
 
 type F7 = ({ a: string, b: number }) => typeof number; 
->F7 : ({ a, b }: { a: any; b: any; }) => any
+>F7 : ({ a: string, b: number }: { a: any; b: any; }) => any
 >a : any
 >string : any
 >b : any
@@ -48,7 +48,7 @@ type F7 = ({ a: string, b: number }) => typeof number;
 >number : any
 
 type F8 = ({ a, b: number }) => typeof number; 
->F8 : ({ a, b }: { a: any; b: any; }) => any
+>F8 : ({ a, b: number }: { a: any; b: any; }) => any
 >a : any
 >b : any
 >number : any
@@ -65,37 +65,37 @@ type G1 = (arg: number) => any;
 >arg : number
 
 type G2 = ({ a: string }: O) => any; 
->G2 : ({ a }: O) => any
+>G2 : ({ a: string }: O) => any
 >a : any
 >string : string
 
 type G3 = ({ a: string, b, c }: O) => any; 
->G3 : ({ a, b, c }: O) => any
+>G3 : ({ a: string, b, c }: O) => any
 >a : any
 >string : string
 >b : number
 >c : number
 
 type G4 = ({ a: string }: O) => any; 
->G4 : ({ a }: O) => any
+>G4 : ({ a: string }: O) => any
 >a : any
 >string : string
 
 type G5 = ({ a: string, b, c }: O) => any; 
->G5 : ({ a, b, c }: O) => any
+>G5 : ({ a: string, b, c }: O) => any
 >a : any
 >string : string
 >b : number
 >c : number
 
 type G6 = ({ a: string }) => typeof string; 
->G6 : ({ a }: { a: any; }) => any
+>G6 : ({ a: string }: { a: any; }) => any
 >a : any
 >string : any
 >string : any
 
 type G7 = ({ a: string, b: number }) => typeof number; 
->G7 : ({ a, b }: { a: any; b: any; }) => any
+>G7 : ({ a: string, b: number }: { a: any; b: any; }) => any
 >a : any
 >string : any
 >b : any
@@ -103,7 +103,7 @@ type G7 = ({ a: string, b: number }) => typeof number;
 >number : any
 
 type G8 = ({ a, b: number }) => typeof number; 
->G8 : ({ a, b }: { a: any; b: any; }) => any
+>G8 : ({ a, b: number }: { a: any; b: any; }) => any
 >a : any
 >b : any
 >number : any
@@ -121,7 +121,7 @@ interface I {
 >arg : number
 
   method2({ a: string }): any; 
->method2 : ({ a }: { a: any; }) => any
+>method2 : ({ a: string }: { a: any; }) => any
 >a : any
 >string : any
 

--- a/tests/baselines/reference/sourceMapValidationDestructuringParameterNestedObjectBindingPattern.types
+++ b/tests/baselines/reference/sourceMapValidationDestructuringParameterNestedObjectBindingPattern.types
@@ -34,7 +34,7 @@ var robotA: Robot = { name: "mower", skills: { primary: "mowing", secondary: "no
 >"none" : "none"
 
 function foo1({ skills: { primary: primaryA, secondary: secondaryA } }: Robot) {
->foo1 : ({ skills: { primary, secondary } }: Robot) => void
+>foo1 : ({ skills: { primary: primaryA, secondary: secondaryA } }: Robot) => void
 >skills : any
 >primary : any
 >primaryA : string
@@ -49,7 +49,7 @@ function foo1({ skills: { primary: primaryA, secondary: secondaryA } }: Robot) {
 >primaryA : string
 }
 function foo2({ name: nameC, skills: { primary: primaryB, secondary: secondaryB } }: Robot) {
->foo2 : ({ name, skills: { primary, secondary } }: Robot) => void
+>foo2 : ({ name: nameC, skills: { primary: primaryB, secondary: secondaryB } }: Robot) => void
 >name : any
 >nameC : string
 >skills : any
@@ -81,12 +81,12 @@ function foo3({ skills }: Robot) {
 
 foo1(robotA);
 >foo1(robotA) : void
->foo1 : ({ skills: { primary, secondary } }: Robot) => void
+>foo1 : ({ skills: { primary: primaryA, secondary: secondaryA } }: Robot) => void
 >robotA : Robot
 
 foo1({ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } });
 >foo1({ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } }) : void
->foo1 : ({ skills: { primary, secondary } }: Robot) => void
+>foo1 : ({ skills: { primary: primaryA, secondary: secondaryA } }: Robot) => void
 >{ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } } : { name: string; skills: { primary: string; secondary: string; }; }
 >name : string
 >"Edger" : "Edger"
@@ -99,12 +99,12 @@ foo1({ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" 
 
 foo2(robotA);
 >foo2(robotA) : void
->foo2 : ({ name, skills: { primary, secondary } }: Robot) => void
+>foo2 : ({ name: nameC, skills: { primary: primaryB, secondary: secondaryB } }: Robot) => void
 >robotA : Robot
 
 foo2({ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } });
 >foo2({ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } }) : void
->foo2 : ({ name, skills: { primary, secondary } }: Robot) => void
+>foo2 : ({ name: nameC, skills: { primary: primaryB, secondary: secondaryB } }: Robot) => void
 >{ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } } : { name: string; skills: { primary: string; secondary: string; }; }
 >name : string
 >"Edger" : "Edger"

--- a/tests/baselines/reference/sourceMapValidationDestructuringParameterNestedObjectBindingPatternDefaultValues.types
+++ b/tests/baselines/reference/sourceMapValidationDestructuringParameterNestedObjectBindingPatternDefaultValues.types
@@ -34,7 +34,7 @@ var robotA: Robot = { name: "mower", skills: { primary: "mowing", secondary: "no
 >"none" : "none"
 
 function foo1(
->foo1 : ({ skills: { primary, secondary } }?: Robot) => void
+>foo1 : ({ skills: { primary: primaryA, secondary: secondaryA } }?: Robot) => void
     {
         skills: {
 >skills : any
@@ -67,7 +67,7 @@ function foo1(
 >primaryA : string
 }
 function foo2(
->foo2 : ({ name, skills: { primary, secondary } }?: Robot) => void
+>foo2 : ({ name: nameC, skills: { primary: primaryB, secondary: secondaryB } }?: Robot) => void
     {
         name: nameC = "name",
 >name : any
@@ -126,12 +126,12 @@ function foo3({ skills = { primary: "SomeSkill", secondary: "someSkill" }  }: Ro
 
 foo1(robotA);
 >foo1(robotA) : void
->foo1 : ({ skills: { primary, secondary } }?: Robot) => void
+>foo1 : ({ skills: { primary: primaryA, secondary: secondaryA } }?: Robot) => void
 >robotA : Robot
 
 foo1({ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } });
 >foo1({ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } }) : void
->foo1 : ({ skills: { primary, secondary } }?: Robot) => void
+>foo1 : ({ skills: { primary: primaryA, secondary: secondaryA } }?: Robot) => void
 >{ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } } : { name: string; skills: { primary: string; secondary: string; }; }
 >name : string
 >"Edger" : "Edger"
@@ -144,12 +144,12 @@ foo1({ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" 
 
 foo2(robotA);
 >foo2(robotA) : void
->foo2 : ({ name, skills: { primary, secondary } }?: Robot) => void
+>foo2 : ({ name: nameC, skills: { primary: primaryB, secondary: secondaryB } }?: Robot) => void
 >robotA : Robot
 
 foo2({ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } });
 >foo2({ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } }) : void
->foo2 : ({ name, skills: { primary, secondary } }?: Robot) => void
+>foo2 : ({ name: nameC, skills: { primary: primaryB, secondary: secondaryB } }?: Robot) => void
 >{ name: "Edger", skills: { primary: "edging", secondary: "branch trimming" } } : { name: string; skills: { primary: string; secondary: string; }; }
 >name : string
 >"Edger" : "Edger"

--- a/tests/baselines/reference/sourceMapValidationDestructuringParameterObjectBindingPattern.types
+++ b/tests/baselines/reference/sourceMapValidationDestructuringParameterObjectBindingPattern.types
@@ -26,7 +26,7 @@ var robotA: Robot = { name: "mower", skill: "mowing" };
 >"mowing" : "mowing"
 
 function foo1({ name: nameA }: Robot) {
->foo1 : ({ name }: Robot) => void
+>foo1 : ({ name: nameA }: Robot) => void
 >name : any
 >nameA : string
 
@@ -38,7 +38,7 @@ function foo1({ name: nameA }: Robot) {
 >nameA : string
 }
 function foo2({ name: nameB, skill: skillB }: Robot) {
->foo2 : ({ name, skill }: Robot) => void
+>foo2 : ({ name: nameB, skill: skillB }: Robot) => void
 >name : any
 >nameB : string
 >skill : any
@@ -65,12 +65,12 @@ function foo3({ name }: Robot) {
 
 foo1(robotA);
 >foo1(robotA) : void
->foo1 : ({ name }: Robot) => void
+>foo1 : ({ name: nameA }: Robot) => void
 >robotA : Robot
 
 foo1({ name: "Edger", skill: "cutting edges" });
 >foo1({ name: "Edger", skill: "cutting edges" }) : void
->foo1 : ({ name }: Robot) => void
+>foo1 : ({ name: nameA }: Robot) => void
 >{ name: "Edger", skill: "cutting edges" } : { name: string; skill: string; }
 >name : string
 >"Edger" : "Edger"
@@ -79,12 +79,12 @@ foo1({ name: "Edger", skill: "cutting edges" });
 
 foo2(robotA);
 >foo2(robotA) : void
->foo2 : ({ name, skill }: Robot) => void
+>foo2 : ({ name: nameB, skill: skillB }: Robot) => void
 >robotA : Robot
 
 foo2({ name: "Edger", skill: "cutting edges" });
 >foo2({ name: "Edger", skill: "cutting edges" }) : void
->foo2 : ({ name, skill }: Robot) => void
+>foo2 : ({ name: nameB, skill: skillB }: Robot) => void
 >{ name: "Edger", skill: "cutting edges" } : { name: string; skill: string; }
 >name : string
 >"Edger" : "Edger"

--- a/tests/baselines/reference/sourceMapValidationDestructuringParameterObjectBindingPatternDefaultValues.types
+++ b/tests/baselines/reference/sourceMapValidationDestructuringParameterObjectBindingPatternDefaultValues.types
@@ -26,7 +26,7 @@ var robotA: Robot = { name: "mower", skill: "mowing" };
 >"mowing" : "mowing"
 
 function foo1({ name: nameA = "<NoName>" }: Robot = { }) {
->foo1 : ({ name }?: Robot) => void
+>foo1 : ({ name: nameA }?: Robot) => void
 >name : any
 >nameA : string
 >"<NoName>" : "<NoName>"
@@ -40,7 +40,7 @@ function foo1({ name: nameA = "<NoName>" }: Robot = { }) {
 >nameA : string
 }
 function foo2({ name: nameB = "<NoName>", skill: skillB = "noSkill" }: Robot = {}) {
->foo2 : ({ name, skill }?: Robot) => void
+>foo2 : ({ name: nameB, skill: skillB }?: Robot) => void
 >name : any
 >nameB : string
 >"<NoName>" : "<NoName>"
@@ -72,12 +72,12 @@ function foo3({ name = "<NoName>" }: Robot = {}) {
 
 foo1(robotA);
 >foo1(robotA) : void
->foo1 : ({ name }?: Robot) => void
+>foo1 : ({ name: nameA }?: Robot) => void
 >robotA : Robot
 
 foo1({ name: "Edger", skill: "cutting edges" });
 >foo1({ name: "Edger", skill: "cutting edges" }) : void
->foo1 : ({ name }?: Robot) => void
+>foo1 : ({ name: nameA }?: Robot) => void
 >{ name: "Edger", skill: "cutting edges" } : { name: string; skill: string; }
 >name : string
 >"Edger" : "Edger"
@@ -86,12 +86,12 @@ foo1({ name: "Edger", skill: "cutting edges" });
 
 foo2(robotA);
 >foo2(robotA) : void
->foo2 : ({ name, skill }?: Robot) => void
+>foo2 : ({ name: nameB, skill: skillB }?: Robot) => void
 >robotA : Robot
 
 foo2({ name: "Edger", skill: "cutting edges" });
 >foo2({ name: "Edger", skill: "cutting edges" }) : void
->foo2 : ({ name, skill }?: Robot) => void
+>foo2 : ({ name: nameB, skill: skillB }?: Robot) => void
 >{ name: "Edger", skill: "cutting edges" } : { name: string; skill: string; }
 >name : string
 >"Edger" : "Edger"

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload1.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload1.types
@@ -75,27 +75,27 @@ const c5 = <OneThing yxx1='ok'>Hello</OneThing>
 
 
 declare function TestingOneThing({y1: string}): JSX.Element;
->TestingOneThing : { ({ y1 }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >y1 : any
 >string : any
 >JSX : any
 
 declare function TestingOneThing(j: {"extra-data": string, yy?: string}): JSX.Element;
->TestingOneThing : { ({ y1 }: { y1: any; }): JSX.Element; (j: {    "extra-data": string;    yy?: string;}): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: {    "extra-data": string;    yy?: string;}): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >j : { "extra-data": string; yy?: string; }
 >"extra-data" : string
 >yy : string
 >JSX : any
 
 declare function TestingOneThing(n: {yy: number, direction?: number}): JSX.Element;
->TestingOneThing : { ({ y1 }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: {    yy: number;    direction?: number;}): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: {    yy: number;    direction?: number;}): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >n : { yy: number; direction?: number; }
 >yy : number
 >direction : number
 >JSX : any
 
 declare function TestingOneThing(n: {yy: string, name: string}): JSX.Element;
->TestingOneThing : { ({ y1 }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: {    yy: string;    name: string;}): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: {    yy: string;    name: string;}): JSX.Element; }
 >n : { yy: string; name: string; }
 >yy : string
 >name : string
@@ -105,27 +105,27 @@ declare function TestingOneThing(n: {yy: string, name: string}): JSX.Element;
 const d1 = <TestingOneThing y1 extra-data />;
 >d1 : JSX.Element
 ><TestingOneThing y1 extra-data /> : JSX.Element
->TestingOneThing : { ({ y1 }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >y1 : true
 >extra-data : true
 
 const d2 = <TestingOneThing extra-data="hello" />;
 >d2 : JSX.Element
 ><TestingOneThing extra-data="hello" /> : JSX.Element
->TestingOneThing : { ({ y1 }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >extra-data : string
 
 const d3 = <TestingOneThing extra-data="hello" yy="hihi" />;
 >d3 : JSX.Element
 ><TestingOneThing extra-data="hello" yy="hihi" /> : JSX.Element
->TestingOneThing : { ({ y1 }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >extra-data : string
 >yy : string
 
 const d4 = <TestingOneThing extra-data="hello" yy={9} direction={10} />;
 >d4 : JSX.Element
 ><TestingOneThing extra-data="hello" yy={9} direction={10} /> : JSX.Element
->TestingOneThing : { ({ y1 }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >extra-data : string
 >yy : number
 >9 : 9
@@ -135,7 +135,7 @@ const d4 = <TestingOneThing extra-data="hello" yy={9} direction={10} />;
 const d5 = <TestingOneThing extra-data="hello" yy="hello" name="Bob" />;
 >d5 : JSX.Element
 ><TestingOneThing extra-data="hello" yy="hello" name="Bob" /> : JSX.Element
->TestingOneThing : { ({ y1 }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >extra-data : string
 >yy : string
 >name : string

--- a/tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.ts
+++ b/tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.ts
@@ -1,0 +1,6 @@
+// @declaration: true
+// @emitDeclarationOnly: true
+
+export const fn1 = ({ prop: a, prop: b }: { prop: number }) => a + b;
+
+export const fn2 = ({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b;


### PR DESCRIPTION
Fixes #50707 (at least to the extent that we have the pre-4.8 behavior).

In a followup PR, I can remove these destructurings/bindings/whatevertheyrecalleds in the declaration emitter.

Note that the new errors added in #41044 remain. I guess the PR had two somewhat-related changes in it?