### PR TITLE
fix(51100): ensure tsserver shuts down when parent process is killed

### DIFF
--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -779,13 +779,6 @@ namespace ts.server {
                 return JSON.stringify(message, undefined, 2);
             }
 
-            public exit() {
-                this.logger.info("Exiting...");
-                this.projectService.closeLog();
-                tracing?.stopTracing();
-                process.exit(0);
-            }
-
             public listen() {
                 process.on("message", (e: any) => {
                     this.onMessage(e);

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -779,9 +779,20 @@ namespace ts.server {
                 return JSON.stringify(message, undefined, 2);
             }
 
+            public exit() {
+                this.logger.info("Exiting...");
+                this.projectService.closeLog();
+                tracing?.stopTracing();
+                process.exit(0);
+            }
+
             public listen() {
                 process.on("message", (e: any) => {
                     this.onMessage(e);
+                });
+
+                process.on("disconnect", () => {
+                    this.exit();
                 });
             }
         }


### PR DESCRIPTION
When using IPC channel (`--useNodeIpc`) for communicating with tsserver, the child tsserver process did not shut down on parent process disconnecting (for example due to it being killed).

Call `exit()` on IPC disconnect, same as stdio-based communication does when pipe to the parent process is destroyed.

~~Initially I've moved the `exit` implementation from `IOSession` to the base `Session` to avoid having it duplicated in `IOSession` and `IpcIOSession` but changed so that implementations are duplicated after @sheetalkamat's [comment](https://github.com/microsoft/TypeScript/issues/51100#issuecomment-1272158840). It's unfortunate that this creates duplication that could potentially go out of sync. I guess potentially there could be intermediary class that have this shared logic but that might be overkill.~~
EDIT: `IpcIOSession` inherits `IOSession` so we don't have to duplicate it.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #51100
