### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/accept-baselines-fix-lints.yaml
+++ b/.github/workflows/accept-baselines-fix-lints.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
 
     - name: Configure Git, Run Tests, Update Baselines, Apply Fixes

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -23,7 +23,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         config-file: ./.github/codeql/codeql-configuration.yml
       # Override language selection by uncommenting this and choosing your languages
@@ -33,7 +33,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -47,4 +47,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/ensure-related-repos-run-crons.yml
+++ b/.github/workflows/ensure-related-repos-run-crons.yml
@@ -22,7 +22,7 @@ jobs:
         git config --global user.email "typescriptbot@microsoft.com"
         git config --global user.name "TypeScript Bot"
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with: 
         repository: 'microsoft/TypeScript-Website'
         path: 'ts-site'
@@ -34,7 +34,7 @@ jobs:
         git config --unset-all http.https://github.com/.extraheader
         git push https://${{ secrets.TS_BOT_GITHUB_TOKEN }}@github.com/microsoft/TypeScript-Website.git
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with: 
         repository: 'microsoft/TypeScript-Make-Monaco-Builds'
         path: 'monaco-builds'

--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - uses: actions/setup-node@v3
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 5
     - run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'microsoft/TypeScript'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
         # Use NODE_AUTH_TOKEN environment variable to authenticate to this registry.

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
     - name: npm install and test
       run: |
@@ -27,7 +27,7 @@ jobs:
         npm pack ./
         mv typescript-*.tgz typescript.tgz
     - name: Upload built tarfile
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: tgz
         path: typescript.tgz

--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 5
 

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - uses: actions/setup-node@v3
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.client_payload.branch_name }}
     # notably, this is essentially the same script as `new-release-branch.yaml` (with fewer inputs), but it assumes the branch already exists

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - uses: actions/setup-node@v3
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}
         fetch-depth: 0

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Get repo name
       run: R=${GITHUB_REPOSITORY%?wiki}; echo "BASENAME=${R##*/}" >> $GITHUB_ENV
     - name: Checkout ${{ env.BASENAME }}-wiki
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: "${{ GITHUB.repository_owner }}/${{ env.BASENAME }}-wiki"
         token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/update-lkg.yml
+++ b/.github/workflows/update-lkg.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
 
     - name: Configure Git and Update LKG

--- a/.github/workflows/update-package-lock.yaml
+++ b/.github/workflows/update-package-lock.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'microsoft/TypeScript'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
     - uses: actions/setup-node@v3


### PR DESCRIPTION
`actions/checkout` was already updated in some workflows.

`github/codeql-action` v1 has been deprecated and will stop working in December: https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/