### PR TITLE
Changed optional thisArg to overload

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -2404,7 +2404,7 @@ interface Uint8ArrayConstructor {
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
     from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number): Uint8Array;
-    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this:U, v: T, k: number) => number, thisArg: V): Uint8Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this:U, v: T, k: number) => number, thisArg: U): Uint8Array;
 
 }
 declare var Uint8Array: Uint8ArrayConstructor;

--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -933,24 +933,12 @@ interface DateConstructor {
 declare var Date: DateConstructor;
 
 interface RegExpMatchArray extends Array<string> {
-    /**
-     * The index of the search at which the result was found.
-     */
     index?: number;
-    /**
-     * A copy of the search string.
-     */
     input?: string;
 }
 
 interface RegExpExecArray extends Array<string> {
-    /**
-     * The index of the search at which the result was found.
-     */
     index: number;
-    /**
-     * A copy of the search string.
-     */
     input: string;
 }
 
@@ -1204,7 +1192,8 @@ interface ReadonlyArray<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every<S extends T>(predicate: (value: T, index: number, array: readonly T[]) => value is S, thisArg?: any): this is readonly S[];
+    every<S extends T>(predicate: (value: T, index: number, array: readonly T[]) => value is S): this is readonly S[];
+    every<S extends T,U>(predicate: (this:U, value: T, index: number, array: readonly T[]) => value is S, thisArg: U): this is readonly S[];
     /**
      * Determines whether all the members of an array satisfy the specified test.
      * @param predicate A function that accepts up to three arguments. The every method calls
@@ -1213,7 +1202,8 @@ interface ReadonlyArray<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: T, index: number, array: readonly T[]) => unknown): boolean;
+    every<U>(predicate: (this: U, value: T, index: number, array: readonly T[]) => unknown, thisArg: U): boolean;
     /**
      * Determines whether the specified callback function returns true for any element of an array.
      * @param predicate A function that accepts up to three arguments. The some method calls
@@ -1222,31 +1212,36 @@ interface ReadonlyArray<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: T, index: number, array: readonly T[]) => unknown): boolean;
+    some<U>(predicate: (this: U, value: T, index: number, array: readonly T[]) => unknown, thisArg: U): boolean;
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: T, index: number, array: readonly T[]) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: T, index: number, array: readonly T[]) => void): void;
+    forEach<U>(callbackfn: (this: U, value: T, index: number, array: readonly T[]) => void, thisArg: U): void;
     /**
      * Calls a defined callback function on each element of an array, and returns an array that contains the results.
      * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    map<U>(callbackfn: (value: T, index: number, array: readonly T[]) => U, thisArg?: any): U[];
+    map<U>(callbackfn: (value: T, index: number, array: readonly T[]) => U): U[];
+    map<U,V>(callbackfn: (this: V, value: T, index: number, array: readonly T[]) => U, thisArg: V): U[];
     /**
      * Returns the elements of an array that meet the condition specified in a callback function.
      * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
      */
-    filter<S extends T>(predicate: (value: T, index: number, array: readonly T[]) => value is S, thisArg?: any): S[];
+    filter<S extends T>(predicate: (value: T, index: number, array: readonly T[]) => value is S): S[];
+    filter<S extends T,U>(predicate: (this:U, value: T, index: number, array: readonly T[]) => value is S, thisArg: U): S[];
     /**
      * Returns the elements of an array that meet the condition specified in a callback function.
      * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): T[];
+    filter(predicate: (value: T, index: number, array: readonly T[]) => unknown): T[];
+    filter<U>(predicate: (this: U, value: T, index: number, array: readonly T[]) => unknown, thisArg: U): T[];
     /**
      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
@@ -1395,7 +1390,8 @@ interface Array<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): this is S[];
+    every<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S): this is S[];
+    every<S extends T,U>(predicate: (this: U, value: T, index: number, array: T[]) => value is S, thisArg: any): this is S[];
     /**
      * Determines whether all the members of an array satisfy the specified test.
      * @param predicate A function that accepts up to three arguments. The every method calls
@@ -1404,7 +1400,8 @@ interface Array<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: T, index: number, array: T[]) => unknown): boolean;
+    every<U>(predicate: (this: U, value: T, index: number, array: T[]) => unknown, thisArg: U): boolean;
     /**
      * Determines whether the specified callback function returns true for any element of an array.
      * @param predicate A function that accepts up to three arguments. The some method calls
@@ -1413,31 +1410,36 @@ interface Array<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: T, index: number, array: T[]) => unknown): boolean;
+    some<U>(predicate: (this: U, value: T, index: number, array: T[]) => unknown, thisArg: U): boolean;
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: T, index: number, array: T[]) => void): void;
+    forEach<U>(callbackfn: (this: U, value: T, index: number, array: T[]) => void, thisArg: U): void;
     /**
      * Calls a defined callback function on each element of an array, and returns an array that contains the results.
      * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
+    map<U>(callbackfn: (value: T, index: number, array: T[]) => U): U[];
+    map<U,V>(callbackfn: (this: V, value: T, index: number, array: T[]) => U, thisArg: V): U[];
     /**
      * Returns the elements of an array that meet the condition specified in a callback function.
      * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
      */
-    filter<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S[];
+    filter<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S): S[];
+    filter<S extends T,U>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg: U): S[];
     /**
      * Returns the elements of an array that meet the condition specified in a callback function.
      * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];
+    filter(predicate: (value: T, index: number, array: T[]) => unknown): T[];
+    filter<U>(predicate: (this: U, value: T, index: number, array: T[]) => unknown, thisArg: U): T[];
     /**
      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
@@ -1596,7 +1598,7 @@ type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
 /**
  * Exclude null and undefined from T
  */
-type NonNullable<T> = T & {};
+type NonNullable<T> = T extends null | undefined ? never : T;
 
 /**
  * Obtain the parameters of a function type in a tuple
@@ -1871,7 +1873,8 @@ interface Int8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Int8Array) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: number, index: number, array: Int8Array) => unknown): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Int8Array) => unknown, thisArg: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -1890,7 +1893,8 @@ interface Int8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Int8Array) => any, thisArg?: any): Int8Array;
+    filter(predicate: (value: number, index: number, array: Int8Array) => any): Int8Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Int8Array) => any, thisArg: U): Int8Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -1901,7 +1905,8 @@ interface Int8Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Int8Array) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: Int8Array) => boolean): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Int8Array) => boolean, thisArg: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -1912,7 +1917,8 @@ interface Int8Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Int8Array) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number, index: number, obj: Int8Array) => boolean): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Int8Array) => boolean, thisArg: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -1921,7 +1927,8 @@ interface Int8Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Int8Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: Int8Array) => void): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Int8Array) => void, thisArg: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -1959,7 +1966,8 @@ interface Int8Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Int8Array) => number, thisArg?: any): Int8Array;
+    map(callbackfn: (value: number, index: number, array: Int8Array) => number): Int8Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Int8Array) => number, thisArg: U): Int8Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -2038,7 +2046,8 @@ interface Int8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Int8Array) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: number, index: number, array: Int8Array) => unknown): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Int8Array) => unknown, thisArg: U): boolean;
 
     /**
      * Sorts an array.
@@ -2103,7 +2112,8 @@ interface Int8ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int8Array;
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number): Int8Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg: any): Int8Array;
 
 
 }
@@ -2153,7 +2163,8 @@ interface Uint8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Uint8Array) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: number, index: number, array: Uint8Array) => unknown): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Uint8Array) => unknown, thisArg: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -2172,7 +2183,8 @@ interface Uint8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Uint8Array) => any, thisArg?: any): Uint8Array;
+    filter(predicate: (value: number, index: number, array: Uint8Array) => any): Uint8Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Uint8Array) => any, thisArg: U): Uint8Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -2183,7 +2195,8 @@ interface Uint8Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Uint8Array) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: Uint8Array) => boolean): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Uint8Array) => boolean, thisArg: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -2194,7 +2207,8 @@ interface Uint8Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Uint8Array) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number, index: number, obj: Uint8Array) => boolean): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Uint8Array) => boolean, thisArg: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -2203,7 +2217,8 @@ interface Uint8Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Uint8Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: Uint8Array) => void): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Uint8Array) => void, thisArg: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -2241,7 +2256,8 @@ interface Uint8Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Uint8Array) => number, thisArg?: any): Uint8Array;
+    map(callbackfn: (value: number, index: number, array: Uint8Array) => number): Uint8Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Uint8Array) => number, thisArg: U): Uint8Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -2320,7 +2336,8 @@ interface Uint8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Uint8Array) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: number, index: number, array: Uint8Array) => unknown): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Uint8Array) => unknown, thisArg: U): boolean;
 
     /**
      * Sorts an array.
@@ -2386,7 +2403,8 @@ interface Uint8ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8Array;
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number): Uint8Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this:U, v: T, k: number) => number, thisArg: V): Uint8Array;
 
 }
 declare var Uint8Array: Uint8ArrayConstructor;
@@ -2435,7 +2453,8 @@ interface Uint8ClampedArray {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Uint8ClampedArray) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: number, index: number, array: Uint8ClampedArray) => unknown): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Uint8ClampedArray) => unknown, thisArg: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -2454,7 +2473,8 @@ interface Uint8ClampedArray {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Uint8ClampedArray) => any, thisArg?: any): Uint8ClampedArray;
+    filter(predicate: (value: number, index: number, array: Uint8ClampedArray) => any): Uint8ClampedArray;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Uint8ClampedArray) => any, thisArg: U): Uint8ClampedArray;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -2465,7 +2485,8 @@ interface Uint8ClampedArray {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Uint8ClampedArray) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: Uint8ClampedArray) => boolean): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Uint8ClampedArray) => boolean, thisArg: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -2476,7 +2497,8 @@ interface Uint8ClampedArray {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Uint8ClampedArray) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number, index: number, obj: Uint8ClampedArray) => boolean): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Uint8ClampedArray) => boolean, thisArg: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -2485,7 +2507,8 @@ interface Uint8ClampedArray {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => void): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Uint8ClampedArray) => void, thisArg: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -2523,7 +2546,8 @@ interface Uint8ClampedArray {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => number, thisArg?: any): Uint8ClampedArray;
+    map(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => number): Uint8ClampedArray;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Uint8ClampedArray) => number, thisArg: U): Uint8ClampedArray;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -2602,7 +2626,8 @@ interface Uint8ClampedArray {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Uint8ClampedArray) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: number, index: number, array: Uint8ClampedArray) => unknown): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Uint8ClampedArray) => unknown, thisArg: U): boolean;
 
     /**
      * Sorts an array.
@@ -2668,7 +2693,8 @@ interface Uint8ClampedArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8ClampedArray;
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number): Uint8ClampedArray;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this:U, v: T, k: number) => number, thisArg: any): Uint8ClampedArray;
 }
 declare var Uint8ClampedArray: Uint8ClampedArrayConstructor;
 
@@ -2716,7 +2742,8 @@ interface Int16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Int16Array) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: number, index: number, array: Int16Array) => unknown): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Int16Array) => unknown, thisArg: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -2735,7 +2762,8 @@ interface Int16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Int16Array) => any, thisArg?: any): Int16Array;
+    filter(predicate: (value: number, index: number, array: Int16Array) => any): Int16Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Int16Array) => any, thisArg: U): Int16Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -2746,7 +2774,8 @@ interface Int16Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Int16Array) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: Int16Array) => boolean): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Int16Array) => boolean, thisArg: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -2757,7 +2786,8 @@ interface Int16Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Int16Array) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number, index: number, obj: Int16Array) => boolean): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Int16Array) => boolean, thisArg: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -2766,7 +2796,8 @@ interface Int16Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Int16Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: Int16Array) => void): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Int16Array) => void, thisArg: U): void;
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -2803,7 +2834,8 @@ interface Int16Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Int16Array) => number, thisArg?: any): Int16Array;
+    map(callbackfn: (value: number, index: number, array: Int16Array) => number): Int16Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Int16Array) => number, thisArg: U): Int16Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -2882,7 +2914,8 @@ interface Int16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Int16Array) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: number, index: number, array: Int16Array) => unknown): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Int16Array) => unknown, thisArg: U): boolean;
 
     /**
      * Sorts an array.
@@ -2948,7 +2981,8 @@ interface Int16ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int16Array;
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number): Int16Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this:U, v: T, k: number) => number, thisArg: U): Int16Array;
 
 
 }
@@ -2998,7 +3032,8 @@ interface Uint16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Uint16Array) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: number, index: number, array: Uint16Array) => unknown): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Uint16Array) => unknown, thisArg: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -3017,7 +3052,8 @@ interface Uint16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Uint16Array) => any, thisArg?: any): Uint16Array;
+    filter(predicate: (value: number, index: number, array: Uint16Array) => any): Uint16Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Uint16Array) => any, thisArg: U): Uint16Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -3028,7 +3064,8 @@ interface Uint16Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Uint16Array) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: Uint16Array) => boolean): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Uint16Array) => boolean, thisArg: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -3039,7 +3076,8 @@ interface Uint16Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Uint16Array) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number, index: number, obj: Uint16Array) => boolean): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Uint16Array) => boolean, thisArg: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -3048,7 +3086,8 @@ interface Uint16Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Uint16Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: Uint16Array) => void): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Uint16Array) => void, thisArg: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -3086,7 +3125,8 @@ interface Uint16Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Uint16Array) => number, thisArg?: any): Uint16Array;
+    map(callbackfn: (value: number, index: number, array: Uint16Array) => number): Uint16Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Uint16Array) => number, thisArg: U): Uint16Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -3165,7 +3205,8 @@ interface Uint16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Uint16Array) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: number, index: number, array: Uint16Array) => unknown): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Uint16Array) => unknown, thisArg: U): boolean;
 
     /**
      * Sorts an array.
@@ -3231,7 +3272,8 @@ interface Uint16ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint16Array;
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number): Uint16Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this:U, v: T, k: number) => number, thisArg: U): Uint16Array;
 
 
 }
@@ -3280,7 +3322,8 @@ interface Int32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Int32Array) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: number, index: number, array: Int32Array) => unknown): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Int32Array) => unknown, thisArg: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -3299,7 +3342,8 @@ interface Int32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Int32Array) => any, thisArg?: any): Int32Array;
+    filter(predicate: (value: number, index: number, array: Int32Array) => any): Int32Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Int32Array) => any, thisArg: U): Int32Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -3310,7 +3354,8 @@ interface Int32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Int32Array) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: Int32Array) => boolean): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Int32Array) => boolean, thisArg: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -3321,7 +3366,8 @@ interface Int32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Int32Array) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number, index: number, obj: Int32Array) => boolean): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Int32Array) => boolean, thisArg: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -3330,7 +3376,8 @@ interface Int32Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Int32Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: Int32Array) => void): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Int32Array) => void, thisArg: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -3368,7 +3415,8 @@ interface Int32Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Int32Array) => number, thisArg?: any): Int32Array;
+    map(callbackfn: (value: number, index: number, array: Int32Array) => number): Int32Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Int32Array) => number, thisArg: U): Int32Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -3447,7 +3495,8 @@ interface Int32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Int32Array) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: number, index: number, array: Int32Array) => unknown): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Int32Array) => unknown, thisArg: U): boolean;
 
     /**
      * Sorts an array.
@@ -3513,7 +3562,8 @@ interface Int32ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int32Array;
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number): Int32Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg: U): Int32Array;
 
 }
 declare var Int32Array: Int32ArrayConstructor;
@@ -3562,7 +3612,8 @@ interface Uint32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Uint32Array) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: number, index: number, array: Uint32Array) => unknown): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Uint32Array) => unknown, thisArg: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -3581,7 +3632,8 @@ interface Uint32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Uint32Array) => any, thisArg?: any): Uint32Array;
+    filter(predicate: (value: number, index: number, array: Uint32Array) => any): Uint32Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Uint32Array) => any, thisArg: U): Uint32Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -3592,7 +3644,8 @@ interface Uint32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Uint32Array) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: Uint32Array) => boolean): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Uint32Array) => boolean, thisArg: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -3603,7 +3656,8 @@ interface Uint32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Uint32Array) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number, index: number, obj: Uint32Array) => boolean): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Uint32Array) => boolean, thisArg: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -3612,7 +3666,8 @@ interface Uint32Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Uint32Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: Uint32Array) => void): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Uint32Array) => void, thisArg: U): void;
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -3649,7 +3704,8 @@ interface Uint32Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Uint32Array) => number, thisArg?: any): Uint32Array;
+    map(callbackfn: (value: number, index: number, array: Uint32Array) => number): Uint32Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Uint32Array) => number, thisArg: U): Uint32Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -3728,7 +3784,8 @@ interface Uint32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Uint32Array) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: number, index: number, array: Uint32Array) => unknown): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Uint32Array) => unknown, thisArg: U): boolean;
 
     /**
      * Sorts an array.
@@ -3794,7 +3851,8 @@ interface Uint32ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint32Array;
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number): Uint32Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg: U): Uint32Array;
 
 }
 declare var Uint32Array: Uint32ArrayConstructor;
@@ -3843,7 +3901,8 @@ interface Float32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Float32Array) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: number, index: number, array: Float32Array) => unknown): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Float32Array) => unknown, thisArg: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -3862,7 +3921,8 @@ interface Float32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Float32Array) => any, thisArg?: any): Float32Array;
+    filter(predicate: (value: number, index: number, array: Float32Array) => any): Float32Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Float32Array) => any, thisArg: U): Float32Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -3873,7 +3933,8 @@ interface Float32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Float32Array) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: Float32Array) => boolean): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Float32Array) => boolean, thisArg: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -3884,7 +3945,8 @@ interface Float32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Float32Array) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number, index: number, obj: Float32Array) => boolean): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Float32Array) => boolean, thisArg: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -3893,7 +3955,8 @@ interface Float32Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Float32Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: Float32Array) => void): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Float32Array) => void, thisArg: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -3931,7 +3994,8 @@ interface Float32Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Float32Array) => number, thisArg?: any): Float32Array;
+    map(callbackfn: (value: number, index: number, array: Float32Array) => number): Float32Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Float32Array) => number, thisArg: U): Float32Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -4010,7 +4074,8 @@ interface Float32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Float32Array) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: number, index: number, array: Float32Array) => unknown): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Float32Array) => unknown, thisArg: U): boolean;
 
     /**
      * Sorts an array.
@@ -4076,7 +4141,8 @@ interface Float32ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Float32Array;
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number): Float32Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg: U): Float32Array;
 
 
 }
@@ -4126,7 +4192,8 @@ interface Float64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Float64Array) => unknown, thisArg?: any): boolean;
+    every(predicate: (value: number, index: number, array: Float64Array) => unknown): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Float64Array) => unknown, thisArg: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -4145,7 +4212,8 @@ interface Float64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Float64Array) => any, thisArg?: any): Float64Array;
+    filter(predicate: (value: number, index: number, array: Float64Array) => any): Float64Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Float64Array) => any, thisArg: U): Float64Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -4156,7 +4224,8 @@ interface Float64Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Float64Array) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: Float64Array) => boolean): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Float64Array) => boolean, thisArg: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -4167,7 +4236,8 @@ interface Float64Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Float64Array) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number, index: number, obj: Float64Array) => boolean): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Float64Array) => boolean, thisArg: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -4176,7 +4246,8 @@ interface Float64Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Float64Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: Float64Array) => void): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Float64Array) => void, thisArg: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -4214,7 +4285,8 @@ interface Float64Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Float64Array) => number, thisArg?: any): Float64Array;
+    map(callbackfn: (value: number, index: number, array: Float64Array) => number): Float64Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Float64Array) => number, thisArg: U): Float64Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -4293,7 +4365,8 @@ interface Float64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Float64Array) => unknown, thisArg?: any): boolean;
+    some(predicate: (value: number, index: number, array: Float64Array) => unknown): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Float64Array) => unknown, thisArg: U): boolean;
 
     /**
      * Sorts an array.
@@ -4350,7 +4423,8 @@ interface Float64ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Float64Array;
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number): Float64Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg: U): Float64Array;
 
 }
 declare var Float64Array: Float64ArrayConstructor;


### PR DESCRIPTION
Made the declarations of various array methods using `thisArg` to set a local `this` in the callback function capture the type of `thisArg` and apply it to the callback function.

This is a smaller, lazy fix which still requires the keyword `this` in the callback function declaration, perhaps a more thorough patch should be applied to make the keyword unnecesary, but I don't even know where to start to implement `this`, _heh_.

Fixes  #50943
