### PR TITLE
Fix services' type's `isLiteral` implementation

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -511,7 +511,7 @@ namespace ts {
             return !!(this.flags & TypeFlags.UnionOrIntersection);
         }
         isLiteral(): this is LiteralType {
-            return !!(this.flags & TypeFlags.Literal);
+            return !!(this.flags & (TypeFlags.StringLiteral | TypeFlags.NumberLiteral | TypeFlags.BigIntLiteral));
         }
         isStringLiteral(): this is StringLiteralType {
             return !!(this.flags & TypeFlags.StringLiteral);

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -511,7 +511,7 @@ namespace ts {
             return !!(this.flags & TypeFlags.UnionOrIntersection);
         }
         isLiteral(): this is LiteralType {
-            return !!(this.flags & TypeFlags.StringOrNumberLiteral);
+            return !!(this.flags & TypeFlags.Literal);
         }
         isStringLiteral(): this is StringLiteralType {
             return !!(this.flags & TypeFlags.StringLiteral);

--- a/tests/cases/fourslash/completionsLiterals.ts
+++ b/tests/cases/fourslash/completionsLiterals.ts
@@ -1,8 +1,7 @@
 /// <reference path="fourslash.ts" />
 
 ////const x: 0 | "one" = /**/;
-////const y: 0 | "one" | 1n | true = /*1*/;
-////const z: boolean = /*2*/;
+////const y: 0 | "one" | 1n = /*1*/;
 
 verify.completions({
     marker: "",
@@ -18,16 +17,6 @@ verify.completions({
         { name: "0", kind: "string", text: "0" },
         { name: '"one"', kind: "string", text: '"one"' },
         { name: "1n", kind: "string", text: "1n" },
-        { name: "true", kind: "keyword", text: "true", sortText: completion.SortText.GlobalsOrKeywords },
-    ],
-    isNewIdentifierLocation: true,
-});
-
-verify.completions({
-    marker: "2",
-    includes: [
-        { name: "true", kind: "keyword", text: "true", sortText: completion.SortText.GlobalsOrKeywords },
-        { name: "false", kind: "keyword", text: "false", sortText: completion.SortText.GlobalsOrKeywords },
     ],
     isNewIdentifierLocation: true,
 });

--- a/tests/cases/fourslash/completionsLiterals.ts
+++ b/tests/cases/fourslash/completionsLiterals.ts
@@ -1,12 +1,33 @@
 /// <reference path="fourslash.ts" />
 
 ////const x: 0 | "one" = /**/;
+////const y: 0 | "one" | 1n | true = /*1*/;
+////const z: boolean = /*2*/;
 
 verify.completions({
     marker: "",
     includes: [
         { name: "0", kind: "string", text: "0" },
         { name: '"one"', kind: "string", text: '"one"' },
+    ],
+    isNewIdentifierLocation: true,
+});
+verify.completions({
+    marker: "1",
+    includes: [
+        { name: "0", kind: "string", text: "0" },
+        { name: '"one"', kind: "string", text: '"one"' },
+        { name: "1n", kind: "string", text: "1n" },
+        { name: "true", kind: "keyword", text: "true", sortText: completion.SortText.GlobalsOrKeywords },
+    ],
+    isNewIdentifierLocation: true,
+});
+
+verify.completions({
+    marker: "2",
+    includes: [
+        { name: "true", kind: "keyword", text: "true", sortText: completion.SortText.GlobalsOrKeywords },
+        { name: "false", kind: "keyword", text: "false", sortText: completion.SortText.GlobalsOrKeywords },
     ],
     isNewIdentifierLocation: true,
 });


### PR DESCRIPTION
Not sure if there's a bug for this, but the implementation of the method `isLiteral()` in `Type` interface in `services` is wrong, and only returned true for number or string literal types. Now it will also return true for boolean literal types and bigint literal types.

This affects our literal completions: before this change, we only completed literals for number and string literal types, never for bigints or booleans.
Note that completions for `true` and `false` are sorted as keywords (because they are keywords).

Note also that this is a breaking API change, but also a bug fix... 🤨