### PR TITLE
Pick correct compilerOptions when checking if we can share emitSignatures

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -176,7 +176,7 @@ namespace ts {
         const canCopyEmitSignatures = compilerOptions.composite &&
             oldState?.emitSignatures &&
             !outFilePath &&
-            !compilerOptionsAffectDeclarationPath(compilerOptions, oldCompilerOptions!);
+            !compilerOptionsAffectDeclarationPath(compilerOptions, oldState.compilerOptions);
         if (useOldState) {
             // Copy old state's changed files set
             oldState!.changedFilesSet?.forEach(value => state.changedFilesSet.add(value));

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -173,6 +173,11 @@ namespace ts {
         const oldCompilerOptions = useOldState ? oldState!.compilerOptions : undefined;
         const canCopySemanticDiagnostics = useOldState && oldState!.semanticDiagnosticsPerFile && !!state.semanticDiagnosticsPerFile &&
             !compilerOptionsAffectSemanticDiagnostics(compilerOptions, oldCompilerOptions!);
+        // Can copy emit signatures that is d.ts signature of files output on the disk is based on whether d.ts file for given file remains same
+        // useOldState is not appropriate to check since apart from checking if oldState is present or not,
+        // it also checks if we can use file references to determine files to emit etc which isnt factor in determining d.ts emit signature
+        // So we directly access oldState here to determine if .d.ts signature file is valid or not
+        // (It is valid if file's d.ts file remains same between compilation eg. if declarationDir option or outDir options doesnt change)
         const canCopyEmitSignatures = compilerOptions.composite &&
             oldState?.emitSignatures &&
             !outFilePath &&

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -173,11 +173,12 @@ namespace ts {
         const oldCompilerOptions = useOldState ? oldState!.compilerOptions : undefined;
         const canCopySemanticDiagnostics = useOldState && oldState!.semanticDiagnosticsPerFile && !!state.semanticDiagnosticsPerFile &&
             !compilerOptionsAffectSemanticDiagnostics(compilerOptions, oldCompilerOptions!);
-        // Can copy emit signatures that is d.ts signature of files output on the disk is based on whether d.ts file for given file remains same
-        // useOldState is not appropriate to check since apart from checking if oldState is present or not,
-        // it also checks if we can use file references to determine files to emit etc which isnt factor in determining d.ts emit signature
-        // So we directly access oldState here to determine if .d.ts signature file is valid or not
-        // (It is valid if file's d.ts file remains same between compilation eg. if declarationDir option or outDir options doesnt change)
+        // We can only reuse emit signatures (i.e. .d.ts signatures) if the .d.ts file is unchanged,
+        // which will eg be depedent on change in options like declarationDir and outDir options are unchanged.
+        // We need to look in oldState.compilerOptions, rather than oldCompilerOptions (i.e.we need to disregard useOldState) because
+        // oldCompilerOptions can be undefined if there was change in say module from None to some other option
+        // which would make useOldState as false since we can now use reference maps that are needed to track what to emit, what to check etc
+        // but that option change does not affect d.ts file name so emitSignatures should still be reused.
         const canCopyEmitSignatures = compilerOptions.composite &&
             oldState?.emitSignatures &&
             !outFilePath &&

--- a/src/testRunner/unittests/tsc/composite.ts
+++ b/src/testRunner/unittests/tsc/composite.ts
@@ -81,5 +81,26 @@ namespace ts {
             }),
             commandLineArgs: ["--composite", "false", "--p", "src/project", "--tsBuildInfoFile", "null"],
         });
+
+        verifyTscWithEdits({
+            scenario: "composite",
+            subScenario: "converting to modules",
+            fs: () => loadProjectFromFiles({
+                "/src/project/src/main.ts": "const x = 10;",
+                "/src/project/tsconfig.json": JSON.stringify({
+                    compilerOptions: {
+                        module: "none",
+                        composite: true,
+                    },
+                }),
+            }),
+            commandLineArgs: ["-p", "/src/project"],
+            edits: [
+                {
+                    subScenario: "convert to modules",
+                    modifyFs: fs => replaceText(fs, "/src/project/tsconfig.json", "none", "es2015"),
+                }
+            ]
+        });
     });
 }

--- a/tests/baselines/reference/tsc/composite/converting-to-modules.js
+++ b/tests/baselines/reference/tsc/composite/converting-to-modules.js
@@ -1,0 +1,126 @@
+Input::
+//// [/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/src/project/src/main.ts]
+const x = 10;
+
+//// [/src/project/tsconfig.json]
+{"compilerOptions":{"module":"none","composite":true}}
+
+
+
+Output::
+/lib/tsc -p /src/project
+exitCode:: ExitStatus.Success
+
+
+//// [/src/project/src/main.d.ts]
+declare const x = 10;
+
+
+//// [/src/project/src/main.js]
+var x = 10;
+
+
+//// [/src/project/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","./src/main.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},{"version":"5029505981-const x = 10;","signature":"-3198459068-declare const x = 10;\r\n","affectsGlobalScope":true}],"options":{"composite":true,"module":0},"semanticDiagnosticsPerFile":[1,2],"latestChangedDtsFile":"./src/main.d.ts"},"version":"FakeTSVersion"}
+
+//// [/src/project/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "./src/main.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "./src/main.ts": {
+        "version": "5029505981-const x = 10;",
+        "signature": "-3198459068-declare const x = 10;\r\n",
+        "affectsGlobalScope": true
+      }
+    },
+    "options": {
+      "composite": true,
+      "module": 0
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "./src/main.ts"
+    ],
+    "latestChangedDtsFile": "./src/main.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 816
+}
+
+
+
+Change:: convert to modules
+Input::
+//// [/src/project/tsconfig.json]
+{"compilerOptions":{"module":"es2015","composite":true}}
+
+
+
+Output::
+/lib/tsc -p /src/project
+exitCode:: ExitStatus.Success
+
+
+//// [/src/project/src/main.js] file written with same contents
+//// [/src/project/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","./src/main.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},{"version":"5029505981-const x = 10;","signature":"-3198459068-declare const x = 10;\r\n","affectsGlobalScope":true}],"options":{"composite":true,"module":5},"referencedMap":[],"exportedModulesMap":[],"semanticDiagnosticsPerFile":[1,2],"latestChangedDtsFile":"./src/main.d.ts"},"version":"FakeTSVersion"}
+
+//// [/src/project/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "./src/main.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "./src/main.ts": {
+        "version": "5029505981-const x = 10;",
+        "signature": "-3198459068-declare const x = 10;\r\n",
+        "affectsGlobalScope": true
+      }
+    },
+    "options": {
+      "composite": true,
+      "module": 5
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "./src/main.ts"
+    ],
+    "latestChangedDtsFile": "./src/main.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 859
+}
+


### PR DESCRIPTION
OldCompilerOptions is set only if referencemaps are created vs not created. `Module.None` does not create reference map but other values do create it. Which is what determines if we can say copy semantic diagnostics etc..
But emit signatures are purely based on declaration path and their contents so they should only use the compilerOptions directly from old state. 

Fixes #50902
