### PR TITLE
Add a compiler error when using `module: esxxxx with moduleResolution: nodexx

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4000,6 +4000,10 @@
         "category": "Error",
         "code": 4125
     },
+    "Using option '{0}: {1}' with '{2}: {3}' is unsupported. Did you mean to use '{4}: {5}' instead?": {
+        "category": "Error",
+        "code": 4126
+    },
 
     "The current host does not support the '{0}' option.": {
         "category": "Error",

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3657,6 +3657,12 @@ namespace ts {
                 createOptionValueDiagnostic("importsNotUsedAsValues", Diagnostics.Option_preserveValueImports_can_only_be_used_when_module_is_set_to_es2015_or_later);
             }
 
+            if (options.moduleResolution && options.moduleResolution >= ModuleResolutionKind.Node16) {
+                if (options.module && options.module >= ModuleKind.ES2015 && options.module <= ModuleKind.ESNext) {
+                    createDiagnosticForOption(/*onKey*/ true, "module", /*key2*/ undefined, Diagnostics.Using_option_0_Colon_1_with_2_Colon_3_is_unsupported_Did_you_mean_to_use_4_Colon_5_instead, "module", ModuleKind[options.module], "moduleResolution", ModuleResolutionKind[options.moduleResolution], "module", "nodenext");
+                }
+            }
+
             // If the emit is enabled make sure that every output file is unique and not overwriting any of the input files
             if (!options.noEmit && !options.suppressOutputPathCheck) {
                 const emitHost = getEmitHost();
@@ -3942,13 +3948,13 @@ namespace ts {
             }
         }
 
-        function createDiagnosticForOption(onKey: boolean, option1: string, option2: string | undefined, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number) {
+        function createDiagnosticForOption(onKey: boolean, option1: string, option2: string | undefined, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number, arg3?: string | number, arg4?: string | number, arg5?: string | number) {
             const compilerOptionsObjectLiteralSyntax = getCompilerOptionsObjectLiteralSyntax();
             const needCompilerDiagnostic = !compilerOptionsObjectLiteralSyntax ||
-                !createOptionDiagnosticInObjectLiteralSyntax(compilerOptionsObjectLiteralSyntax, onKey, option1, option2, message, arg0, arg1, arg2);
+                !createOptionDiagnosticInObjectLiteralSyntax(compilerOptionsObjectLiteralSyntax, onKey, option1, option2, message, arg0, arg1, arg2, arg3, arg4, arg5);
 
             if (needCompilerDiagnostic) {
-                programDiagnostics.add(createCompilerDiagnostic(message, arg0, arg1, arg2));
+                programDiagnostics.add(createCompilerDiagnostic(message, arg0, arg1, arg2, arg3, arg4, arg5));
             }
         }
 
@@ -3968,10 +3974,10 @@ namespace ts {
             return _compilerOptionsObjectLiteralSyntax || undefined;
         }
 
-        function createOptionDiagnosticInObjectLiteralSyntax(objectLiteral: ObjectLiteralExpression, onKey: boolean, key1: string, key2: string | undefined, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number): boolean {
+        function createOptionDiagnosticInObjectLiteralSyntax(objectLiteral: ObjectLiteralExpression, onKey: boolean, key1: string, key2: string | undefined, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number, arg3?: string | number, arg4?: string | number, arg5?: string | number): boolean {
             const props = getPropertyAssignment(objectLiteral, key1, key2);
             for (const prop of props) {
-                programDiagnostics.add(createDiagnosticForNodeInSourceFile(options.configFile!, onKey ? prop.name : prop.initializer, message, arg0, arg1, arg2));
+                programDiagnostics.add(createDiagnosticForNodeInSourceFile(options.configFile!, onKey ? prop.name : prop.initializer, message, arg0, arg1, arg2, arg3, arg4, arg5));
             }
             return !!props.length;
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1050,9 +1050,9 @@ namespace ts {
         return createFileDiagnostic(sourceFile, start, nodes.end - start, message, arg0, arg1, arg2, arg3);
     }
 
-    export function createDiagnosticForNodeInSourceFile(sourceFile: SourceFile, node: Node, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number, arg3?: string | number): DiagnosticWithLocation {
+    export function createDiagnosticForNodeInSourceFile(sourceFile: SourceFile, node: Node, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number, arg3?: string | number, arg4?: string | number, arg5?: string | number): DiagnosticWithLocation {
         const span = getErrorSpanForNode(sourceFile, node);
-        return createFileDiagnostic(sourceFile, span.start, span.length, message, arg0, arg1, arg2, arg3);
+        return createFileDiagnostic(sourceFile, span.start, span.length, message, arg0, arg1, arg2, arg3, arg4, arg5);
     }
 
     export function createDiagnosticForNodeFromMessageChain(node: Node, messageChain: DiagnosticMessageChain, relatedInformation?: DiagnosticRelatedInformation[]): DiagnosticWithLocation {

--- a/tests/baselines/reference/elidedJSImport2(module=es2022).errors.txt
+++ b/tests/baselines/reference/elidedJSImport2(module=es2022).errors.txt
@@ -1,0 +1,31 @@
+error TS4126: Using option 'module: ES2022' with 'moduleResolution: Node16' is unsupported. Did you mean to use 'module: nodenext' instead?
+
+
+!!! error TS4126: Using option 'module: ES2022' with 'moduleResolution: Node16' is unsupported. Did you mean to use 'module: nodenext' instead?
+==== tests/cases/compiler/index.js (0 errors) ====
+    import { Foo } from "./other.js";
+    import * as other from "./other.js";
+    import defaultFoo from "./other.js";
+    
+    const x = new Foo();
+    const y = other.Foo();
+    const z = new defaultFoo();
+    
+==== tests/cases/compiler/other.d.ts (0 errors) ====
+    export interface Foo {
+        bar: number;
+    }
+    
+    export default interface Bar {
+        foo: number;
+    }
+    
+==== tests/cases/compiler/other.js (0 errors) ====
+    export class Foo {
+        bar = 2.4;
+    }
+    
+    export default class Bar {
+        foo = 1.2;
+    }
+    

--- a/tests/baselines/reference/elidedJSImport2(module=es2022).types
+++ b/tests/baselines/reference/elidedJSImport2(module=es2022).types
@@ -9,21 +9,21 @@ import defaultFoo from "./other.js";
 >defaultFoo : any
 
 const x = new Foo();
->x : error
->new Foo() : error
->Foo : error
+>x : any
+>new Foo() : any
+>Foo : any
 
 const y = other.Foo();
->y : error
->other.Foo() : error
->other.Foo : error
+>y : any
+>other.Foo() : any
+>other.Foo : any
 >other : typeof other
 >Foo : any
 
 const z = new defaultFoo();
->z : error
->new defaultFoo() : error
->defaultFoo : error
+>z : any
+>new defaultFoo() : any
+>defaultFoo : any
 
 === tests/cases/compiler/other.d.ts ===
 export interface Foo {


### PR DESCRIPTION
Since this combination of options can have confusing behavior for, eg, `.cjs` or `.cts` files, which are emitted as esm in this mode. We don't _really_ intend to support this combination of flags, so while it does work and does do _something_, it's probably not what whoever combined the flags is hoping for, given what `moduleResolution` and `module` are each responsible for. (The other old module flags make a degree of sense, since they trigger emitting everything as cjs/amd/umd/system, which are all downlevel formats)

Fixes #50647