### PR TITLE
Overloads shouldn't gain @deprecated tags of other overloads in quick info

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -725,8 +725,9 @@ namespace ts.SymbolDisplay {
 
             if (allSignatures.length > 1 && documentation.length === 0 && tags.length === 0) {
                 documentation = allSignatures[0].getDocumentationComment(typeChecker);
-                tags = allSignatures[0].getJsDocTags();
+                tags = allSignatures[0].getJsDocTags().filter(tag => tag.name !== "deprecated"); // should only include @deprecated JSDoc tag on the first overload (#49368)
             }
+
         }
 
         function writeTypeParametersOfSymbol(symbol: Symbol, enclosingDeclaration: Node | undefined) {

--- a/tests/cases/fourslash/quickInfoJsDocTagsFunctionOverload06.ts
+++ b/tests/cases/fourslash/quickInfoJsDocTagsFunctionOverload06.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+// @target: esnext
+
+// @Filename: /a.ts
+/////**
+//// * A function that gets the length of an array.
+//// * @param testParam
+//// * @deprecated Use the new method instead.
+//// */
+////export function getArrayLength(arr: string[]): number;
+////export function getArrayLength(arr: boolean[]): number;
+
+// @Filename: /b.ts
+////import { getArrayLength } from "/a";
+/////*1*/getArrayLength(["1"]);
+/////*2*/getArrayLength([true]);
+
+
+goTo.file("/b.ts");
+goTo.marker("1")
+verify.quickInfoIs("(alias) getArrayLength(arr: string[]): number (+1 overload)\nimport getArrayLength", "A function that gets the length of an array.", [{name: "param", text: "testParam"}, {name: "deprecated", text: "Use the new method instead."}])
+goTo.marker("2")
+verify.quickInfoIs("(alias) getArrayLength(arr: boolean[]): number (+1 overload)\nimport getArrayLength", "A function that gets the length of an array.", [{name: "param", text: "testParam"}])

--- a/tests/cases/fourslash/quickInfoJsDocTagsFunctionOverload06.ts
+++ b/tests/cases/fourslash/quickInfoJsDocTagsFunctionOverload06.ts
@@ -12,8 +12,9 @@
 
 // @Filename: /b.ts
 ////import { getArrayLength } from "/a";
-/////*1*/getArrayLength(["1"]);
+/////*1*/getArrayLength(["hello"]);
 /////*2*/getArrayLength([true]);
+/////*3*/getArrayLength(["hello"]);
 
 
 goTo.file("/b.ts");
@@ -21,3 +22,5 @@ goTo.marker("1")
 verify.quickInfoIs("(alias) getArrayLength(arr: string[]): number (+1 overload)\nimport getArrayLength", "A function that gets the length of an array.", [{name: "param", text: "testParam"}, {name: "deprecated", text: "Use the new method instead."}])
 goTo.marker("2")
 verify.quickInfoIs("(alias) getArrayLength(arr: boolean[]): number (+1 overload)\nimport getArrayLength", "A function that gets the length of an array.", [{name: "param", text: "testParam"}])
+goTo.marker("3")
+verify.quickInfoIs("(alias) getArrayLength(arr: string[]): number (+1 overload)\nimport getArrayLength", "A function that gets the length of an array.", [{name: "param", text: "testParam"}, {name: "deprecated", text: "Use the new method instead."}])


### PR DESCRIPTION
Fixes #49368

This PR updates the hover text for overloaded function signatures: it prevents the `@deprecated` JSDoc tag from being passed on to other signatures of the same overloaded function (see the linked issue for examples).
This is relevant because it enables the author of the module to deprecate only certain signatures. This behaviour also now aligns the hover text with the existing behaviour of the VS Code "strikethrough" styling.

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [?] There are new or updated unit tests validating the change
    * I've added fourslash tests

