### PR TITLE
Use paths in package.json 'files' array that work with npm 6 and later.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
         "node": ">=4.2.0"
     },
     "files": [
-        "./bin",
-        "./lib",
-        "!./lib/enu",
-        "./LICENSE.txt",
-        "./README.md",
-        "./SECURITY.md",
-        "./ThirdPartyNoticeText.txt",
+        "bin",
+        "lib",
+        "!lib/enu",
+        "LICENSE.txt",
+        "README.md",
+        "SECURITY.md",
+        "ThirdPartyNoticeText.txt",
         "!**/.gitattributes"
     ],
     "devDependencies": {


### PR DESCRIPTION
Fixes #50927 for future releases.