### PR TITLE
fix(50858): parameters in function signatures inferred from default generic types sometimes not assigned instantiated types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27551,7 +27551,7 @@ namespace ts {
                     else if((apparentType.flags & TypeFlags.Union)) {
                         const signatureList = getContextualSignatureListFromApparentTypes((apparentType as UnionType).types, node as FunctionExpression | ArrowFunction | MethodDeclaration);
 
-                        if(!signatureList) {
+                        if (!signatureList) {
                             // At this point, the signature type is guaranteed to eventually collapse into any
                             // because it is a union of incompatible function signatures
                             return instantiateInstantiableTypes(contextualType, inferenceContext.nonFixingMapper);

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameter.js
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameter.js
@@ -1,0 +1,17 @@
+//// [genericInferenceDefaultTypeParameter.ts]
+type Type = {
+    a: (e: string) => void,
+    b: (e: number) => void,
+}
+  
+function f1<T extends keyof Type = 'a'>(props: Type[T]): any {
+    return null
+}
+
+f1((event) => { })
+
+//// [genericInferenceDefaultTypeParameter.js]
+function f1(props) {
+    return null;
+}
+f1(function (event) { });

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameter.symbols
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameter.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/genericInferenceDefaultTypeParameter.ts ===
+type Type = {
+>Type : Symbol(Type, Decl(genericInferenceDefaultTypeParameter.ts, 0, 0))
+
+    a: (e: string) => void,
+>a : Symbol(a, Decl(genericInferenceDefaultTypeParameter.ts, 0, 13))
+>e : Symbol(e, Decl(genericInferenceDefaultTypeParameter.ts, 1, 8))
+
+    b: (e: number) => void,
+>b : Symbol(b, Decl(genericInferenceDefaultTypeParameter.ts, 1, 27))
+>e : Symbol(e, Decl(genericInferenceDefaultTypeParameter.ts, 2, 8))
+}
+  
+function f1<T extends keyof Type = 'a'>(props: Type[T]): any {
+>f1 : Symbol(f1, Decl(genericInferenceDefaultTypeParameter.ts, 3, 1))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameter.ts, 5, 12))
+>Type : Symbol(Type, Decl(genericInferenceDefaultTypeParameter.ts, 0, 0))
+>props : Symbol(props, Decl(genericInferenceDefaultTypeParameter.ts, 5, 40))
+>Type : Symbol(Type, Decl(genericInferenceDefaultTypeParameter.ts, 0, 0))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameter.ts, 5, 12))
+
+    return null
+}
+
+f1((event) => { })
+>f1 : Symbol(f1, Decl(genericInferenceDefaultTypeParameter.ts, 3, 1))
+>event : Symbol(event, Decl(genericInferenceDefaultTypeParameter.ts, 9, 4))
+

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameter.types
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameter.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/genericInferenceDefaultTypeParameter.ts ===
+type Type = {
+>Type : { a: (e: string) => void; b: (e: number) => void; }
+
+    a: (e: string) => void,
+>a : (e: string) => void
+>e : string
+
+    b: (e: number) => void,
+>b : (e: number) => void
+>e : number
+}
+  
+function f1<T extends keyof Type = 'a'>(props: Type[T]): any {
+>f1 : <T extends keyof Type = "a">(props: Type[T]) => any
+>props : Type[T]
+
+    return null
+>null : null
+}
+
+f1((event) => { })
+>f1((event) => { }) : any
+>f1 : <T extends keyof Type = "a">(props: Type[T]) => any
+>(event) => { } : (event: string) => void
+>event : string
+

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.js
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.js
@@ -1,0 +1,27 @@
+//// [genericInferenceDefaultTypeParameterJsxReact.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+import React, { ComponentPropsWithRef, ElementType, ReactNode } from 'react'
+
+type ButtonBaseProps<T extends ElementType> =
+   ComponentPropsWithRef<T> & {
+  children?: ReactNode
+}
+
+function Component<T extends ElementType = 'span'>(props: ButtonBaseProps<T>) {
+  return <></>
+}
+
+const v1 = <Component onClick={e => e.preventDefault()} />
+
+//// [genericInferenceDefaultTypeParameterJsxReact.js]
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+exports.__esModule = true;
+/// <reference path="react16.d.ts" />
+var react_1 = __importDefault(require("react"));
+function Component(props) {
+    return react_1["default"].createElement(react_1["default"].Fragment, null);
+}
+var v1 = react_1["default"].createElement(Component, { onClick: function (e) { return e.preventDefault(); } });

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.symbols
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.symbols
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx ===
+/// <reference path="react16.d.ts" />
+import React, { ComponentPropsWithRef, ElementType, ReactNode } from 'react'
+>React : Symbol(React, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 1, 6))
+>ComponentPropsWithRef : Symbol(ComponentPropsWithRef, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 1, 15))
+>ElementType : Symbol(ElementType, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 1, 38))
+>ReactNode : Symbol(ReactNode, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 1, 51))
+
+type ButtonBaseProps<T extends ElementType> =
+>ButtonBaseProps : Symbol(ButtonBaseProps, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 1, 76))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 3, 21))
+>ElementType : Symbol(ElementType, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 1, 38))
+
+   ComponentPropsWithRef<T> & {
+>ComponentPropsWithRef : Symbol(ComponentPropsWithRef, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 1, 15))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 3, 21))
+
+  children?: ReactNode
+>children : Symbol(children, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 31))
+>ReactNode : Symbol(ReactNode, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 1, 51))
+}
+
+function Component<T extends ElementType = 'span'>(props: ButtonBaseProps<T>) {
+>Component : Symbol(Component, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 6, 1))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 8, 19))
+>ElementType : Symbol(ElementType, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 1, 38))
+>props : Symbol(props, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 8, 51))
+>ButtonBaseProps : Symbol(ButtonBaseProps, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 1, 76))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 8, 19))
+
+  return <></>
+}
+
+const v1 = <Component onClick={e => e.preventDefault()} />
+>v1 : Symbol(v1, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 12, 5))
+>Component : Symbol(Component, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 6, 1))
+>onClick : Symbol(onClick, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 12, 21))
+>e : Symbol(e, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 12, 31))
+>e.preventDefault : Symbol(React.SyntheticEvent.preventDefault, Decl(react16.d.ts, 642, 31))
+>e : Symbol(e, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 12, 31))
+>preventDefault : Symbol(React.SyntheticEvent.preventDefault, Decl(react16.d.ts, 642, 31))
+

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.types
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.types
@@ -1,0 +1,36 @@
+=== tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx ===
+/// <reference path="react16.d.ts" />
+import React, { ComponentPropsWithRef, ElementType, ReactNode } from 'react'
+>React : typeof React
+>ComponentPropsWithRef : any
+>ElementType : any
+>ReactNode : any
+
+type ButtonBaseProps<T extends ElementType> =
+>ButtonBaseProps : ButtonBaseProps<T>
+
+   ComponentPropsWithRef<T> & {
+  children?: ReactNode
+>children : React.ReactNode
+}
+
+function Component<T extends ElementType = 'span'>(props: ButtonBaseProps<T>) {
+>Component : <T extends React.ElementType<any> = "span">(props: ButtonBaseProps<T>) => JSX.Element
+>props : ButtonBaseProps<T>
+
+  return <></>
+><></> : JSX.Element
+}
+
+const v1 = <Component onClick={e => e.preventDefault()} />
+>v1 : JSX.Element
+><Component onClick={e => e.preventDefault()} /> : JSX.Element
+>Component : <T extends React.ElementType<any> = "span">(props: ButtonBaseProps<T>) => JSX.Element
+>onClick : (e: React.MouseEvent<HTMLSpanElement>) => void
+>e => e.preventDefault() : (e: React.MouseEvent<HTMLSpanElement>) => void
+>e : React.MouseEvent<HTMLSpanElement>
+>e.preventDefault() : void
+>e.preventDefault : () => void
+>e : React.MouseEvent<HTMLSpanElement>
+>preventDefault : () => void
+

--- a/tests/cases/compiler/genericInferenceDefaultTypeParameter.ts
+++ b/tests/cases/compiler/genericInferenceDefaultTypeParameter.ts
@@ -1,0 +1,12 @@
+// @noImplicitAny: true
+
+type Type = {
+    a: (e: string) => void,
+    b: (e: number) => void,
+}
+  
+function f1<T extends keyof Type = 'a'>(props: Type[T]): any {
+    return null
+}
+
+f1((event) => { })

--- a/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
+++ b/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
@@ -1,0 +1,17 @@
+// @noImplicitAny: true
+// @esModuleInterop: true
+// @jsx: react
+
+/// <reference path="/.lib/react16.d.ts" />
+import React, { ComponentPropsWithRef, ElementType, ReactNode } from 'react'
+
+type ButtonBaseProps<T extends ElementType> =
+   ComponentPropsWithRef<T> & {
+  children?: ReactNode
+}
+
+function Component<T extends ElementType = 'span'>(props: ButtonBaseProps<T>) {
+  return <></>
+}
+
+const v1 = <Component onClick={e => e.preventDefault()} />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #50858 

This issue is specifically about functions within the arguments of generic-inferring call expressions. Early in the execution flow, the internal function's signature will only be instantiated with types when some inferences have already been made about them, but this misses the case where those generics have default values. Instead of taking default values, the signature falls back to a base type. If that base type is a union of incompatible signatures or `any`, then the signature's parameters will be set to `any`.

Later in the execution flow, the signature is properly instantiated; however by that time diagnostics have already been created and the signature's symbol type may already have been set to `any`.

See below for a more in-depth look at the call stack.

# Example

Consider the following test:

```typescript
type Type = {
    a: (e: string) => void,
    b: (e: number) => void,
}
  
function f1<T extends keyof Type = 'a'>(props: Type[T]): any {
    return null
}

f1((event) => { })
```

The function call `f1` should take a default type parameter of `"a"` for type parameter `T`, and so we expect `event` to take its contextual type of `string`. However, due to this issue, it is of type `any` and throws a `noImplicitAny` diagnostic.

## Call Stack

<details>
<summary>Call Stack Analysis of Example (in checker.ts)</summary>

 - `resolveCallExpression` on call expression `f1((event) => { })` -> `resolveCall` -> `chooseOverload`
   - `chooseOverload`: No `typeParameters` are specified, so `inferTypeArguments` is called twice. The first call skips context sensitive parameters (such as `(event) => {}`), so we are interested in the second call
     - `inferTypeArguments`: calls `checkExpressionWithContextualType` to get the type of each argument before making any type inferences
       - `checkExpressionWithContextualType` -> ... -> `contextuallyCheckFunctionExpressionOrObjectLiteralMethod`
         - `contextuallyCheckFunctionExpressionOrObjectLiteralMethod`: Gets contextual signature of argument by calling `getContextualSignature`
           - `getContextualSignature`: Gets type from `getApparentTypeOfContextualType`
             - `getApparentTypeOfContextualType`: `contextualType` is the type `Type[T]` of kind `IndexedAccess`. We then try and instantiate that type by calling `instantiateContextualType`
               - `instantiateContextualType`: Since no inferences have been made, the type is not instantiated, and the `contextualType` is returned
             - The return of `instantiateContextualType` does nothing, so we find the apparent type of `Type[T]`, which in this case is the base type, which is `(e: string) => void|(e: number) => void`
           - A union of incompatible function signatures cannot be flattened into one, so `undefined` is returned
         - Since the contextual signature is `undefined`, the parameter type is assigned with `assignNonContextualParameterTypes`
           - `assignNonContextualParameterTypes`: Calls `assignParameterType` with `undefined` type on each parameter
             - The parameter type being `undefined`, another attempt is made to infer it contextually, which ultimately hits `getContextualSignature` again which like before returns `undefined`
               - -> ... -> `widenTypeForVariableLikeDeclaration`: Type is `undefined` so `anyType` is returned and a **diagnostic is thrown**
     - `inferTypes` is now called, which makes type inferences
   - The signature is now properly instantiated with `getSignatureInstantiation`, and the resulting signature is correct (has `(event: string) => void` as a parameter)
   - ...
   - `getSignatureApplicabilityError` is called, which flows through the same call stack as before with the instantiated signature, until `contextuallyCheckFunctionExpressionOrObjectLiteralMethod` because the previous execution stack already "checked the context" and set `NodeCheckFlags.ContextChecked`. 
</details>

This issue is caused by `instantiateContextualType`, which is in the call stack of `inferTypeArguments` in `chooseOverload`. There is a cyclic dependency: the result of `inferTypeArguments` is necessary to fully instantiate the signature with `getSignatureInstantiation`, but (it would seem) a fully instantiated signature is expected by the return result of `instantiateContextualType` within `getApparentTypeOfContextualType`, which is in the call stack of `inferTypeArguments`.

# Solution

The solution presented is to instantiate from within `instantiateContextualType` whenever the apparent type of `contextualType` is "degenerate" - that is, when it is either `any` or a union of incompatible signatures - since, in this case, essentially no further information on the parameters of the signature can be gleamed if we return it. So, in the worst case, we get back another degenerate type from instantiation, but in the best case, we get more type information.

In cases like the previous example, the call stack off of `inferTypeArguments` will generate the correct signature, and the correct parameter type will be assigned.
<details>
<summary>Further thoughts</summary>

I doubt this fixes every single possible instance of this bug, but it fixes the linked issue and many others. But I presume the types of the function parameters should be set after or during the instantiation of the signature, not during `inferTypeArguments`. It is indeed rather strange as well that a function named "`assignNonContextualParameterTypes`" ends up trying to infer a lot of contextual information. But my familiarity with the codebase is not excellent, so if somebody can clear that up, please do!

One more potential concern I had was that `instantiateContextualType` may now end up inferring "too much" - perhaps returning a non-any type where an any type is required. All of the tests pass, however, so this doesn't seem likely.

My original assumption was that `inferTypeArguments` should have a flag to never result in a call of `assignParameterType`, however I wasn't able to get this to work without destroying generic inference; it seems that many instances of type inference require types to be set from the call to `inferTypeArguments`, and not from the call to `getSignatureApplicabilityError` with the instantiated signature.

Another thought was to allow `getSignatureApplicabilityError` to set the type by resetting `NodeCheckFlags.ContextChecked` on the arguments. This does not work, however, since `assignParameterType` prevents setting the parameter type to one different than was cached; moreover, the diagnostic errors have already been thrown.

Note that removing the check in `instantiateContextualType` that "no inferences have been made" understandably breaks the codebase as well, since this will (I assume) instantiate preemptively in many cases.

If anyone has any ideas on how to make the previous approaches work, please respond, since I think they're significantly more elegant solutions to the problem than the one presented.
</details>