### PR TITLE
Fix debug.ts __debugKind check

### DIFF
--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -625,7 +625,7 @@ namespace ts {
             ];
 
             for (const ctor of nodeConstructors) {
-                if (!hasProperty(ctor, "__debugKind")) {
+                if (!hasProperty(ctor.prototype, "__debugKind")) {
                     Object.defineProperties(ctor.prototype, {
                         // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
                         __tsDebuggerDisplay: {


### PR DESCRIPTION
Fixes my oops in #50422.

The old code was:

```ts
if (!ctor.prototype.hasOwnProperty("__debugKind")) { ... }
```

Which I changed to:

```ts
if (!hasProperty(ctor, "__debugKind")) { ... }
```	

But it should have been:

```ts
if (!hasProperty(ctor.prototype, "__debugKind")) { ... }
```	
