### PR TITLE
Fix test around RegExp match vs. exec results

### DIFF
--- a/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=false).errors.txt
+++ b/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=false).errors.txt
@@ -1,9 +1,11 @@
 error TS5052: Option 'exactOptionalPropertyTypes' cannot be specified without specifying option 'strictNullChecks'.
+tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(20,9): error TS2322: Type 'RegExpMatchArray' is not assignable to type 'RegExpExecArray'.
+  Property 'index' is optional in type 'RegExpMatchArray' but required in type 'RegExpExecArray'.
 
 
 !!! error TS5052: Option 'exactOptionalPropertyTypes' cannot be specified without specifying option 'strictNullChecks'.
-==== tests/cases/compiler/regexpExecAndMatchTypeUsages.ts (0 errors) ====
-    export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
+==== tests/cases/compiler/regexpExecAndMatchTypeUsages.ts (1 errors) ====
+    export function foo(matchResult: RegExpMatchArray, execResult: RegExpExecArray) {
         matchResult[0].length;
         matchResult[999].length;
         matchResult.index + 0;
@@ -23,6 +25,9 @@ error TS5052: Option 'exactOptionalPropertyTypes' cannot be specified without sp
         }
         else {
             execResult = matchResult
+            ~~~~~~~~~~
+!!! error TS2322: Type 'RegExpMatchArray' is not assignable to type 'RegExpExecArray'.
+!!! error TS2322:   Property 'index' is optional in type 'RegExpMatchArray' but required in type 'RegExpExecArray'.
         }
     }
     

--- a/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=false).js
+++ b/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=false).js
@@ -1,5 +1,5 @@
 //// [regexpExecAndMatchTypeUsages.ts]
-export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
+export function foo(matchResult: RegExpMatchArray, execResult: RegExpExecArray) {
     matchResult[0].length;
     matchResult[999].length;
     matchResult.index + 0;

--- a/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=false).symbols
+++ b/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=false).symbols
@@ -1,15 +1,15 @@
 === tests/cases/compiler/regexpExecAndMatchTypeUsages.ts ===
-export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
+export function foo(matchResult: RegExpMatchArray, execResult: RegExpExecArray) {
 >foo : Symbol(foo, Decl(regexpExecAndMatchTypeUsages.ts, 0, 0))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->RegExpExecArray : Symbol(RegExpExecArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>RegExpMatchArray : Symbol(RegExpMatchArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >RegExpExecArray : Symbol(RegExpExecArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --))
 
     matchResult[0].length;
 >matchResult[0].length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->0 : Symbol(RegExpExecArray[0], Decl(lib.es5.d.ts, --, --))
+>0 : Symbol(RegExpMatchArray[0], Decl(lib.es5.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     matchResult[999].length;
@@ -18,63 +18,63 @@ export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     matchResult.index + 0;
->matchResult.index : Symbol(RegExpExecArray.index, Decl(lib.es5.d.ts, --, --))
+>matchResult.index : Symbol(RegExpMatchArray.index, Decl(lib.es5.d.ts, --, --))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->index : Symbol(RegExpExecArray.index, Decl(lib.es5.d.ts, --, --))
+>index : Symbol(RegExpMatchArray.index, Decl(lib.es5.d.ts, --, --))
 
     matchResult.input.length;
 >matchResult.input.length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->matchResult.input : Symbol(RegExpExecArray.input, Decl(lib.es5.d.ts, --, --))
+>matchResult.input : Symbol(RegExpMatchArray.input, Decl(lib.es5.d.ts, --, --))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->input : Symbol(RegExpExecArray.input, Decl(lib.es5.d.ts, --, --))
+>input : Symbol(RegExpMatchArray.input, Decl(lib.es5.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     matchResult.groups["someVariable"].length;
 >matchResult.groups["someVariable"].length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->matchResult.groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
+>matchResult.groups : Symbol(RegExpMatchArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
+>groups : Symbol(RegExpMatchArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     matchResult.groups = undefined;
->matchResult.groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
+>matchResult.groups : Symbol(RegExpMatchArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
+>groups : Symbol(RegExpMatchArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >undefined : Symbol(undefined)
 
     execResult[0].length;
 >execResult[0].length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >0 : Symbol(RegExpExecArray[0], Decl(lib.es5.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     execResult[999].length;
 >execResult[999].length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     execResult.index + 0;
 >execResult.index : Symbol(RegExpExecArray.index, Decl(lib.es5.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >index : Symbol(RegExpExecArray.index, Decl(lib.es5.d.ts, --, --))
 
     execResult.input.length;
 >execResult.input.length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 >execResult.input : Symbol(RegExpExecArray.input, Decl(lib.es5.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >input : Symbol(RegExpExecArray.input, Decl(lib.es5.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     execResult.groups["someVariable"].length;
 >execResult.groups["someVariable"].length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 >execResult.groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     execResult.groups = undefined;
 >execResult.groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >undefined : Symbol(undefined)
 
@@ -85,11 +85,11 @@ export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
 
         matchResult = execResult;
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
     }
     else {
         execResult = matchResult
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
     }
 }

--- a/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=false).types
+++ b/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=false).types
@@ -1,34 +1,34 @@
 === tests/cases/compiler/regexpExecAndMatchTypeUsages.ts ===
-export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
->foo : (matchResult: RegExpExecArray, execResult: RegExpExecArray) => void
->matchResult : RegExpExecArray
+export function foo(matchResult: RegExpMatchArray, execResult: RegExpExecArray) {
+>foo : (matchResult: RegExpMatchArray, execResult: RegExpExecArray) => void
+>matchResult : RegExpMatchArray
 >execResult : RegExpExecArray
 
     matchResult[0].length;
 >matchResult[0].length : number
 >matchResult[0] : string
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >0 : 0
 >length : number
 
     matchResult[999].length;
 >matchResult[999].length : number
 >matchResult[999] : string
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >999 : 999
 >length : number
 
     matchResult.index + 0;
 >matchResult.index + 0 : number
 >matchResult.index : number
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >index : number
 >0 : 0
 
     matchResult.input.length;
 >matchResult.input.length : number
 >matchResult.input : string
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >input : string
 >length : number
 
@@ -36,7 +36,7 @@ export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
 >matchResult.groups["someVariable"].length : number
 >matchResult.groups["someVariable"] : string
 >matchResult.groups : { [key: string]: string; }
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >groups : { [key: string]: string; }
 >"someVariable" : "someVariable"
 >length : number
@@ -44,7 +44,7 @@ export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
     matchResult.groups = undefined;
 >matchResult.groups = undefined : undefined
 >matchResult.groups : { [key: string]: string; }
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >groups : { [key: string]: string; }
 >undefined : undefined
 
@@ -100,14 +100,14 @@ export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
 
         matchResult = execResult;
 >matchResult = execResult : RegExpExecArray
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >execResult : RegExpExecArray
     }
     else {
         execResult = matchResult
->execResult = matchResult : RegExpExecArray
+>execResult = matchResult : RegExpMatchArray
 >execResult : RegExpExecArray
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
     }
 }
 

--- a/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=true).errors.txt
+++ b/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=true).errors.txt
@@ -1,24 +1,32 @@
 tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(3,5): error TS2532: Object is possibly 'undefined'.
-tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(6,5): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(4,5): error TS18048: 'matchResult.index' is possibly 'undefined'.
+tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(5,5): error TS18048: 'matchResult.input' is possibly 'undefined'.
+tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(6,5): error TS18048: 'matchResult.groups' is possibly 'undefined'.
 tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(6,5): error TS2532: Object is possibly 'undefined'.
 tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(7,5): error TS2412: Type 'undefined' is not assignable to type '{ [key: string]: string; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the type of the target.
 tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(10,5): error TS2532: Object is possibly 'undefined'.
-tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(13,5): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(13,5): error TS18048: 'execResult.groups' is possibly 'undefined'.
 tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(13,5): error TS2532: Object is possibly 'undefined'.
 tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(14,5): error TS2412: Type 'undefined' is not assignable to type '{ [key: string]: string; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the type of the target.
+tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(20,9): error TS2375: Type 'RegExpMatchArray' is not assignable to type 'RegExpExecArray' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
+  Property 'index' is optional in type 'RegExpMatchArray' but required in type 'RegExpExecArray'.
 
 
-==== tests/cases/compiler/regexpExecAndMatchTypeUsages.ts (8 errors) ====
-    export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
+==== tests/cases/compiler/regexpExecAndMatchTypeUsages.ts (11 errors) ====
+    export function foo(matchResult: RegExpMatchArray, execResult: RegExpExecArray) {
         matchResult[0].length;
         matchResult[999].length;
         ~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
         matchResult.index + 0;
+        ~~~~~~~~~~~~~~~~~
+!!! error TS18048: 'matchResult.index' is possibly 'undefined'.
         matchResult.input.length;
+        ~~~~~~~~~~~~~~~~~
+!!! error TS18048: 'matchResult.input' is possibly 'undefined'.
         matchResult.groups["someVariable"].length;
         ~~~~~~~~~~~~~~~~~~
-!!! error TS2532: Object is possibly 'undefined'.
+!!! error TS18048: 'matchResult.groups' is possibly 'undefined'.
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
         matchResult.groups = undefined;
@@ -33,7 +41,7 @@ tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(14,5): error TS2412: Type '
         execResult.input.length;
         execResult.groups["someVariable"].length;
         ~~~~~~~~~~~~~~~~~
-!!! error TS2532: Object is possibly 'undefined'.
+!!! error TS18048: 'execResult.groups' is possibly 'undefined'.
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
         execResult.groups = undefined;
@@ -45,6 +53,9 @@ tests/cases/compiler/regexpExecAndMatchTypeUsages.ts(14,5): error TS2412: Type '
         }
         else {
             execResult = matchResult
+            ~~~~~~~~~~
+!!! error TS2375: Type 'RegExpMatchArray' is not assignable to type 'RegExpExecArray' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
+!!! error TS2375:   Property 'index' is optional in type 'RegExpMatchArray' but required in type 'RegExpExecArray'.
         }
     }
     

--- a/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=true).js
+++ b/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=true).js
@@ -1,5 +1,5 @@
 //// [regexpExecAndMatchTypeUsages.ts]
-export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
+export function foo(matchResult: RegExpMatchArray, execResult: RegExpExecArray) {
     matchResult[0].length;
     matchResult[999].length;
     matchResult.index + 0;

--- a/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=true).symbols
+++ b/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=true).symbols
@@ -1,15 +1,15 @@
 === tests/cases/compiler/regexpExecAndMatchTypeUsages.ts ===
-export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
+export function foo(matchResult: RegExpMatchArray, execResult: RegExpExecArray) {
 >foo : Symbol(foo, Decl(regexpExecAndMatchTypeUsages.ts, 0, 0))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->RegExpExecArray : Symbol(RegExpExecArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>RegExpMatchArray : Symbol(RegExpMatchArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >RegExpExecArray : Symbol(RegExpExecArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.regexp.d.ts, --, --))
 
     matchResult[0].length;
 >matchResult[0].length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->0 : Symbol(RegExpExecArray[0], Decl(lib.es5.d.ts, --, --))
+>0 : Symbol(RegExpMatchArray[0], Decl(lib.es5.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     matchResult[999].length;
@@ -18,63 +18,63 @@ export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     matchResult.index + 0;
->matchResult.index : Symbol(RegExpExecArray.index, Decl(lib.es5.d.ts, --, --))
+>matchResult.index : Symbol(RegExpMatchArray.index, Decl(lib.es5.d.ts, --, --))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->index : Symbol(RegExpExecArray.index, Decl(lib.es5.d.ts, --, --))
+>index : Symbol(RegExpMatchArray.index, Decl(lib.es5.d.ts, --, --))
 
     matchResult.input.length;
 >matchResult.input.length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->matchResult.input : Symbol(RegExpExecArray.input, Decl(lib.es5.d.ts, --, --))
+>matchResult.input : Symbol(RegExpMatchArray.input, Decl(lib.es5.d.ts, --, --))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->input : Symbol(RegExpExecArray.input, Decl(lib.es5.d.ts, --, --))
+>input : Symbol(RegExpMatchArray.input, Decl(lib.es5.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     matchResult.groups["someVariable"].length;
 >matchResult.groups["someVariable"].length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->matchResult.groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
+>matchResult.groups : Symbol(RegExpMatchArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
+>groups : Symbol(RegExpMatchArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     matchResult.groups = undefined;
->matchResult.groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
+>matchResult.groups : Symbol(RegExpMatchArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
+>groups : Symbol(RegExpMatchArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >undefined : Symbol(undefined)
 
     execResult[0].length;
 >execResult[0].length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >0 : Symbol(RegExpExecArray[0], Decl(lib.es5.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     execResult[999].length;
 >execResult[999].length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     execResult.index + 0;
 >execResult.index : Symbol(RegExpExecArray.index, Decl(lib.es5.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >index : Symbol(RegExpExecArray.index, Decl(lib.es5.d.ts, --, --))
 
     execResult.input.length;
 >execResult.input.length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 >execResult.input : Symbol(RegExpExecArray.input, Decl(lib.es5.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >input : Symbol(RegExpExecArray.input, Decl(lib.es5.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     execResult.groups["someVariable"].length;
 >execResult.groups["someVariable"].length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 >execResult.groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
     execResult.groups = undefined;
 >execResult.groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >groups : Symbol(RegExpExecArray.groups, Decl(lib.es2018.regexp.d.ts, --, --))
 >undefined : Symbol(undefined)
 
@@ -85,11 +85,11 @@ export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
 
         matchResult = execResult;
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
     }
     else {
         execResult = matchResult
->execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 49))
+>execResult : Symbol(execResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 50))
 >matchResult : Symbol(matchResult, Decl(regexpExecAndMatchTypeUsages.ts, 0, 20))
     }
 }

--- a/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=true).types
+++ b/tests/baselines/reference/regexpExecAndMatchTypeUsages(strict=true).types
@@ -1,42 +1,42 @@
 === tests/cases/compiler/regexpExecAndMatchTypeUsages.ts ===
-export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
->foo : (matchResult: RegExpExecArray, execResult: RegExpExecArray) => void
->matchResult : RegExpExecArray
+export function foo(matchResult: RegExpMatchArray, execResult: RegExpExecArray) {
+>foo : (matchResult: RegExpMatchArray, execResult: RegExpExecArray) => void
+>matchResult : RegExpMatchArray
 >execResult : RegExpExecArray
 
     matchResult[0].length;
 >matchResult[0].length : number
 >matchResult[0] : string
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >0 : 0
 >length : number
 
     matchResult[999].length;
 >matchResult[999].length : number
 >matchResult[999] : string | undefined
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >999 : 999
 >length : number
 
     matchResult.index + 0;
 >matchResult.index + 0 : number
->matchResult.index : number
->matchResult : RegExpExecArray
->index : number
+>matchResult.index : number | undefined
+>matchResult : RegExpMatchArray
+>index : number | undefined
 >0 : 0
 
     matchResult.input.length;
 >matchResult.input.length : number
->matchResult.input : string
->matchResult : RegExpExecArray
->input : string
+>matchResult.input : string | undefined
+>matchResult : RegExpMatchArray
+>input : string | undefined
 >length : number
 
     matchResult.groups["someVariable"].length;
 >matchResult.groups["someVariable"].length : number
 >matchResult.groups["someVariable"] : string | undefined
 >matchResult.groups : { [key: string]: string; } | undefined
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >groups : { [key: string]: string; } | undefined
 >"someVariable" : "someVariable"
 >length : number
@@ -44,7 +44,7 @@ export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
     matchResult.groups = undefined;
 >matchResult.groups = undefined : undefined
 >matchResult.groups : { [key: string]: string; }
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >groups : { [key: string]: string; }
 >undefined : undefined
 
@@ -100,14 +100,14 @@ export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
 
         matchResult = execResult;
 >matchResult = execResult : RegExpExecArray
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
 >execResult : RegExpExecArray
     }
     else {
         execResult = matchResult
->execResult = matchResult : RegExpExecArray
+>execResult = matchResult : RegExpMatchArray
 >execResult : RegExpExecArray
->matchResult : RegExpExecArray
+>matchResult : RegExpMatchArray
     }
 }
 

--- a/tests/cases/compiler/regexpExecAndMatchTypeUsages.ts
+++ b/tests/cases/compiler/regexpExecAndMatchTypeUsages.ts
@@ -3,7 +3,7 @@
 // @exactOptionalPropertyTypes: true
 // @lib: es2018
 
-export function foo(matchResult: RegExpExecArray, execResult: RegExpExecArray) {
+export function foo(matchResult: RegExpMatchArray, execResult: RegExpExecArray) {
     matchResult[0].length;
     matchResult[999].length;
     matchResult.index + 0;


### PR DESCRIPTION
Addresses the mistake I found at https://github.com/microsoft/TypeScript/pull/50713#discussion_r973486426 just after merging https://github.com/microsoft/TypeScript/pull/50713.