### PR TITLE
Include type parameter defaults in contextual typing

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27534,7 +27534,7 @@ namespace ts {
                 const inferenceContext = getInferenceContext(node);
                 // If no inferences have been made, nothing is gained from instantiating as type parameters
                 // would just be replaced with their defaults similar to the apparent type.
-                if (inferenceContext && contextFlags! & ContextFlags.Signature && some(inferenceContext.inferences, hasInferenceCandidates)) {
+                if (inferenceContext && contextFlags! & ContextFlags.Signature && some(inferenceContext.inferences, hasInferenceCandidatesOrDefault)) {
                     // For contextual signatures we incorporate all inferences made so far, e.g. from return
                     // types as well as arguments to the left in a function call.
                     return instantiateInstantiableTypes(contextualType, inferenceContext.nonFixingMapper);
@@ -35143,6 +35143,10 @@ namespace ts {
 
         function hasInferenceCandidates(info: InferenceInfo) {
             return !!(info.candidates || info.contraCandidates);
+        }
+
+        function hasInferenceCandidatesOrDefault(info: InferenceInfo) {
+            return !!(info.candidates || info.contraCandidates || hasTypeParameterDefault(info.typeParameter));
         }
 
         function hasOverlappingInferences(a: InferenceInfo[], b: InferenceInfo[]) {

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameter.js
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameter.js
@@ -1,0 +1,21 @@
+//// [genericInferenceDefaultTypeParameter.ts]
+// Repro from #50858
+
+type Type = {
+    a: (e: string) => void;
+    b: (e: number) => void;
+}
+
+declare function f1<T extends keyof Type = "a">(props: Type[T]): void;
+
+f1(event => { });
+f1<"a">(event => { });
+f1<"b">(event => { });
+
+
+//// [genericInferenceDefaultTypeParameter.js]
+"use strict";
+// Repro from #50858
+f1(function (event) { });
+f1(function (event) { });
+f1(function (event) { });

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameter.symbols
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameter.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/genericInferenceDefaultTypeParameter.ts ===
+// Repro from #50858
+
+type Type = {
+>Type : Symbol(Type, Decl(genericInferenceDefaultTypeParameter.ts, 0, 0))
+
+    a: (e: string) => void;
+>a : Symbol(a, Decl(genericInferenceDefaultTypeParameter.ts, 2, 13))
+>e : Symbol(e, Decl(genericInferenceDefaultTypeParameter.ts, 3, 8))
+
+    b: (e: number) => void;
+>b : Symbol(b, Decl(genericInferenceDefaultTypeParameter.ts, 3, 27))
+>e : Symbol(e, Decl(genericInferenceDefaultTypeParameter.ts, 4, 8))
+}
+
+declare function f1<T extends keyof Type = "a">(props: Type[T]): void;
+>f1 : Symbol(f1, Decl(genericInferenceDefaultTypeParameter.ts, 5, 1))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameter.ts, 7, 20))
+>Type : Symbol(Type, Decl(genericInferenceDefaultTypeParameter.ts, 0, 0))
+>props : Symbol(props, Decl(genericInferenceDefaultTypeParameter.ts, 7, 48))
+>Type : Symbol(Type, Decl(genericInferenceDefaultTypeParameter.ts, 0, 0))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameter.ts, 7, 20))
+
+f1(event => { });
+>f1 : Symbol(f1, Decl(genericInferenceDefaultTypeParameter.ts, 5, 1))
+>event : Symbol(event, Decl(genericInferenceDefaultTypeParameter.ts, 9, 3))
+
+f1<"a">(event => { });
+>f1 : Symbol(f1, Decl(genericInferenceDefaultTypeParameter.ts, 5, 1))
+>event : Symbol(event, Decl(genericInferenceDefaultTypeParameter.ts, 10, 8))
+
+f1<"b">(event => { });
+>f1 : Symbol(f1, Decl(genericInferenceDefaultTypeParameter.ts, 5, 1))
+>event : Symbol(event, Decl(genericInferenceDefaultTypeParameter.ts, 11, 8))
+

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameter.types
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameter.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/genericInferenceDefaultTypeParameter.ts ===
+// Repro from #50858
+
+type Type = {
+>Type : { a: (e: string) => void; b: (e: number) => void; }
+
+    a: (e: string) => void;
+>a : (e: string) => void
+>e : string
+
+    b: (e: number) => void;
+>b : (e: number) => void
+>e : number
+}
+
+declare function f1<T extends keyof Type = "a">(props: Type[T]): void;
+>f1 : <T extends keyof Type = "a">(props: Type[T]) => void
+>props : Type[T]
+
+f1(event => { });
+>f1(event => { }) : void
+>f1 : <T extends keyof Type = "a">(props: Type[T]) => void
+>event => { } : (event: string) => void
+>event : string
+
+f1<"a">(event => { });
+>f1<"a">(event => { }) : void
+>f1 : <T extends keyof Type = "a">(props: Type[T]) => void
+>event => { } : (event: string) => void
+>event : string
+
+f1<"b">(event => { });
+>f1<"b">(event => { }) : void
+>f1 : <T extends keyof Type = "a">(props: Type[T]) => void
+>event => { } : (event: number) => void
+>event : number
+

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.js
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.js
@@ -1,0 +1,29 @@
+//// [genericInferenceDefaultTypeParameterJsxReact.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+
+// Repro from #50858
+
+import React, { ComponentPropsWithRef, ElementType, ReactNode } from 'react';
+
+type ButtonBaseProps<T extends ElementType> = ComponentPropsWithRef<T> & { children?: ReactNode };
+
+function Component<T extends ElementType = 'span'>(props: ButtonBaseProps<T>) {
+    return <></>;
+}
+
+const v1 = <Component onClick={e => e.preventDefault()} />;
+
+
+//// [genericInferenceDefaultTypeParameterJsxReact.js]
+"use strict";
+/// <reference path="react16.d.ts" />
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+exports.__esModule = true;
+// Repro from #50858
+var react_1 = __importDefault(require("react"));
+function Component(props) {
+    return react_1["default"].createElement(react_1["default"].Fragment, null);
+}
+var v1 = react_1["default"].createElement(Component, { onClick: function (e) { return e.preventDefault(); } });

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.symbols
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.symbols
@@ -1,0 +1,40 @@
+=== tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx ===
+/// <reference path="react16.d.ts" />
+
+// Repro from #50858
+
+import React, { ComponentPropsWithRef, ElementType, ReactNode } from 'react';
+>React : Symbol(React, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 6))
+>ComponentPropsWithRef : Symbol(ComponentPropsWithRef, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 15))
+>ElementType : Symbol(ElementType, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 38))
+>ReactNode : Symbol(ReactNode, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 51))
+
+type ButtonBaseProps<T extends ElementType> = ComponentPropsWithRef<T> & { children?: ReactNode };
+>ButtonBaseProps : Symbol(ButtonBaseProps, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 77))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 6, 21))
+>ElementType : Symbol(ElementType, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 38))
+>ComponentPropsWithRef : Symbol(ComponentPropsWithRef, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 15))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 6, 21))
+>children : Symbol(children, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 6, 74))
+>ReactNode : Symbol(ReactNode, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 51))
+
+function Component<T extends ElementType = 'span'>(props: ButtonBaseProps<T>) {
+>Component : Symbol(Component, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 6, 98))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 8, 19))
+>ElementType : Symbol(ElementType, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 38))
+>props : Symbol(props, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 8, 51))
+>ButtonBaseProps : Symbol(ButtonBaseProps, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 4, 77))
+>T : Symbol(T, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 8, 19))
+
+    return <></>;
+}
+
+const v1 = <Component onClick={e => e.preventDefault()} />;
+>v1 : Symbol(v1, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 12, 5))
+>Component : Symbol(Component, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 6, 98))
+>onClick : Symbol(onClick, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 12, 21))
+>e : Symbol(e, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 12, 31))
+>e.preventDefault : Symbol(React.SyntheticEvent.preventDefault, Decl(react16.d.ts, 642, 31))
+>e : Symbol(e, Decl(genericInferenceDefaultTypeParameterJsxReact.tsx, 12, 31))
+>preventDefault : Symbol(React.SyntheticEvent.preventDefault, Decl(react16.d.ts, 642, 31))
+

--- a/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.types
+++ b/tests/baselines/reference/genericInferenceDefaultTypeParameterJsxReact.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx ===
+/// <reference path="react16.d.ts" />
+
+// Repro from #50858
+
+import React, { ComponentPropsWithRef, ElementType, ReactNode } from 'react';
+>React : typeof React
+>ComponentPropsWithRef : any
+>ElementType : any
+>ReactNode : any
+
+type ButtonBaseProps<T extends ElementType> = ComponentPropsWithRef<T> & { children?: ReactNode };
+>ButtonBaseProps : ButtonBaseProps<T>
+>children : React.ReactNode
+
+function Component<T extends ElementType = 'span'>(props: ButtonBaseProps<T>) {
+>Component : <T extends React.ElementType<any> = "span">(props: ButtonBaseProps<T>) => JSX.Element
+>props : ButtonBaseProps<T>
+
+    return <></>;
+><></> : JSX.Element
+}
+
+const v1 = <Component onClick={e => e.preventDefault()} />;
+>v1 : JSX.Element
+><Component onClick={e => e.preventDefault()} /> : JSX.Element
+>Component : <T extends React.ElementType<any> = "span">(props: ButtonBaseProps<T>) => JSX.Element
+>onClick : (e: React.MouseEvent<HTMLSpanElement>) => void
+>e => e.preventDefault() : (e: React.MouseEvent<HTMLSpanElement>) => void
+>e : React.MouseEvent<HTMLSpanElement>
+>e.preventDefault() : void
+>e.preventDefault : () => void
+>e : React.MouseEvent<HTMLSpanElement>
+>preventDefault : () => void
+

--- a/tests/cases/compiler/genericInferenceDefaultTypeParameter.ts
+++ b/tests/cases/compiler/genericInferenceDefaultTypeParameter.ts
@@ -1,0 +1,14 @@
+// @strict: true
+
+// Repro from #50858
+
+type Type = {
+    a: (e: string) => void;
+    b: (e: number) => void;
+}
+
+declare function f1<T extends keyof Type = "a">(props: Type[T]): void;
+
+f1(event => { });
+f1<"a">(event => { });
+f1<"b">(event => { });

--- a/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
+++ b/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
@@ -1,0 +1,17 @@
+// @strict: true
+// @esModuleInterop: true
+// @jsx: react
+
+/// <reference path="/.lib/react16.d.ts" />
+
+// Repro from #50858
+
+import React, { ComponentPropsWithRef, ElementType, ReactNode } from 'react';
+
+type ButtonBaseProps<T extends ElementType> = ComponentPropsWithRef<T> & { children?: ReactNode };
+
+function Component<T extends ElementType = 'span'>(props: ButtonBaseProps<T>) {
+    return <></>;
+}
+
+const v1 = <Component onClick={e => e.preventDefault()} />;


### PR DESCRIPTION
This PR supersedes #50960 and fixes #50858.

Thanks @msxdev for calling attention to this issue and proposing a fix. This PR effectively implements the same idea as #50960 in a simpler manner. Also, this PR borrows the tests from #50960.

Fixes #50858.