### PR TITLE
Use typescript.d.ts in APISample tests

### DIFF
--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -177,8 +177,6 @@ namespace Harness {
     }
 
     export const libFolder = "built/local/";
-    const tcServicesFileName = ts.combinePaths(libFolder, "typescriptServices.js");
-    export const tcServicesFile = IO.readFile(tcServicesFileName) + IO.newLine() + `//# sourceURL=${IO.resolvePath(tcServicesFileName)}`;
 
     export type SourceMapEmitterCallback = (
         emittedFile: string,

--- a/tests/baselines/reference/APISample_Watch.js
+++ b/tests/baselines/reference/APISample_Watch.js
@@ -1,8 +1,9 @@
 //// [tests/cases/compiler/APISample_Watch.ts] ////
 
-//// [index.d.ts]
-declare module "typescript" {
-    export = ts;
+//// [package.json]
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 //// [APISample_Watch.ts]

--- a/tests/baselines/reference/APISample_WatchWithDefaults.js
+++ b/tests/baselines/reference/APISample_WatchWithDefaults.js
@@ -1,8 +1,9 @@
 //// [tests/cases/compiler/APISample_WatchWithDefaults.ts] ////
 
-//// [index.d.ts]
-declare module "typescript" {
-    export = ts;
+//// [package.json]
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 //// [APISample_WatchWithDefaults.ts]

--- a/tests/baselines/reference/APISample_WatchWithOwnWatchHost.js
+++ b/tests/baselines/reference/APISample_WatchWithOwnWatchHost.js
@@ -1,8 +1,9 @@
 //// [tests/cases/compiler/APISample_WatchWithOwnWatchHost.ts] ////
 
-//// [index.d.ts]
-declare module "typescript" {
-    export = ts;
+//// [package.json]
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 //// [APISample_WatchWithOwnWatchHost.ts]

--- a/tests/baselines/reference/APISample_compile.js
+++ b/tests/baselines/reference/APISample_compile.js
@@ -1,8 +1,9 @@
 //// [tests/cases/compiler/APISample_compile.ts] ////
 
-//// [index.d.ts]
-declare module "typescript" {
-    export = ts;
+//// [package.json]
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 //// [APISample_compile.ts]

--- a/tests/baselines/reference/APISample_jsdoc.js
+++ b/tests/baselines/reference/APISample_jsdoc.js
@@ -1,8 +1,9 @@
 //// [tests/cases/compiler/APISample_jsdoc.ts] ////
 
-//// [index.d.ts]
-declare module "typescript" {
-    export = ts;
+//// [package.json]
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 //// [APISample_jsdoc.ts]

--- a/tests/baselines/reference/APISample_linter.js
+++ b/tests/baselines/reference/APISample_linter.js
@@ -1,8 +1,9 @@
 //// [tests/cases/compiler/APISample_linter.ts] ////
 
-//// [index.d.ts]
-declare module "typescript" {
-    export = ts;
+//// [package.json]
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 //// [APISample_linter.ts]
@@ -69,6 +70,7 @@ fileNames.forEach(fileName => {
     // delint it
     delint(sourceFile);
 });
+
 
 //// [APISample_linter.js]
 "use strict";

--- a/tests/baselines/reference/APISample_parseConfig.js
+++ b/tests/baselines/reference/APISample_parseConfig.js
@@ -1,8 +1,9 @@
 //// [tests/cases/compiler/APISample_parseConfig.ts] ////
 
-//// [index.d.ts]
-declare module "typescript" {
-    export = ts;
+//// [package.json]
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 //// [APISample_parseConfig.ts]
@@ -41,6 +42,7 @@ export function createProgram(rootFiles: string[], compilerOptionsJson: string):
     }
     return ts.createProgram(rootFiles, settings.options);
 }
+
 
 //// [APISample_parseConfig.js]
 "use strict";

--- a/tests/baselines/reference/APISample_transform.js
+++ b/tests/baselines/reference/APISample_transform.js
@@ -1,8 +1,9 @@
 //// [tests/cases/compiler/APISample_transform.ts] ////
 
-//// [index.d.ts]
-declare module "typescript" {
-    export = ts;
+//// [package.json]
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 //// [APISample_transform.ts]
@@ -21,6 +22,7 @@ const source = "let x: string  = 'string'";
 let result = ts.transpile(source, { module: ts.ModuleKind.CommonJS });
 
 console.log(JSON.stringify(result));
+
 
 //// [APISample_transform.js]
 "use strict";

--- a/tests/baselines/reference/APISample_watcher.js
+++ b/tests/baselines/reference/APISample_watcher.js
@@ -1,8 +1,9 @@
 //// [tests/cases/compiler/APISample_watcher.ts] ////
 
-//// [index.d.ts]
-declare module "typescript" {
-    export = ts;
+//// [package.json]
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 //// [APISample_watcher.ts]

--- a/tests/cases/compiler/APISample_Watch.ts
+++ b/tests/cases/compiler/APISample_Watch.ts
@@ -1,12 +1,12 @@
 ﻿// @module: commonjs
 // @skipLibCheck: true
-// @includebuiltfile: typescriptServices.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true
 
-// @filename: node_modules/typescript/index.d.ts
-declare module "typescript" {
-    export = ts;
+// @filename: node_modules/typescript/package.json
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 // @filename: APISample_Watch.ts

--- a/tests/cases/compiler/APISample_WatchWithDefaults.ts
+++ b/tests/cases/compiler/APISample_WatchWithDefaults.ts
@@ -1,12 +1,12 @@
 ﻿// @module: commonjs
 // @skipLibCheck: true
-// @includebuiltfile: typescriptServices.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true
 
-// @filename: node_modules/typescript/index.d.ts
-declare module "typescript" {
-    export = ts;
+// @filename: node_modules/typescript/package.json
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 // @filename: APISample_WatchWithDefaults.ts

--- a/tests/cases/compiler/APISample_WatchWithOwnWatchHost.ts
+++ b/tests/cases/compiler/APISample_WatchWithOwnWatchHost.ts
@@ -1,12 +1,12 @@
 ﻿// @module: commonjs
 // @skipLibCheck: true
-// @includebuiltfile: typescriptServices.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true
 
-// @filename: node_modules/typescript/index.d.ts
-declare module "typescript" {
-    export = ts;
+// @filename: node_modules/typescript/package.json
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 // @filename: APISample_WatchWithOwnWatchHost.ts

--- a/tests/cases/compiler/APISample_compile.ts
+++ b/tests/cases/compiler/APISample_compile.ts
@@ -1,12 +1,12 @@
 ﻿// @module: commonjs
 // @skipLibCheck: true
-// @includebuiltfile: typescriptServices.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true
 
-// @filename: node_modules/typescript/index.d.ts
-declare module "typescript" {
-    export = ts;
+// @filename: node_modules/typescript/package.json
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 // @filename: APISample_compile.ts

--- a/tests/cases/compiler/APISample_jsdoc.ts
+++ b/tests/cases/compiler/APISample_jsdoc.ts
@@ -1,12 +1,12 @@
 // @module: commonjs
 // @skipLibCheck: true
-// @includebuiltfile: typescriptServices.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true
 
-// @filename: node_modules/typescript/index.d.ts
-declare module "typescript" {
-    export = ts;
+// @filename: node_modules/typescript/package.json
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 // @filename: APISample_jsdoc.ts

--- a/tests/cases/compiler/APISample_linter.ts
+++ b/tests/cases/compiler/APISample_linter.ts
@@ -1,12 +1,12 @@
 ﻿// @module: commonjs
 // @skipLibCheck: true
-// @includebuiltfile: typescriptServices.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true
 
-// @filename: node_modules/typescript/index.d.ts
-declare module "typescript" {
-    export = ts;
+// @filename: node_modules/typescript/package.json
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 // @filename: APISample_linter.ts

--- a/tests/cases/compiler/APISample_parseConfig.ts
+++ b/tests/cases/compiler/APISample_parseConfig.ts
@@ -1,12 +1,12 @@
 // @module: commonjs
 // @skipLibCheck: true
-// @includebuiltfile: typescriptServices.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true
 
-// @filename: node_modules/typescript/index.d.ts
-declare module "typescript" {
-    export = ts;
+// @filename: node_modules/typescript/package.json
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 // @filename: APISample_parseConfig.ts

--- a/tests/cases/compiler/APISample_transform.ts
+++ b/tests/cases/compiler/APISample_transform.ts
@@ -1,12 +1,12 @@
 ﻿// @module: commonjs
 // @skipLibCheck: true
-// @includebuiltfile: typescriptServices.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true
 
-// @filename: node_modules/typescript/index.d.ts
-declare module "typescript" {
-    export = ts;
+// @filename: node_modules/typescript/package.json
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 // @filename: APISample_transform.ts

--- a/tests/cases/compiler/APISample_watcher.ts
+++ b/tests/cases/compiler/APISample_watcher.ts
@@ -1,12 +1,12 @@
 ﻿// @module: commonjs
 // @skipLibCheck: true
-// @includebuiltfile: typescriptServices.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true
 
-// @filename: node_modules/typescript/index.d.ts
-declare module "typescript" {
-    export = ts;
+// @filename: node_modules/typescript/package.json
+{
+    "name": "typescript",
+    "types": "/.ts/typescript.d.ts"
 }
 
 // @filename: APISample_watcher.ts


### PR DESCRIPTION
The way we pull in the types for typescript in these tests works by including typescriptServices.d.ts into the project, which declares a global namespace, which then is reexported as a faked typescript package.

This reexport is already what the current typescript.d.ts does, so use that instead. This will allow us to remove `typescriptServices.d.ts` in the future.

This has been pulled out of #51026 as it's a change that can be made without removing typescriptServices.
