### PR TITLE
Adds optional parameter to createPrinter (in emitter.ts) to allow spe…

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -898,6 +898,7 @@ namespace ts {
         const newLine = getNewLineCharacter(printerOptions);
         const moduleKind = getEmitModuleKind(printerOptions);
         const bundledHelpers = new Map<string, boolean>();
+        const indentation = printerOptions.indentation;
 
         let currentSourceFile: SourceFile | undefined;
         let nodeIdToGeneratedName: string[]; // Map of generated names for specific nodes.
@@ -1155,7 +1156,7 @@ namespace ts {
         }
 
         function beginPrint() {
-            return ownWriter || (ownWriter = createTextWriter(newLine));
+            return ownWriter || (ownWriter = createTextWriter(newLine, indentation));
         }
 
         function endPrint() {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8770,6 +8770,7 @@ namespace ts {
         newLine?: NewLineKind;
         omitTrailingSemicolon?: boolean;
         noEmitHelpers?: boolean;
+        indentation?: string | number;
         /*@internal*/ module?: CompilerOptions["module"];
         /*@internal*/ target?: CompilerOptions["target"];
         /*@internal*/ sourceMap?: boolean;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4121,6 +4121,28 @@ namespace ts {
         return indentStrings[level];
     }
 
+    export function setIndentString(indentation?: string | number) {
+        let singleLevel;
+        if (typeof indentation === "string") {
+            singleLevel = indentation;
+        }
+        else if (typeof indentation === "number") {
+            if (indentation < 0 || indentation > 9) {
+                indentation = 4;
+            }
+            singleLevel = "".padStart(indentation, " ");
+        }
+        else {
+            singleLevel = "    ";
+        }
+        if (indentStrings[1] !== singleLevel) {
+            const cacheLength = indentStrings.length;
+            //... clear current cache and repopulate with new indentation
+            indentStrings.splice(1, cacheLength - 1, singleLevel);
+            getIndentString(cacheLength);
+        }
+    }
+
     export function getIndentSize() {
         return indentStrings[1].length;
     }
@@ -4129,13 +4151,16 @@ namespace ts {
         return stringContains(version, "-dev") || stringContains(version, "-insiders");
     }
 
-    export function createTextWriter(newLine: string): EmitTextWriter {
+    export function createTextWriter(newLine: string, indentation?: string | number): EmitTextWriter {
         let output: string;
         let indent: number;
         let lineStart: boolean;
         let lineCount: number;
         let linePos: number;
         let hasTrailingComment = false;
+        if (indentation || indentation === 0) {
+            setIndentString(indentation);
+        }
 
         function updateLineCountAndPosFor(s: string) {
             const lineStartsOfS = computeLineStarts(s);

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -1149,10 +1149,10 @@ namespace ts.textChanges {
 
     interface TextChangesWriter extends EmitTextWriter, PrintHandlers {}
 
-    export function createWriter(newLine: string): TextChangesWriter {
+    export function createWriter(newLine: string, indentation?: string | number): TextChangesWriter {
         let lastNonTriviaPosition = 0;
 
-        const writer = createTextWriter(newLine);
+        const writer = createTextWriter(newLine, indentation);
         const onBeforeEmitNode: PrintHandlers["onBeforeEmitNode"] = node => {
             if (node) {
                 setPos(node, lastNonTriviaPosition);

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4049,6 +4049,7 @@ declare namespace ts {
         newLine?: NewLineKind;
         omitTrailingSemicolon?: boolean;
         noEmitHelpers?: boolean;
+        indentation?: string | number;
     }
     export interface GetEffectiveTypeRootsHost {
         directoryExists?(directoryName: string): boolean;

--- a/tests/baselines/reference/writerOptionalIndentation.js
+++ b/tests/baselines/reference/writerOptionalIndentation.js
@@ -1,0 +1,116 @@
+//// [tests/cases/compiler/writerOptionalIndentation.ts] ////
+
+//// [index.d.ts]
+declare module "typescript" {
+    export = ts;
+}
+
+//// [writerOptionalIndentation.ts]
+import * as ts from "typescript";
+
+const nl = ts.sys.newLine;
+
+type ExpectedResults = {
+    [indentation: string | number]: string;
+}
+
+const expectedResults: ExpectedResults = {
+    0: `export function abc(): string {${nl}let abc: string = \"abc\";${nl}return abc;${nl}}${nl}`,
+    1: `export function abc(): string {${nl} let abc: string = \"abc\";${nl} return abc;${nl}}${nl}`,
+    2: `export function abc(): string {${nl}  let abc: string = \"abc\";${nl}  return abc;${nl}}${nl}`,
+    3: `export function abc(): string {${nl}   let abc: string = \"abc\";${nl}   return abc;${nl}}${nl}`,
+    4: `export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}`,
+    6: `export function abc(): string {${nl}      let abc: string = \"abc\";${nl}      return abc;${nl}}${nl}`,
+    10: `export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}`,
+    "a": `export function abc(): string {${nl}alet abc: string = \"abc\";${nl}areturn abc;${nl}}${nl}`,
+    ".": `export function abc(): string {${nl}.let abc: string = \"abc\";${nl}.return abc;${nl}}${nl}`,
+    "\t": `export function abc(): string {${nl}\tlet abc: string = \"abc\";${nl}\treturn abc;${nl}}${nl}`,
+    "\t\t": `export function abc(): string {${nl}\t\tlet abc: string = \"abc\";${nl}\t\treturn abc;${nl}}${nl}`
+};
+
+
+let sourceFile = ts.createSourceFile(
+    "writerOptionalIndentationTest.ts",
+    `
+      export 
+  function abc (   )    :
+        string
+        {
+          let abc :   string   =    "abc";
+      return     abc
+        }
+    `,
+    ts.ScriptTarget.ESNext
+);
+
+function testIndentation(indentation?: string | number): void {
+    let printer;
+    if (indentation !== undefined) {
+        printer = ts.createPrinter({indentation});
+    } else {
+        printer = ts.createPrinter();
+        indentation = 4;
+    }
+    let result = printer.printNode(ts.EmitHint.Unspecified, sourceFile, sourceFile);
+    if (result !== expectedResults[indentation]) {
+        let workIndentationSize = indentation === undefined ? "<default>" : indentation;
+        throw new Error(`writerOptionalIndentation - Failed indentation for >>${workIndentationSize}<<${nl}Expected:-${nl}${expectedResults[indentation]}${nl}Have:-${nl}${result}`);
+    }
+}
+
+testIndentation(); //... testing with no indentationSize - uses default of 4 spaces
+for (let indentation in expectedResults) {
+    let test = parseInt(indentation);
+    if (indentation === "0" || test > 0) {
+        testIndentation(test);
+    }
+    else {
+      testIndentation(indentation);
+    }
+}
+
+
+//// [writerOptionalIndentation.js]
+"use strict";
+exports.__esModule = true;
+var ts = require("typescript");
+var nl = ts.sys.newLine;
+var expectedResults = {
+    0: "export function abc(): string {".concat(nl, "let abc: string = \"abc\";").concat(nl, "return abc;").concat(nl, "}").concat(nl),
+    1: "export function abc(): string {".concat(nl, " let abc: string = \"abc\";").concat(nl, " return abc;").concat(nl, "}").concat(nl),
+    2: "export function abc(): string {".concat(nl, "  let abc: string = \"abc\";").concat(nl, "  return abc;").concat(nl, "}").concat(nl),
+    3: "export function abc(): string {".concat(nl, "   let abc: string = \"abc\";").concat(nl, "   return abc;").concat(nl, "}").concat(nl),
+    4: "export function abc(): string {".concat(nl, "    let abc: string = \"abc\";").concat(nl, "    return abc;").concat(nl, "}").concat(nl),
+    6: "export function abc(): string {".concat(nl, "      let abc: string = \"abc\";").concat(nl, "      return abc;").concat(nl, "}").concat(nl),
+    10: "export function abc(): string {".concat(nl, "    let abc: string = \"abc\";").concat(nl, "    return abc;").concat(nl, "}").concat(nl),
+    "a": "export function abc(): string {".concat(nl, "alet abc: string = \"abc\";").concat(nl, "areturn abc;").concat(nl, "}").concat(nl),
+    ".": "export function abc(): string {".concat(nl, ".let abc: string = \"abc\";").concat(nl, ".return abc;").concat(nl, "}").concat(nl),
+    "\t": "export function abc(): string {".concat(nl, "\tlet abc: string = \"abc\";").concat(nl, "\treturn abc;").concat(nl, "}").concat(nl),
+    "\t\t": "export function abc(): string {".concat(nl, "\t\tlet abc: string = \"abc\";").concat(nl, "\t\treturn abc;").concat(nl, "}").concat(nl)
+};
+var sourceFile = ts.createSourceFile("writerOptionalIndentationTest.ts", "\n      export \n  function abc (   )    :\n        string\n        {\n          let abc :   string   =    \"abc\";\n      return     abc\n        }\n    ", ts.ScriptTarget.ESNext);
+function testIndentation(indentation) {
+    var printer;
+    if (indentation !== undefined) {
+        printer = ts.createPrinter({ indentation: indentation });
+    }
+    else {
+        printer = ts.createPrinter();
+        indentation = 4;
+    }
+    var result = printer.printNode(ts.EmitHint.Unspecified, sourceFile, sourceFile);
+    if (result !== expectedResults[indentation]) {
+        var workIndentationSize = indentation === undefined ? "<default>" : indentation;
+        throw new Error("writerOptionalIndentation - Failed indentation for >>".concat(workIndentationSize, "<<").concat(nl, "Expected:-").concat(nl).concat(expectedResults[indentation]).concat(nl, "Have:-").concat(nl).concat(result));
+    }
+}
+testIndentation(); //... testing with no indentationSize - uses default of 4 spaces
+for (var indentation in expectedResults) {
+    var test = parseInt(indentation);
+    if (indentation === "0" || test > 0) {
+        testIndentation(test);
+    }
+    else {
+        testIndentation(indentation);
+    }
+}

--- a/tests/baselines/reference/writerOptionalIndentation.symbols
+++ b/tests/baselines/reference/writerOptionalIndentation.symbols
@@ -1,0 +1,228 @@
+=== tests/cases/compiler/node_modules/typescript/index.d.ts ===
+declare module "typescript" {
+>"typescript" : Symbol("typescript", Decl(index.d.ts, 0, 0))
+
+    export = ts;
+>ts : Symbol(ts, Decl(typescriptServices.d.ts, 0, 0), Decl(typescriptServices.d.ts, 91, 1), Decl(typescriptServices.d.ts, 4178, 49), Decl(typescriptServices.d.ts, 4235, 1), Decl(typescriptServices.d.ts, 4298, 1) ... and 32 more)
+}
+
+=== tests/cases/compiler/writerOptionalIndentation.ts ===
+import * as ts from "typescript";
+>ts : Symbol(ts, Decl(writerOptionalIndentation.ts, 0, 6))
+
+const nl = ts.sys.newLine;
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>ts.sys.newLine : Symbol(ts.System.newLine, Decl(typescriptServices.d.ts, 4188, 23))
+>ts.sys : Symbol(ts.sys, Decl(typescriptServices.d.ts, 4233, 14))
+>ts : Symbol(ts, Decl(writerOptionalIndentation.ts, 0, 6))
+>sys : Symbol(ts.sys, Decl(typescriptServices.d.ts, 4233, 14))
+>newLine : Symbol(ts.System.newLine, Decl(typescriptServices.d.ts, 4188, 23))
+
+type ExpectedResults = {
+>ExpectedResults : Symbol(ExpectedResults, Decl(writerOptionalIndentation.ts, 2, 26))
+
+    [indentation: string | number]: string;
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 5, 5))
+}
+
+const expectedResults: ExpectedResults = {
+>expectedResults : Symbol(expectedResults, Decl(writerOptionalIndentation.ts, 8, 5))
+>ExpectedResults : Symbol(ExpectedResults, Decl(writerOptionalIndentation.ts, 2, 26))
+
+    0: `export function abc(): string {${nl}let abc: string = \"abc\";${nl}return abc;${nl}}${nl}`,
+>0 : Symbol(0, Decl(writerOptionalIndentation.ts, 8, 42))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+    1: `export function abc(): string {${nl} let abc: string = \"abc\";${nl} return abc;${nl}}${nl}`,
+>1 : Symbol(1, Decl(writerOptionalIndentation.ts, 9, 99))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+    2: `export function abc(): string {${nl}  let abc: string = \"abc\";${nl}  return abc;${nl}}${nl}`,
+>2 : Symbol(2, Decl(writerOptionalIndentation.ts, 10, 101))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+    3: `export function abc(): string {${nl}   let abc: string = \"abc\";${nl}   return abc;${nl}}${nl}`,
+>3 : Symbol(3, Decl(writerOptionalIndentation.ts, 11, 103))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+    4: `export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}`,
+>4 : Symbol(4, Decl(writerOptionalIndentation.ts, 12, 105))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+    6: `export function abc(): string {${nl}      let abc: string = \"abc\";${nl}      return abc;${nl}}${nl}`,
+>6 : Symbol(6, Decl(writerOptionalIndentation.ts, 13, 107))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+    10: `export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}`,
+>10 : Symbol(10, Decl(writerOptionalIndentation.ts, 14, 111))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+    "a": `export function abc(): string {${nl}alet abc: string = \"abc\";${nl}areturn abc;${nl}}${nl}`,
+>"a" : Symbol("a", Decl(writerOptionalIndentation.ts, 15, 108))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+    ".": `export function abc(): string {${nl}.let abc: string = \"abc\";${nl}.return abc;${nl}}${nl}`,
+>"." : Symbol(".", Decl(writerOptionalIndentation.ts, 16, 103))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+    "\t": `export function abc(): string {${nl}\tlet abc: string = \"abc\";${nl}\treturn abc;${nl}}${nl}`,
+>"\t" : Symbol("\t", Decl(writerOptionalIndentation.ts, 17, 103))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+    "\t\t": `export function abc(): string {${nl}\t\tlet abc: string = \"abc\";${nl}\t\treturn abc;${nl}}${nl}`
+>"\t\t" : Symbol("\t\t", Decl(writerOptionalIndentation.ts, 18, 106))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+
+};
+
+
+let sourceFile = ts.createSourceFile(
+>sourceFile : Symbol(sourceFile, Decl(writerOptionalIndentation.ts, 23, 3))
+>ts.createSourceFile : Symbol(ts.createSourceFile, Decl(typescriptServices.d.ts, 4890, 5))
+>ts : Symbol(ts, Decl(writerOptionalIndentation.ts, 0, 6))
+>createSourceFile : Symbol(ts.createSourceFile, Decl(typescriptServices.d.ts, 4890, 5))
+
+    "writerOptionalIndentationTest.ts",
+    `
+      export 
+  function abc (   )    :
+        string
+        {
+          let abc :   string   =    "abc";
+      return     abc
+        }
+    `,
+    ts.ScriptTarget.ESNext
+>ts.ScriptTarget.ESNext : Symbol(ts.ScriptTarget.ESNext, Decl(typescriptServices.d.ts, 3172, 19))
+>ts.ScriptTarget : Symbol(ts.ScriptTarget, Decl(typescriptServices.d.ts, 3161, 5))
+>ts : Symbol(ts, Decl(writerOptionalIndentation.ts, 0, 6))
+>ScriptTarget : Symbol(ts.ScriptTarget, Decl(typescriptServices.d.ts, 3161, 5))
+>ESNext : Symbol(ts.ScriptTarget.ESNext, Decl(typescriptServices.d.ts, 3172, 19))
+
+);
+
+function testIndentation(indentation?: string | number): void {
+>testIndentation : Symbol(testIndentation, Decl(writerOptionalIndentation.ts, 35, 2))
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 37, 25))
+
+    let printer;
+>printer : Symbol(printer, Decl(writerOptionalIndentation.ts, 38, 7))
+
+    if (indentation !== undefined) {
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 37, 25))
+>undefined : Symbol(undefined)
+
+        printer = ts.createPrinter({indentation});
+>printer : Symbol(printer, Decl(writerOptionalIndentation.ts, 38, 7))
+>ts.createPrinter : Symbol(ts.createPrinter, Decl(typescriptServices.d.ts, 5144, 127))
+>ts : Symbol(ts, Decl(writerOptionalIndentation.ts, 0, 6))
+>createPrinter : Symbol(ts.createPrinter, Decl(typescriptServices.d.ts, 5144, 127))
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 40, 36))
+
+    } else {
+        printer = ts.createPrinter();
+>printer : Symbol(printer, Decl(writerOptionalIndentation.ts, 38, 7))
+>ts.createPrinter : Symbol(ts.createPrinter, Decl(typescriptServices.d.ts, 5144, 127))
+>ts : Symbol(ts, Decl(writerOptionalIndentation.ts, 0, 6))
+>createPrinter : Symbol(ts.createPrinter, Decl(typescriptServices.d.ts, 5144, 127))
+
+        indentation = 4;
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 37, 25))
+    }
+    let result = printer.printNode(ts.EmitHint.Unspecified, sourceFile, sourceFile);
+>result : Symbol(result, Decl(writerOptionalIndentation.ts, 45, 7))
+>printer.printNode : Symbol(ts.Printer.printNode, Decl(typescriptServices.d.ts, 3970, 30))
+>printer : Symbol(printer, Decl(writerOptionalIndentation.ts, 38, 7))
+>printNode : Symbol(ts.Printer.printNode, Decl(typescriptServices.d.ts, 3970, 30))
+>ts.EmitHint.Unspecified : Symbol(ts.EmitHint.Unspecified, Decl(typescriptServices.d.ts, 3384, 32))
+>ts.EmitHint : Symbol(ts.EmitHint, Decl(typescriptServices.d.ts, 3379, 72))
+>ts : Symbol(ts, Decl(writerOptionalIndentation.ts, 0, 6))
+>EmitHint : Symbol(ts.EmitHint, Decl(typescriptServices.d.ts, 3379, 72))
+>Unspecified : Symbol(ts.EmitHint.Unspecified, Decl(typescriptServices.d.ts, 3384, 32))
+>sourceFile : Symbol(sourceFile, Decl(writerOptionalIndentation.ts, 23, 3))
+>sourceFile : Symbol(sourceFile, Decl(writerOptionalIndentation.ts, 23, 3))
+
+    if (result !== expectedResults[indentation]) {
+>result : Symbol(result, Decl(writerOptionalIndentation.ts, 45, 7))
+>expectedResults : Symbol(expectedResults, Decl(writerOptionalIndentation.ts, 8, 5))
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 37, 25))
+
+        let workIndentationSize = indentation === undefined ? "<default>" : indentation;
+>workIndentationSize : Symbol(workIndentationSize, Decl(writerOptionalIndentation.ts, 47, 11))
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 37, 25))
+>undefined : Symbol(undefined)
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 37, 25))
+
+        throw new Error(`writerOptionalIndentation - Failed indentation for >>${workIndentationSize}<<${nl}Expected:-${nl}${expectedResults[indentation]}${nl}Have:-${nl}${result}`);
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>workIndentationSize : Symbol(workIndentationSize, Decl(writerOptionalIndentation.ts, 47, 11))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>expectedResults : Symbol(expectedResults, Decl(writerOptionalIndentation.ts, 8, 5))
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 37, 25))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>nl : Symbol(nl, Decl(writerOptionalIndentation.ts, 2, 5))
+>result : Symbol(result, Decl(writerOptionalIndentation.ts, 45, 7))
+    }
+}
+
+testIndentation(); //... testing with no indentationSize - uses default of 4 spaces
+>testIndentation : Symbol(testIndentation, Decl(writerOptionalIndentation.ts, 35, 2))
+
+for (let indentation in expectedResults) {
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 53, 8))
+>expectedResults : Symbol(expectedResults, Decl(writerOptionalIndentation.ts, 8, 5))
+
+    let test = parseInt(indentation);
+>test : Symbol(test, Decl(writerOptionalIndentation.ts, 54, 7))
+>parseInt : Symbol(parseInt, Decl(lib.es5.d.ts, --, --))
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 53, 8))
+
+    if (indentation === "0" || test > 0) {
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 53, 8))
+>test : Symbol(test, Decl(writerOptionalIndentation.ts, 54, 7))
+
+        testIndentation(test);
+>testIndentation : Symbol(testIndentation, Decl(writerOptionalIndentation.ts, 35, 2))
+>test : Symbol(test, Decl(writerOptionalIndentation.ts, 54, 7))
+    }
+    else {
+      testIndentation(indentation);
+>testIndentation : Symbol(testIndentation, Decl(writerOptionalIndentation.ts, 35, 2))
+>indentation : Symbol(indentation, Decl(writerOptionalIndentation.ts, 53, 8))
+    }
+}
+

--- a/tests/baselines/reference/writerOptionalIndentation.types
+++ b/tests/baselines/reference/writerOptionalIndentation.types
@@ -1,0 +1,270 @@
+=== tests/cases/compiler/node_modules/typescript/index.d.ts ===
+declare module "typescript" {
+>"typescript" : typeof import("typescript")
+
+    export = ts;
+>ts : typeof ts
+}
+
+=== tests/cases/compiler/writerOptionalIndentation.ts ===
+import * as ts from "typescript";
+>ts : typeof ts
+
+const nl = ts.sys.newLine;
+>nl : string
+>ts.sys.newLine : string
+>ts.sys : ts.System
+>ts : typeof ts
+>sys : ts.System
+>newLine : string
+
+type ExpectedResults = {
+>ExpectedResults : { [indentation: string]: string; [indentation: number]: string; }
+
+    [indentation: string | number]: string;
+>indentation : string | number
+}
+
+const expectedResults: ExpectedResults = {
+>expectedResults : ExpectedResults
+>{    0: `export function abc(): string {${nl}let abc: string = \"abc\";${nl}return abc;${nl}}${nl}`,    1: `export function abc(): string {${nl} let abc: string = \"abc\";${nl} return abc;${nl}}${nl}`,    2: `export function abc(): string {${nl}  let abc: string = \"abc\";${nl}  return abc;${nl}}${nl}`,    3: `export function abc(): string {${nl}   let abc: string = \"abc\";${nl}   return abc;${nl}}${nl}`,    4: `export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}`,    6: `export function abc(): string {${nl}      let abc: string = \"abc\";${nl}      return abc;${nl}}${nl}`,    10: `export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}`,    "a": `export function abc(): string {${nl}alet abc: string = \"abc\";${nl}areturn abc;${nl}}${nl}`,    ".": `export function abc(): string {${nl}.let abc: string = \"abc\";${nl}.return abc;${nl}}${nl}`,    "\t": `export function abc(): string {${nl}\tlet abc: string = \"abc\";${nl}\treturn abc;${nl}}${nl}`,    "\t\t": `export function abc(): string {${nl}\t\tlet abc: string = \"abc\";${nl}\t\treturn abc;${nl}}${nl}`} : { 0: string; 1: string; 2: string; 3: string; 4: string; 6: string; 10: string; a: string; ".": string; "\t": string; "\t\t": string; }
+
+    0: `export function abc(): string {${nl}let abc: string = \"abc\";${nl}return abc;${nl}}${nl}`,
+>0 : string
+>`export function abc(): string {${nl}let abc: string = \"abc\";${nl}return abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+    1: `export function abc(): string {${nl} let abc: string = \"abc\";${nl} return abc;${nl}}${nl}`,
+>1 : string
+>`export function abc(): string {${nl} let abc: string = \"abc\";${nl} return abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+    2: `export function abc(): string {${nl}  let abc: string = \"abc\";${nl}  return abc;${nl}}${nl}`,
+>2 : string
+>`export function abc(): string {${nl}  let abc: string = \"abc\";${nl}  return abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+    3: `export function abc(): string {${nl}   let abc: string = \"abc\";${nl}   return abc;${nl}}${nl}`,
+>3 : string
+>`export function abc(): string {${nl}   let abc: string = \"abc\";${nl}   return abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+    4: `export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}`,
+>4 : string
+>`export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+    6: `export function abc(): string {${nl}      let abc: string = \"abc\";${nl}      return abc;${nl}}${nl}`,
+>6 : string
+>`export function abc(): string {${nl}      let abc: string = \"abc\";${nl}      return abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+    10: `export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}`,
+>10 : string
+>`export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+    "a": `export function abc(): string {${nl}alet abc: string = \"abc\";${nl}areturn abc;${nl}}${nl}`,
+>"a" : string
+>`export function abc(): string {${nl}alet abc: string = \"abc\";${nl}areturn abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+    ".": `export function abc(): string {${nl}.let abc: string = \"abc\";${nl}.return abc;${nl}}${nl}`,
+>"." : string
+>`export function abc(): string {${nl}.let abc: string = \"abc\";${nl}.return abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+    "\t": `export function abc(): string {${nl}\tlet abc: string = \"abc\";${nl}\treturn abc;${nl}}${nl}`,
+>"\t" : string
+>`export function abc(): string {${nl}\tlet abc: string = \"abc\";${nl}\treturn abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+    "\t\t": `export function abc(): string {${nl}\t\tlet abc: string = \"abc\";${nl}\t\treturn abc;${nl}}${nl}`
+>"\t\t" : string
+>`export function abc(): string {${nl}\t\tlet abc: string = \"abc\";${nl}\t\treturn abc;${nl}}${nl}` : string
+>nl : string
+>nl : string
+>nl : string
+>nl : string
+
+};
+
+
+let sourceFile = ts.createSourceFile(
+>sourceFile : ts.SourceFile
+>ts.createSourceFile(    "writerOptionalIndentationTest.ts",    `      export   function abc (   )    :        string        {          let abc :   string   =    "abc";      return     abc        }    `,    ts.ScriptTarget.ESNext) : ts.SourceFile
+>ts.createSourceFile : (fileName: string, sourceText: string, languageVersionOrOptions: ts.ScriptTarget | ts.CreateSourceFileOptions, setParentNodes?: boolean | undefined, scriptKind?: ts.ScriptKind | undefined) => ts.SourceFile
+>ts : typeof ts
+>createSourceFile : (fileName: string, sourceText: string, languageVersionOrOptions: ts.ScriptTarget | ts.CreateSourceFileOptions, setParentNodes?: boolean | undefined, scriptKind?: ts.ScriptKind | undefined) => ts.SourceFile
+
+    "writerOptionalIndentationTest.ts",
+>"writerOptionalIndentationTest.ts" : "writerOptionalIndentationTest.ts"
+
+    `
+>`      export   function abc (   )    :        string        {          let abc :   string   =    "abc";      return     abc        }    ` : "\n      export \n  function abc (   )    :\n        string\n        {\n          let abc :   string   =    \"abc\";\n      return     abc\n        }\n    "
+
+      export 
+  function abc (   )    :
+        string
+        {
+          let abc :   string   =    "abc";
+      return     abc
+        }
+    `,
+    ts.ScriptTarget.ESNext
+>ts.ScriptTarget.ESNext : ts.ScriptTarget.ESNext
+>ts.ScriptTarget : typeof ts.ScriptTarget
+>ts : typeof ts
+>ScriptTarget : typeof ts.ScriptTarget
+>ESNext : ts.ScriptTarget.ESNext
+
+);
+
+function testIndentation(indentation?: string | number): void {
+>testIndentation : (indentation?: string | number) => void
+>indentation : string | number | undefined
+
+    let printer;
+>printer : any
+
+    if (indentation !== undefined) {
+>indentation !== undefined : boolean
+>indentation : string | number | undefined
+>undefined : undefined
+
+        printer = ts.createPrinter({indentation});
+>printer = ts.createPrinter({indentation}) : ts.Printer
+>printer : any
+>ts.createPrinter({indentation}) : ts.Printer
+>ts.createPrinter : (printerOptions?: ts.PrinterOptions | undefined, handlers?: ts.PrintHandlers | undefined) => ts.Printer
+>ts : typeof ts
+>createPrinter : (printerOptions?: ts.PrinterOptions | undefined, handlers?: ts.PrintHandlers | undefined) => ts.Printer
+>{indentation} : { indentation: string | number; }
+>indentation : string | number
+
+    } else {
+        printer = ts.createPrinter();
+>printer = ts.createPrinter() : ts.Printer
+>printer : any
+>ts.createPrinter() : ts.Printer
+>ts.createPrinter : (printerOptions?: ts.PrinterOptions | undefined, handlers?: ts.PrintHandlers | undefined) => ts.Printer
+>ts : typeof ts
+>createPrinter : (printerOptions?: ts.PrinterOptions | undefined, handlers?: ts.PrintHandlers | undefined) => ts.Printer
+
+        indentation = 4;
+>indentation = 4 : 4
+>indentation : string | number | undefined
+>4 : 4
+    }
+    let result = printer.printNode(ts.EmitHint.Unspecified, sourceFile, sourceFile);
+>result : string
+>printer.printNode(ts.EmitHint.Unspecified, sourceFile, sourceFile) : string
+>printer.printNode : (hint: ts.EmitHint, node: ts.Node, sourceFile: ts.SourceFile) => string
+>printer : ts.Printer
+>printNode : (hint: ts.EmitHint, node: ts.Node, sourceFile: ts.SourceFile) => string
+>ts.EmitHint.Unspecified : ts.EmitHint.Unspecified
+>ts.EmitHint : typeof ts.EmitHint
+>ts : typeof ts
+>EmitHint : typeof ts.EmitHint
+>Unspecified : ts.EmitHint.Unspecified
+>sourceFile : ts.SourceFile
+>sourceFile : ts.SourceFile
+
+    if (result !== expectedResults[indentation]) {
+>result !== expectedResults[indentation] : boolean
+>result : string
+>expectedResults[indentation] : string
+>expectedResults : ExpectedResults
+>indentation : string | number
+
+        let workIndentationSize = indentation === undefined ? "<default>" : indentation;
+>workIndentationSize : string | number
+>indentation === undefined ? "<default>" : indentation : string | number
+>indentation === undefined : boolean
+>indentation : string | number
+>undefined : undefined
+>"<default>" : "<default>"
+>indentation : string | number
+
+        throw new Error(`writerOptionalIndentation - Failed indentation for >>${workIndentationSize}<<${nl}Expected:-${nl}${expectedResults[indentation]}${nl}Have:-${nl}${result}`);
+>new Error(`writerOptionalIndentation - Failed indentation for >>${workIndentationSize}<<${nl}Expected:-${nl}${expectedResults[indentation]}${nl}Have:-${nl}${result}`) : Error
+>Error : ErrorConstructor
+>`writerOptionalIndentation - Failed indentation for >>${workIndentationSize}<<${nl}Expected:-${nl}${expectedResults[indentation]}${nl}Have:-${nl}${result}` : string
+>workIndentationSize : string | number
+>nl : string
+>nl : string
+>expectedResults[indentation] : string
+>expectedResults : ExpectedResults
+>indentation : string | number
+>nl : string
+>nl : string
+>result : string
+    }
+}
+
+testIndentation(); //... testing with no indentationSize - uses default of 4 spaces
+>testIndentation() : void
+>testIndentation : (indentation?: string | number | undefined) => void
+
+for (let indentation in expectedResults) {
+>indentation : string
+>expectedResults : ExpectedResults
+
+    let test = parseInt(indentation);
+>test : number
+>parseInt(indentation) : number
+>parseInt : (string: string, radix?: number | undefined) => number
+>indentation : string
+
+    if (indentation === "0" || test > 0) {
+>indentation === "0" || test > 0 : boolean
+>indentation === "0" : boolean
+>indentation : string
+>"0" : "0"
+>test > 0 : boolean
+>test : number
+>0 : 0
+
+        testIndentation(test);
+>testIndentation(test) : void
+>testIndentation : (indentation?: string | number | undefined) => void
+>test : number
+    }
+    else {
+      testIndentation(indentation);
+>testIndentation(indentation) : void
+>testIndentation : (indentation?: string | number | undefined) => void
+>indentation : string
+    }
+}
+

--- a/tests/cases/compiler/writerOptionalIndentation.ts
+++ b/tests/cases/compiler/writerOptionalIndentation.ts
@@ -1,0 +1,74 @@
+// @module: commonjs
+// @skipLibCheck: true
+// @includebuiltfile: typescriptServices.d.ts
+// @noImplicitAny:true
+// @strictNullChecks:true
+
+// @filename: node_modules/typescript/index.d.ts
+declare module "typescript" {
+    export = ts;
+}
+
+// @filename: writerOptionalIndentation.ts
+import * as ts from "typescript";
+
+const nl = ts.sys.newLine;
+
+type ExpectedResults = {
+    [indentation: string | number]: string;
+}
+
+const expectedResults: ExpectedResults = {
+    0: `export function abc(): string {${nl}let abc: string = \"abc\";${nl}return abc;${nl}}${nl}`,
+    1: `export function abc(): string {${nl} let abc: string = \"abc\";${nl} return abc;${nl}}${nl}`,
+    2: `export function abc(): string {${nl}  let abc: string = \"abc\";${nl}  return abc;${nl}}${nl}`,
+    3: `export function abc(): string {${nl}   let abc: string = \"abc\";${nl}   return abc;${nl}}${nl}`,
+    4: `export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}`,
+    6: `export function abc(): string {${nl}      let abc: string = \"abc\";${nl}      return abc;${nl}}${nl}`,
+    10: `export function abc(): string {${nl}    let abc: string = \"abc\";${nl}    return abc;${nl}}${nl}`,
+    "a": `export function abc(): string {${nl}alet abc: string = \"abc\";${nl}areturn abc;${nl}}${nl}`,
+    ".": `export function abc(): string {${nl}.let abc: string = \"abc\";${nl}.return abc;${nl}}${nl}`,
+    "\t": `export function abc(): string {${nl}\tlet abc: string = \"abc\";${nl}\treturn abc;${nl}}${nl}`,
+    "\t\t": `export function abc(): string {${nl}\t\tlet abc: string = \"abc\";${nl}\t\treturn abc;${nl}}${nl}`
+};
+
+
+let sourceFile = ts.createSourceFile(
+    "writerOptionalIndentationTest.ts",
+    `
+      export 
+  function abc (   )    :
+        string
+        {
+          let abc :   string   =    "abc";
+      return     abc
+        }
+    `,
+    ts.ScriptTarget.ESNext
+);
+
+function testIndentation(indentation?: string | number): void {
+    let printer;
+    if (indentation !== undefined) {
+        printer = ts.createPrinter({indentation});
+    } else {
+        printer = ts.createPrinter();
+        indentation = 4;
+    }
+    let result = printer.printNode(ts.EmitHint.Unspecified, sourceFile, sourceFile);
+    if (result !== expectedResults[indentation]) {
+        let workIndentationSize = indentation === undefined ? "<default>" : indentation;
+        throw new Error(`writerOptionalIndentation - Failed indentation for >>${workIndentationSize}<<${nl}Expected:-${nl}${expectedResults[indentation]}${nl}Have:-${nl}${result}`);
+    }
+}
+
+testIndentation(); //... testing with no indentationSize - uses default of 4 spaces
+for (let indentation in expectedResults) {
+    let test = parseInt(indentation);
+    if (indentation === "0" || test > 0) {
+        testIndentation(test);
+    }
+    else {
+      testIndentation(indentation);
+    }
+}


### PR DESCRIPTION
…cifying the indentation either as a number of spaces or a sequence of 1+ characters (be that tab(s) or any other character(s) of choice).

This pull request addresses open issue https://github.com/microsoft/TypeScript/issues/2306.

How this works?  Currently the indentation is hardcoded in the utilities.ts (called indentStrings) as a cached array of strings where each string in the array is the next step of indentation to be used... position 0 = "", 1 = "    ", 2 = "        ", etc.  ... and it cannot be changed.  The modifications in this pull request includes a method that will 'rebuild' the content of that array using the information provided by a new PrinterOptions property called 'indentation'.  Note:  the array is the same instance... just the content changes.

If 'indentation' is not supplied (the default (and also fully backwards compatiable) or is not a string or number) then the cached array is left as is.
If 'indentation' is a number between 0 to 9 (negative numbers or numbers higher than 9 are treated as a default of 4) then the cached array content is rebuilt with strings incremented in each subsequent position with the supplied number of spaces...   e.g.   3 = ["", "   ", "      ", ...]
if 'indentation' is a string then the cached array content is rebuilt with that string as the indentation step... "\t" = ["", "\t", "\t\t", ...]

Special note: The current implementation of the indentation is a 'static' cached array (all createPrinter instances use the same array).  It is possibly to see unexpected results when 2 or more instances of a printer are created in parallel (and the indentation is different).  The latest createPrinter call will dictate the size and content of each indentation step at the time of the call.  This can only be fixed by moving the indentation cache into the 'printer' instance and is beyond the scope of this pull request.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #
