### PR TITLE
Js doc overloads

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1639,6 +1639,7 @@ namespace ts {
                     case SyntaxKind.JSDocTag:
                     case SyntaxKind.JSDocClassTag:
                     case SyntaxKind.JSDocOverrideTag:
+                    case SyntaxKind.JSDocOverloadTag:
                         return emitJSDocSimpleTag(node as JSDocTag);
                     case SyntaxKind.JSDocAugmentsTag:
                     case SyntaxKind.JSDocImplementsTag:

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -390,6 +390,8 @@ namespace ts {
             get updateJSDocReadonlyTag() { return getJSDocSimpleTagUpdateFunction<JSDocReadonlyTag>(SyntaxKind.JSDocReadonlyTag); },
             get createJSDocOverrideTag() { return getJSDocSimpleTagCreateFunction<JSDocOverrideTag>(SyntaxKind.JSDocOverrideTag); },
             get updateJSDocOverrideTag() { return getJSDocSimpleTagUpdateFunction<JSDocOverrideTag>(SyntaxKind.JSDocOverrideTag); },
+            get createJSDocOverloadTag() { return getJSDocSimpleTagCreateFunction<JSDocOverloadTag>(SyntaxKind.JSDocOverloadTag); },
+            get updateJSDocOverloadTag() { return getJSDocSimpleTagUpdateFunction<JSDocOverloadTag>(SyntaxKind.JSDocOverloadTag); },
             get createJSDocDeprecatedTag() { return getJSDocSimpleTagCreateFunction<JSDocDeprecatedTag>(SyntaxKind.JSDocDeprecatedTag); },
             get updateJSDocDeprecatedTag() { return getJSDocSimpleTagUpdateFunction<JSDocDeprecatedTag>(SyntaxKind.JSDocDeprecatedTag); },
             createJSDocUnknownTag,
@@ -4630,6 +4632,7 @@ namespace ts {
                 : node;
         }
 
+
         // @api
         function createJSDocAugmentsTag(tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment?: string | NodeArray<JSDocComment>): JSDocAugmentsTag {
             const node = createBaseJSDocTag<JSDocAugmentsTag>(SyntaxKind.JSDocAugmentsTag, tagName ?? createIdentifier("augments"), comment);
@@ -6334,6 +6337,7 @@ namespace ts {
             case SyntaxKind.JSDocProtectedTag: return "protected";
             case SyntaxKind.JSDocReadonlyTag: return "readonly";
             case SyntaxKind.JSDocOverrideTag: return "override";
+            case SyntaxKind.JSDocOverloadTag: return "overload";
             case SyntaxKind.JSDocTemplateTag: return "template";
             case SyntaxKind.JSDocTypedefTag: return "typedef";
             case SyntaxKind.JSDocParameterTag: return "param";

--- a/src/compiler/factory/nodeTests.ts
+++ b/src/compiler/factory/nodeTests.ts
@@ -898,6 +898,10 @@ namespace ts {
         return node.kind === SyntaxKind.JSDocOverrideTag;
     }
 
+    export function isJSDocOverloadTag(node: Node): node is JSDocOverloadTag {
+        return node.kind === SyntaxKind.JSDocOverloadTag;
+    }
+
     export function isJSDocDeprecatedTag(node: Node): node is JSDocDeprecatedTag {
         return node.kind === SyntaxKind.JSDocDeprecatedTag;
     }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -8359,6 +8359,9 @@ namespace ts {
                         case "override":
                             tag = parseSimpleTag(start, factory.createJSDocOverrideTag, tagName, margin, indentText);
                             break;
+                        case "overload":
+                            tag = parseSimpleTag(start, factory.createJSDocOverloadTag, tagName, margin, indentText);
+                            break;
                         case "deprecated":
                             hasDeprecatedTag = true;
                             tag = parseSimpleTag(start, factory.createJSDocDeprecatedTag, tagName, margin, indentText);

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -738,6 +738,7 @@ namespace ts {
      *      to reduceLeft. If false, iteration stops when the callback returns a truthy value.
      * @param text The source text to scan.
      * @param pos The position at which to start scanning.
+     * @param end The position at which to stop scanning.
      * @param trailing If false, whitespace is skipped until the first line break and comments
      *      between that location and the next token are returned. If true, comments occurring
      *      between the given position and the next line break are returned.
@@ -747,7 +748,7 @@ namespace ts {
      * @returns If "reduce" is true, the accumulated value. If "reduce" is false, the first truthy
      *      return value of the callback.
      */
-    function iterateCommentRanges<T, U>(reduce: boolean, text: string, pos: number, trailing: boolean, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U | undefined) => U, state: T, initial?: U): U | undefined {
+     function iterateCommentRanges<T, U>(reduce: boolean, text: string, pos: number, end: number | undefined, trailing: boolean, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U | undefined) => U, state: T, initial?: U): U | undefined {
         let pendingPos!: number;
         let pendingEnd!: number;
         let pendingKind!: CommentKind;
@@ -762,7 +763,8 @@ namespace ts {
                 pos = shebang.length;
             }
         }
-        scan: while (pos >= 0 && pos < text.length) {
+        const endOfScanning = typeof end === "undefined" ? text.length : Math.min(text.length, end);
+        scan: while (pos >= 0 && pos < endOfScanning) {
             const ch = text.charCodeAt(pos);
             switch (ch) {
                 case CharacterCodes.carriageReturn:
@@ -852,24 +854,24 @@ namespace ts {
         return accumulator;
     }
 
-    export function forEachLeadingCommentRange<U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
-    export function forEachLeadingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
-    export function forEachLeadingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state?: T): U | undefined {
-        return iterateCommentRanges(/*reduce*/ false, text, pos, /*trailing*/ false, cb, state);
+    export function forEachLeadingCommentRange<U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
+    export function forEachLeadingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
+    export function forEachLeadingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state?: T): U | undefined {
+        return iterateCommentRanges(/*reduce*/ false, text, pos, end, /*trailing*/ false, cb, state);
     }
 
-    export function forEachTrailingCommentRange<U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
-    export function forEachTrailingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
-    export function forEachTrailingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state?: T): U | undefined {
-        return iterateCommentRanges(/*reduce*/ false, text, pos, /*trailing*/ true, cb, state);
+    export function forEachTrailingCommentRange<U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
+    export function forEachTrailingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
+    export function forEachTrailingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state?: T): U | undefined {
+        return iterateCommentRanges(/*reduce*/ false, text, pos, end, /*trailing*/ true, cb, state);
     }
 
-    export function reduceEachLeadingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U) {
-        return iterateCommentRanges(/*reduce*/ true, text, pos, /*trailing*/ false, cb, state, initial);
+    export function reduceEachLeadingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U) {
+        return iterateCommentRanges(/*reduce*/ true, text, pos, end, /*trailing*/ false, cb, state, initial);
     }
 
-    export function reduceEachTrailingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U) {
-        return iterateCommentRanges(/*reduce*/ true, text, pos, /*trailing*/ true, cb, state, initial);
+    export function reduceEachTrailingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U) {
+        return iterateCommentRanges(/*reduce*/ true, text, pos, end, /*trailing*/ true, cb, state, initial);
     }
 
     function appendCommentRange(pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, _state: any, comments: CommentRange[]) {
@@ -881,12 +883,12 @@ namespace ts {
         return comments;
     }
 
-    export function getLeadingCommentRanges(text: string, pos: number): CommentRange[] | undefined {
-        return reduceEachLeadingCommentRange(text, pos, appendCommentRange, /*state*/ undefined, /*initial*/ undefined);
+    export function getLeadingCommentRanges(text: string, pos: number, end?: number): CommentRange[] | undefined {
+        return reduceEachLeadingCommentRange(text, pos, end, appendCommentRange, /*state*/ undefined, /*initial*/ undefined);
     }
 
-    export function getTrailingCommentRanges(text: string, pos: number): CommentRange[] | undefined {
-        return reduceEachTrailingCommentRange(text, pos, appendCommentRange, /*state*/ undefined, /*initial*/ undefined);
+    export function getTrailingCommentRanges(text: string, pos: number, end?: number): CommentRange[] | undefined {
+        return reduceEachTrailingCommentRange(text, pos, end, appendCommentRange, /*state*/ undefined, /*initial*/ undefined);
     }
 
     /** Optionally, get the shebang */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -401,6 +401,7 @@ namespace ts {
         JSDocProtectedTag,
         JSDocReadonlyTag,
         JSDocOverrideTag,
+        JSDocOverloadTag,
         JSDocCallbackTag,
         JSDocEnumTag,
         JSDocParameterTag,
@@ -3721,6 +3722,10 @@ namespace ts {
 
     export interface JSDocOverrideTag extends JSDocTag {
         readonly kind: SyntaxKind.JSDocOverrideTag;
+    }
+
+    export interface JSDocOverloadTag extends JSDocTag {
+        readonly kind: SyntaxKind.JSDocOverloadTag;
     }
 
     export interface JSDocEnumTag extends JSDocTag, Declaration {
@@ -8053,6 +8058,8 @@ namespace ts {
         updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocDeprecatedTag;
         createJSDocOverrideTag(tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverrideTag;
         updateJSDocOverrideTag(node: JSDocOverrideTag, tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverrideTag;
+        createJSDocOverloadTag(tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverloadTag;
+        updateJSDocOverloadTag(node: JSDocOverloadTag, tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverloadTag;
         createJSDocText(text: string): JSDocText;
         updateJSDocText(node: JSDocText, text: string): JSDocText;
         createJSDocComment(comment?: string | NodeArray<JSDocComment> | undefined, tags?: readonly JSDocTag[] | undefined): JSDoc;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2677,12 +2677,11 @@ namespace ts {
     }
 
     export function copyLeadingComments(sourceNode: Node, targetNode: Node, sourceFile: SourceFile, commentKind?: CommentKind, hasTrailingNewLine?: boolean) {
-        forEachLeadingCommentRange(sourceFile.text, sourceNode.pos, getAddCommentsFunction(targetNode, sourceFile, commentKind, hasTrailingNewLine, addSyntheticLeadingComment));
+        forEachLeadingCommentRange(sourceFile.text, sourceNode.pos, /*end*/ undefined, getAddCommentsFunction(targetNode, sourceFile, commentKind, hasTrailingNewLine, addSyntheticLeadingComment));
     }
 
-
     export function copyTrailingComments(sourceNode: Node, targetNode: Node, sourceFile: SourceFile, commentKind?: CommentKind, hasTrailingNewLine?: boolean) {
-        forEachTrailingCommentRange(sourceFile.text, sourceNode.end, getAddCommentsFunction(targetNode, sourceFile, commentKind, hasTrailingNewLine, addSyntheticTrailingComment));
+        forEachTrailingCommentRange(sourceFile.text, sourceNode.end, /*end*/ undefined, getAddCommentsFunction(targetNode, sourceFile, commentKind, hasTrailingNewLine, addSyntheticTrailingComment));
     }
 
     /**
@@ -2693,7 +2692,7 @@ namespace ts {
      * The comment refers to `a` but belongs to the `(` token, but we might want to copy it.
      */
     export function copyTrailingAsLeadingComments(sourceNode: Node, targetNode: Node, sourceFile: SourceFile, commentKind?: CommentKind, hasTrailingNewLine?: boolean) {
-        forEachTrailingCommentRange(sourceFile.text, sourceNode.pos, getAddCommentsFunction(targetNode, sourceFile, commentKind, hasTrailingNewLine, addSyntheticLeadingComment));
+        forEachTrailingCommentRange(sourceFile.text, sourceNode.pos, /*end*/ undefined, getAddCommentsFunction(targetNode, sourceFile, commentKind, hasTrailingNewLine, addSyntheticLeadingComment));
     }
 
     function getAddCommentsFunction(targetNode: Node, sourceFile: SourceFile, commentKind: CommentKind | undefined, hasTrailingNewLine: boolean | undefined, cb: (node: Node, kind: CommentKind, text: string, hasTrailingNewLine?: boolean) => void) {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -14,7 +14,7 @@ and limitations under the License.
 ***************************************************************************** */
 
 declare namespace ts {
-    const versionMajorMinor = "4.9";
+    const versionMajorMinor = "4.8";
     /** The version of the TypeScript compiler release */
     const version: string;
     /**
@@ -254,217 +254,216 @@ declare namespace ts {
         RequireKeyword = 146,
         NumberKeyword = 147,
         ObjectKeyword = 148,
-        SatisfiesKeyword = 149,
-        SetKeyword = 150,
-        StringKeyword = 151,
-        SymbolKeyword = 152,
-        TypeKeyword = 153,
-        UndefinedKeyword = 154,
-        UniqueKeyword = 155,
-        UnknownKeyword = 156,
-        FromKeyword = 157,
-        GlobalKeyword = 158,
-        BigIntKeyword = 159,
-        OverrideKeyword = 160,
-        OfKeyword = 161,
-        QualifiedName = 162,
-        ComputedPropertyName = 163,
-        TypeParameter = 164,
-        Parameter = 165,
-        Decorator = 166,
-        PropertySignature = 167,
-        PropertyDeclaration = 168,
-        MethodSignature = 169,
-        MethodDeclaration = 170,
-        ClassStaticBlockDeclaration = 171,
-        Constructor = 172,
-        GetAccessor = 173,
-        SetAccessor = 174,
-        CallSignature = 175,
-        ConstructSignature = 176,
-        IndexSignature = 177,
-        TypePredicate = 178,
-        TypeReference = 179,
-        FunctionType = 180,
-        ConstructorType = 181,
-        TypeQuery = 182,
-        TypeLiteral = 183,
-        ArrayType = 184,
-        TupleType = 185,
-        OptionalType = 186,
-        RestType = 187,
-        UnionType = 188,
-        IntersectionType = 189,
-        ConditionalType = 190,
-        InferType = 191,
-        ParenthesizedType = 192,
-        ThisType = 193,
-        TypeOperator = 194,
-        IndexedAccessType = 195,
-        MappedType = 196,
-        LiteralType = 197,
-        NamedTupleMember = 198,
-        TemplateLiteralType = 199,
-        TemplateLiteralTypeSpan = 200,
-        ImportType = 201,
-        ObjectBindingPattern = 202,
-        ArrayBindingPattern = 203,
-        BindingElement = 204,
-        ArrayLiteralExpression = 205,
-        ObjectLiteralExpression = 206,
-        PropertyAccessExpression = 207,
-        ElementAccessExpression = 208,
-        CallExpression = 209,
-        NewExpression = 210,
-        TaggedTemplateExpression = 211,
-        TypeAssertionExpression = 212,
-        ParenthesizedExpression = 213,
-        FunctionExpression = 214,
-        ArrowFunction = 215,
-        DeleteExpression = 216,
-        TypeOfExpression = 217,
-        VoidExpression = 218,
-        AwaitExpression = 219,
-        PrefixUnaryExpression = 220,
-        PostfixUnaryExpression = 221,
-        BinaryExpression = 222,
-        ConditionalExpression = 223,
-        TemplateExpression = 224,
-        YieldExpression = 225,
-        SpreadElement = 226,
-        ClassExpression = 227,
-        OmittedExpression = 228,
-        ExpressionWithTypeArguments = 229,
-        AsExpression = 230,
-        NonNullExpression = 231,
-        MetaProperty = 232,
-        SyntheticExpression = 233,
-        SatisfiesExpression = 234,
-        TemplateSpan = 235,
-        SemicolonClassElement = 236,
-        Block = 237,
-        EmptyStatement = 238,
-        VariableStatement = 239,
-        ExpressionStatement = 240,
-        IfStatement = 241,
-        DoStatement = 242,
-        WhileStatement = 243,
-        ForStatement = 244,
-        ForInStatement = 245,
-        ForOfStatement = 246,
-        ContinueStatement = 247,
-        BreakStatement = 248,
-        ReturnStatement = 249,
-        WithStatement = 250,
-        SwitchStatement = 251,
-        LabeledStatement = 252,
-        ThrowStatement = 253,
-        TryStatement = 254,
-        DebuggerStatement = 255,
-        VariableDeclaration = 256,
-        VariableDeclarationList = 257,
-        FunctionDeclaration = 258,
-        ClassDeclaration = 259,
-        InterfaceDeclaration = 260,
-        TypeAliasDeclaration = 261,
-        EnumDeclaration = 262,
-        ModuleDeclaration = 263,
-        ModuleBlock = 264,
-        CaseBlock = 265,
-        NamespaceExportDeclaration = 266,
-        ImportEqualsDeclaration = 267,
-        ImportDeclaration = 268,
-        ImportClause = 269,
-        NamespaceImport = 270,
-        NamedImports = 271,
-        ImportSpecifier = 272,
-        ExportAssignment = 273,
-        ExportDeclaration = 274,
-        NamedExports = 275,
-        NamespaceExport = 276,
-        ExportSpecifier = 277,
-        MissingDeclaration = 278,
-        ExternalModuleReference = 279,
-        JsxElement = 280,
-        JsxSelfClosingElement = 281,
-        JsxOpeningElement = 282,
-        JsxClosingElement = 283,
-        JsxFragment = 284,
-        JsxOpeningFragment = 285,
-        JsxClosingFragment = 286,
-        JsxAttribute = 287,
-        JsxAttributes = 288,
-        JsxSpreadAttribute = 289,
-        JsxExpression = 290,
-        CaseClause = 291,
-        DefaultClause = 292,
-        HeritageClause = 293,
-        CatchClause = 294,
-        AssertClause = 295,
-        AssertEntry = 296,
-        ImportTypeAssertionContainer = 297,
-        PropertyAssignment = 298,
-        ShorthandPropertyAssignment = 299,
-        SpreadAssignment = 300,
-        EnumMember = 301,
-        UnparsedPrologue = 302,
-        UnparsedPrepend = 303,
-        UnparsedText = 304,
-        UnparsedInternalText = 305,
-        UnparsedSyntheticReference = 306,
-        SourceFile = 307,
-        Bundle = 308,
-        UnparsedSource = 309,
-        InputFiles = 310,
-        JSDocTypeExpression = 311,
-        JSDocNameReference = 312,
-        JSDocMemberName = 313,
-        JSDocAllType = 314,
-        JSDocUnknownType = 315,
-        JSDocNullableType = 316,
-        JSDocNonNullableType = 317,
-        JSDocOptionalType = 318,
-        JSDocFunctionType = 319,
-        JSDocVariadicType = 320,
-        JSDocNamepathType = 321,
-        JSDoc = 322,
+        SetKeyword = 149,
+        StringKeyword = 150,
+        SymbolKeyword = 151,
+        TypeKeyword = 152,
+        UndefinedKeyword = 153,
+        UniqueKeyword = 154,
+        UnknownKeyword = 155,
+        FromKeyword = 156,
+        GlobalKeyword = 157,
+        BigIntKeyword = 158,
+        OverrideKeyword = 159,
+        OfKeyword = 160,
+        QualifiedName = 161,
+        ComputedPropertyName = 162,
+        TypeParameter = 163,
+        Parameter = 164,
+        Decorator = 165,
+        PropertySignature = 166,
+        PropertyDeclaration = 167,
+        MethodSignature = 168,
+        MethodDeclaration = 169,
+        ClassStaticBlockDeclaration = 170,
+        Constructor = 171,
+        GetAccessor = 172,
+        SetAccessor = 173,
+        CallSignature = 174,
+        ConstructSignature = 175,
+        IndexSignature = 176,
+        TypePredicate = 177,
+        TypeReference = 178,
+        FunctionType = 179,
+        ConstructorType = 180,
+        TypeQuery = 181,
+        TypeLiteral = 182,
+        ArrayType = 183,
+        TupleType = 184,
+        OptionalType = 185,
+        RestType = 186,
+        UnionType = 187,
+        IntersectionType = 188,
+        ConditionalType = 189,
+        InferType = 190,
+        ParenthesizedType = 191,
+        ThisType = 192,
+        TypeOperator = 193,
+        IndexedAccessType = 194,
+        MappedType = 195,
+        LiteralType = 196,
+        NamedTupleMember = 197,
+        TemplateLiteralType = 198,
+        TemplateLiteralTypeSpan = 199,
+        ImportType = 200,
+        ObjectBindingPattern = 201,
+        ArrayBindingPattern = 202,
+        BindingElement = 203,
+        ArrayLiteralExpression = 204,
+        ObjectLiteralExpression = 205,
+        PropertyAccessExpression = 206,
+        ElementAccessExpression = 207,
+        CallExpression = 208,
+        NewExpression = 209,
+        TaggedTemplateExpression = 210,
+        TypeAssertionExpression = 211,
+        ParenthesizedExpression = 212,
+        FunctionExpression = 213,
+        ArrowFunction = 214,
+        DeleteExpression = 215,
+        TypeOfExpression = 216,
+        VoidExpression = 217,
+        AwaitExpression = 218,
+        PrefixUnaryExpression = 219,
+        PostfixUnaryExpression = 220,
+        BinaryExpression = 221,
+        ConditionalExpression = 222,
+        TemplateExpression = 223,
+        YieldExpression = 224,
+        SpreadElement = 225,
+        ClassExpression = 226,
+        OmittedExpression = 227,
+        ExpressionWithTypeArguments = 228,
+        AsExpression = 229,
+        NonNullExpression = 230,
+        MetaProperty = 231,
+        SyntheticExpression = 232,
+        TemplateSpan = 233,
+        SemicolonClassElement = 234,
+        Block = 235,
+        EmptyStatement = 236,
+        VariableStatement = 237,
+        ExpressionStatement = 238,
+        IfStatement = 239,
+        DoStatement = 240,
+        WhileStatement = 241,
+        ForStatement = 242,
+        ForInStatement = 243,
+        ForOfStatement = 244,
+        ContinueStatement = 245,
+        BreakStatement = 246,
+        ReturnStatement = 247,
+        WithStatement = 248,
+        SwitchStatement = 249,
+        LabeledStatement = 250,
+        ThrowStatement = 251,
+        TryStatement = 252,
+        DebuggerStatement = 253,
+        VariableDeclaration = 254,
+        VariableDeclarationList = 255,
+        FunctionDeclaration = 256,
+        ClassDeclaration = 257,
+        InterfaceDeclaration = 258,
+        TypeAliasDeclaration = 259,
+        EnumDeclaration = 260,
+        ModuleDeclaration = 261,
+        ModuleBlock = 262,
+        CaseBlock = 263,
+        NamespaceExportDeclaration = 264,
+        ImportEqualsDeclaration = 265,
+        ImportDeclaration = 266,
+        ImportClause = 267,
+        NamespaceImport = 268,
+        NamedImports = 269,
+        ImportSpecifier = 270,
+        ExportAssignment = 271,
+        ExportDeclaration = 272,
+        NamedExports = 273,
+        NamespaceExport = 274,
+        ExportSpecifier = 275,
+        MissingDeclaration = 276,
+        ExternalModuleReference = 277,
+        JsxElement = 278,
+        JsxSelfClosingElement = 279,
+        JsxOpeningElement = 280,
+        JsxClosingElement = 281,
+        JsxFragment = 282,
+        JsxOpeningFragment = 283,
+        JsxClosingFragment = 284,
+        JsxAttribute = 285,
+        JsxAttributes = 286,
+        JsxSpreadAttribute = 287,
+        JsxExpression = 288,
+        CaseClause = 289,
+        DefaultClause = 290,
+        HeritageClause = 291,
+        CatchClause = 292,
+        AssertClause = 293,
+        AssertEntry = 294,
+        ImportTypeAssertionContainer = 295,
+        PropertyAssignment = 296,
+        ShorthandPropertyAssignment = 297,
+        SpreadAssignment = 298,
+        EnumMember = 299,
+        UnparsedPrologue = 300,
+        UnparsedPrepend = 301,
+        UnparsedText = 302,
+        UnparsedInternalText = 303,
+        UnparsedSyntheticReference = 304,
+        SourceFile = 305,
+        Bundle = 306,
+        UnparsedSource = 307,
+        InputFiles = 308,
+        JSDocTypeExpression = 309,
+        JSDocNameReference = 310,
+        JSDocMemberName = 311,
+        JSDocAllType = 312,
+        JSDocUnknownType = 313,
+        JSDocNullableType = 314,
+        JSDocNonNullableType = 315,
+        JSDocOptionalType = 316,
+        JSDocFunctionType = 317,
+        JSDocVariadicType = 318,
+        JSDocNamepathType = 319,
+        JSDoc = 320,
         /** @deprecated Use SyntaxKind.JSDoc */
-        JSDocComment = 322,
-        JSDocText = 323,
-        JSDocTypeLiteral = 324,
-        JSDocSignature = 325,
-        JSDocLink = 326,
-        JSDocLinkCode = 327,
-        JSDocLinkPlain = 328,
-        JSDocTag = 329,
-        JSDocAugmentsTag = 330,
-        JSDocImplementsTag = 331,
-        JSDocAuthorTag = 332,
-        JSDocDeprecatedTag = 333,
-        JSDocClassTag = 334,
-        JSDocPublicTag = 335,
-        JSDocPrivateTag = 336,
-        JSDocProtectedTag = 337,
-        JSDocReadonlyTag = 338,
-        JSDocOverrideTag = 339,
-        JSDocCallbackTag = 340,
-        JSDocEnumTag = 341,
-        JSDocParameterTag = 342,
-        JSDocReturnTag = 343,
-        JSDocThisTag = 344,
-        JSDocTypeTag = 345,
-        JSDocTemplateTag = 346,
-        JSDocTypedefTag = 347,
-        JSDocSeeTag = 348,
-        JSDocPropertyTag = 349,
-        SyntaxList = 350,
-        NotEmittedStatement = 351,
-        PartiallyEmittedExpression = 352,
-        CommaListExpression = 353,
-        MergeDeclarationMarker = 354,
-        EndOfDeclarationMarker = 355,
-        SyntheticReferenceExpression = 356,
-        Count = 357,
+        JSDocComment = 320,
+        JSDocText = 321,
+        JSDocTypeLiteral = 322,
+        JSDocSignature = 323,
+        JSDocLink = 324,
+        JSDocLinkCode = 325,
+        JSDocLinkPlain = 326,
+        JSDocTag = 327,
+        JSDocAugmentsTag = 328,
+        JSDocImplementsTag = 329,
+        JSDocAuthorTag = 330,
+        JSDocDeprecatedTag = 331,
+        JSDocClassTag = 332,
+        JSDocPublicTag = 333,
+        JSDocPrivateTag = 334,
+        JSDocProtectedTag = 335,
+        JSDocReadonlyTag = 336,
+        JSDocOverrideTag = 337,
+        JSDocOverloadTag = 338,
+        JSDocCallbackTag = 339,
+        JSDocEnumTag = 340,
+        JSDocParameterTag = 341,
+        JSDocReturnTag = 342,
+        JSDocThisTag = 343,
+        JSDocTypeTag = 344,
+        JSDocTemplateTag = 345,
+        JSDocTypedefTag = 346,
+        JSDocSeeTag = 347,
+        JSDocPropertyTag = 348,
+        SyntaxList = 349,
+        NotEmittedStatement = 350,
+        PartiallyEmittedExpression = 351,
+        CommaListExpression = 352,
+        MergeDeclarationMarker = 353,
+        EndOfDeclarationMarker = 354,
+        SyntheticReferenceExpression = 355,
+        Count = 356,
         FirstAssignment = 63,
         LastAssignment = 78,
         FirstCompoundAssignment = 64,
@@ -472,15 +471,15 @@ declare namespace ts {
         FirstReservedWord = 81,
         LastReservedWord = 116,
         FirstKeyword = 81,
-        LastKeyword = 161,
+        LastKeyword = 160,
         FirstFutureReservedWord = 117,
         LastFutureReservedWord = 125,
-        FirstTypeNode = 178,
-        LastTypeNode = 201,
+        FirstTypeNode = 177,
+        LastTypeNode = 200,
         FirstPunctuation = 18,
         LastPunctuation = 78,
         FirstToken = 0,
-        LastToken = 161,
+        LastToken = 160,
         FirstTriviaToken = 2,
         LastTriviaToken = 7,
         FirstLiteralToken = 8,
@@ -489,19 +488,19 @@ declare namespace ts {
         LastTemplateToken = 17,
         FirstBinaryOperator = 29,
         LastBinaryOperator = 78,
-        FirstStatement = 239,
-        LastStatement = 255,
-        FirstNode = 162,
-        FirstJSDocNode = 311,
-        LastJSDocNode = 349,
-        FirstJSDocTagNode = 329,
-        LastJSDocTagNode = 349,
+        FirstStatement = 237,
+        LastStatement = 253,
+        FirstNode = 161,
+        FirstJSDocNode = 309,
+        LastJSDocNode = 348,
+        FirstJSDocTagNode = 327,
+        LastJSDocTagNode = 348,
     }
     export type TriviaSyntaxKind = SyntaxKind.SingleLineCommentTrivia | SyntaxKind.MultiLineCommentTrivia | SyntaxKind.NewLineTrivia | SyntaxKind.WhitespaceTrivia | SyntaxKind.ShebangTrivia | SyntaxKind.ConflictMarkerTrivia;
     export type LiteralSyntaxKind = SyntaxKind.NumericLiteral | SyntaxKind.BigIntLiteral | SyntaxKind.StringLiteral | SyntaxKind.JsxText | SyntaxKind.JsxTextAllWhiteSpaces | SyntaxKind.RegularExpressionLiteral | SyntaxKind.NoSubstitutionTemplateLiteral;
     export type PseudoLiteralSyntaxKind = SyntaxKind.TemplateHead | SyntaxKind.TemplateMiddle | SyntaxKind.TemplateTail;
     export type PunctuationSyntaxKind = SyntaxKind.OpenBraceToken | SyntaxKind.CloseBraceToken | SyntaxKind.OpenParenToken | SyntaxKind.CloseParenToken | SyntaxKind.OpenBracketToken | SyntaxKind.CloseBracketToken | SyntaxKind.DotToken | SyntaxKind.DotDotDotToken | SyntaxKind.SemicolonToken | SyntaxKind.CommaToken | SyntaxKind.QuestionDotToken | SyntaxKind.LessThanToken | SyntaxKind.LessThanSlashToken | SyntaxKind.GreaterThanToken | SyntaxKind.LessThanEqualsToken | SyntaxKind.GreaterThanEqualsToken | SyntaxKind.EqualsEqualsToken | SyntaxKind.ExclamationEqualsToken | SyntaxKind.EqualsEqualsEqualsToken | SyntaxKind.ExclamationEqualsEqualsToken | SyntaxKind.EqualsGreaterThanToken | SyntaxKind.PlusToken | SyntaxKind.MinusToken | SyntaxKind.AsteriskToken | SyntaxKind.AsteriskAsteriskToken | SyntaxKind.SlashToken | SyntaxKind.PercentToken | SyntaxKind.PlusPlusToken | SyntaxKind.MinusMinusToken | SyntaxKind.LessThanLessThanToken | SyntaxKind.GreaterThanGreaterThanToken | SyntaxKind.GreaterThanGreaterThanGreaterThanToken | SyntaxKind.AmpersandToken | SyntaxKind.BarToken | SyntaxKind.CaretToken | SyntaxKind.ExclamationToken | SyntaxKind.TildeToken | SyntaxKind.AmpersandAmpersandToken | SyntaxKind.BarBarToken | SyntaxKind.QuestionQuestionToken | SyntaxKind.QuestionToken | SyntaxKind.ColonToken | SyntaxKind.AtToken | SyntaxKind.BacktickToken | SyntaxKind.HashToken | SyntaxKind.EqualsToken | SyntaxKind.PlusEqualsToken | SyntaxKind.MinusEqualsToken | SyntaxKind.AsteriskEqualsToken | SyntaxKind.AsteriskAsteriskEqualsToken | SyntaxKind.SlashEqualsToken | SyntaxKind.PercentEqualsToken | SyntaxKind.LessThanLessThanEqualsToken | SyntaxKind.GreaterThanGreaterThanEqualsToken | SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken | SyntaxKind.AmpersandEqualsToken | SyntaxKind.BarEqualsToken | SyntaxKind.CaretEqualsToken;
-    export type KeywordSyntaxKind = SyntaxKind.AbstractKeyword | SyntaxKind.AnyKeyword | SyntaxKind.AsKeyword | SyntaxKind.AssertsKeyword | SyntaxKind.AssertKeyword | SyntaxKind.AsyncKeyword | SyntaxKind.AwaitKeyword | SyntaxKind.BigIntKeyword | SyntaxKind.BooleanKeyword | SyntaxKind.BreakKeyword | SyntaxKind.CaseKeyword | SyntaxKind.CatchKeyword | SyntaxKind.ClassKeyword | SyntaxKind.ConstKeyword | SyntaxKind.ConstructorKeyword | SyntaxKind.ContinueKeyword | SyntaxKind.DebuggerKeyword | SyntaxKind.DeclareKeyword | SyntaxKind.DefaultKeyword | SyntaxKind.DeleteKeyword | SyntaxKind.DoKeyword | SyntaxKind.ElseKeyword | SyntaxKind.EnumKeyword | SyntaxKind.ExportKeyword | SyntaxKind.ExtendsKeyword | SyntaxKind.FalseKeyword | SyntaxKind.FinallyKeyword | SyntaxKind.ForKeyword | SyntaxKind.FromKeyword | SyntaxKind.FunctionKeyword | SyntaxKind.GetKeyword | SyntaxKind.GlobalKeyword | SyntaxKind.IfKeyword | SyntaxKind.ImplementsKeyword | SyntaxKind.ImportKeyword | SyntaxKind.InferKeyword | SyntaxKind.InKeyword | SyntaxKind.InstanceOfKeyword | SyntaxKind.InterfaceKeyword | SyntaxKind.IntrinsicKeyword | SyntaxKind.IsKeyword | SyntaxKind.KeyOfKeyword | SyntaxKind.LetKeyword | SyntaxKind.ModuleKeyword | SyntaxKind.NamespaceKeyword | SyntaxKind.NeverKeyword | SyntaxKind.NewKeyword | SyntaxKind.NullKeyword | SyntaxKind.NumberKeyword | SyntaxKind.ObjectKeyword | SyntaxKind.OfKeyword | SyntaxKind.PackageKeyword | SyntaxKind.PrivateKeyword | SyntaxKind.ProtectedKeyword | SyntaxKind.PublicKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.OutKeyword | SyntaxKind.OverrideKeyword | SyntaxKind.RequireKeyword | SyntaxKind.ReturnKeyword | SyntaxKind.SatisfiesKeyword | SyntaxKind.SetKeyword | SyntaxKind.StaticKeyword | SyntaxKind.StringKeyword | SyntaxKind.SuperKeyword | SyntaxKind.SwitchKeyword | SyntaxKind.SymbolKeyword | SyntaxKind.ThisKeyword | SyntaxKind.ThrowKeyword | SyntaxKind.TrueKeyword | SyntaxKind.TryKeyword | SyntaxKind.TypeKeyword | SyntaxKind.TypeOfKeyword | SyntaxKind.UndefinedKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.UnknownKeyword | SyntaxKind.VarKeyword | SyntaxKind.VoidKeyword | SyntaxKind.WhileKeyword | SyntaxKind.WithKeyword | SyntaxKind.YieldKeyword;
+    export type KeywordSyntaxKind = SyntaxKind.AbstractKeyword | SyntaxKind.AnyKeyword | SyntaxKind.AsKeyword | SyntaxKind.AssertsKeyword | SyntaxKind.AssertKeyword | SyntaxKind.AsyncKeyword | SyntaxKind.AwaitKeyword | SyntaxKind.BigIntKeyword | SyntaxKind.BooleanKeyword | SyntaxKind.BreakKeyword | SyntaxKind.CaseKeyword | SyntaxKind.CatchKeyword | SyntaxKind.ClassKeyword | SyntaxKind.ConstKeyword | SyntaxKind.ConstructorKeyword | SyntaxKind.ContinueKeyword | SyntaxKind.DebuggerKeyword | SyntaxKind.DeclareKeyword | SyntaxKind.DefaultKeyword | SyntaxKind.DeleteKeyword | SyntaxKind.DoKeyword | SyntaxKind.ElseKeyword | SyntaxKind.EnumKeyword | SyntaxKind.ExportKeyword | SyntaxKind.ExtendsKeyword | SyntaxKind.FalseKeyword | SyntaxKind.FinallyKeyword | SyntaxKind.ForKeyword | SyntaxKind.FromKeyword | SyntaxKind.FunctionKeyword | SyntaxKind.GetKeyword | SyntaxKind.GlobalKeyword | SyntaxKind.IfKeyword | SyntaxKind.ImplementsKeyword | SyntaxKind.ImportKeyword | SyntaxKind.InferKeyword | SyntaxKind.InKeyword | SyntaxKind.InstanceOfKeyword | SyntaxKind.InterfaceKeyword | SyntaxKind.IntrinsicKeyword | SyntaxKind.IsKeyword | SyntaxKind.KeyOfKeyword | SyntaxKind.LetKeyword | SyntaxKind.ModuleKeyword | SyntaxKind.NamespaceKeyword | SyntaxKind.NeverKeyword | SyntaxKind.NewKeyword | SyntaxKind.NullKeyword | SyntaxKind.NumberKeyword | SyntaxKind.ObjectKeyword | SyntaxKind.OfKeyword | SyntaxKind.PackageKeyword | SyntaxKind.PrivateKeyword | SyntaxKind.ProtectedKeyword | SyntaxKind.PublicKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.OutKeyword | SyntaxKind.OverrideKeyword | SyntaxKind.RequireKeyword | SyntaxKind.ReturnKeyword | SyntaxKind.SetKeyword | SyntaxKind.StaticKeyword | SyntaxKind.StringKeyword | SyntaxKind.SuperKeyword | SyntaxKind.SwitchKeyword | SyntaxKind.SymbolKeyword | SyntaxKind.ThisKeyword | SyntaxKind.ThrowKeyword | SyntaxKind.TrueKeyword | SyntaxKind.TryKeyword | SyntaxKind.TypeKeyword | SyntaxKind.TypeOfKeyword | SyntaxKind.UndefinedKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.UnknownKeyword | SyntaxKind.VarKeyword | SyntaxKind.VoidKeyword | SyntaxKind.WhileKeyword | SyntaxKind.WithKeyword | SyntaxKind.YieldKeyword;
     export type ModifierSyntaxKind = SyntaxKind.AbstractKeyword | SyntaxKind.AsyncKeyword | SyntaxKind.ConstKeyword | SyntaxKind.DeclareKeyword | SyntaxKind.DefaultKeyword | SyntaxKind.ExportKeyword | SyntaxKind.InKeyword | SyntaxKind.PrivateKeyword | SyntaxKind.ProtectedKeyword | SyntaxKind.PublicKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.OutKeyword | SyntaxKind.OverrideKeyword | SyntaxKind.StaticKeyword;
     export type KeywordTypeSyntaxKind = SyntaxKind.AnyKeyword | SyntaxKind.BigIntKeyword | SyntaxKind.BooleanKeyword | SyntaxKind.IntrinsicKeyword | SyntaxKind.NeverKeyword | SyntaxKind.NumberKeyword | SyntaxKind.ObjectKeyword | SyntaxKind.StringKeyword | SyntaxKind.SymbolKeyword | SyntaxKind.UndefinedKeyword | SyntaxKind.UnknownKeyword | SyntaxKind.VoidKeyword;
     export type TokenSyntaxKind = SyntaxKind.Unknown | SyntaxKind.EndOfFileToken | TriviaSyntaxKind | LiteralSyntaxKind | PseudoLiteralSyntaxKind | PunctuationSyntaxKind | SyntaxKind.Identifier | KeywordSyntaxKind;
@@ -1342,11 +1341,6 @@ declare namespace ts {
         readonly type: TypeNode;
         readonly expression: UnaryExpression;
     }
-    export interface SatisfiesExpression extends Expression {
-        readonly kind: SyntaxKind.SatisfiesExpression;
-        readonly expression: Expression;
-        readonly type: TypeNode;
-    }
     export type AssertionExpression = TypeAssertion | AsExpression;
     export interface NonNullExpression extends LeftHandSideExpression {
         readonly kind: SyntaxKind.NonNullExpression;
@@ -1934,6 +1928,9 @@ declare namespace ts {
     export interface JSDocOverrideTag extends JSDocTag {
         readonly kind: SyntaxKind.JSDocOverrideTag;
     }
+    export interface JSDocOverloadTag extends JSDocTag {
+        readonly kind: SyntaxKind.JSDocOverloadTag;
+    }
     export interface JSDocEnumTag extends JSDocTag, Declaration {
         readonly kind: SyntaxKind.JSDocEnumTag;
         readonly parent: JSDoc;
@@ -2323,7 +2320,6 @@ declare namespace ts {
         getPrivateIdentifierPropertyOfType(leftType: Type, name: string, location: Node): Symbol | undefined;
         getIndexInfoOfType(type: Type, kind: IndexKind): IndexInfo | undefined;
         getIndexInfosOfType(type: Type): readonly IndexInfo[];
-        getIndexInfosOfIndexSymbol: (indexSymbol: Symbol) => IndexInfo[];
         getSignaturesOfType(type: Type, kind: SignatureKind): readonly Signature[];
         getIndexTypeOfType(type: Type, kind: IndexKind): Type | undefined;
         getBaseTypes(type: InterfaceType): BaseType[];
@@ -2840,7 +2836,7 @@ declare namespace ts {
     export interface SubstitutionType extends InstantiableType {
         objectFlags: ObjectFlags;
         baseType: Type;
-        constraint: Type;
+        substitute: Type;
     }
     export enum SignatureKind {
         Call = 0,
@@ -3595,8 +3591,6 @@ declare namespace ts {
         updateNonNullChain(node: NonNullChain, expression: Expression): NonNullChain;
         createMetaProperty(keywordToken: MetaProperty["keywordToken"], name: Identifier): MetaProperty;
         updateMetaProperty(node: MetaProperty, name: Identifier): MetaProperty;
-        createSatisfiesExpression(expression: Expression, type: TypeNode): SatisfiesExpression;
-        updateSatisfiesExpression(node: SatisfiesExpression, expression: Expression, type: TypeNode): SatisfiesExpression;
         createTemplateSpan(expression: Expression, literal: TemplateMiddle | TemplateTail): TemplateSpan;
         updateTemplateSpan(node: TemplateSpan, expression: Expression, literal: TemplateMiddle | TemplateTail): TemplateSpan;
         createSemicolonClassElement(): SemicolonClassElement;
@@ -3760,6 +3754,8 @@ declare namespace ts {
         updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocDeprecatedTag;
         createJSDocOverrideTag(tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverrideTag;
         updateJSDocOverrideTag(node: JSDocOverrideTag, tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverrideTag;
+        createJSDocOverloadTag(tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverloadTag;
+        updateJSDocOverloadTag(node: JSDocOverloadTag, tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverloadTag;
         createJSDocText(text: string): JSDocText;
         updateJSDocText(node: JSDocText, text: string): JSDocText;
         createJSDocComment(comment?: string | NodeArray<JSDocComment> | undefined, tags?: readonly JSDocTag[] | undefined): JSDoc;
@@ -4273,14 +4269,14 @@ declare namespace ts {
     function isWhiteSpaceSingleLine(ch: number): boolean;
     function isLineBreak(ch: number): boolean;
     function couldStartTrivia(text: string, pos: number): boolean;
-    function forEachLeadingCommentRange<U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
-    function forEachLeadingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
-    function forEachTrailingCommentRange<U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
-    function forEachTrailingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
-    function reduceEachLeadingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U): U | undefined;
-    function reduceEachTrailingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U): U | undefined;
-    function getLeadingCommentRanges(text: string, pos: number): CommentRange[] | undefined;
-    function getTrailingCommentRanges(text: string, pos: number): CommentRange[] | undefined;
+    function forEachLeadingCommentRange<U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
+    function forEachLeadingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
+    function forEachTrailingCommentRange<U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
+    function forEachTrailingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
+    function reduceEachLeadingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U): U | undefined;
+    function reduceEachTrailingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U): U | undefined;
+    function getLeadingCommentRanges(text: string, pos: number, end?: number): CommentRange[] | undefined;
+    function getTrailingCommentRanges(text: string, pos: number, end?: number): CommentRange[] | undefined;
     /** Optionally, get the shebang */
     function getShebang(text: string): string | undefined;
     function isIdentifierStart(ch: number, languageVersion: ScriptTarget | undefined): boolean;
@@ -4726,7 +4722,6 @@ declare namespace ts {
     function isOmittedExpression(node: Node): node is OmittedExpression;
     function isExpressionWithTypeArguments(node: Node): node is ExpressionWithTypeArguments;
     function isAsExpression(node: Node): node is AsExpression;
-    function isSatisfiesExpression(node: Node): node is SatisfiesExpression;
     function isNonNullExpression(node: Node): node is NonNullExpression;
     function isMetaProperty(node: Node): node is MetaProperty;
     function isSyntheticExpression(node: Node): node is SyntheticExpression;
@@ -4830,6 +4825,7 @@ declare namespace ts {
     function isJSDocProtectedTag(node: Node): node is JSDocProtectedTag;
     function isJSDocReadonlyTag(node: Node): node is JSDocReadonlyTag;
     function isJSDocOverrideTag(node: Node): node is JSDocOverrideTag;
+    function isJSDocOverloadTag(node: Node): node is JSDocOverloadTag;
     function isJSDocDeprecatedTag(node: Node): node is JSDocDeprecatedTag;
     function isJSDocSeeTag(node: Node): node is JSDocSeeTag;
     function isJSDocEnumTag(node: Node): node is JSDocEnumTag;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -14,7 +14,7 @@ and limitations under the License.
 ***************************************************************************** */
 
 declare namespace ts {
-    const versionMajorMinor = "4.9";
+    const versionMajorMinor = "4.8";
     /** The version of the TypeScript compiler release */
     const version: string;
     /**
@@ -254,217 +254,216 @@ declare namespace ts {
         RequireKeyword = 146,
         NumberKeyword = 147,
         ObjectKeyword = 148,
-        SatisfiesKeyword = 149,
-        SetKeyword = 150,
-        StringKeyword = 151,
-        SymbolKeyword = 152,
-        TypeKeyword = 153,
-        UndefinedKeyword = 154,
-        UniqueKeyword = 155,
-        UnknownKeyword = 156,
-        FromKeyword = 157,
-        GlobalKeyword = 158,
-        BigIntKeyword = 159,
-        OverrideKeyword = 160,
-        OfKeyword = 161,
-        QualifiedName = 162,
-        ComputedPropertyName = 163,
-        TypeParameter = 164,
-        Parameter = 165,
-        Decorator = 166,
-        PropertySignature = 167,
-        PropertyDeclaration = 168,
-        MethodSignature = 169,
-        MethodDeclaration = 170,
-        ClassStaticBlockDeclaration = 171,
-        Constructor = 172,
-        GetAccessor = 173,
-        SetAccessor = 174,
-        CallSignature = 175,
-        ConstructSignature = 176,
-        IndexSignature = 177,
-        TypePredicate = 178,
-        TypeReference = 179,
-        FunctionType = 180,
-        ConstructorType = 181,
-        TypeQuery = 182,
-        TypeLiteral = 183,
-        ArrayType = 184,
-        TupleType = 185,
-        OptionalType = 186,
-        RestType = 187,
-        UnionType = 188,
-        IntersectionType = 189,
-        ConditionalType = 190,
-        InferType = 191,
-        ParenthesizedType = 192,
-        ThisType = 193,
-        TypeOperator = 194,
-        IndexedAccessType = 195,
-        MappedType = 196,
-        LiteralType = 197,
-        NamedTupleMember = 198,
-        TemplateLiteralType = 199,
-        TemplateLiteralTypeSpan = 200,
-        ImportType = 201,
-        ObjectBindingPattern = 202,
-        ArrayBindingPattern = 203,
-        BindingElement = 204,
-        ArrayLiteralExpression = 205,
-        ObjectLiteralExpression = 206,
-        PropertyAccessExpression = 207,
-        ElementAccessExpression = 208,
-        CallExpression = 209,
-        NewExpression = 210,
-        TaggedTemplateExpression = 211,
-        TypeAssertionExpression = 212,
-        ParenthesizedExpression = 213,
-        FunctionExpression = 214,
-        ArrowFunction = 215,
-        DeleteExpression = 216,
-        TypeOfExpression = 217,
-        VoidExpression = 218,
-        AwaitExpression = 219,
-        PrefixUnaryExpression = 220,
-        PostfixUnaryExpression = 221,
-        BinaryExpression = 222,
-        ConditionalExpression = 223,
-        TemplateExpression = 224,
-        YieldExpression = 225,
-        SpreadElement = 226,
-        ClassExpression = 227,
-        OmittedExpression = 228,
-        ExpressionWithTypeArguments = 229,
-        AsExpression = 230,
-        NonNullExpression = 231,
-        MetaProperty = 232,
-        SyntheticExpression = 233,
-        SatisfiesExpression = 234,
-        TemplateSpan = 235,
-        SemicolonClassElement = 236,
-        Block = 237,
-        EmptyStatement = 238,
-        VariableStatement = 239,
-        ExpressionStatement = 240,
-        IfStatement = 241,
-        DoStatement = 242,
-        WhileStatement = 243,
-        ForStatement = 244,
-        ForInStatement = 245,
-        ForOfStatement = 246,
-        ContinueStatement = 247,
-        BreakStatement = 248,
-        ReturnStatement = 249,
-        WithStatement = 250,
-        SwitchStatement = 251,
-        LabeledStatement = 252,
-        ThrowStatement = 253,
-        TryStatement = 254,
-        DebuggerStatement = 255,
-        VariableDeclaration = 256,
-        VariableDeclarationList = 257,
-        FunctionDeclaration = 258,
-        ClassDeclaration = 259,
-        InterfaceDeclaration = 260,
-        TypeAliasDeclaration = 261,
-        EnumDeclaration = 262,
-        ModuleDeclaration = 263,
-        ModuleBlock = 264,
-        CaseBlock = 265,
-        NamespaceExportDeclaration = 266,
-        ImportEqualsDeclaration = 267,
-        ImportDeclaration = 268,
-        ImportClause = 269,
-        NamespaceImport = 270,
-        NamedImports = 271,
-        ImportSpecifier = 272,
-        ExportAssignment = 273,
-        ExportDeclaration = 274,
-        NamedExports = 275,
-        NamespaceExport = 276,
-        ExportSpecifier = 277,
-        MissingDeclaration = 278,
-        ExternalModuleReference = 279,
-        JsxElement = 280,
-        JsxSelfClosingElement = 281,
-        JsxOpeningElement = 282,
-        JsxClosingElement = 283,
-        JsxFragment = 284,
-        JsxOpeningFragment = 285,
-        JsxClosingFragment = 286,
-        JsxAttribute = 287,
-        JsxAttributes = 288,
-        JsxSpreadAttribute = 289,
-        JsxExpression = 290,
-        CaseClause = 291,
-        DefaultClause = 292,
-        HeritageClause = 293,
-        CatchClause = 294,
-        AssertClause = 295,
-        AssertEntry = 296,
-        ImportTypeAssertionContainer = 297,
-        PropertyAssignment = 298,
-        ShorthandPropertyAssignment = 299,
-        SpreadAssignment = 300,
-        EnumMember = 301,
-        UnparsedPrologue = 302,
-        UnparsedPrepend = 303,
-        UnparsedText = 304,
-        UnparsedInternalText = 305,
-        UnparsedSyntheticReference = 306,
-        SourceFile = 307,
-        Bundle = 308,
-        UnparsedSource = 309,
-        InputFiles = 310,
-        JSDocTypeExpression = 311,
-        JSDocNameReference = 312,
-        JSDocMemberName = 313,
-        JSDocAllType = 314,
-        JSDocUnknownType = 315,
-        JSDocNullableType = 316,
-        JSDocNonNullableType = 317,
-        JSDocOptionalType = 318,
-        JSDocFunctionType = 319,
-        JSDocVariadicType = 320,
-        JSDocNamepathType = 321,
-        JSDoc = 322,
+        SetKeyword = 149,
+        StringKeyword = 150,
+        SymbolKeyword = 151,
+        TypeKeyword = 152,
+        UndefinedKeyword = 153,
+        UniqueKeyword = 154,
+        UnknownKeyword = 155,
+        FromKeyword = 156,
+        GlobalKeyword = 157,
+        BigIntKeyword = 158,
+        OverrideKeyword = 159,
+        OfKeyword = 160,
+        QualifiedName = 161,
+        ComputedPropertyName = 162,
+        TypeParameter = 163,
+        Parameter = 164,
+        Decorator = 165,
+        PropertySignature = 166,
+        PropertyDeclaration = 167,
+        MethodSignature = 168,
+        MethodDeclaration = 169,
+        ClassStaticBlockDeclaration = 170,
+        Constructor = 171,
+        GetAccessor = 172,
+        SetAccessor = 173,
+        CallSignature = 174,
+        ConstructSignature = 175,
+        IndexSignature = 176,
+        TypePredicate = 177,
+        TypeReference = 178,
+        FunctionType = 179,
+        ConstructorType = 180,
+        TypeQuery = 181,
+        TypeLiteral = 182,
+        ArrayType = 183,
+        TupleType = 184,
+        OptionalType = 185,
+        RestType = 186,
+        UnionType = 187,
+        IntersectionType = 188,
+        ConditionalType = 189,
+        InferType = 190,
+        ParenthesizedType = 191,
+        ThisType = 192,
+        TypeOperator = 193,
+        IndexedAccessType = 194,
+        MappedType = 195,
+        LiteralType = 196,
+        NamedTupleMember = 197,
+        TemplateLiteralType = 198,
+        TemplateLiteralTypeSpan = 199,
+        ImportType = 200,
+        ObjectBindingPattern = 201,
+        ArrayBindingPattern = 202,
+        BindingElement = 203,
+        ArrayLiteralExpression = 204,
+        ObjectLiteralExpression = 205,
+        PropertyAccessExpression = 206,
+        ElementAccessExpression = 207,
+        CallExpression = 208,
+        NewExpression = 209,
+        TaggedTemplateExpression = 210,
+        TypeAssertionExpression = 211,
+        ParenthesizedExpression = 212,
+        FunctionExpression = 213,
+        ArrowFunction = 214,
+        DeleteExpression = 215,
+        TypeOfExpression = 216,
+        VoidExpression = 217,
+        AwaitExpression = 218,
+        PrefixUnaryExpression = 219,
+        PostfixUnaryExpression = 220,
+        BinaryExpression = 221,
+        ConditionalExpression = 222,
+        TemplateExpression = 223,
+        YieldExpression = 224,
+        SpreadElement = 225,
+        ClassExpression = 226,
+        OmittedExpression = 227,
+        ExpressionWithTypeArguments = 228,
+        AsExpression = 229,
+        NonNullExpression = 230,
+        MetaProperty = 231,
+        SyntheticExpression = 232,
+        TemplateSpan = 233,
+        SemicolonClassElement = 234,
+        Block = 235,
+        EmptyStatement = 236,
+        VariableStatement = 237,
+        ExpressionStatement = 238,
+        IfStatement = 239,
+        DoStatement = 240,
+        WhileStatement = 241,
+        ForStatement = 242,
+        ForInStatement = 243,
+        ForOfStatement = 244,
+        ContinueStatement = 245,
+        BreakStatement = 246,
+        ReturnStatement = 247,
+        WithStatement = 248,
+        SwitchStatement = 249,
+        LabeledStatement = 250,
+        ThrowStatement = 251,
+        TryStatement = 252,
+        DebuggerStatement = 253,
+        VariableDeclaration = 254,
+        VariableDeclarationList = 255,
+        FunctionDeclaration = 256,
+        ClassDeclaration = 257,
+        InterfaceDeclaration = 258,
+        TypeAliasDeclaration = 259,
+        EnumDeclaration = 260,
+        ModuleDeclaration = 261,
+        ModuleBlock = 262,
+        CaseBlock = 263,
+        NamespaceExportDeclaration = 264,
+        ImportEqualsDeclaration = 265,
+        ImportDeclaration = 266,
+        ImportClause = 267,
+        NamespaceImport = 268,
+        NamedImports = 269,
+        ImportSpecifier = 270,
+        ExportAssignment = 271,
+        ExportDeclaration = 272,
+        NamedExports = 273,
+        NamespaceExport = 274,
+        ExportSpecifier = 275,
+        MissingDeclaration = 276,
+        ExternalModuleReference = 277,
+        JsxElement = 278,
+        JsxSelfClosingElement = 279,
+        JsxOpeningElement = 280,
+        JsxClosingElement = 281,
+        JsxFragment = 282,
+        JsxOpeningFragment = 283,
+        JsxClosingFragment = 284,
+        JsxAttribute = 285,
+        JsxAttributes = 286,
+        JsxSpreadAttribute = 287,
+        JsxExpression = 288,
+        CaseClause = 289,
+        DefaultClause = 290,
+        HeritageClause = 291,
+        CatchClause = 292,
+        AssertClause = 293,
+        AssertEntry = 294,
+        ImportTypeAssertionContainer = 295,
+        PropertyAssignment = 296,
+        ShorthandPropertyAssignment = 297,
+        SpreadAssignment = 298,
+        EnumMember = 299,
+        UnparsedPrologue = 300,
+        UnparsedPrepend = 301,
+        UnparsedText = 302,
+        UnparsedInternalText = 303,
+        UnparsedSyntheticReference = 304,
+        SourceFile = 305,
+        Bundle = 306,
+        UnparsedSource = 307,
+        InputFiles = 308,
+        JSDocTypeExpression = 309,
+        JSDocNameReference = 310,
+        JSDocMemberName = 311,
+        JSDocAllType = 312,
+        JSDocUnknownType = 313,
+        JSDocNullableType = 314,
+        JSDocNonNullableType = 315,
+        JSDocOptionalType = 316,
+        JSDocFunctionType = 317,
+        JSDocVariadicType = 318,
+        JSDocNamepathType = 319,
+        JSDoc = 320,
         /** @deprecated Use SyntaxKind.JSDoc */
-        JSDocComment = 322,
-        JSDocText = 323,
-        JSDocTypeLiteral = 324,
-        JSDocSignature = 325,
-        JSDocLink = 326,
-        JSDocLinkCode = 327,
-        JSDocLinkPlain = 328,
-        JSDocTag = 329,
-        JSDocAugmentsTag = 330,
-        JSDocImplementsTag = 331,
-        JSDocAuthorTag = 332,
-        JSDocDeprecatedTag = 333,
-        JSDocClassTag = 334,
-        JSDocPublicTag = 335,
-        JSDocPrivateTag = 336,
-        JSDocProtectedTag = 337,
-        JSDocReadonlyTag = 338,
-        JSDocOverrideTag = 339,
-        JSDocCallbackTag = 340,
-        JSDocEnumTag = 341,
-        JSDocParameterTag = 342,
-        JSDocReturnTag = 343,
-        JSDocThisTag = 344,
-        JSDocTypeTag = 345,
-        JSDocTemplateTag = 346,
-        JSDocTypedefTag = 347,
-        JSDocSeeTag = 348,
-        JSDocPropertyTag = 349,
-        SyntaxList = 350,
-        NotEmittedStatement = 351,
-        PartiallyEmittedExpression = 352,
-        CommaListExpression = 353,
-        MergeDeclarationMarker = 354,
-        EndOfDeclarationMarker = 355,
-        SyntheticReferenceExpression = 356,
-        Count = 357,
+        JSDocComment = 320,
+        JSDocText = 321,
+        JSDocTypeLiteral = 322,
+        JSDocSignature = 323,
+        JSDocLink = 324,
+        JSDocLinkCode = 325,
+        JSDocLinkPlain = 326,
+        JSDocTag = 327,
+        JSDocAugmentsTag = 328,
+        JSDocImplementsTag = 329,
+        JSDocAuthorTag = 330,
+        JSDocDeprecatedTag = 331,
+        JSDocClassTag = 332,
+        JSDocPublicTag = 333,
+        JSDocPrivateTag = 334,
+        JSDocProtectedTag = 335,
+        JSDocReadonlyTag = 336,
+        JSDocOverrideTag = 337,
+        JSDocOverloadTag = 338,
+        JSDocCallbackTag = 339,
+        JSDocEnumTag = 340,
+        JSDocParameterTag = 341,
+        JSDocReturnTag = 342,
+        JSDocThisTag = 343,
+        JSDocTypeTag = 344,
+        JSDocTemplateTag = 345,
+        JSDocTypedefTag = 346,
+        JSDocSeeTag = 347,
+        JSDocPropertyTag = 348,
+        SyntaxList = 349,
+        NotEmittedStatement = 350,
+        PartiallyEmittedExpression = 351,
+        CommaListExpression = 352,
+        MergeDeclarationMarker = 353,
+        EndOfDeclarationMarker = 354,
+        SyntheticReferenceExpression = 355,
+        Count = 356,
         FirstAssignment = 63,
         LastAssignment = 78,
         FirstCompoundAssignment = 64,
@@ -472,15 +471,15 @@ declare namespace ts {
         FirstReservedWord = 81,
         LastReservedWord = 116,
         FirstKeyword = 81,
-        LastKeyword = 161,
+        LastKeyword = 160,
         FirstFutureReservedWord = 117,
         LastFutureReservedWord = 125,
-        FirstTypeNode = 178,
-        LastTypeNode = 201,
+        FirstTypeNode = 177,
+        LastTypeNode = 200,
         FirstPunctuation = 18,
         LastPunctuation = 78,
         FirstToken = 0,
-        LastToken = 161,
+        LastToken = 160,
         FirstTriviaToken = 2,
         LastTriviaToken = 7,
         FirstLiteralToken = 8,
@@ -489,19 +488,19 @@ declare namespace ts {
         LastTemplateToken = 17,
         FirstBinaryOperator = 29,
         LastBinaryOperator = 78,
-        FirstStatement = 239,
-        LastStatement = 255,
-        FirstNode = 162,
-        FirstJSDocNode = 311,
-        LastJSDocNode = 349,
-        FirstJSDocTagNode = 329,
-        LastJSDocTagNode = 349,
+        FirstStatement = 237,
+        LastStatement = 253,
+        FirstNode = 161,
+        FirstJSDocNode = 309,
+        LastJSDocNode = 348,
+        FirstJSDocTagNode = 327,
+        LastJSDocTagNode = 348,
     }
     export type TriviaSyntaxKind = SyntaxKind.SingleLineCommentTrivia | SyntaxKind.MultiLineCommentTrivia | SyntaxKind.NewLineTrivia | SyntaxKind.WhitespaceTrivia | SyntaxKind.ShebangTrivia | SyntaxKind.ConflictMarkerTrivia;
     export type LiteralSyntaxKind = SyntaxKind.NumericLiteral | SyntaxKind.BigIntLiteral | SyntaxKind.StringLiteral | SyntaxKind.JsxText | SyntaxKind.JsxTextAllWhiteSpaces | SyntaxKind.RegularExpressionLiteral | SyntaxKind.NoSubstitutionTemplateLiteral;
     export type PseudoLiteralSyntaxKind = SyntaxKind.TemplateHead | SyntaxKind.TemplateMiddle | SyntaxKind.TemplateTail;
     export type PunctuationSyntaxKind = SyntaxKind.OpenBraceToken | SyntaxKind.CloseBraceToken | SyntaxKind.OpenParenToken | SyntaxKind.CloseParenToken | SyntaxKind.OpenBracketToken | SyntaxKind.CloseBracketToken | SyntaxKind.DotToken | SyntaxKind.DotDotDotToken | SyntaxKind.SemicolonToken | SyntaxKind.CommaToken | SyntaxKind.QuestionDotToken | SyntaxKind.LessThanToken | SyntaxKind.LessThanSlashToken | SyntaxKind.GreaterThanToken | SyntaxKind.LessThanEqualsToken | SyntaxKind.GreaterThanEqualsToken | SyntaxKind.EqualsEqualsToken | SyntaxKind.ExclamationEqualsToken | SyntaxKind.EqualsEqualsEqualsToken | SyntaxKind.ExclamationEqualsEqualsToken | SyntaxKind.EqualsGreaterThanToken | SyntaxKind.PlusToken | SyntaxKind.MinusToken | SyntaxKind.AsteriskToken | SyntaxKind.AsteriskAsteriskToken | SyntaxKind.SlashToken | SyntaxKind.PercentToken | SyntaxKind.PlusPlusToken | SyntaxKind.MinusMinusToken | SyntaxKind.LessThanLessThanToken | SyntaxKind.GreaterThanGreaterThanToken | SyntaxKind.GreaterThanGreaterThanGreaterThanToken | SyntaxKind.AmpersandToken | SyntaxKind.BarToken | SyntaxKind.CaretToken | SyntaxKind.ExclamationToken | SyntaxKind.TildeToken | SyntaxKind.AmpersandAmpersandToken | SyntaxKind.BarBarToken | SyntaxKind.QuestionQuestionToken | SyntaxKind.QuestionToken | SyntaxKind.ColonToken | SyntaxKind.AtToken | SyntaxKind.BacktickToken | SyntaxKind.HashToken | SyntaxKind.EqualsToken | SyntaxKind.PlusEqualsToken | SyntaxKind.MinusEqualsToken | SyntaxKind.AsteriskEqualsToken | SyntaxKind.AsteriskAsteriskEqualsToken | SyntaxKind.SlashEqualsToken | SyntaxKind.PercentEqualsToken | SyntaxKind.LessThanLessThanEqualsToken | SyntaxKind.GreaterThanGreaterThanEqualsToken | SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken | SyntaxKind.AmpersandEqualsToken | SyntaxKind.BarEqualsToken | SyntaxKind.CaretEqualsToken;
-    export type KeywordSyntaxKind = SyntaxKind.AbstractKeyword | SyntaxKind.AnyKeyword | SyntaxKind.AsKeyword | SyntaxKind.AssertsKeyword | SyntaxKind.AssertKeyword | SyntaxKind.AsyncKeyword | SyntaxKind.AwaitKeyword | SyntaxKind.BigIntKeyword | SyntaxKind.BooleanKeyword | SyntaxKind.BreakKeyword | SyntaxKind.CaseKeyword | SyntaxKind.CatchKeyword | SyntaxKind.ClassKeyword | SyntaxKind.ConstKeyword | SyntaxKind.ConstructorKeyword | SyntaxKind.ContinueKeyword | SyntaxKind.DebuggerKeyword | SyntaxKind.DeclareKeyword | SyntaxKind.DefaultKeyword | SyntaxKind.DeleteKeyword | SyntaxKind.DoKeyword | SyntaxKind.ElseKeyword | SyntaxKind.EnumKeyword | SyntaxKind.ExportKeyword | SyntaxKind.ExtendsKeyword | SyntaxKind.FalseKeyword | SyntaxKind.FinallyKeyword | SyntaxKind.ForKeyword | SyntaxKind.FromKeyword | SyntaxKind.FunctionKeyword | SyntaxKind.GetKeyword | SyntaxKind.GlobalKeyword | SyntaxKind.IfKeyword | SyntaxKind.ImplementsKeyword | SyntaxKind.ImportKeyword | SyntaxKind.InferKeyword | SyntaxKind.InKeyword | SyntaxKind.InstanceOfKeyword | SyntaxKind.InterfaceKeyword | SyntaxKind.IntrinsicKeyword | SyntaxKind.IsKeyword | SyntaxKind.KeyOfKeyword | SyntaxKind.LetKeyword | SyntaxKind.ModuleKeyword | SyntaxKind.NamespaceKeyword | SyntaxKind.NeverKeyword | SyntaxKind.NewKeyword | SyntaxKind.NullKeyword | SyntaxKind.NumberKeyword | SyntaxKind.ObjectKeyword | SyntaxKind.OfKeyword | SyntaxKind.PackageKeyword | SyntaxKind.PrivateKeyword | SyntaxKind.ProtectedKeyword | SyntaxKind.PublicKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.OutKeyword | SyntaxKind.OverrideKeyword | SyntaxKind.RequireKeyword | SyntaxKind.ReturnKeyword | SyntaxKind.SatisfiesKeyword | SyntaxKind.SetKeyword | SyntaxKind.StaticKeyword | SyntaxKind.StringKeyword | SyntaxKind.SuperKeyword | SyntaxKind.SwitchKeyword | SyntaxKind.SymbolKeyword | SyntaxKind.ThisKeyword | SyntaxKind.ThrowKeyword | SyntaxKind.TrueKeyword | SyntaxKind.TryKeyword | SyntaxKind.TypeKeyword | SyntaxKind.TypeOfKeyword | SyntaxKind.UndefinedKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.UnknownKeyword | SyntaxKind.VarKeyword | SyntaxKind.VoidKeyword | SyntaxKind.WhileKeyword | SyntaxKind.WithKeyword | SyntaxKind.YieldKeyword;
+    export type KeywordSyntaxKind = SyntaxKind.AbstractKeyword | SyntaxKind.AnyKeyword | SyntaxKind.AsKeyword | SyntaxKind.AssertsKeyword | SyntaxKind.AssertKeyword | SyntaxKind.AsyncKeyword | SyntaxKind.AwaitKeyword | SyntaxKind.BigIntKeyword | SyntaxKind.BooleanKeyword | SyntaxKind.BreakKeyword | SyntaxKind.CaseKeyword | SyntaxKind.CatchKeyword | SyntaxKind.ClassKeyword | SyntaxKind.ConstKeyword | SyntaxKind.ConstructorKeyword | SyntaxKind.ContinueKeyword | SyntaxKind.DebuggerKeyword | SyntaxKind.DeclareKeyword | SyntaxKind.DefaultKeyword | SyntaxKind.DeleteKeyword | SyntaxKind.DoKeyword | SyntaxKind.ElseKeyword | SyntaxKind.EnumKeyword | SyntaxKind.ExportKeyword | SyntaxKind.ExtendsKeyword | SyntaxKind.FalseKeyword | SyntaxKind.FinallyKeyword | SyntaxKind.ForKeyword | SyntaxKind.FromKeyword | SyntaxKind.FunctionKeyword | SyntaxKind.GetKeyword | SyntaxKind.GlobalKeyword | SyntaxKind.IfKeyword | SyntaxKind.ImplementsKeyword | SyntaxKind.ImportKeyword | SyntaxKind.InferKeyword | SyntaxKind.InKeyword | SyntaxKind.InstanceOfKeyword | SyntaxKind.InterfaceKeyword | SyntaxKind.IntrinsicKeyword | SyntaxKind.IsKeyword | SyntaxKind.KeyOfKeyword | SyntaxKind.LetKeyword | SyntaxKind.ModuleKeyword | SyntaxKind.NamespaceKeyword | SyntaxKind.NeverKeyword | SyntaxKind.NewKeyword | SyntaxKind.NullKeyword | SyntaxKind.NumberKeyword | SyntaxKind.ObjectKeyword | SyntaxKind.OfKeyword | SyntaxKind.PackageKeyword | SyntaxKind.PrivateKeyword | SyntaxKind.ProtectedKeyword | SyntaxKind.PublicKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.OutKeyword | SyntaxKind.OverrideKeyword | SyntaxKind.RequireKeyword | SyntaxKind.ReturnKeyword | SyntaxKind.SetKeyword | SyntaxKind.StaticKeyword | SyntaxKind.StringKeyword | SyntaxKind.SuperKeyword | SyntaxKind.SwitchKeyword | SyntaxKind.SymbolKeyword | SyntaxKind.ThisKeyword | SyntaxKind.ThrowKeyword | SyntaxKind.TrueKeyword | SyntaxKind.TryKeyword | SyntaxKind.TypeKeyword | SyntaxKind.TypeOfKeyword | SyntaxKind.UndefinedKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.UnknownKeyword | SyntaxKind.VarKeyword | SyntaxKind.VoidKeyword | SyntaxKind.WhileKeyword | SyntaxKind.WithKeyword | SyntaxKind.YieldKeyword;
     export type ModifierSyntaxKind = SyntaxKind.AbstractKeyword | SyntaxKind.AsyncKeyword | SyntaxKind.ConstKeyword | SyntaxKind.DeclareKeyword | SyntaxKind.DefaultKeyword | SyntaxKind.ExportKeyword | SyntaxKind.InKeyword | SyntaxKind.PrivateKeyword | SyntaxKind.ProtectedKeyword | SyntaxKind.PublicKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.OutKeyword | SyntaxKind.OverrideKeyword | SyntaxKind.StaticKeyword;
     export type KeywordTypeSyntaxKind = SyntaxKind.AnyKeyword | SyntaxKind.BigIntKeyword | SyntaxKind.BooleanKeyword | SyntaxKind.IntrinsicKeyword | SyntaxKind.NeverKeyword | SyntaxKind.NumberKeyword | SyntaxKind.ObjectKeyword | SyntaxKind.StringKeyword | SyntaxKind.SymbolKeyword | SyntaxKind.UndefinedKeyword | SyntaxKind.UnknownKeyword | SyntaxKind.VoidKeyword;
     export type TokenSyntaxKind = SyntaxKind.Unknown | SyntaxKind.EndOfFileToken | TriviaSyntaxKind | LiteralSyntaxKind | PseudoLiteralSyntaxKind | PunctuationSyntaxKind | SyntaxKind.Identifier | KeywordSyntaxKind;
@@ -1342,11 +1341,6 @@ declare namespace ts {
         readonly type: TypeNode;
         readonly expression: UnaryExpression;
     }
-    export interface SatisfiesExpression extends Expression {
-        readonly kind: SyntaxKind.SatisfiesExpression;
-        readonly expression: Expression;
-        readonly type: TypeNode;
-    }
     export type AssertionExpression = TypeAssertion | AsExpression;
     export interface NonNullExpression extends LeftHandSideExpression {
         readonly kind: SyntaxKind.NonNullExpression;
@@ -1934,6 +1928,9 @@ declare namespace ts {
     export interface JSDocOverrideTag extends JSDocTag {
         readonly kind: SyntaxKind.JSDocOverrideTag;
     }
+    export interface JSDocOverloadTag extends JSDocTag {
+        readonly kind: SyntaxKind.JSDocOverloadTag;
+    }
     export interface JSDocEnumTag extends JSDocTag, Declaration {
         readonly kind: SyntaxKind.JSDocEnumTag;
         readonly parent: JSDoc;
@@ -2323,7 +2320,6 @@ declare namespace ts {
         getPrivateIdentifierPropertyOfType(leftType: Type, name: string, location: Node): Symbol | undefined;
         getIndexInfoOfType(type: Type, kind: IndexKind): IndexInfo | undefined;
         getIndexInfosOfType(type: Type): readonly IndexInfo[];
-        getIndexInfosOfIndexSymbol: (indexSymbol: Symbol) => IndexInfo[];
         getSignaturesOfType(type: Type, kind: SignatureKind): readonly Signature[];
         getIndexTypeOfType(type: Type, kind: IndexKind): Type | undefined;
         getBaseTypes(type: InterfaceType): BaseType[];
@@ -2840,7 +2836,7 @@ declare namespace ts {
     export interface SubstitutionType extends InstantiableType {
         objectFlags: ObjectFlags;
         baseType: Type;
-        constraint: Type;
+        substitute: Type;
     }
     export enum SignatureKind {
         Call = 0,
@@ -3595,8 +3591,6 @@ declare namespace ts {
         updateNonNullChain(node: NonNullChain, expression: Expression): NonNullChain;
         createMetaProperty(keywordToken: MetaProperty["keywordToken"], name: Identifier): MetaProperty;
         updateMetaProperty(node: MetaProperty, name: Identifier): MetaProperty;
-        createSatisfiesExpression(expression: Expression, type: TypeNode): SatisfiesExpression;
-        updateSatisfiesExpression(node: SatisfiesExpression, expression: Expression, type: TypeNode): SatisfiesExpression;
         createTemplateSpan(expression: Expression, literal: TemplateMiddle | TemplateTail): TemplateSpan;
         updateTemplateSpan(node: TemplateSpan, expression: Expression, literal: TemplateMiddle | TemplateTail): TemplateSpan;
         createSemicolonClassElement(): SemicolonClassElement;
@@ -3760,6 +3754,8 @@ declare namespace ts {
         updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocDeprecatedTag;
         createJSDocOverrideTag(tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverrideTag;
         updateJSDocOverrideTag(node: JSDocOverrideTag, tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverrideTag;
+        createJSDocOverloadTag(tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverloadTag;
+        updateJSDocOverloadTag(node: JSDocOverloadTag, tagName: Identifier, comment?: string | NodeArray<JSDocComment>): JSDocOverloadTag;
         createJSDocText(text: string): JSDocText;
         updateJSDocText(node: JSDocText, text: string): JSDocText;
         createJSDocComment(comment?: string | NodeArray<JSDocComment> | undefined, tags?: readonly JSDocTag[] | undefined): JSDoc;
@@ -4273,14 +4269,14 @@ declare namespace ts {
     function isWhiteSpaceSingleLine(ch: number): boolean;
     function isLineBreak(ch: number): boolean;
     function couldStartTrivia(text: string, pos: number): boolean;
-    function forEachLeadingCommentRange<U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
-    function forEachLeadingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
-    function forEachTrailingCommentRange<U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
-    function forEachTrailingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
-    function reduceEachLeadingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U): U | undefined;
-    function reduceEachTrailingCommentRange<T, U>(text: string, pos: number, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U): U | undefined;
-    function getLeadingCommentRanges(text: string, pos: number): CommentRange[] | undefined;
-    function getTrailingCommentRanges(text: string, pos: number): CommentRange[] | undefined;
+    function forEachLeadingCommentRange<U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
+    function forEachLeadingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
+    function forEachTrailingCommentRange<U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean) => U): U | undefined;
+    function forEachTrailingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T) => U, state: T): U | undefined;
+    function reduceEachLeadingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U): U | undefined;
+    function reduceEachTrailingCommentRange<T, U>(text: string, pos: number, end: number | undefined, cb: (pos: number, end: number, kind: CommentKind, hasTrailingNewLine: boolean, state: T, memo: U) => U, state: T, initial: U): U | undefined;
+    function getLeadingCommentRanges(text: string, pos: number, end?: number): CommentRange[] | undefined;
+    function getTrailingCommentRanges(text: string, pos: number, end?: number): CommentRange[] | undefined;
     /** Optionally, get the shebang */
     function getShebang(text: string): string | undefined;
     function isIdentifierStart(ch: number, languageVersion: ScriptTarget | undefined): boolean;
@@ -4726,7 +4722,6 @@ declare namespace ts {
     function isOmittedExpression(node: Node): node is OmittedExpression;
     function isExpressionWithTypeArguments(node: Node): node is ExpressionWithTypeArguments;
     function isAsExpression(node: Node): node is AsExpression;
-    function isSatisfiesExpression(node: Node): node is SatisfiesExpression;
     function isNonNullExpression(node: Node): node is NonNullExpression;
     function isMetaProperty(node: Node): node is MetaProperty;
     function isSyntheticExpression(node: Node): node is SyntheticExpression;
@@ -4830,6 +4825,7 @@ declare namespace ts {
     function isJSDocProtectedTag(node: Node): node is JSDocProtectedTag;
     function isJSDocReadonlyTag(node: Node): node is JSDocReadonlyTag;
     function isJSDocOverrideTag(node: Node): node is JSDocOverrideTag;
+    function isJSDocOverloadTag(node: Node): node is JSDocOverloadTag;
     function isJSDocDeprecatedTag(node: Node): node is JSDocDeprecatedTag;
     function isJSDocSeeTag(node: Node): node is JSDocSeeTag;
     function isJSDocEnumTag(node: Node): node is JSDocEnumTag;

--- a/tests/baselines/reference/jsFileFunctionOverloads.symbols
+++ b/tests/baselines/reference/jsFileFunctionOverloads.symbols
@@ -1,0 +1,87 @@
+=== tests/cases/compiler/0.js ===
+/**
+ * @overload
+ * @param {number} x
+ * @returns {'number'}
+ */
+/**
+ * @overload
+ * @param {string} x
+ * @returns {'string'}
+ */
+/**
+ * @overload
+ * @param {boolean} x
+ * @returns {'boolean'}
+ */
+/**
+ * @param {unknown} x
+ * @returns {string}
+ */
+ function getTypeName(x) {
+>getTypeName : Symbol(getTypeName, Decl(0.js, 0, 0), Decl(0.js, 4, 3), Decl(0.js, 9, 3), Decl(0.js, 14, 3))
+>x : Symbol(x, Decl(0.js, 19, 22))
+
+  return typeof x;
+>x : Symbol(x, Decl(0.js, 19, 22))
+}
+
+/**
+ * @template T
+ * @param {T} x 
+ * @returns {T}
+ */
+const identity = x => x;
+>identity : Symbol(identity, Decl(0.js, 28, 5))
+>x : Symbol(x, Decl(0.js, 28, 16))
+>x : Symbol(x, Decl(0.js, 28, 16))
+
+/**
+ * @template T
+ * @template U
+ * @overload
+ * @param {T[]} array 
+ * @param {(x: T) => U[]} iterable 
+ * @returns {U[]}
+ */
+/**
+ * @template T
+ * @overload
+ * @param {T[][]} array
+ * @returns {T[]}
+ */
+/**
+ * @param {unknown[]} array 
+ * @param {(x: unknown) => unknown} iterable 
+ * @returns {unknown[]}
+ */
+function flatMap(array, iterable = identity) {
+>flatMap : Symbol(flatMap, Decl(0.js, 28, 24), Decl(0.js, 37, 3), Decl(0.js, 43, 3))
+>array : Symbol(array, Decl(0.js, 49, 17))
+>iterable : Symbol(iterable, Decl(0.js, 49, 23))
+>identity : Symbol(identity, Decl(0.js, 28, 5))
+
+  /** @type {unknown[]} */
+  const result = [];
+>result : Symbol(result, Decl(0.js, 51, 7))
+
+  for (let i = 0; i < array.length; i += 1) {
+>i : Symbol(i, Decl(0.js, 52, 10))
+>i : Symbol(i, Decl(0.js, 52, 10))
+>array.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>array : Symbol(array, Decl(0.js, 49, 17))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>i : Symbol(i, Decl(0.js, 52, 10))
+
+    result.push(.../** @type {unknown[]} */(iterable(array[i])));
+>result.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>result : Symbol(result, Decl(0.js, 51, 7))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>iterable : Symbol(iterable, Decl(0.js, 49, 23))
+>array : Symbol(array, Decl(0.js, 49, 17))
+>i : Symbol(i, Decl(0.js, 52, 10))
+  }
+  return result;
+>result : Symbol(result, Decl(0.js, 51, 7))
+}
+

--- a/tests/baselines/reference/jsFileFunctionOverloads.types
+++ b/tests/baselines/reference/jsFileFunctionOverloads.types
@@ -1,0 +1,99 @@
+=== tests/cases/compiler/0.js ===
+/**
+ * @overload
+ * @param {number} x
+ * @returns {'number'}
+ */
+/**
+ * @overload
+ * @param {string} x
+ * @returns {'string'}
+ */
+/**
+ * @overload
+ * @param {boolean} x
+ * @returns {'boolean'}
+ */
+/**
+ * @param {unknown} x
+ * @returns {string}
+ */
+ function getTypeName(x) {
+>getTypeName : { (x: number): "number"; (x: string): "string"; (x: boolean): "boolean"; }
+>x : unknown
+
+  return typeof x;
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+}
+
+/**
+ * @template T
+ * @param {T} x 
+ * @returns {T}
+ */
+const identity = x => x;
+>identity : <T>(x: T) => T
+>x => x : <T>(x: T) => T
+>x : T
+>x : T
+
+/**
+ * @template T
+ * @template U
+ * @overload
+ * @param {T[]} array 
+ * @param {(x: T) => U[]} iterable 
+ * @returns {U[]}
+ */
+/**
+ * @template T
+ * @overload
+ * @param {T[][]} array
+ * @returns {T[]}
+ */
+/**
+ * @param {unknown[]} array 
+ * @param {(x: unknown) => unknown} iterable 
+ * @returns {unknown[]}
+ */
+function flatMap(array, iterable = identity) {
+>flatMap : { <T, U>(array: T[], iterable: (x: T) => U[]): U[]; <T>(array: T[][]): T[]; }
+>array : unknown[]
+>iterable : (x: unknown) => unknown
+>identity : <T>(x: T) => T
+
+  /** @type {unknown[]} */
+  const result = [];
+>result : unknown[]
+>[] : undefined[]
+
+  for (let i = 0; i < array.length; i += 1) {
+>i : number
+>0 : 0
+>i < array.length : boolean
+>i : number
+>array.length : number
+>array : unknown[]
+>length : number
+>i += 1 : number
+>i : number
+>1 : 1
+
+    result.push(.../** @type {unknown[]} */(iterable(array[i])));
+>result.push(.../** @type {unknown[]} */(iterable(array[i]))) : number
+>result.push : (...items: unknown[]) => number
+>result : unknown[]
+>push : (...items: unknown[]) => number
+>.../** @type {unknown[]} */(iterable(array[i])) : unknown
+>(iterable(array[i])) : unknown[]
+>iterable(array[i]) : unknown
+>iterable : (x: unknown) => unknown
+>array[i] : unknown
+>array : unknown[]
+>i : number
+  }
+  return result;
+>result : unknown[]
+}
+

--- a/tests/baselines/reference/jsFileMethodsOverloads.symbols
+++ b/tests/baselines/reference/jsFileMethodsOverloads.symbols
@@ -1,0 +1,72 @@
+=== tests/cases/compiler/0.js ===
+/**
+ * @template T
+ */
+ class Example {
+>Example : Symbol(Example, Decl(0.js, 0, 0))
+
+  /**
+   * @param {T} value 
+   */
+  constructor(value) {
+>value : Symbol(value, Decl(0.js, 7, 14))
+
+    this.value = value;
+>this.value : Symbol(Example.value, Decl(0.js, 7, 22))
+>this : Symbol(Example, Decl(0.js, 0, 0))
+>value : Symbol(Example.value, Decl(0.js, 7, 22))
+>value : Symbol(value, Decl(0.js, 7, 14))
+  }
+
+  /**
+   * @overload
+   * @this {Example<'number'>}
+   * @returns {'number'}
+   */
+  /**
+   * @overload
+   * @this {Example<'string'>}
+   * @returns {'string'}
+   */
+  /**
+   * @returns {string}
+   */
+  getTypeName() {
+>getTypeName : Symbol(Example.getTypeName, Decl(0.js, 9, 3), Decl(0.js, 15, 5), Decl(0.js, 20, 5))
+
+    return typeof this.value;
+>this.value : Symbol(Example.value, Decl(0.js, 7, 22))
+>this : Symbol(Example, Decl(0.js, 0, 0))
+>value : Symbol(Example.value, Decl(0.js, 7, 22))
+  }
+
+  /**
+   * @template U
+   * @overload
+   * @param {(y: T) => U} fn
+   * @returns {U}
+   */
+  /**
+   * @overload
+   * @returns {T}
+   */
+  /**
+   * @param {(y: T) => unknown} [fn]
+   * @returns {unknown}
+   */
+  transform(fn) {
+>transform : Symbol(Example.transform, Decl(0.js, 26, 3), Decl(0.js, 33, 5), Decl(0.js, 37, 5))
+>fn : Symbol(fn, Decl(0.js, 42, 12))
+
+    return fn ? fn(this.value) : this.value;
+>fn : Symbol(fn, Decl(0.js, 42, 12))
+>fn : Symbol(fn, Decl(0.js, 42, 12))
+>this.value : Symbol(Example.value, Decl(0.js, 7, 22))
+>this : Symbol(Example, Decl(0.js, 0, 0))
+>value : Symbol(Example.value, Decl(0.js, 7, 22))
+>this.value : Symbol(Example.value, Decl(0.js, 7, 22))
+>this : Symbol(Example, Decl(0.js, 0, 0))
+>value : Symbol(Example.value, Decl(0.js, 7, 22))
+  }
+}
+

--- a/tests/baselines/reference/jsFileMethodsOverloads.types
+++ b/tests/baselines/reference/jsFileMethodsOverloads.types
@@ -1,0 +1,76 @@
+=== tests/cases/compiler/0.js ===
+/**
+ * @template T
+ */
+ class Example {
+>Example : Example<T>
+
+  /**
+   * @param {T} value 
+   */
+  constructor(value) {
+>value : T
+
+    this.value = value;
+>this.value = value : T
+>this.value : any
+>this : this
+>value : any
+>value : T
+  }
+
+  /**
+   * @overload
+   * @this {Example<'number'>}
+   * @returns {'number'}
+   */
+  /**
+   * @overload
+   * @this {Example<'string'>}
+   * @returns {'string'}
+   */
+  /**
+   * @returns {string}
+   */
+  getTypeName() {
+>getTypeName : { (this: Example<"number">): "number"; (this: Example<"string">): "string"; }
+
+    return typeof this.value;
+>typeof this.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>this.value : T
+>this : this
+>value : T
+  }
+
+  /**
+   * @template U
+   * @overload
+   * @param {(y: T) => U} fn
+   * @returns {U}
+   */
+  /**
+   * @overload
+   * @returns {T}
+   */
+  /**
+   * @param {(y: T) => unknown} [fn]
+   * @returns {unknown}
+   */
+  transform(fn) {
+>transform : { <U>(fn: (y: T) => U): U; (): T; }
+>fn : (y: T) => unknown
+
+    return fn ? fn(this.value) : this.value;
+>fn ? fn(this.value) : this.value : unknown
+>fn : (y: T) => unknown
+>fn(this.value) : unknown
+>fn : (y: T) => unknown
+>this.value : T
+>this : this
+>value : T
+>this.value : T
+>this : this
+>value : T
+  }
+}
+

--- a/tests/cases/compiler/jsFileFunctionOverloads.ts
+++ b/tests/cases/compiler/jsFileFunctionOverloads.ts
@@ -1,0 +1,61 @@
+// @allowJs: true
+// @noEmit: true
+// @filename: 0.js
+
+/**
+ * @overload
+ * @param {number} x
+ * @returns {'number'}
+ */
+/**
+ * @overload
+ * @param {string} x
+ * @returns {'string'}
+ */
+/**
+ * @overload
+ * @param {boolean} x
+ * @returns {'boolean'}
+ */
+/**
+ * @param {unknown} x
+ * @returns {string}
+ */
+ function getTypeName(x) {
+  return typeof x;
+}
+
+/**
+ * @template T
+ * @param {T} x 
+ * @returns {T}
+ */
+const identity = x => x;
+
+/**
+ * @template T
+ * @template U
+ * @overload
+ * @param {T[]} array 
+ * @param {(x: T) => U[]} iterable 
+ * @returns {U[]}
+ */
+/**
+ * @template T
+ * @overload
+ * @param {T[][]} array
+ * @returns {T[]}
+ */
+/**
+ * @param {unknown[]} array 
+ * @param {(x: unknown) => unknown} iterable 
+ * @returns {unknown[]}
+ */
+function flatMap(array, iterable = identity) {
+  /** @type {unknown[]} */
+  const result = [];
+  for (let i = 0; i < array.length; i += 1) {
+    result.push(.../** @type {unknown[]} */(iterable(array[i])));
+  }
+  return result;
+}

--- a/tests/cases/compiler/jsFileMethodsOverloads.ts
+++ b/tests/cases/compiler/jsFileMethodsOverloads.ts
@@ -1,0 +1,50 @@
+// @allowJs: true
+// @noEmit: true
+// @filename: 0.js
+
+/**
+ * @template T
+ */
+ class Example {
+  /**
+   * @param {T} value 
+   */
+  constructor(value) {
+    this.value = value;
+  }
+
+  /**
+   * @overload
+   * @this {Example<'number'>}
+   * @returns {'number'}
+   */
+  /**
+   * @overload
+   * @this {Example<'string'>}
+   * @returns {'string'}
+   */
+  /**
+   * @returns {string}
+   */
+  getTypeName() {
+    return typeof this.value;
+  }
+
+  /**
+   * @template U
+   * @overload
+   * @param {(y: T) => U} fn
+   * @returns {U}
+   */
+  /**
+   * @overload
+   * @returns {T}
+   */
+  /**
+   * @param {(y: T) => unknown} [fn]
+   * @returns {unknown}
+   */
+  transform(fn) {
+    return fn ? fn(this.value) : this.value;
+  }
+}


### PR DESCRIPTION
Fixes #25590

Since there was no final consensus, I ended up using a new `@overload` tag to ensure backwards compatibility, e.g.
```js
/**
 * @overload
 * @param {number} x
 * @returns {'number'}
 */
/**
 * @overload
 * @param {string} x
 * @returns {'string'}
 */
/**
 * @overload
 * @param {boolean} x
 * @returns {'boolean'}
 */
/**
 * @param {unknown} x
 * @returns {string}
 */
function typeName(x) {
  return typeof x;
}
```
I would be happy to modify the implementation if someone suggests a better approach.