### PR TITLE
feat: Allow mixin constructors with type arguments

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10327,13 +10327,13 @@ namespace ts {
             return concatenate(getOuterTypeParametersOfClassOrInterface(symbol), getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(symbol));
         }
 
-        // A type is a mixin constructor if it has a single construct signature taking no type parameters and a single
+        // A type is a mixin constructor if it has a single construct signature and a single
         // rest parameter of type any[].
         function isMixinConstructorType(type: Type) {
             const signatures = getSignaturesOfType(type, SignatureKind.Construct);
             if (signatures.length === 1) {
                 const s = signatures[0];
-                if (!s.typeParameters && s.parameters.length === 1 && signatureHasRestParameter(s)) {
+                if (s.parameters.length === 1 && signatureHasRestParameter(s)) {
                     const paramType = getTypeOfParameter(s.parameters[0]);
                     return isTypeAny(paramType) || getElementTypeOfArrayType(paramType) === anyType;
                 }

--- a/tests/baselines/reference/mixinGeneric.errors.txt
+++ b/tests/baselines/reference/mixinGeneric.errors.txt
@@ -1,0 +1,32 @@
+tests/cases/compiler/mixinGeneric.ts(25,15): error TS2749: 'ACB' refers to a value, but is being used as a type here. Did you mean 'typeof ACB'?
+
+
+==== tests/cases/compiler/mixinGeneric.ts (1 errors) ====
+    type Constructor<T> = new(...args: any[]) => T;
+    
+    class A {
+        a!: number;
+    }
+    class B {
+        b!: number;
+    }
+    function mixinC<TBase extends Constructor<{}>>(Base: TBase) {
+        return class C<T> extends Base {
+            c!: T;
+        };
+    }
+    
+    const ACB = mixinC(A)<B>;
+    const acb = new ACB();
+    const acbC: B = acb.c;
+    
+    class D {
+        d!: number;
+    }
+    
+    const ACBCD = mixinC(ACB)<D>;
+    const acbcd = new ACBCD();
+    const acbcdC: ACB = acbcd.c;
+                  ~~~
+!!! error TS2749: 'ACB' refers to a value, but is being used as a type here. Did you mean 'typeof ACB'?
+    

--- a/tests/baselines/reference/mixinGeneric.js
+++ b/tests/baselines/reference/mixinGeneric.js
@@ -1,0 +1,74 @@
+//// [mixinGeneric.ts]
+type Constructor<T> = new(...args: any[]) => T;
+
+class A {
+    a!: number;
+}
+class B {
+    b!: number;
+}
+function mixinC<TBase extends Constructor<{}>>(Base: TBase) {
+    return class C<T> extends Base {
+        c!: T;
+    };
+}
+
+const ACB = mixinC(A)<B>;
+const acb = new ACB();
+const acbC: B = acb.c;
+
+class D {
+    d!: number;
+}
+
+const ACBCD = mixinC(ACB)<D>;
+const acbcd = new ACBCD();
+const acbcdC: ACB = acbcd.c;
+
+
+//// [mixinGeneric.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+var B = /** @class */ (function () {
+    function B() {
+    }
+    return B;
+}());
+function mixinC(Base) {
+    return /** @class */ (function (_super) {
+        __extends(C, _super);
+        function C() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        return C;
+    }(Base));
+}
+var ACB = (mixinC(A));
+var acb = new ACB();
+var acbC = acb.c;
+var D = /** @class */ (function () {
+    function D() {
+    }
+    return D;
+}());
+var ACBCD = (mixinC(ACB));
+var acbcd = new ACBCD();
+var acbcdC = acbcd.c;

--- a/tests/baselines/reference/mixinGeneric.symbols
+++ b/tests/baselines/reference/mixinGeneric.symbols
@@ -1,0 +1,79 @@
+=== tests/cases/compiler/mixinGeneric.ts ===
+type Constructor<T> = new(...args: any[]) => T;
+>Constructor : Symbol(Constructor, Decl(mixinGeneric.ts, 0, 0))
+>T : Symbol(T, Decl(mixinGeneric.ts, 0, 17))
+>args : Symbol(args, Decl(mixinGeneric.ts, 0, 26))
+>T : Symbol(T, Decl(mixinGeneric.ts, 0, 17))
+
+class A {
+>A : Symbol(A, Decl(mixinGeneric.ts, 0, 47))
+
+    a!: number;
+>a : Symbol(A.a, Decl(mixinGeneric.ts, 2, 9))
+}
+class B {
+>B : Symbol(B, Decl(mixinGeneric.ts, 4, 1))
+
+    b!: number;
+>b : Symbol(B.b, Decl(mixinGeneric.ts, 5, 9))
+}
+function mixinC<TBase extends Constructor<{}>>(Base: TBase) {
+>mixinC : Symbol(mixinC, Decl(mixinGeneric.ts, 7, 1))
+>TBase : Symbol(TBase, Decl(mixinGeneric.ts, 8, 16))
+>Constructor : Symbol(Constructor, Decl(mixinGeneric.ts, 0, 0))
+>Base : Symbol(Base, Decl(mixinGeneric.ts, 8, 47))
+>TBase : Symbol(TBase, Decl(mixinGeneric.ts, 8, 16))
+
+    return class C<T> extends Base {
+>C : Symbol(C, Decl(mixinGeneric.ts, 9, 10))
+>T : Symbol(T, Decl(mixinGeneric.ts, 9, 19))
+>Base : Symbol(Base, Decl(mixinGeneric.ts, 8, 47))
+
+        c!: T;
+>c : Symbol(C.c, Decl(mixinGeneric.ts, 9, 36))
+>T : Symbol(T, Decl(mixinGeneric.ts, 9, 19))
+
+    };
+}
+
+const ACB = mixinC(A)<B>;
+>ACB : Symbol(ACB, Decl(mixinGeneric.ts, 14, 5))
+>mixinC : Symbol(mixinC, Decl(mixinGeneric.ts, 7, 1))
+>A : Symbol(A, Decl(mixinGeneric.ts, 0, 47))
+>B : Symbol(B, Decl(mixinGeneric.ts, 4, 1))
+
+const acb = new ACB();
+>acb : Symbol(acb, Decl(mixinGeneric.ts, 15, 5))
+>ACB : Symbol(ACB, Decl(mixinGeneric.ts, 14, 5))
+
+const acbC: B = acb.c;
+>acbC : Symbol(acbC, Decl(mixinGeneric.ts, 16, 5))
+>B : Symbol(B, Decl(mixinGeneric.ts, 4, 1))
+>acb.c : Symbol(C.c, Decl(mixinGeneric.ts, 9, 36))
+>acb : Symbol(acb, Decl(mixinGeneric.ts, 15, 5))
+>c : Symbol(C.c, Decl(mixinGeneric.ts, 9, 36))
+
+class D {
+>D : Symbol(D, Decl(mixinGeneric.ts, 16, 22))
+
+    d!: number;
+>d : Symbol(D.d, Decl(mixinGeneric.ts, 18, 9))
+}
+
+const ACBCD = mixinC(ACB)<D>;
+>ACBCD : Symbol(ACBCD, Decl(mixinGeneric.ts, 22, 5))
+>mixinC : Symbol(mixinC, Decl(mixinGeneric.ts, 7, 1))
+>ACB : Symbol(ACB, Decl(mixinGeneric.ts, 14, 5))
+>D : Symbol(D, Decl(mixinGeneric.ts, 16, 22))
+
+const acbcd = new ACBCD();
+>acbcd : Symbol(acbcd, Decl(mixinGeneric.ts, 23, 5))
+>ACBCD : Symbol(ACBCD, Decl(mixinGeneric.ts, 22, 5))
+
+const acbcdC: ACB = acbcd.c;
+>acbcdC : Symbol(acbcdC, Decl(mixinGeneric.ts, 24, 5))
+>ACB : Symbol(ACB)
+>acbcd.c : Symbol(C.c, Decl(mixinGeneric.ts, 9, 36))
+>acbcd : Symbol(acbcd, Decl(mixinGeneric.ts, 23, 5))
+>c : Symbol(C.c, Decl(mixinGeneric.ts, 9, 36))
+

--- a/tests/baselines/reference/mixinGeneric.types
+++ b/tests/baselines/reference/mixinGeneric.types
@@ -1,0 +1,75 @@
+=== tests/cases/compiler/mixinGeneric.ts ===
+type Constructor<T> = new(...args: any[]) => T;
+>Constructor : Constructor<T>
+>args : any[]
+
+class A {
+>A : A
+
+    a!: number;
+>a : number
+}
+class B {
+>B : B
+
+    b!: number;
+>b : number
+}
+function mixinC<TBase extends Constructor<{}>>(Base: TBase) {
+>mixinC : <TBase extends Constructor<{}>>(Base: TBase) => { new <T>(...args: any[]): C<T>; prototype: mixinC<any>.C<any>; } & TBase
+>Base : TBase
+
+    return class C<T> extends Base {
+>class C<T> extends Base {        c!: T;    } : { new <T>(...args: any[]): C<T>; prototype: mixinC<any>.C<any>; } & TBase
+>C : { new <T>(...args: any[]): C<T>; prototype: mixinC<any>.C<any>; } & TBase
+>Base : {}
+
+        c!: T;
+>c : T
+
+    };
+}
+
+const ACB = mixinC(A)<B>;
+>ACB : { new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }
+>mixinC(A)<B> : { new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }
+>mixinC(A) : { new <T>(...args: any[]): mixinC<typeof A>.C<T>; prototype: mixinC<any>.C<any>; } & typeof A
+>mixinC : <TBase extends Constructor<{}>>(Base: TBase) => { new <T>(...args: any[]): C<T>; prototype: mixinC<any>.C<any>; } & TBase
+>A : typeof A
+
+const acb = new ACB();
+>acb : mixinC<typeof A>.C<B>
+>new ACB() : mixinC<typeof A>.C<B>
+>ACB : { new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }
+
+const acbC: B = acb.c;
+>acbC : B
+>acb.c : B
+>acb : mixinC<typeof A>.C<B>
+>c : B
+
+class D {
+>D : D
+
+    d!: number;
+>d : number
+}
+
+const ACBCD = mixinC(ACB)<D>;
+>ACBCD : { new (...args: any[]): mixinC<{ new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }>.C<D>; prototype: mixinC<any>.C<any>; } & { prototype: mixinC<any>.C<any>; } & { prototype: A; }
+>mixinC(ACB)<D> : { new (...args: any[]): mixinC<{ new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }>.C<D>; prototype: mixinC<any>.C<any>; } & { prototype: mixinC<any>.C<any>; } & { prototype: A; }
+>mixinC(ACB) : { new <T>(...args: any[]): mixinC<{ new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }>.C<T>; prototype: mixinC<any>.C<any>; } & { new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }
+>mixinC : <TBase extends Constructor<{}>>(Base: TBase) => { new <T>(...args: any[]): C<T>; prototype: mixinC<any>.C<any>; } & TBase
+>ACB : { new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }
+
+const acbcd = new ACBCD();
+>acbcd : mixinC<{ new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }>.C<D>
+>new ACBCD() : mixinC<{ new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }>.C<D>
+>ACBCD : { new (...args: any[]): mixinC<{ new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }>.C<D>; prototype: mixinC<any>.C<any>; } & { prototype: mixinC<any>.C<any>; } & { prototype: A; }
+
+const acbcdC: ACB = acbcd.c;
+>acbcdC : ACB
+>acbcd.c : D
+>acbcd : mixinC<{ new (...args: any[]): mixinC<typeof A>.C<B>; prototype: mixinC<any>.C<any>; } & { prototype: A; }>.C<D>
+>c : D
+

--- a/tests/cases/compiler/mixinGeneric.ts
+++ b/tests/cases/compiler/mixinGeneric.ts
@@ -1,0 +1,25 @@
+type Constructor<T> = new(...args: any[]) => T;
+
+class A {
+    a!: number;
+}
+class B {
+    b!: number;
+}
+function mixinC<TBase extends Constructor<{}>>(Base: TBase) {
+    return class C<T> extends Base {
+        c!: T;
+    };
+}
+
+const ACB = mixinC(A)<B>;
+const acb = new ACB();
+const acbC: B = acb.c;
+
+class D {
+    d!: number;
+}
+
+const ACBCD = mixinC(ACB)<D>;
+const acbcd = new ACBCD();
+const acbcdC: ACB = acbcd.c;


### PR DESCRIPTION
This constraint can be loosened without breakage.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md
-->

Partially fixes #24122.

Example code that now works:
```typescript
type Constructor<T> = new(...args: any[]) => T;

class A {
    a!: number;
}
class B {
    b!: number;
}
function mixinC<TBase extends Constructor<{}>>(Base: TBase) {
    return class C<T> extends Base {
        c!: T;
    };
}

const ACB = mixinC(A)<B>;
const acb = new ACB();
const acbC: B = acb.c;
```
Previously, compiling the class expression would fail with error TS2545:
```
tests/cases/compiler/mixinGeneric.ts:10:18 - error TS2545: A mixin class must have a constructor with a single rest parameter of type 'any[]'.

10     return class C<T> extends Base {
                    ~
```
It errors because unapplied `C`'s constructor has a type signature of `new <T>(...args: any[]) => C<T>`. However, this doesn't turn out to be an issue. Code & types generate properly, and applying the resulting generic type properly monomorphizes `new` (e.g. `ACB: new (...args: any[]) => mixinC<typeof A>.C<B>`).