### PR TITLE
fix(49196): The '/ * *' snippet should support parameter deconstruction of typescript interface member functions

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -439,11 +439,17 @@ namespace ts.JsDoc {
 
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.InterfaceDeclaration:
-            case SyntaxKind.PropertySignature:
             case SyntaxKind.EnumDeclaration:
             case SyntaxKind.EnumMember:
             case SyntaxKind.TypeAliasDeclaration:
                 return { commentOwner };
+
+            case SyntaxKind.PropertySignature: {
+                const host = commentOwner as PropertySignature;
+                return host.type && isFunctionTypeNode(host.type)
+                    ? { commentOwner, parameters: host.type.parameters, hasReturn: hasReturn(host.type, options) }
+                    : { commentOwner };
+            }
 
             case SyntaxKind.VariableStatement: {
                 const varStatement = commentOwner as VariableStatement;
@@ -486,7 +492,7 @@ namespace ts.JsDoc {
 
     function hasReturn(node: Node, options: DocCommentTemplateOptions | undefined) {
         return !!options?.generateReturnInDocTemplate &&
-            (isArrowFunction(node) && isExpression(node.body)
+            (isFunctionTypeNode(node) || isArrowFunction(node) && isExpression(node.body)
                 || isFunctionLikeDeclaration(node) && node.body && isBlock(node.body) && !!forEachReturnStatement(node.body, n => n));
     }
 

--- a/tests/cases/fourslash/docCommentTemplateInterfacePropertyFunctionType.ts
+++ b/tests/cases/fourslash/docCommentTemplateInterfacePropertyFunctionType.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+////interface I {
+////    /**/
+////    foo: (a: number, b: string) => void;
+////}
+
+verify.docCommentTemplateAt("", 12,
+   `/**
+     * 
+     * @param a
+     * @param b
+     * @returns
+     */`);
+
+verify.docCommentTemplateAt("", 12,
+   `/**
+     * 
+     * @param a
+     * @param b
+     */`, { generateReturnInDocTemplate: false });


### PR DESCRIPTION
Fixes #49196