### PR TITLE
Fix nightly publish oops in Gulpfile

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -536,7 +536,7 @@ task("generate-spec").description = "Generates a Markdown version of the Languag
 task("clean", series(parallel(cleanTasks), cleanBuilt));
 task("clean").description = "Cleans build outputs";
 
-const configureNightly = () => exec(process.execPath, ["scripts/configurePrerelease.js", "dev", "package.json", "src/compiler/corePublic.ts"]);
+const configureNightly = () => exec(process.execPath, ["scripts/configurePrerelease.mjs", "dev", "package.json", "src/compiler/corePublic.ts"]);
 task("configure-nightly", series(buildScripts, configureNightly));
 task("configure-nightly").description = "Runs scripts/configurePrerelease.ts to prepare a build for nightly publishing";
 


### PR DESCRIPTION
I missed one, so the nightly has been failing. I rechecked and no more `.js` files are referenced anywhere after this change.