### PR TITLE
Handle if project for open file will get recollected because of pending cleanup from closed script info

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1167,20 +1167,22 @@ namespace ts.server {
         }
 
         /* @internal */
-        tryGetDefaultProjectForFile(fileName: NormalizedPath): Project | undefined {
-            const scriptInfo = this.getScriptInfoForNormalizedPath(fileName);
+        tryGetDefaultProjectForFile(fileNameOrScriptInfo: NormalizedPath | ScriptInfo): Project | undefined {
+            const scriptInfo = isString(fileNameOrScriptInfo) ? this.getScriptInfoForNormalizedPath(fileNameOrScriptInfo) : fileNameOrScriptInfo;
             return scriptInfo && !scriptInfo.isOrphan() ? scriptInfo.getDefaultProject() : undefined;
         }
 
         /* @internal */
-        ensureDefaultProjectForFile(fileName: NormalizedPath): Project {
+        ensureDefaultProjectForFile(fileName: NormalizedPath | ScriptInfo): Project {
             return this.tryGetDefaultProjectForFile(fileName) || this.doEnsureDefaultProjectForFile(fileName);
         }
 
-        private doEnsureDefaultProjectForFile(fileName: NormalizedPath): Project {
+        private doEnsureDefaultProjectForFile(fileNameOrScriptInfo: NormalizedPath | ScriptInfo): Project {
             this.ensureProjectStructuresUptoDate();
-            const scriptInfo = this.getScriptInfoForNormalizedPath(fileName);
-            return scriptInfo ? scriptInfo.getDefaultProject() : (this.logErrorForScriptInfoNotFound(fileName), Errors.ThrowNoProject());
+            const scriptInfo = isString(fileNameOrScriptInfo) ? this.getScriptInfoForNormalizedPath(fileNameOrScriptInfo) : fileNameOrScriptInfo;
+            return scriptInfo ?
+                scriptInfo.getDefaultProject() :
+                (this.logErrorForScriptInfoNotFound(isString(fileNameOrScriptInfo) ? fileNameOrScriptInfo : fileNameOrScriptInfo.fileName), Errors.ThrowNoProject());
         }
 
         getScriptInfoEnsuringProjectsUptoDate(uncheckedFileName: string) {
@@ -3648,7 +3650,7 @@ namespace ts.server {
                 return;
             }
 
-            const project = scriptInfo.getDefaultProject();
+            const project = this.ensureDefaultProjectForFile(scriptInfo);
             if (!project.languageServiceEnabled) {
                 return;
             }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1173,8 +1173,8 @@ namespace ts.server {
         }
 
         /* @internal */
-        ensureDefaultProjectForFile(fileName: NormalizedPath | ScriptInfo): Project {
-            return this.tryGetDefaultProjectForFile(fileName) || this.doEnsureDefaultProjectForFile(fileName);
+        ensureDefaultProjectForFile(fileNameOrScriptInfo: NormalizedPath | ScriptInfo): Project {
+            return this.tryGetDefaultProjectForFile(fileNameOrScriptInfo) || this.doEnsureDefaultProjectForFile(fileNameOrScriptInfo);
         }
 
         private doEnsureDefaultProjectForFile(fileNameOrScriptInfo: NormalizedPath | ScriptInfo): Project {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1719,6 +1719,10 @@ namespace ts.server {
                     this.projectService.logErrorForScriptInfoNotFound(args.file);
                     return Errors.ThrowNoProject();
                 }
+                else if (!getScriptInfoEnsuringProjectsUptoDate) {
+                    // Ensure there are containing projects are present
+                    this.projectService.ensureDefaultProjectForFile(scriptInfo);
+                }
                 projects = scriptInfo.containingProjects;
                 symLinkedProjects = this.projectService.getSymlinkedProjects(scriptInfo);
             }
@@ -1867,13 +1871,7 @@ namespace ts.server {
         }
 
         private getFileAndLanguageServiceForSyntacticOperation(args: protocol.FileRequestArgs) {
-            // Since this is syntactic operation, there should always be project for the file
-            // throw if we dont get project
-            const file = toNormalizedPath(args.file);
-            const project = this.getProject(args.projectFileName) || this.projectService.ensureDefaultProjectForFile(file);
-            if (!project) {
-                return Errors.ThrowNoProject();
-            }
+            const { file, project } = this.getFileAndProject(args);
             return {
                 file,
                 languageService: project.getLanguageService(/*ensureSynchronized*/ false)

--- a/src/testRunner/unittests/tsserver/helpers.ts
+++ b/src/testRunner/unittests/tsserver/helpers.ts
@@ -95,6 +95,7 @@ namespace ts.projectSystem {
         function msg(s: string, type = server.Msg.Err, write: (s: string) => void) {
             s = `[${nowString()}] ${s}`;
             if (!inGroup || firstInGroup) s = padStringRight(type + " " + seq.toString(), "          ") + s;
+            if (Debug.isDebugging) console.log(s);
             write(s);
             if (!inGroup) seq++;
         }

--- a/tests/baselines/reference/tsserver/projects/js-file-opened-is-in-configured-project-that-will-be-removed.js
+++ b/tests/baselines/reference/tsserver/projects/js-file-opened-is-in-configured-project-that-will-be-removed.js
@@ -1,0 +1,396 @@
+Info 0    [00:00:37.000] Provided types map file "/a/lib/typesMap.json" doesn't exist
+Info 1    [00:00:38.000] request:
+    {
+      "seq": 0,
+      "type": "request",
+      "command": "open",
+      "arguments": {
+        "file": "/user/username/projects/myproject/mocks/cssMock.js"
+      }
+    }
+Before request
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"allowJs":true}}
+
+//// [/user/username/projects/myproject/mocks/cssMock.js]
+function foo() { }
+
+//// [/user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js]
+function bar() { }
+
+//// [/user/username/projects/myproject/apps/editor/tsconfig.json]
+{"extends":"../../tsconfig.json","include":["./src"]}
+
+//// [/user/username/projects/myproject/apps/editor/src/src.js]
+function fooBar() { }
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+
+PolledWatches::
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Info 2    [00:00:39.000] Search path: /user/username/projects/myproject/mocks
+Info 3    [00:00:40.000] For info: /user/username/projects/myproject/mocks/cssMock.js :: Config file name: /user/username/projects/myproject/tsconfig.json
+Info 4    [00:00:41.000] Creating configuration project /user/username/projects/myproject/tsconfig.json
+Info 5    [00:00:42.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Info 6    [00:00:43.000] event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/mocks/cssMock.js to open"}}
+Info 7    [00:00:44.000] Config: /user/username/projects/myproject/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js",
+  "/user/username/projects/myproject/apps/editor/src/src.js",
+  "/user/username/projects/myproject/mocks/cssMock.js"
+ ],
+ "options": {
+  "allowJs": true,
+  "configFilePath": "/user/username/projects/myproject/tsconfig.json"
+ }
+}
+Info 8    [00:00:45.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Info 9    [00:00:46.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Info 10   [00:00:47.000] Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Info 11   [00:00:48.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js 500 undefined WatchType: Closed Script info
+Info 12   [00:00:49.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/src/src.js 500 undefined WatchType: Closed Script info
+Info 13   [00:00:50.000] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
+Info 14   [00:00:51.000] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+Info 15   [00:00:52.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Info 16   [00:00:53.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Info 17   [00:00:54.000] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info 18   [00:00:55.000] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+Info 19   [00:00:56.000] 	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js
+	/user/username/projects/myproject/apps/editor/src/src.js
+	/user/username/projects/myproject/mocks/cssMock.js
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es3'
+	apps/editor/scripts/createConfigVariable.js
+	  Matched by default include pattern '**/*'
+	apps/editor/src/src.js
+	  Matched by default include pattern '**/*'
+	mocks/cssMock.js
+	  Matched by default include pattern '**/*'
+
+Info 20   [00:00:57.000] -----------------------------------------------
+Info 21   [00:00:58.000] event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/tsconfig.json"}}
+Info 22   [00:00:59.000] event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"4a33d78ee40d836c4f4e64c59aed976628aea0013be9585c5ff171dfc41baf98","fileStats":{"js":3,"jsSize":57,"jsx":0,"jsxSize":0,"ts":0,"tsSize":0,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"allowJs":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":false,"files":false,"include":false,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"FakeVersion"}}}
+Info 23   [00:01:00.000] event:
+    {"seq":0,"type":"event","event":"configFileDiag","body":{"triggerFile":"/user/username/projects/myproject/mocks/cssMock.js","configFile":"/user/username/projects/myproject/tsconfig.json","diagnostics":[{"text":"Cannot write file '/user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js' because it would overwrite input file.","code":5055,"category":"error"},{"text":"Cannot write file '/user/username/projects/myproject/apps/editor/src/src.js' because it would overwrite input file.","code":5055,"category":"error"},{"text":"Cannot write file '/user/username/projects/myproject/mocks/cssMock.js' because it would overwrite input file.","code":5055,"category":"error"}]}}
+Info 24   [00:01:01.000] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+Info 24   [00:01:02.000] 	Files (4)
+
+Info 24   [00:01:03.000] -----------------------------------------------
+Info 24   [00:01:04.000] Open files: 
+Info 24   [00:01:05.000] 	FileName: /user/username/projects/myproject/mocks/cssMock.js ProjectRootPath: undefined
+Info 24   [00:01:06.000] 		Projects: /user/username/projects/myproject/tsconfig.json
+After request
+
+PolledWatches::
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/tsconfig.json:
+  {}
+/user/username/projects/myproject/apps/editor/scripts/createconfigvariable.js:
+  {}
+/user/username/projects/myproject/apps/editor/src/src.js:
+  {}
+/a/lib/lib.d.ts:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject:
+  {}
+
+Info 24   [00:01:07.000] response:
+    {
+      "responseRequired": false
+    }
+Info 25   [00:01:08.000] request:
+    {
+      "seq": 0,
+      "type": "request",
+      "command": "close",
+      "arguments": {
+        "file": "/user/username/projects/myproject/mocks/cssMock.js"
+      }
+    }
+Before request
+
+PolledWatches::
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/tsconfig.json:
+  {}
+/user/username/projects/myproject/apps/editor/scripts/createconfigvariable.js:
+  {}
+/user/username/projects/myproject/apps/editor/src/src.js:
+  {}
+/a/lib/lib.d.ts:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject:
+  {}
+
+Info 26   [00:01:09.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/mocks/cssMock.js 500 undefined WatchType: Closed Script info
+Info 27   [00:01:10.000] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+Info 27   [00:01:11.000] 	Files (4)
+
+Info 27   [00:01:12.000] -----------------------------------------------
+Info 27   [00:01:13.000] Open files: 
+After request
+
+PolledWatches::
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/tsconfig.json:
+  {}
+/user/username/projects/myproject/apps/editor/scripts/createconfigvariable.js:
+  {}
+/user/username/projects/myproject/apps/editor/src/src.js:
+  {}
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/myproject/mocks/cssmock.js:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject:
+  {}
+
+Info 27   [00:01:14.000] response:
+    {
+      "responseRequired": false
+    }
+Info 28   [00:01:15.000] request:
+    {
+      "seq": 0,
+      "type": "request",
+      "command": "open",
+      "arguments": {
+        "file": "/user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js"
+      }
+    }
+Before request
+
+PolledWatches::
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/tsconfig.json:
+  {}
+/user/username/projects/myproject/apps/editor/scripts/createconfigvariable.js:
+  {}
+/user/username/projects/myproject/apps/editor/src/src.js:
+  {}
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/myproject/mocks/cssmock.js:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject:
+  {}
+
+Info 29   [00:01:16.000] FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js 500 undefined WatchType: Closed Script info
+Info 30   [00:01:17.000] Search path: /user/username/projects/myproject/apps/editor/scripts
+Info 31   [00:01:18.000] For info: /user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js :: Config file name: /user/username/projects/myproject/apps/editor/tsconfig.json
+Info 32   [00:01:19.000] Creating configuration project /user/username/projects/myproject/apps/editor/tsconfig.json
+Info 33   [00:01:20.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/apps/editor/tsconfig.json WatchType: Config file
+Info 34   [00:01:21.000] event:
+    {"seq":0,"type":"event","event":"projectLoadingStart","body":{"projectName":"/user/username/projects/myproject/apps/editor/tsconfig.json","reason":"Creating possible configured project for /user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js to open"}}
+Info 35   [00:01:22.000] Config: /user/username/projects/myproject/apps/editor/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/apps/editor/src/src.js"
+ ],
+ "options": {
+  "allowJs": true,
+  "configFilePath": "/user/username/projects/myproject/apps/editor/tsconfig.json"
+ }
+}
+Info 36   [00:01:23.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Config: /user/username/projects/myproject/apps/editor/tsconfig.json WatchType: Extended config file
+Info 37   [00:01:24.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/src 1 undefined Config: /user/username/projects/myproject/apps/editor/tsconfig.json WatchType: Wild card directory
+Info 38   [00:01:25.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/src 1 undefined Config: /user/username/projects/myproject/apps/editor/tsconfig.json WatchType: Wild card directory
+Info 39   [00:01:26.000] Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Info 40   [00:01:27.000] Starting updateGraphWorker: Project: /user/username/projects/myproject/apps/editor/tsconfig.json
+Info 41   [00:01:28.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/node_modules/@types 1 undefined Project: /user/username/projects/myproject/apps/editor/tsconfig.json WatchType: Type roots
+Info 42   [00:01:29.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/node_modules/@types 1 undefined Project: /user/username/projects/myproject/apps/editor/tsconfig.json WatchType: Type roots
+Info 43   [00:01:30.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/node_modules/@types 1 undefined Project: /user/username/projects/myproject/apps/editor/tsconfig.json WatchType: Type roots
+Info 44   [00:01:31.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/node_modules/@types 1 undefined Project: /user/username/projects/myproject/apps/editor/tsconfig.json WatchType: Type roots
+Info 45   [00:01:32.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/apps/editor/tsconfig.json WatchType: Type roots
+Info 46   [00:01:33.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/apps/editor/tsconfig.json WatchType: Type roots
+Info 47   [00:01:34.000] Finishing updateGraphWorker: Project: /user/username/projects/myproject/apps/editor/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info 48   [00:01:35.000] Project '/user/username/projects/myproject/apps/editor/tsconfig.json' (Configured)
+Info 49   [00:01:36.000] 	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/apps/editor/src/src.js
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es3'
+	src/src.js
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+Info 50   [00:01:37.000] -----------------------------------------------
+Info 51   [00:01:38.000] event:
+    {"seq":0,"type":"event","event":"projectLoadingFinish","body":{"projectName":"/user/username/projects/myproject/apps/editor/tsconfig.json"}}
+Info 52   [00:01:39.000] event:
+    {"seq":0,"type":"event","event":"telemetry","body":{"telemetryEventName":"projectInfo","payload":{"projectId":"3a35a87188335633b0bee242201aa5e01b96dbee6cfae401ebff6e26120b2aa7","fileStats":{"js":1,"jsSize":21,"jsx":0,"jsxSize":0,"ts":0,"tsSize":0,"tsx":0,"tsxSize":0,"dts":1,"dtsSize":334,"deferred":0,"deferredSize":0},"compilerOptions":{"allowJs":true},"typeAcquisition":{"enable":false,"include":false,"exclude":false},"extends":true,"files":false,"include":true,"exclude":false,"compileOnSave":false,"configFileName":"tsconfig.json","projectType":"configured","languageServiceEnabled":true,"version":"FakeVersion"}}}
+Info 53   [00:01:40.000] `remove Project::
+Info 54   [00:01:41.000] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
+Info 55   [00:01:42.000] 	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js
+	/user/username/projects/myproject/apps/editor/src/src.js
+	/user/username/projects/myproject/mocks/cssMock.js
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es3'
+	apps/editor/scripts/createConfigVariable.js
+	  Matched by default include pattern '**/*'
+	apps/editor/src/src.js
+	  Matched by default include pattern '**/*'
+	mocks/cssMock.js
+	  Matched by default include pattern '**/*'
+
+Info 56   [00:01:43.000] -----------------------------------------------
+Info 57   [00:01:44.000] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Info 58   [00:01:45.000] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+Info 59   [00:01:46.000] FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Config file
+Info 60   [00:01:47.000] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Info 61   [00:01:48.000] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
+Info 62   [00:01:49.000] FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/mocks/cssMock.js 500 undefined WatchType: Closed Script info
+Info 63   [00:01:50.000] Before ensureProjectForOpenFiles:
+Info 64   [00:01:51.000] Project '/user/username/projects/myproject/apps/editor/tsconfig.json' (Configured)
+Info 64   [00:01:52.000] 	Files (2)
+
+Info 64   [00:01:53.000] -----------------------------------------------
+Info 64   [00:01:54.000] Open files: 
+Info 64   [00:01:55.000] 	FileName: /user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js ProjectRootPath: undefined
+Info 64   [00:01:56.000] 		Projects: 
+Info 64   [00:01:57.000] Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Info 65   [00:01:58.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/scripts/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 66   [00:01:59.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/scripts/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 67   [00:02:00.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 68   [00:02:01.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 69   [00:02:02.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 70   [00:02:03.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 71   [00:02:04.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 72   [00:02:05.000] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Info 73   [00:02:06.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/scripts/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 74   [00:02:07.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/scripts/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 75   [00:02:08.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 76   [00:02:09.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/editor/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 77   [00:02:10.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 78   [00:02:11.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/apps/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 79   [00:02:12.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 80   [00:02:13.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 81   [00:02:14.000] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info 82   [00:02:15.000] Project '/dev/null/inferredProject1*' (Inferred)
+Info 83   [00:02:16.000] 	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	createConfigVariable.js
+	  Root file specified for compilation
+
+Info 84   [00:02:17.000] -----------------------------------------------
+Info 85   [00:02:18.000] After ensureProjectForOpenFiles:
+Info 86   [00:02:19.000] Project '/user/username/projects/myproject/apps/editor/tsconfig.json' (Configured)
+Info 86   [00:02:20.000] 	Files (2)
+
+Info 86   [00:02:21.000] -----------------------------------------------
+Info 86   [00:02:22.000] Project '/dev/null/inferredProject1*' (Inferred)
+Info 86   [00:02:23.000] 	Files (2)
+
+Info 86   [00:02:24.000] -----------------------------------------------
+Info 86   [00:02:25.000] Open files: 
+Info 86   [00:02:26.000] 	FileName: /user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js ProjectRootPath: undefined
+Info 86   [00:02:27.000] 		Projects: /dev/null/inferredProject1*
+Info 86   [00:02:28.000] Project '/user/username/projects/myproject/apps/editor/tsconfig.json' (Configured)
+Info 86   [00:02:29.000] 	Files (2)
+
+Info 86   [00:02:30.000] -----------------------------------------------
+Info 86   [00:02:31.000] Project '/dev/null/inferredProject1*' (Inferred)
+Info 86   [00:02:32.000] 	Files (2)
+
+Info 86   [00:02:33.000] -----------------------------------------------
+Info 86   [00:02:34.000] Open files: 
+Info 86   [00:02:35.000] 	FileName: /user/username/projects/myproject/apps/editor/scripts/createConfigVariable.js ProjectRootPath: undefined
+Info 86   [00:02:36.000] 		Projects: /dev/null/inferredProject1*
+After request
+
+PolledWatches::
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/apps/editor/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/apps/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/apps/editor/scripts/tsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/apps/editor/scripts/jsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/apps/editor/jsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/apps/tsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/apps/jsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/jsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/apps/editor/scripts/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/apps/editor/scripts/bower_components:
+  {"pollingInterval":500}
+/user/username/projects/myproject/apps/editor/scripts/node_modules:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/tsconfig.json:
+  {}
+/user/username/projects/myproject/apps/editor/src/src.js:
+  {}
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/myproject/apps/editor/tsconfig.json:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject/apps/editor/src:
+  {}
+
+Info 86   [00:02:37.000] response:
+    {
+      "responseRequired": false
+    }

--- a/tests/baselines/reference/tsserver/projects/references-on-file-opened-is-in-configured-project-that-will-be-removed.js
+++ b/tests/baselines/reference/tsserver/projects/references-on-file-opened-is-in-configured-project-that-will-be-removed.js
@@ -1,0 +1,475 @@
+Info 0    [00:00:35.000] Provided types map file "/a/lib/typesMap.json" doesn't exist
+Info 1    [00:00:36.000] request:
+    {
+      "seq": 0,
+      "type": "request",
+      "command": "open",
+      "arguments": {
+        "file": "/user/username/projects/myproject/playground/tests.ts"
+      }
+    }
+Before request
+//// [/user/username/projects/myproject/playground/tsconfig.json]
+{}
+
+//// [/user/username/projects/myproject/playground/tests.ts]
+export function foo() {}
+
+//// [/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts]
+export function bar() { }
+
+//// [/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json]
+{"include":["./src"]}
+
+//// [/user/username/projects/myproject/playground/tsconfig-json/src/src.ts]
+export function foobar() { }
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+
+PolledWatches::
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Info 2    [00:00:37.000] Search path: /user/username/projects/myproject/playground
+Info 3    [00:00:38.000] For info: /user/username/projects/myproject/playground/tests.ts :: Config file name: /user/username/projects/myproject/playground/tsconfig.json
+Info 4    [00:00:39.000] Creating configuration project /user/username/projects/myproject/playground/tsconfig.json
+Info 5    [00:00:40.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Config file
+Info 6    [00:00:41.000] Config: /user/username/projects/myproject/playground/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/playground/tests.ts",
+  "/user/username/projects/myproject/playground/tsconfig-json/src/src.ts",
+  "/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/playground/tsconfig.json"
+ }
+}
+Info 7    [00:00:42.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground 1 undefined Config: /user/username/projects/myproject/playground/tsconfig.json WatchType: Wild card directory
+Info 8    [00:00:43.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground 1 undefined Config: /user/username/projects/myproject/playground/tsconfig.json WatchType: Wild card directory
+Info 9    [00:00:44.000] Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Info 10   [00:00:45.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/src/src.ts 500 undefined WatchType: Closed Script info
+Info 11   [00:00:46.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts 500 undefined WatchType: Closed Script info
+Info 12   [00:00:47.000] Starting updateGraphWorker: Project: /user/username/projects/myproject/playground/tsconfig.json
+Info 13   [00:00:48.000] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+Info 14   [00:00:49.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Info 15   [00:00:50.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Info 16   [00:00:51.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Info 17   [00:00:52.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Info 18   [00:00:53.000] Finishing updateGraphWorker: Project: /user/username/projects/myproject/playground/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info 19   [00:00:54.000] Project '/user/username/projects/myproject/playground/tsconfig.json' (Configured)
+Info 20   [00:00:55.000] 	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/playground/tests.ts
+	/user/username/projects/myproject/playground/tsconfig-json/src/src.ts
+	/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library for target 'es3'
+	tests.ts
+	  Matched by default include pattern '**/*'
+	tsconfig-json/src/src.ts
+	  Matched by default include pattern '**/*'
+	tsconfig-json/tests/spec.ts
+	  Matched by default include pattern '**/*'
+
+Info 21   [00:00:56.000] -----------------------------------------------
+Info 22   [00:00:57.000] Project '/user/username/projects/myproject/playground/tsconfig.json' (Configured)
+Info 22   [00:00:58.000] 	Files (4)
+
+Info 22   [00:00:59.000] -----------------------------------------------
+Info 22   [00:01:00.000] Open files: 
+Info 22   [00:01:01.000] 	FileName: /user/username/projects/myproject/playground/tests.ts ProjectRootPath: undefined
+Info 22   [00:01:02.000] 		Projects: /user/username/projects/myproject/playground/tsconfig.json
+After request
+
+PolledWatches::
+/user/username/projects/myproject/playground/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/playground/tsconfig.json:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/src/src.ts:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts:
+  {}
+/a/lib/lib.d.ts:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject/playground:
+  {}
+
+Info 22   [00:01:03.000] response:
+    {
+      "responseRequired": false
+    }
+Info 23   [00:01:04.000] request:
+    {
+      "seq": 0,
+      "type": "request",
+      "command": "close",
+      "arguments": {
+        "file": "/user/username/projects/myproject/playground/tests.ts"
+      }
+    }
+Before request
+
+PolledWatches::
+/user/username/projects/myproject/playground/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/playground/tsconfig.json:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/src/src.ts:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts:
+  {}
+/a/lib/lib.d.ts:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject/playground:
+  {}
+
+Info 24   [00:01:05.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tests.ts 500 undefined WatchType: Closed Script info
+Info 25   [00:01:06.000] Project '/user/username/projects/myproject/playground/tsconfig.json' (Configured)
+Info 25   [00:01:07.000] 	Files (4)
+
+Info 25   [00:01:08.000] -----------------------------------------------
+Info 25   [00:01:09.000] Open files: 
+After request
+
+PolledWatches::
+/user/username/projects/myproject/playground/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/playground/tsconfig.json:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/src/src.ts:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts:
+  {}
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/myproject/playground/tests.ts:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject/playground:
+  {}
+
+Info 25   [00:01:10.000] response:
+    {
+      "responseRequired": false
+    }
+Info 26   [00:01:11.000] request:
+    {
+      "seq": 0,
+      "type": "request",
+      "command": "open",
+      "arguments": {
+        "file": "/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts"
+      }
+    }
+Before request
+
+PolledWatches::
+/user/username/projects/myproject/playground/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/playground/tsconfig.json:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/src/src.ts:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts:
+  {}
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/myproject/playground/tests.ts:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject/playground:
+  {}
+
+Info 27   [00:01:12.000] FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts 500 undefined WatchType: Closed Script info
+Info 28   [00:01:13.000] Search path: /user/username/projects/myproject/playground/tsconfig-json/tests
+Info 29   [00:01:14.000] For info: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts :: Config file name: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json
+Info 30   [00:01:15.000] Creating configuration project /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json
+Info 31   [00:01:16.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Config file
+Info 32   [00:01:17.000] Config: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/myproject/playground/tsconfig-json/src/src.ts"
+ ],
+ "options": {
+  "configFilePath": "/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json"
+ }
+}
+Info 33   [00:01:18.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/src 1 undefined Config: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Wild card directory
+Info 34   [00:01:19.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/src 1 undefined Config: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Wild card directory
+Info 35   [00:01:20.000] Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Info 36   [00:01:21.000] Starting updateGraphWorker: Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json
+Info 37   [00:01:22.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+Info 38   [00:01:23.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+Info 39   [00:01:24.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+Info 40   [00:01:25.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+Info 41   [00:01:26.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+Info 42   [00:01:27.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json WatchType: Type roots
+Info 43   [00:01:28.000] Finishing updateGraphWorker: Project: /user/username/projects/myproject/playground/tsconfig-json/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info 44   [00:01:29.000] Project '/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json' (Configured)
+Info 45   [00:01:30.000] 	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/playground/tsconfig-json/src/src.ts
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es3'
+	src/src.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+Info 46   [00:01:31.000] -----------------------------------------------
+Info 47   [00:01:32.000] `remove Project::
+Info 48   [00:01:33.000] Project '/user/username/projects/myproject/playground/tsconfig.json' (Configured)
+Info 49   [00:01:34.000] 	Files (4)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/playground/tests.ts
+	/user/username/projects/myproject/playground/tsconfig-json/src/src.ts
+	/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts
+
+
+	../../../../../a/lib/lib.d.ts
+	  Default library for target 'es3'
+	tests.ts
+	  Matched by default include pattern '**/*'
+	tsconfig-json/src/src.ts
+	  Matched by default include pattern '**/*'
+	tsconfig-json/tests/spec.ts
+	  Matched by default include pattern '**/*'
+
+Info 50   [00:01:35.000] -----------------------------------------------
+Info 51   [00:01:36.000] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground 1 undefined Config: /user/username/projects/myproject/playground/tsconfig.json WatchType: Wild card directory
+Info 52   [00:01:37.000] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground 1 undefined Config: /user/username/projects/myproject/playground/tsconfig.json WatchType: Wild card directory
+Info 53   [00:01:38.000] FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground/tsconfig.json 2000 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Config file
+Info 54   [00:01:39.000] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Info 55   [00:01:40.000] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Info 56   [00:01:41.000] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Info 57   [00:01:42.000] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/playground/tsconfig.json WatchType: Type roots
+Info 58   [00:01:43.000] FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/playground/tests.ts 500 undefined WatchType: Closed Script info
+Info 59   [00:01:44.000] Project '/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json' (Configured)
+Info 59   [00:01:45.000] 	Files (2)
+
+Info 59   [00:01:46.000] -----------------------------------------------
+Info 59   [00:01:47.000] Open files: 
+Info 59   [00:01:48.000] 	FileName: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts ProjectRootPath: undefined
+Info 59   [00:01:49.000] 		Projects: 
+After request
+
+PolledWatches::
+/user/username/projects/myproject/playground/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/playground/tsconfig-json/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/playground/tsconfig-json/src/src.ts:
+  {}
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject/playground/tsconfig-json/src:
+  {}
+
+Info 59   [00:01:50.000] response:
+    {
+      "responseRequired": false
+    }
+Info 60   [00:01:51.000] request:
+    {
+      "command": "references",
+      "arguments": {
+        "file": "/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts",
+        "line": 1,
+        "offset": 17
+      },
+      "seq": 1,
+      "type": "request"
+    }
+Before request
+
+PolledWatches::
+/user/username/projects/myproject/playground/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/playground/tsconfig-json/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/myproject/playground/tsconfig-json/src/src.ts:
+  {}
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject/playground/tsconfig-json/src:
+  {}
+
+Info 61   [00:01:52.000] Before ensureProjectForOpenFiles:
+Info 62   [00:01:53.000] Project '/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json' (Configured)
+Info 62   [00:01:54.000] 	Files (2)
+
+Info 62   [00:01:55.000] -----------------------------------------------
+Info 62   [00:01:56.000] Open files: 
+Info 62   [00:01:57.000] 	FileName: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts ProjectRootPath: undefined
+Info 62   [00:01:58.000] 		Projects: 
+Info 62   [00:01:59.000] Plugins were requested but not running in environment that supports 'require'. Nothing will be loaded
+Info 63   [00:02:00.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 64   [00:02:01.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 65   [00:02:02.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 66   [00:02:03.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 67   [00:02:04.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 68   [00:02:05.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 69   [00:02:06.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info 70   [00:02:07.000] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Info 71   [00:02:08.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 72   [00:02:09.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 73   [00:02:10.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 74   [00:02:11.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 75   [00:02:12.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 76   [00:02:13.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 77   [00:02:14.000] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 78   [00:02:15.000] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info 79   [00:02:16.000] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info 80   [00:02:17.000] Project '/dev/null/inferredProject1*' (Inferred)
+Info 81   [00:02:18.000] 	Files (2)
+	/a/lib/lib.d.ts
+	/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts
+
+
+	../../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	spec.ts
+	  Root file specified for compilation
+
+Info 82   [00:02:19.000] -----------------------------------------------
+Info 83   [00:02:20.000] After ensureProjectForOpenFiles:
+Info 84   [00:02:21.000] Project '/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json' (Configured)
+Info 84   [00:02:22.000] 	Files (2)
+
+Info 84   [00:02:23.000] -----------------------------------------------
+Info 84   [00:02:24.000] Project '/dev/null/inferredProject1*' (Inferred)
+Info 84   [00:02:25.000] 	Files (2)
+
+Info 84   [00:02:26.000] -----------------------------------------------
+Info 84   [00:02:27.000] Open files: 
+Info 84   [00:02:28.000] 	FileName: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts ProjectRootPath: undefined
+Info 84   [00:02:29.000] 		Projects: /dev/null/inferredProject1*
+Info 84   [00:02:30.000] Finding references to /user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts position 16 in project /dev/null/inferredProject1*
+Info 85   [00:02:31.000] FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/playground/tsconfig-json/tests/spec.d.ts 2000 undefined Project: /dev/null/inferredProject1* WatchType: Missing generated file
+After request
+
+PolledWatches::
+/user/username/projects/myproject/playground/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/playground/tsconfig-json/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/playground/tsconfig-json/tests/tsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/playground/tsconfig-json/tests/jsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/playground/tsconfig-json/jsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/playground/jsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/tsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/jsconfig.json:
+  {"pollingInterval":2000}
+/user/username/projects/myproject/playground/tsconfig-json/tests/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/myproject/playground/tsconfig-json/tests/spec.d.ts:
+  {"pollingInterval":2000}
+
+FsWatches::
+/user/username/projects/myproject/playground/tsconfig-json/src/src.ts:
+  {}
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/myproject/playground/tsconfig-json/tsconfig.json:
+  {}
+/user/username/projects/myproject/playground/tsconfig.json:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/myproject/playground/tsconfig-json/src:
+  {}
+
+Info 86   [00:02:32.000] response:
+    {
+      "response": {
+        "refs": [
+          {
+            "file": "/user/username/projects/myproject/playground/tsconfig-json/tests/spec.ts",
+            "start": {
+              "line": 1,
+              "offset": 17
+            },
+            "end": {
+              "line": 1,
+              "offset": 20
+            },
+            "contextStart": {
+              "line": 1,
+              "offset": 1
+            },
+            "contextEnd": {
+              "line": 1,
+              "offset": 26
+            },
+            "lineText": "export function bar() { }",
+            "isWriteAccess": true,
+            "isDefinition": true
+          }
+        ],
+        "symbolName": "bar",
+        "symbolStartOffset": 17,
+        "symbolDisplayString": "function bar(): void"
+      },
+      "responseRequired": true
+    }


### PR DESCRIPTION
This is similar to #50418 but this handles telemetry event and references like operations
Fixes #50868
