### PR TITLE
Narrow intersected classes using `instanceof`

### DIFF
--- a/tests/baselines/reference/instanceofNarrowIntersection.symbols
+++ b/tests/baselines/reference/instanceofNarrowIntersection.symbols
@@ -1,0 +1,36 @@
+=== tests/cases/compiler/instanceofNarrowIntersection.ts ===
+// repro #50844
+
+interface InstanceOne {
+>InstanceOne : Symbol(InstanceOne, Decl(instanceofNarrowIntersection.ts, 0, 0))
+
+  one(): void
+>one : Symbol(InstanceOne.one, Decl(instanceofNarrowIntersection.ts, 2, 23))
+}
+interface InstanceTwo {
+>InstanceTwo : Symbol(InstanceTwo, Decl(instanceofNarrowIntersection.ts, 4, 1))
+
+  two(): void
+>two : Symbol(InstanceTwo.two, Decl(instanceofNarrowIntersection.ts, 5, 23))
+}
+
+declare const instance: InstanceOne | InstanceTwo
+>instance : Symbol(instance, Decl(instanceofNarrowIntersection.ts, 9, 13))
+>InstanceOne : Symbol(InstanceOne, Decl(instanceofNarrowIntersection.ts, 0, 0))
+>InstanceTwo : Symbol(InstanceTwo, Decl(instanceofNarrowIntersection.ts, 4, 1))
+
+declare const SomeCls: { new (): InstanceOne } & { foo: true }
+>SomeCls : Symbol(SomeCls, Decl(instanceofNarrowIntersection.ts, 10, 13))
+>InstanceOne : Symbol(InstanceOne, Decl(instanceofNarrowIntersection.ts, 0, 0))
+>foo : Symbol(foo, Decl(instanceofNarrowIntersection.ts, 10, 50))
+
+if (instance instanceof SomeCls) {
+>instance : Symbol(instance, Decl(instanceofNarrowIntersection.ts, 9, 13))
+>SomeCls : Symbol(SomeCls, Decl(instanceofNarrowIntersection.ts, 10, 13))
+
+  instance.one()
+>instance.one : Symbol(InstanceOne.one, Decl(instanceofNarrowIntersection.ts, 2, 23))
+>instance : Symbol(instance, Decl(instanceofNarrowIntersection.ts, 9, 13))
+>one : Symbol(InstanceOne.one, Decl(instanceofNarrowIntersection.ts, 2, 23))
+}
+

--- a/tests/baselines/reference/instanceofNarrowIntersection.types
+++ b/tests/baselines/reference/instanceofNarrowIntersection.types
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/instanceofNarrowIntersection.ts ===
+// repro #50844
+
+interface InstanceOne {
+  one(): void
+>one : () => void
+}
+interface InstanceTwo {
+  two(): void
+>two : () => void
+}
+
+declare const instance: InstanceOne | InstanceTwo
+>instance : InstanceOne | InstanceTwo
+
+declare const SomeCls: { new (): InstanceOne } & { foo: true }
+>SomeCls : (new () => InstanceOne) & { foo: true; }
+>foo : true
+>true : true
+
+if (instance instanceof SomeCls) {
+>instance instanceof SomeCls : boolean
+>instance : InstanceOne | InstanceTwo
+>SomeCls : (new () => InstanceOne) & { foo: true; }
+
+  instance.one()
+>instance.one() : void
+>instance.one : () => void
+>instance : InstanceOne
+>one : () => void
+}
+

--- a/tests/cases/compiler/instanceofNarrowIntersection.ts
+++ b/tests/cases/compiler/instanceofNarrowIntersection.ts
@@ -1,0 +1,18 @@
+// @strict: true
+// @noEmit: true
+
+// repro #50844
+
+interface InstanceOne {
+  one(): void
+}
+interface InstanceTwo {
+  two(): void
+}
+
+declare const instance: InstanceOne | InstanceTwo
+declare const SomeCls: { new (): InstanceOne } & { foo: true }
+
+if (instance instanceof SomeCls) {
+  instance.one()
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/50844

1. the logic was exiting from handling the intersection based on this `isTypeDerivedFrom` check [here](https://github.dev/microsoft/TypeScript/blob/8a1b85880f89c9cff606c5844e8883e5f483c7db/src/compiler/checker.ts#L25693-L25695) in the `narrowTypeByInstanceof`
2. `isTypeDerivedFrom` was not happy about the `source` state because it wasn't an object type, it was an intersection. So I've adjusted the check [here](https://github.dev/microsoft/TypeScript/blob/8a1b85880f89c9cff606c5844e8883e5f483c7db/src/compiler/checker.ts#L17778)
3. I added intersection handling to `isFunctionObjectType` as that seemed cleaner to me.