### PR TITLE
fix(51112): Parameter JSDoc for a destructured parameter emits an error when a function uses arguments

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40134,7 +40134,7 @@ namespace ts {
                 }
             }
             else {
-                forEach(jsdocParameters, ({ name }, index) => {
+                forEach(jsdocParameters, ({ name, isNameFirst }, index) => {
                     if (excludedParameters.has(index) || isIdentifier(name) && parameters.has(name.escapedText)) {
                         return;
                     }
@@ -40144,7 +40144,9 @@ namespace ts {
                         }
                     }
                     else {
-                        errorOrSuggestion(isJs, name, Diagnostics.JSDoc_param_tag_has_name_0_but_there_is_no_parameter_with_that_name, idText(name));
+                        if (!isNameFirst) {
+                            errorOrSuggestion(isJs, name, Diagnostics.JSDoc_param_tag_has_name_0_but_there_is_no_parameter_with_that_name, idText(name));
+                        }
                     }
                 });
             }

--- a/tests/baselines/reference/jsdocParamTag2.errors.txt
+++ b/tests/baselines/reference/jsdocParamTag2.errors.txt
@@ -1,10 +1,9 @@
-tests/cases/conformance/jsdoc/0.js(56,20): error TS8024: JSDoc '@param' tag has name 'obj', but there is no parameter with that name.
 tests/cases/conformance/jsdoc/0.js(61,19): error TS2339: Property 'a' does not exist on type 'String'.
 tests/cases/conformance/jsdoc/0.js(61,22): error TS2339: Property 'b' does not exist on type 'String'.
 tests/cases/conformance/jsdoc/0.js(63,20): error TS8024: JSDoc '@param' tag has name 'y', but there is no parameter with that name.
 
 
-==== tests/cases/conformance/jsdoc/0.js (4 errors) ====
+==== tests/cases/conformance/jsdoc/0.js (3 errors) ====
     // Object literal syntax
     /**
      * @param {{a: string, b: string}} obj
@@ -61,8 +60,6 @@ tests/cases/conformance/jsdoc/0.js(63,20): error TS8024: JSDoc '@param' tag has 
     
     /**
      * @param {object} obj - this type gets ignored
-                       ~~~
-!!! error TS8024: JSDoc '@param' tag has name 'obj', but there is no parameter with that name.
      * @param {string} obj.a
      * @param {string} obj.b - and x's type gets used for both parameters
      * @param {string} x

--- a/tests/baselines/reference/paramTagWrapping.errors.txt
+++ b/tests/baselines/reference/paramTagWrapping.errors.txt
@@ -1,5 +1,4 @@
 tests/cases/conformance/jsdoc/bad.js(2,11): error TS1003: Identifier expected.
-tests/cases/conformance/jsdoc/bad.js(2,11): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 tests/cases/conformance/jsdoc/bad.js(5,4): error TS1003: Identifier expected.
 tests/cases/conformance/jsdoc/bad.js(5,4): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 tests/cases/conformance/jsdoc/bad.js(6,20): error TS1003: Identifier expected.
@@ -24,13 +23,11 @@ tests/cases/conformance/jsdoc/bad.js(9,20): error TS7006: Parameter 'z' implicit
     good(1, 2, 3)
     
     
-==== tests/cases/conformance/jsdoc/bad.js (9 errors) ====
+==== tests/cases/conformance/jsdoc/bad.js (8 errors) ====
     /**
      * @param *
               
 !!! error TS1003: Identifier expected.
-              
-!!! error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
      * {number} x Arg x.
      * @param {number}
      * * y Arg y.


### PR DESCRIPTION
Fixes #51112