### PR TITLE
Marking options as publicly available in CompilerOptions type

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6574,8 +6574,8 @@ namespace ts {
         exactOptionalPropertyTypes?: boolean;
         experimentalDecorators?: boolean;
         forceConsistentCasingInFileNames?: boolean;
-        /*@internal*/generateCpuProfile?: string;
-        /*@internal*/generateTrace?: string;
+        generateCpuProfile?: string;
+        generateTrace?: string;
         /*@internal*/help?: boolean;
         importHelpers?: boolean;
         importsNotUsedAsValues?: ImportsNotUsedAsValues;
@@ -6586,9 +6586,9 @@ namespace ts {
         jsx?: JsxEmit;
         keyofStringsOnly?: boolean;
         lib?: string[];
-        /*@internal*/listEmittedFiles?: boolean;
-        /*@internal*/listFiles?: boolean;
-        /*@internal*/explainFiles?: boolean;
+        listEmittedFiles?: boolean;
+        listFiles?: boolean;
+        explainFiles?: boolean;
         /*@internal*/listFilesOnly?: boolean;
         locale?: string;
         mapRoot?: string;
@@ -6631,7 +6631,7 @@ namespace ts {
         preserveValueImports?: boolean;
         /* @internal */ preserveWatchOutput?: boolean;
         project?: string;
-        /* @internal */ pretty?: boolean;
+        pretty?: boolean;
         reactNamespace?: string;
         jsxFactory?: string;
         jsxFragmentFactory?: string;


### PR DESCRIPTION
There's several fields in CompilerOptions that are marked internal but are now publicly supported. It would be great to be able to get at them in a typesafe way.

I left plugin as internal because I don't have a ton of context on that option. Feel free to hand this over to someone with way more context.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes # https://github.com/microsoft/TypeScript/issues/50962
