### PR TITLE
Modified optional thisArg to capture type

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -2344,7 +2344,7 @@ declare var AudioParam: {
 };
 
 interface AudioParamMap {
-    forEach(callbackfn: (value: AudioParam, key: string, parent: AudioParamMap) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: AudioParam, key: string, parent: AudioParamMap) => void, thisArg?: U): void;
 }
 
 declare var AudioParamMap: {
@@ -4248,7 +4248,7 @@ interface DOMTokenList {
      * Throws an "InvalidCharacterError" DOMException if token contains any spaces.
      */
     toggle(token: string, force?: boolean): boolean;
-    forEach(callbackfn: (value: string, key: number, parent: DOMTokenList) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: string, key: number, parent: DOMTokenList) => void, thisArg?: U): void;
     [index: number]: string;
 }
 
@@ -5182,7 +5182,7 @@ declare var Event: {
 };
 
 interface EventCounts {
-    forEach(callbackfn: (value: number, key: string, parent: EventCounts) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: number, key: string, parent: EventCounts) => void, thisArg?: U): void;
 }
 
 declare var EventCounts: {
@@ -5481,7 +5481,7 @@ interface FontFaceSet extends EventTarget {
     readonly status: FontFaceSetLoadStatus;
     check(font: string, text?: string): boolean;
     load(font: string, text?: string): Promise<FontFace[]>;
-    forEach(callbackfn: (value: FontFace, key: FontFace, parent: FontFaceSet) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: FontFace, key: FontFace, parent: FontFaceSet) => void, thisArg?: U): void;
     addEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: (this: FontFaceSet, ev: FontFaceSetEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: (this: FontFaceSet, ev: FontFaceSetEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -5514,7 +5514,7 @@ interface FormData {
     getAll(name: string): FormDataEntryValue[];
     has(name: string): boolean;
     set(name: string, value: string | Blob, fileName?: string): void;
-    forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: U): void;
 }
 
 declare var FormData: {
@@ -8541,7 +8541,7 @@ interface Headers {
     get(name: string): string | null;
     has(name: string): boolean;
     set(name: string, value: string): void;
-    forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: string, key: string, parent: Headers) => void, thisArg?: U): void;
 }
 
 declare var Headers: {
@@ -9395,7 +9395,7 @@ interface MediaKeyStatusMap {
     readonly size: number;
     get(keyId: BufferSource): MediaKeyStatus | undefined;
     has(keyId: BufferSource): boolean;
-    forEach(callbackfn: (value: MediaKeyStatus, key: BufferSource, parent: MediaKeyStatusMap) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: MediaKeyStatus, key: BufferSource, parent: MediaKeyStatusMap) => void, thisArg?: U): void;
 }
 
 declare var MediaKeyStatusMap: {
@@ -10173,7 +10173,7 @@ interface NodeList {
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: Node, key: number, parent: NodeList) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: Node, key: number, parent: NodeList) => void, thisArg?: U): void;
     [index: number]: Node;
 }
 
@@ -10189,7 +10189,7 @@ interface NodeListOf<TNode extends Node> extends NodeList {
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: TNode, key: number, parent: NodeListOf<TNode>) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: TNode, key: number, parent: NodeListOf<TNode>) => void, thisArg?: U): void;
     [index: number]: TNode;
 }
 
@@ -11402,7 +11402,7 @@ declare var RTCSessionDescription: {
 };
 
 interface RTCStatsReport {
-    forEach(callbackfn: (value: any, key: string, parent: RTCStatsReport) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: any, key: string, parent: RTCStatsReport) => void, thisArg?: U): void;
 }
 
 declare var RTCStatsReport: {
@@ -14424,7 +14424,7 @@ interface URLSearchParams {
     sort(): void;
     /** Returns a string containing a query string suitable for use in a URL. Does not include the question mark. */
     toString(): string;
-    forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: string, key: string, parent: URLSearchParams) => void, thisArg?: U): void;
 }
 
 declare var URLSearchParams: {

--- a/src/lib/dom.iterable.d.ts
+++ b/src/lib/dom.iterable.d.ts
@@ -30,7 +30,7 @@ interface NodeList {
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: Node, index: number, listObj: NodeList) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: Node, index: number, listObj: NodeList) => void, thisArg?: U): void;
     /**
      * Returns an list of keys in the list
      */
@@ -57,7 +57,7 @@ interface NodeListOf<TNode extends Node> {
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: TNode, index: number, listObj: NodeListOf<TNode>) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: TNode, index: number, listObj: NodeListOf<TNode>) => void, thisArg?: U): void;
     /**
      * Returns an list of keys in the list
      */

--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -8,7 +8,7 @@ interface Map<K, V> {
     /**
      * Executes a provided function once per each key/value pair in the Map, in insertion order.
      */
-    forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: V, key: K, map: Map<K, V>) => void, thisArg?: U): void;
     /**
      * Returns a specified element from the Map object. If the value that is associated to the provided key is an object, then you will get a reference to that object and any change made to that object will effectively modify it inside the Map.
      * @returns Returns the element associated with the specified key. If no element is associated with the specified key, undefined is returned.
@@ -36,7 +36,7 @@ interface MapConstructor {
 declare var Map: MapConstructor;
 
 interface ReadonlyMap<K, V> {
-    forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: U): void;
     get(key: K): V | undefined;
     has(key: K): boolean;
     readonly size: number;
@@ -84,7 +84,7 @@ interface Set<T> {
     /**
      * Executes a provided function once per each value in the Set object, in insertion order.
      */
-    forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: T, value2: T, set: Set<T>) => void, thisArg?: U): void;
     /**
      * @returns a boolean indicating whether an element with the specified value exists in the Set or not.
      */
@@ -102,7 +102,7 @@ interface SetConstructor {
 declare var Set: SetConstructor;
 
 interface ReadonlySet<T> {
-    forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: U): void;
     has(value: T): boolean;
     readonly size: number;
 }

--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -8,8 +8,8 @@ interface Array<T> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find<S extends T>(predicate: (this: void, value: T, index: number, obj: T[]) => value is S, thisArg?: any): S | undefined;
-    find(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): T | undefined;
+    find<S extends T,U>(predicate: (this: U, value: T, index: number, obj: T[]) => value is S, thisArg?: U): S | undefined;
+    find<U>(predicate: (this: U, value: T, index: number, obj: T[]) => unknown, thisArg?: U): T | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -20,7 +20,8 @@ interface Array<T> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: T, index: number, obj: T[]) => unknown, thisArg?: U): number;
+    findIndex(predicate: (value: T, index: number, obj: T[]) => unknown): number;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -57,7 +58,7 @@ interface ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): U[];
+    from<T, U, V>(arrayLike: ArrayLike<T>, mapfn: (this: V, v: T, k: number) => U, thisArg?: V): U[];
 
     /**
      * Returns a new array from a set of elements.
@@ -329,8 +330,8 @@ interface ReadonlyArray<T> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find<S extends T>(predicate: (this: void, value: T, index: number, obj: readonly T[]) => value is S, thisArg?: any): S | undefined;
-    find(predicate: (value: T, index: number, obj: readonly T[]) => unknown, thisArg?: any): T | undefined;
+    find<S extends T,U>(predicate: (this: U, value: T, index: number, obj: readonly T[]) => value is S, thisArg?: U): S | undefined;
+    find<U>(predicate: (this: U, value: T, index: number, obj: readonly T[]) => unknown, thisArg?: U): T | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -341,7 +342,7 @@ interface ReadonlyArray<T> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: T, index: number, obj: readonly T[]) => unknown, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: T, index: number, obj: readonly T[]) => unknown, thisArg?: U): number;
 }
 
 interface RegExp {

--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -68,7 +68,7 @@ interface ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T, U>(iterable: Iterable<T> | ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): U[];
+    from<T, U, V>(iterable: Iterable<T> | ArrayLike<T>, mapfn: (this: V, v: T, k: number) => U, thisArg?: V): U[];
 }
 
 interface ReadonlyArray<T> {
@@ -245,7 +245,7 @@ interface Int8ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Int8Array;
+    from<U>(arrayLike: Iterable<number>, mapfn?: (this: U, v: number, k: number) => number, thisArg?: U): Int8Array;
 }
 
 interface Uint8Array {
@@ -273,7 +273,7 @@ interface Uint8ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Uint8Array;
+    from<U>(arrayLike: Iterable<number>, mapfn?: (this: U, v: number, k: number) => number, thisArg?: U): Uint8Array;
 }
 
 interface Uint8ClampedArray {
@@ -304,7 +304,7 @@ interface Uint8ClampedArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Uint8ClampedArray;
+    from<U>(arrayLike: Iterable<number>, mapfn?: (this: U, v: number, k: number) => number, thisArg?: U): Uint8ClampedArray;
 }
 
 interface Int16Array {
@@ -334,7 +334,7 @@ interface Int16ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Int16Array;
+    from<U>(arrayLike: Iterable<number>, mapfn?: (this: U, v: number, k: number) => number, thisArg?: U): Int16Array;
 }
 
 interface Uint16Array {
@@ -362,7 +362,7 @@ interface Uint16ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Uint16Array;
+    from<U>(arrayLike: Iterable<number>, mapfn?: (this: U, v: number, k: number) => number, thisArg?: U): Uint16Array;
 }
 
 interface Int32Array {
@@ -390,7 +390,7 @@ interface Int32ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Int32Array;
+    from<U>(arrayLike: Iterable<number>, mapfn?: (this: U, v: number, k: number) => number, thisArg?: U): Int32Array;
 }
 
 interface Uint32Array {
@@ -418,7 +418,7 @@ interface Uint32ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Uint32Array;
+    from<U>(arrayLike: Iterable<number>, mapfn?: (this: U, v: number, k: number) => number, thisArg?: U): Uint32Array;
 }
 
 interface Float32Array {
@@ -446,7 +446,7 @@ interface Float32ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Float32Array;
+    from<U>(arrayLike: Iterable<number>, mapfn?: (this: U, v: number, k: number) => number, thisArg?: U): Float32Array;
 }
 
 interface Float64Array {
@@ -474,5 +474,5 @@ interface Float64ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Float64Array;
+    from<U>(arrayLike: Iterable<number>, mapfn?: (this: U, v: number, k: number) => number, thisArg?: U): Float64Array;
 }

--- a/src/lib/es2020.bigint.d.ts
+++ b/src/lib/es2020.bigint.d.ts
@@ -163,7 +163,7 @@ interface BigInt64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -182,7 +182,7 @@ interface BigInt64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: bigint, index: number, array: BigInt64Array) => any, thisArg?: any): BigInt64Array;
+    filter<U>(predicate: (this: U, value: bigint, index: number, array: BigInt64Array) => any, thisArg?: U): BigInt64Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -193,7 +193,7 @@ interface BigInt64Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: any): bigint | undefined;
+    find<U>(predicate: (this: U, value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: U): bigint | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -204,7 +204,7 @@ interface BigInt64Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -213,7 +213,7 @@ interface BigInt64Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: bigint, index: number, array: BigInt64Array) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: bigint, index: number, array: BigInt64Array) => void, thisArg?: U): void;
 
     /**
      * Determines whether an array includes a certain element, returning true or false as appropriate.
@@ -259,7 +259,7 @@ interface BigInt64Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: bigint, index: number, array: BigInt64Array) => bigint, thisArg?: any): BigInt64Array;
+    map<U>(callbackfn: (this: U, value: bigint, index: number, array: BigInt64Array) => bigint, thisArg?: U): BigInt64Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -334,7 +334,7 @@ interface BigInt64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: U): boolean;
 
     /**
      * Sorts the array.
@@ -391,7 +391,7 @@ interface BigInt64ArrayConstructor {
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
     from(arrayLike: ArrayLike<bigint>): BigInt64Array;
-    from<U>(arrayLike: ArrayLike<U>, mapfn: (v: U, k: number) => bigint, thisArg?: any): BigInt64Array;
+    from<U, V>(arrayLike: ArrayLike<U>, mapfn: (this: V, v: U, k: number) => bigint, thisArg?: V): BigInt64Array;
 }
 
 declare var BigInt64Array: BigInt64ArrayConstructor;
@@ -435,7 +435,7 @@ interface BigUint64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -454,7 +454,7 @@ interface BigUint64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: bigint, index: number, array: BigUint64Array) => any, thisArg?: any): BigUint64Array;
+    filter<U>(predicate: (this: U, value: bigint, index: number, array: BigUint64Array) => any, thisArg?: U): BigUint64Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -465,7 +465,7 @@ interface BigUint64Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: any): bigint | undefined;
+    find<U>(predicate: (this: U, value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: U): bigint | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -476,7 +476,7 @@ interface BigUint64Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -485,7 +485,7 @@ interface BigUint64Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: bigint, index: number, array: BigUint64Array) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: bigint, index: number, array: BigUint64Array) => void, thisArg?: U): void;
 
     /**
      * Determines whether an array includes a certain element, returning true or false as appropriate.
@@ -531,7 +531,7 @@ interface BigUint64Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: bigint, index: number, array: BigUint64Array) => bigint, thisArg?: any): BigUint64Array;
+    map<U>(callbackfn: (this: U, value: bigint, index: number, array: BigUint64Array) => bigint, thisArg?: U): BigUint64Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -606,7 +606,7 @@ interface BigUint64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: U): boolean;
 
     /**
      * Sorts the array.
@@ -663,7 +663,7 @@ interface BigUint64ArrayConstructor {
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
     from(arrayLike: ArrayLike<bigint>): BigUint64Array;
-    from<U>(arrayLike: ArrayLike<U>, mapfn: (v: U, k: number) => bigint, thisArg?: any): BigUint64Array;
+    from<U, V>(arrayLike: ArrayLike<U>, mapfn: (this: V, v: U, k: number) => bigint, thisArg?: V): BigUint64Array;
 }
 
 declare var BigUint64Array: BigUint64ArrayConstructor;

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1196,7 +1196,7 @@ interface ReadonlyArray<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every<S extends T>(predicate: (value: T, index: number, array: readonly T[]) => value is S, thisArg?: any): this is readonly S[];
+    every<S extends T,U>(predicate: (this: U, value: T, index: number, array: readonly T[]) => value is S, thisArg?: U): this is readonly S[];
     /**
      * Determines whether all the members of an array satisfy the specified test.
      * @param predicate A function that accepts up to three arguments. The every method calls
@@ -1205,7 +1205,7 @@ interface ReadonlyArray<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: T, index: number, array: readonly T[]) => unknown, thisArg?: U): boolean;
     /**
      * Determines whether the specified callback function returns true for any element of an array.
      * @param predicate A function that accepts up to three arguments. The some method calls
@@ -1214,31 +1214,31 @@ interface ReadonlyArray<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: T, index: number, array: readonly T[]) => unknown, thisArg?: U): boolean;
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: T, index: number, array: readonly T[]) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: T, index: number, array: readonly T[]) => void, thisArg?: U): void;
     /**
      * Calls a defined callback function on each element of an array, and returns an array that contains the results.
      * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    map<U>(callbackfn: (value: T, index: number, array: readonly T[]) => U, thisArg?: any): U[];
+    map<U,V>(callbackfn: (this: V, value: T, index: number, array: readonly T[]) => U, thisArg?: V): U[];
     /**
      * Returns the elements of an array that meet the condition specified in a callback function.
      * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
      */
-    filter<S extends T>(predicate: (value: T, index: number, array: readonly T[]) => value is S, thisArg?: any): S[];
+    filter<S extends T,U>(predicate: (this: U, value: T, index: number, array: readonly T[]) => value is S, thisArg?: U): S[];
     /**
      * Returns the elements of an array that meet the condition specified in a callback function.
      * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): T[];
+    filter<U>(predicate: (this: U, value: T, index: number, array: readonly T[]) => unknown, thisArg?: U): T[];
     /**
      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
@@ -1387,7 +1387,7 @@ interface Array<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): this is S[];
+    every<S extends T,U>(predicate: (this: U, value: T, index: number, array: T[]) => value is S, thisArg?: U): this is S[];
     /**
      * Determines whether all the members of an array satisfy the specified test.
      * @param predicate A function that accepts up to three arguments. The every method calls
@@ -1396,7 +1396,7 @@ interface Array<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: T, index: number, array: T[]) => unknown, thisArg?: U): boolean;
     /**
      * Determines whether the specified callback function returns true for any element of an array.
      * @param predicate A function that accepts up to three arguments. The some method calls
@@ -1405,31 +1405,31 @@ interface Array<T> {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: T, index: number, array: T[]) => unknown, thisArg?: U): boolean;
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: T, index: number, array: T[]) => void, thisArg?: U): void;
     /**
      * Calls a defined callback function on each element of an array, and returns an array that contains the results.
      * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
-    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
+    map<U,V>(callbackfn: (this: V, value: T, index: number, array: T[]) => U, thisArg?: V): U[];
     /**
      * Returns the elements of an array that meet the condition specified in a callback function.
      * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
      */
-    filter<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S[];
+    filter<S extends T,U>(predicate: (this: U, value: T, index: number, array: T[]) => value is S, thisArg?: U): S[];
     /**
      * Returns the elements of an array that meet the condition specified in a callback function.
      * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];
+    filter<U>(predicate: (this: U, value: T, index: number, array: T[]) => unknown, thisArg?: U): T[];
     /**
      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
@@ -1863,7 +1863,7 @@ interface Int8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Int8Array) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Int8Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -1882,7 +1882,7 @@ interface Int8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Int8Array) => any, thisArg?: any): Int8Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Int8Array) => any, thisArg?: U): Int8Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -1893,7 +1893,7 @@ interface Int8Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Int8Array) => boolean, thisArg?: any): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Int8Array) => boolean, thisArg?: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -1904,7 +1904,7 @@ interface Int8Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Int8Array) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Int8Array) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -1913,7 +1913,7 @@ interface Int8Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Int8Array) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Int8Array) => void, thisArg?: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -1951,7 +1951,7 @@ interface Int8Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Int8Array) => number, thisArg?: any): Int8Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Int8Array) => number, thisArg?: U): Int8Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -2030,7 +2030,7 @@ interface Int8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Int8Array) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Int8Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Sorts an array.
@@ -2095,7 +2095,7 @@ interface Int8ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int8Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg?: U): Int8Array;
 
 
 }
@@ -2145,7 +2145,7 @@ interface Uint8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Uint8Array) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Uint8Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -2164,7 +2164,7 @@ interface Uint8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Uint8Array) => any, thisArg?: any): Uint8Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Uint8Array) => any, thisArg?: U): Uint8Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -2175,7 +2175,7 @@ interface Uint8Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Uint8Array) => boolean, thisArg?: any): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Uint8Array) => boolean, thisArg?: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -2186,7 +2186,7 @@ interface Uint8Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Uint8Array) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Uint8Array) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -2195,7 +2195,7 @@ interface Uint8Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Uint8Array) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Uint8Array) => void, thisArg?: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -2233,7 +2233,7 @@ interface Uint8Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Uint8Array) => number, thisArg?: any): Uint8Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Uint8Array) => number, thisArg?: U): Uint8Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -2312,7 +2312,7 @@ interface Uint8Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Uint8Array) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Uint8Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Sorts an array.
@@ -2378,7 +2378,7 @@ interface Uint8ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg?: U): Uint8Array;
 
 }
 declare var Uint8Array: Uint8ArrayConstructor;
@@ -2427,7 +2427,7 @@ interface Uint8ClampedArray {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Uint8ClampedArray) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Uint8ClampedArray) => unknown, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -2446,7 +2446,7 @@ interface Uint8ClampedArray {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Uint8ClampedArray) => any, thisArg?: any): Uint8ClampedArray;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Uint8ClampedArray) => any, thisArg?: U): Uint8ClampedArray;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -2457,7 +2457,7 @@ interface Uint8ClampedArray {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Uint8ClampedArray) => boolean, thisArg?: any): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Uint8ClampedArray) => boolean, thisArg?: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -2468,7 +2468,7 @@ interface Uint8ClampedArray {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Uint8ClampedArray) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Uint8ClampedArray) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -2477,7 +2477,7 @@ interface Uint8ClampedArray {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Uint8ClampedArray) => void, thisArg?: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -2515,7 +2515,7 @@ interface Uint8ClampedArray {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => number, thisArg?: any): Uint8ClampedArray;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Uint8ClampedArray) => number, thisArg?: U): Uint8ClampedArray;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -2594,7 +2594,7 @@ interface Uint8ClampedArray {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Uint8ClampedArray) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Uint8ClampedArray) => unknown, thisArg?: U): boolean;
 
     /**
      * Sorts an array.
@@ -2660,7 +2660,7 @@ interface Uint8ClampedArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8ClampedArray;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg?: U): Uint8ClampedArray;
 }
 declare var Uint8ClampedArray: Uint8ClampedArrayConstructor;
 
@@ -2708,7 +2708,7 @@ interface Int16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Int16Array) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Int16Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -2727,7 +2727,7 @@ interface Int16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Int16Array) => any, thisArg?: any): Int16Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Int16Array) => any, thisArg?: U): Int16Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -2738,7 +2738,7 @@ interface Int16Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Int16Array) => boolean, thisArg?: any): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Int16Array) => boolean, thisArg?: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -2749,7 +2749,7 @@ interface Int16Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Int16Array) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Int16Array) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -2758,7 +2758,7 @@ interface Int16Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Int16Array) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Int16Array) => void, thisArg?: U): void;
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -2795,7 +2795,7 @@ interface Int16Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Int16Array) => number, thisArg?: any): Int16Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Int16Array) => number, thisArg?: U): Int16Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -2874,7 +2874,7 @@ interface Int16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Int16Array) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Int16Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Sorts an array.
@@ -2940,7 +2940,7 @@ interface Int16ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int16Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg?: U): Int16Array;
 
 
 }
@@ -2990,7 +2990,7 @@ interface Uint16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Uint16Array) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Uint16Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -3009,7 +3009,7 @@ interface Uint16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Uint16Array) => any, thisArg?: any): Uint16Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Uint16Array) => any, thisArg?: U): Uint16Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -3020,7 +3020,7 @@ interface Uint16Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Uint16Array) => boolean, thisArg?: any): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Uint16Array) => boolean, thisArg?: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -3031,7 +3031,7 @@ interface Uint16Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Uint16Array) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Uint16Array) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -3040,7 +3040,7 @@ interface Uint16Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Uint16Array) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Uint16Array) => void, thisArg?: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -3078,7 +3078,7 @@ interface Uint16Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Uint16Array) => number, thisArg?: any): Uint16Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Uint16Array) => number, thisArg?: U): Uint16Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -3157,7 +3157,7 @@ interface Uint16Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Uint16Array) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Uint16Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Sorts an array.
@@ -3223,7 +3223,7 @@ interface Uint16ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint16Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg?: U): Uint16Array;
 
 
 }
@@ -3272,7 +3272,7 @@ interface Int32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Int32Array) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Int32Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -3291,7 +3291,7 @@ interface Int32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Int32Array) => any, thisArg?: any): Int32Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Int32Array) => any, thisArg?: U): Int32Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -3302,7 +3302,7 @@ interface Int32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Int32Array) => boolean, thisArg?: any): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Int32Array) => boolean, thisArg?: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -3313,7 +3313,7 @@ interface Int32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Int32Array) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Int32Array) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -3322,7 +3322,7 @@ interface Int32Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Int32Array) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Int32Array) => void, thisArg?: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -3360,7 +3360,7 @@ interface Int32Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Int32Array) => number, thisArg?: any): Int32Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Int32Array) => number, thisArg?: U): Int32Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -3439,7 +3439,7 @@ interface Int32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Int32Array) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Int32Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Sorts an array.
@@ -3505,7 +3505,7 @@ interface Int32ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int32Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg?: U): Int32Array;
 
 }
 declare var Int32Array: Int32ArrayConstructor;
@@ -3554,7 +3554,7 @@ interface Uint32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Uint32Array) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Uint32Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -3573,7 +3573,7 @@ interface Uint32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Uint32Array) => any, thisArg?: any): Uint32Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Uint32Array) => any, thisArg?: U): Uint32Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -3584,7 +3584,7 @@ interface Uint32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Uint32Array) => boolean, thisArg?: any): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Uint32Array) => boolean, thisArg?: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -3595,7 +3595,7 @@ interface Uint32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Uint32Array) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Uint32Array) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -3604,7 +3604,7 @@ interface Uint32Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Uint32Array) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Uint32Array) => void, thisArg?: U): void;
     /**
      * Returns the index of the first occurrence of a value in an array.
      * @param searchElement The value to locate in the array.
@@ -3641,7 +3641,7 @@ interface Uint32Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Uint32Array) => number, thisArg?: any): Uint32Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Uint32Array) => number, thisArg?: U): Uint32Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -3720,7 +3720,7 @@ interface Uint32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Uint32Array) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Uint32Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Sorts an array.
@@ -3786,7 +3786,7 @@ interface Uint32ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint32Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg?: U): Uint32Array;
 
 }
 declare var Uint32Array: Uint32ArrayConstructor;
@@ -3835,7 +3835,7 @@ interface Float32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Float32Array) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Float32Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -3854,7 +3854,7 @@ interface Float32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Float32Array) => any, thisArg?: any): Float32Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Float32Array) => any, thisArg?: U): Float32Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -3865,7 +3865,7 @@ interface Float32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Float32Array) => boolean, thisArg?: any): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Float32Array) => boolean, thisArg?: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -3876,7 +3876,7 @@ interface Float32Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Float32Array) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Float32Array) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -3885,7 +3885,7 @@ interface Float32Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Float32Array) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Float32Array) => void, thisArg?: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -3923,7 +3923,7 @@ interface Float32Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Float32Array) => number, thisArg?: any): Float32Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Float32Array) => number, thisArg?: U): Float32Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -4002,7 +4002,7 @@ interface Float32Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Float32Array) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Float32Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Sorts an array.
@@ -4068,7 +4068,7 @@ interface Float32ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Float32Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg?: U): Float32Array;
 
 
 }
@@ -4118,7 +4118,7 @@ interface Float64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    every(predicate: (value: number, index: number, array: Float64Array) => unknown, thisArg?: any): boolean;
+    every<U>(predicate: (this: U, value: number, index: number, array: Float64Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
@@ -4137,7 +4137,7 @@ interface Float64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    filter(predicate: (value: number, index: number, array: Float64Array) => any, thisArg?: any): Float64Array;
+    filter<U>(predicate: (this: U, value: number, index: number, array: Float64Array) => any, thisArg?: U): Float64Array;
 
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -4148,7 +4148,7 @@ interface Float64Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: number, index: number, obj: Float64Array) => boolean, thisArg?: any): number | undefined;
+    find<U>(predicate: (this: U, value: number, index: number, obj: Float64Array) => boolean, thisArg?: U): number | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -4159,7 +4159,7 @@ interface Float64Array {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: number, index: number, obj: Float64Array) => boolean, thisArg?: any): number;
+    findIndex<U>(predicate: (this: U, value: number, index: number, obj: Float64Array) => boolean, thisArg?: U): number;
 
     /**
      * Performs the specified action for each element in an array.
@@ -4168,7 +4168,7 @@ interface Float64Array {
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    forEach(callbackfn: (value: number, index: number, array: Float64Array) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: number, index: number, array: Float64Array) => void, thisArg?: U): void;
 
     /**
      * Returns the index of the first occurrence of a value in an array.
@@ -4206,7 +4206,7 @@ interface Float64Array {
      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    map(callbackfn: (value: number, index: number, array: Float64Array) => number, thisArg?: any): Float64Array;
+    map<U>(callbackfn: (this: U, value: number, index: number, array: Float64Array) => number, thisArg?: U): Float64Array;
 
     /**
      * Calls the specified callback function for all the elements in an array. The return value of
@@ -4285,7 +4285,7 @@ interface Float64Array {
      * @param thisArg An object to which the this keyword can refer in the predicate function.
      * If thisArg is omitted, undefined is used as the this value.
      */
-    some(predicate: (value: number, index: number, array: Float64Array) => unknown, thisArg?: any): boolean;
+    some<U>(predicate: (this: U, value: number, index: number, array: Float64Array) => unknown, thisArg?: U): boolean;
 
     /**
      * Sorts an array.
@@ -4342,7 +4342,7 @@ interface Float64ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Float64Array;
+    from<T,U>(arrayLike: ArrayLike<T>, mapfn: (this: U, v: T, k: number) => number, thisArg?: U): Float64Array;
 
 }
 declare var Float64Array: Float64ArrayConstructor;

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -1676,7 +1676,7 @@ interface FontFaceSet extends EventTarget {
     readonly status: FontFaceSetLoadStatus;
     check(font: string, text?: string): boolean;
     load(font: string, text?: string): Promise<FontFace[]>;
-    forEach(callbackfn: (value: FontFace, key: FontFace, parent: FontFaceSet) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: FontFace, key: FontFace, parent: FontFaceSet) => void, thisArg?: U): void;
     addEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: (this: FontFaceSet, ev: FontFaceSetEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: (this: FontFaceSet, ev: FontFaceSetEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -1709,7 +1709,7 @@ interface FormData {
     getAll(name: string): FormDataEntryValue[];
     has(name: string): boolean;
     set(name: string, value: string | Blob, fileName?: string): void;
-    forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: U): void;
 }
 
 declare var FormData: {
@@ -1729,7 +1729,7 @@ interface Headers {
     get(name: string): string | null;
     has(name: string): boolean;
     set(name: string, value: string): void;
-    forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: string, key: string, parent: Headers) => void, thisArg?: U): void;
 }
 
 declare var Headers: {
@@ -3210,7 +3210,7 @@ interface URLSearchParams {
     sort(): void;
     /** Returns a string containing a query string suitable for use in a URL. Does not include the question mark. */
     toString(): string;
-    forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
+    forEach<U>(callbackfn: (this: U, value: string, key: string, parent: URLSearchParams) => void, thisArg?: U): void;
 }
 
 declare var URLSearchParams: {


### PR DESCRIPTION
This change makes most method accepting a `thisArg` parameter generic, thus enabling them to capture the type of the parameter and properly recognising it in the callback function.

This makes it possible to write the wordy

```ts
const object = {
   test: (n:number):boolean => (n % 2) === 0,
   method: (n:number):void => console.log(n)
};

[1,2,3].forEach(
   function(this:{test:(n:number)=>boolean,method:(n:number)=>void},n) {
      if (this.test(n))
         object.method(n)
   },
   object)

```

as

```ts
const object = {
   test: (n:number):boolean => (n % 2) === 0,
   method: (n:number):void => console.log(n)
};

[1,2,3].forEach(
   function(n) {
      if (this.test(n))
         this.method(n)
   },
   object)
```

Fixes #50943
