### PR TITLE
Allow un-narrowing of `never` to the declared type using postfix `!`

### DIFF
--- a/tests/baselines/reference/exhaustiveSwitchStatements1.errors.txt
+++ b/tests/baselines/reference/exhaustiveSwitchStatements1.errors.txt
@@ -1,9 +1,8 @@
 tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts(7,9): error TS7027: Unreachable code detected.
 tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts(235,5): error TS2367: This comparison appears to be unintentional because the types 'keyof O' and '"c"' have no overlap.
-tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts(247,10): error TS2339: Property 'kind' does not exist on type 'never'.
 
 
-==== tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts (3 errors) ====
+==== tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts (2 errors) ====
     function f1(x: 1 | 2): string {
         if (!!true) {
             switch (x) {
@@ -255,7 +254,5 @@ tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts(247,10): erro
         case "def": return;
         default:
           a!.kind; // Error expected
-             ~~~~
-!!! error TS2339: Property 'kind' does not exist on type 'never'.
       }
     }

--- a/tests/baselines/reference/exhaustiveSwitchStatements1.symbols
+++ b/tests/baselines/reference/exhaustiveSwitchStatements1.symbols
@@ -623,6 +623,8 @@ function f35431(a: A) {
     case "def": return;
     default:
       a!.kind; // Error expected
+>a!.kind : Symbol(kind, Decl(exhaustiveSwitchStatements1.ts, 239, 10), Decl(exhaustiveSwitchStatements1.ts, 239, 28))
 >a : Symbol(a, Decl(exhaustiveSwitchStatements1.ts, 241, 16))
+>kind : Symbol(kind, Decl(exhaustiveSwitchStatements1.ts, 239, 10), Decl(exhaustiveSwitchStatements1.ts, 239, 28))
   }
 }

--- a/tests/baselines/reference/exhaustiveSwitchStatements1.types
+++ b/tests/baselines/reference/exhaustiveSwitchStatements1.types
@@ -727,9 +727,9 @@ function f35431(a: A) {
 
     default:
       a!.kind; // Error expected
->a!.kind : any
->a! : never
+>a!.kind : never
+>a! : A
 >a : never
->kind : any
+>kind : never
   }
 }


### PR DESCRIPTION
Implements #51097 

For demonstration purposes only (hence no tests)