### PR TITLE
Remove reverse mapping const enums on preserveConstEnums

### DIFF
--- a/tests/baselines/reference/amdModuleConstEnumUsage.js
+++ b/tests/baselines/reference/amdModuleConstEnumUsage.js
@@ -21,8 +21,8 @@ define(["require", "exports"], function (require, exports) {
     exports.CharCode = void 0;
     var CharCode;
     (function (CharCode) {
-        CharCode[CharCode["A"] = 0] = "A";
-        CharCode[CharCode["B"] = 1] = "B";
+        CharCode["A"] = 0;
+        CharCode["B"] = 1;
     })(CharCode = exports.CharCode || (exports.CharCode = {}));
 });
 //// [file.js]

--- a/tests/baselines/reference/blockScopedEnumVariablesUseBeforeDef_preserve.js
+++ b/tests/baselines/reference/blockScopedEnumVariablesUseBeforeDef_preserve.js
@@ -21,6 +21,6 @@ function foo2() {
     return 0 /* E.A */;
     var E;
     (function (E) {
-        E[E["A"] = 0] = "A";
+        E["A"] = 0;
     })(E || (E = {}));
 }

--- a/tests/baselines/reference/constEnumMergingWithValues5.js
+++ b/tests/baselines/reference/constEnumMergingWithValues5.js
@@ -12,7 +12,7 @@ define(["require", "exports"], function (require, exports) {
     (function (foo) {
         var E;
         (function (E) {
-            E[E["X"] = 0] = "X";
+            E["X"] = 0;
         })(E || (E = {}));
     })(foo || (foo = {}));
     return foo;

--- a/tests/baselines/reference/constEnumNamespaceReferenceCausesNoImport(isolatedmodules=true).js
+++ b/tests/baselines/reference/constEnumNamespaceReferenceCausesNoImport(isolatedmodules=true).js
@@ -23,9 +23,9 @@ exports.__esModule = true;
 exports.fooFunc = exports.ConstFooEnum = void 0;
 var ConstFooEnum;
 (function (ConstFooEnum) {
-    ConstFooEnum[ConstFooEnum["Some"] = 0] = "Some";
-    ConstFooEnum[ConstFooEnum["Values"] = 1] = "Values";
-    ConstFooEnum[ConstFooEnum["Here"] = 2] = "Here";
+    ConstFooEnum["Some"] = 0;
+    ConstFooEnum["Values"] = 1;
+    ConstFooEnum["Here"] = 2;
 })(ConstFooEnum = exports.ConstFooEnum || (exports.ConstFooEnum = {}));
 ;
 function fooFunc() { }

--- a/tests/baselines/reference/constEnumNamespaceReferenceCausesNoImport2.js
+++ b/tests/baselines/reference/constEnumNamespaceReferenceCausesNoImport2.js
@@ -30,9 +30,9 @@ var ConstEnumOnlyModule;
 (function (ConstEnumOnlyModule) {
     var ConstFooEnum;
     (function (ConstFooEnum) {
-        ConstFooEnum[ConstFooEnum["Some"] = 0] = "Some";
-        ConstFooEnum[ConstFooEnum["Values"] = 1] = "Values";
-        ConstFooEnum[ConstFooEnum["Here"] = 2] = "Here";
+        ConstFooEnum["Some"] = 0;
+        ConstFooEnum["Values"] = 1;
+        ConstFooEnum["Here"] = 2;
     })(ConstFooEnum = ConstEnumOnlyModule.ConstFooEnum || (ConstEnumOnlyModule.ConstFooEnum = {}));
 })(ConstEnumOnlyModule = exports.ConstEnumOnlyModule || (exports.ConstEnumOnlyModule = {}));
 //// [reexport.js]

--- a/tests/baselines/reference/constEnumPreserveEmitNamedExport1.js
+++ b/tests/baselines/reference/constEnumPreserveEmitNamedExport1.js
@@ -14,7 +14,7 @@ export { A };
 //// [a.js]
 var A;
 (function (A) {
-    A[A["Foo"] = 0] = "Foo";
+    A["Foo"] = 0;
 })(A || (A = {}));
 ;
 export { A };

--- a/tests/baselines/reference/constEnumPreserveEmitNamedExport2.js
+++ b/tests/baselines/reference/constEnumPreserveEmitNamedExport2.js
@@ -14,7 +14,7 @@ export { A as B };
 //// [a.js]
 var A;
 (function (A) {
-    A[A["Foo"] = 0] = "Foo";
+    A["Foo"] = 0;
 })(A || (A = {}));
 ;
 export { A };

--- a/tests/baselines/reference/constEnumPreserveEmitReexport.js
+++ b/tests/baselines/reference/constEnumPreserveEmitReexport.js
@@ -17,8 +17,8 @@ exports.__esModule = true;
 exports.MyConstEnum = void 0;
 var MyConstEnum;
 (function (MyConstEnum) {
-    MyConstEnum[MyConstEnum["Foo"] = 0] = "Foo";
-    MyConstEnum[MyConstEnum["Bar"] = 1] = "Bar";
+    MyConstEnum["Foo"] = 0;
+    MyConstEnum["Bar"] = 1;
 })(MyConstEnum = exports.MyConstEnum || (exports.MyConstEnum = {}));
 ;
 //// [ImportExport.js]

--- a/tests/baselines/reference/es6ModuleConstEnumDeclaration2.js
+++ b/tests/baselines/reference/es6ModuleConstEnumDeclaration2.js
@@ -48,15 +48,15 @@ module m2 {
 //// [es6ModuleConstEnumDeclaration2.js]
 export var e1;
 (function (e1) {
-    e1[e1["a"] = 0] = "a";
-    e1[e1["b"] = 1] = "b";
-    e1[e1["c"] = 2] = "c";
+    e1["a"] = 0;
+    e1["b"] = 1;
+    e1["c"] = 2;
 })(e1 || (e1 = {}));
 var e2;
 (function (e2) {
-    e2[e2["x"] = 0] = "x";
-    e2[e2["y"] = 1] = "y";
-    e2[e2["z"] = 2] = "z";
+    e2["x"] = 0;
+    e2["y"] = 1;
+    e2["z"] = 2;
 })(e2 || (e2 = {}));
 var x = 0 /* e1.a */;
 var y = 0 /* e2.x */;
@@ -64,15 +64,15 @@ export var m1;
 (function (m1) {
     let e3;
     (function (e3) {
-        e3[e3["a"] = 0] = "a";
-        e3[e3["b"] = 1] = "b";
-        e3[e3["c"] = 2] = "c";
+        e3["a"] = 0;
+        e3["b"] = 1;
+        e3["c"] = 2;
     })(e3 = m1.e3 || (m1.e3 = {}));
     let e4;
     (function (e4) {
-        e4[e4["x"] = 0] = "x";
-        e4[e4["y"] = 1] = "y";
-        e4[e4["z"] = 2] = "z";
+        e4["x"] = 0;
+        e4["y"] = 1;
+        e4["z"] = 2;
     })(e4 || (e4 = {}));
     var x1 = 0 /* e1.a */;
     var y1 = 0 /* e2.x */;
@@ -83,15 +83,15 @@ var m2;
 (function (m2) {
     let e5;
     (function (e5) {
-        e5[e5["a"] = 0] = "a";
-        e5[e5["b"] = 1] = "b";
-        e5[e5["c"] = 2] = "c";
+        e5["a"] = 0;
+        e5["b"] = 1;
+        e5["c"] = 2;
     })(e5 = m2.e5 || (m2.e5 = {}));
     let e6;
     (function (e6) {
-        e6[e6["x"] = 0] = "x";
-        e6[e6["y"] = 1] = "y";
-        e6[e6["z"] = 2] = "z";
+        e6["x"] = 0;
+        e6["y"] = 1;
+        e6["z"] = 2;
     })(e6 || (e6 = {}));
     var x1 = 0 /* e1.a */;
     var y1 = 0 /* e2.x */;

--- a/tests/baselines/reference/es6modulekindWithES5Target5.js
+++ b/tests/baselines/reference/es6modulekindWithES5Target5.js
@@ -14,5 +14,5 @@ export var E1;
 })(E1 || (E1 = {}));
 export var E2;
 (function (E2) {
-    E2[E2["value1"] = 0] = "value1";
+    E2["value1"] = 0;
 })(E2 || (E2 = {}));

--- a/tests/baselines/reference/esnextmodulekindWithES5Target5.js
+++ b/tests/baselines/reference/esnextmodulekindWithES5Target5.js
@@ -14,5 +14,5 @@ export var E1;
 })(E1 || (E1 = {}));
 export var E2;
 (function (E2) {
-    E2[E2["value1"] = 0] = "value1";
+    E2["value1"] = 0;
 })(E2 || (E2 = {}));

--- a/tests/baselines/reference/isolatedModulesImportConstEnum.js
+++ b/tests/baselines/reference/isolatedModulesImportConstEnum.js
@@ -16,7 +16,7 @@ exports.__esModule = true;
 exports.Foo = void 0;
 var Foo;
 (function (Foo) {
-    Foo[Foo["BAR"] = 0] = "BAR";
+    Foo["BAR"] = 0;
 })(Foo = exports.Foo || (exports.Foo = {}));
 //// [file1.js]
 "use strict";

--- a/tests/baselines/reference/isolatedModulesImportConstEnumTypeOnly.js
+++ b/tests/baselines/reference/isolatedModulesImportConstEnumTypeOnly.js
@@ -14,7 +14,7 @@ exports.__esModule = true;
 exports.Foo = void 0;
 var Foo;
 (function (Foo) {
-    Foo[Foo["Bar"] = 0] = "Bar";
+    Foo["Bar"] = 0;
 })(Foo = exports.Foo || (exports.Foo = {}));
 //// [index.js]
 "use strict";

--- a/tests/baselines/reference/isolatedModulesNonAmbientConstEnum.js
+++ b/tests/baselines/reference/isolatedModulesNonAmbientConstEnum.js
@@ -6,7 +6,7 @@ export var x;
 //// [file1.js]
 var E;
 (function (E) {
-    E[E["X"] = 100] = "X";
+    E["X"] = 100;
 })(E || (E = {}));
 ;
 var e = E.X;

--- a/tests/baselines/reference/preserveConstEnums.js
+++ b/tests/baselines/reference/preserveConstEnums.js
@@ -6,6 +6,6 @@ const enum E {
 //// [preserveConstEnums.js]
 var E;
 (function (E) {
-    E[E["Value"] = 1] = "Value";
-    E[E["Value2"] = 1] = "Value2";
+    E["Value"] = 1;
+    E["Value2"] = 1;
 })(E || (E = {}));

--- a/tests/baselines/reference/reachabilityChecks1.js
+++ b/tests/baselines/reference/reachabilityChecks1.js
@@ -110,7 +110,7 @@ var A4;
     (function (A) {
         var E;
         (function (E) {
-            E[E["X"] = 0] = "X";
+            E["X"] = 0;
         })(E || (E = {}));
     })(A || (A = {}));
 })(A4 || (A4 = {}));
@@ -150,6 +150,6 @@ function f4() {
     }
     var E;
     (function (E) {
-        E[E["X"] = 1] = "X";
+        E["X"] = 1;
     })(E || (E = {}));
 }

--- a/tests/baselines/reference/systemModuleConstEnumsSeparateCompilation.js
+++ b/tests/baselines/reference/systemModuleConstEnumsSeparateCompilation.js
@@ -25,12 +25,12 @@ System.register([], function (exports_1, context_1) {
         setters: [],
         execute: function () {
             (function (TopLevelConstEnum) {
-                TopLevelConstEnum[TopLevelConstEnum["X"] = 0] = "X";
+                TopLevelConstEnum["X"] = 0;
             })(TopLevelConstEnum || (TopLevelConstEnum = {}));
             (function (M) {
                 var NonTopLevelConstEnum;
                 (function (NonTopLevelConstEnum) {
-                    NonTopLevelConstEnum[NonTopLevelConstEnum["X"] = 0] = "X";
+                    NonTopLevelConstEnum["X"] = 0;
                 })(NonTopLevelConstEnum = M.NonTopLevelConstEnum || (M.NonTopLevelConstEnum = {}));
             })(M || (M = {}));
         }


### PR DESCRIPTION
Makes it so const enums will not reverse map when using `preserveConstEnums`.
Fixes #37282
