### PR TITLE
Add an extra regression test for awaited unresolvable recursive union

### DIFF
--- a/tests/baselines/reference/unresolvableSelfReferencingAwaitedUnion.errors.txt
+++ b/tests/baselines/reference/unresolvableSelfReferencingAwaitedUnion.errors.txt
@@ -1,9 +1,10 @@
 tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts(9,32): error TS2322: Type 'SimpleType' is not assignable to type 'T'.
   'T' could be instantiated with an arbitrary type which could be unrelated to 'SimpleType'.
 tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts(16,19): error TS1062: Type is referenced directly or indirectly in the fulfillment callback of its own 'then' method.
+tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts(29,30): error TS1062: Type is referenced directly or indirectly in the fulfillment callback of its own 'then' method.
 
 
-==== tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts (2 errors) ====
+==== tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts (3 errors) ====
     // repro #49646
     
     type EnvFunction = <T>() => T;
@@ -26,5 +27,21 @@ tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts(16,19): error TS
       const awaited = await param
                       ~~~~~~~~~~~
 !!! error TS1062: Type is referenced directly or indirectly in the fulfillment callback of its own 'then' method.
+    }
+    
+    // repro #42948
+    
+    type EffectResult =
+      | (() => EffectResult)
+      | Promise<EffectResult>;
+    
+    export async function handleEffectResult(result: EffectResult) {
+      if (result instanceof Function) {
+        await handleEffectResult(result());
+      } else if (result instanceof Promise) {
+        await handleEffectResult(await result);
+                                 ~~~~~~~~~~~~
+!!! error TS1062: Type is referenced directly or indirectly in the fulfillment callback of its own 'then' method.
+      }
     }
     

--- a/tests/baselines/reference/unresolvableSelfReferencingAwaitedUnion.symbols
+++ b/tests/baselines/reference/unresolvableSelfReferencingAwaitedUnion.symbols
@@ -8,7 +8,7 @@ type EnvFunction = <T>() => T;
 
 type SimpleType = string | Promise<SimpleType>;
 >SimpleType : Symbol(SimpleType, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 2, 30))
->Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
 >SimpleType : Symbol(SimpleType, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 2, 30))
 
 declare const simple: SimpleType;
@@ -24,7 +24,7 @@ const env: EnvFunction = () => simple;
 
 type T1 = 1 | Promise<T1> | T1[];
 >T1 : Symbol(T1, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 8, 38))
->Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
 >T1 : Symbol(T1, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 8, 38))
 >T1 : Symbol(T1, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 8, 38))
 
@@ -36,5 +36,40 @@ export async function myFunction(param: T1) {
   const awaited = await param
 >awaited : Symbol(awaited, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 15, 7))
 >param : Symbol(param, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 14, 33))
+}
+
+// repro #42948
+
+type EffectResult =
+>EffectResult : Symbol(EffectResult, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 16, 1))
+
+  | (() => EffectResult)
+>EffectResult : Symbol(EffectResult, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 16, 1))
+
+  | Promise<EffectResult>;
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>EffectResult : Symbol(EffectResult, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 16, 1))
+
+export async function handleEffectResult(result: EffectResult) {
+>handleEffectResult : Symbol(handleEffectResult, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 22, 26))
+>result : Symbol(result, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 24, 41))
+>EffectResult : Symbol(EffectResult, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 16, 1))
+
+  if (result instanceof Function) {
+>result : Symbol(result, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 24, 41))
+>Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    await handleEffectResult(result());
+>handleEffectResult : Symbol(handleEffectResult, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 22, 26))
+>result : Symbol(result, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 24, 41))
+
+  } else if (result instanceof Promise) {
+>result : Symbol(result, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 24, 41))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+    await handleEffectResult(await result);
+>handleEffectResult : Symbol(handleEffectResult, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 22, 26))
+>result : Symbol(result, Decl(unresolvableSelfReferencingAwaitedUnion.ts, 24, 41))
+  }
 }
 

--- a/tests/baselines/reference/unresolvableSelfReferencingAwaitedUnion.types
+++ b/tests/baselines/reference/unresolvableSelfReferencingAwaitedUnion.types
@@ -30,3 +30,41 @@ export async function myFunction(param: T1) {
 >param : T1
 }
 
+// repro #42948
+
+type EffectResult =
+>EffectResult : (() => EffectResult) | Promise<EffectResult>
+
+  | (() => EffectResult)
+  | Promise<EffectResult>;
+
+export async function handleEffectResult(result: EffectResult) {
+>handleEffectResult : (result: EffectResult) => Promise<void>
+>result : EffectResult
+
+  if (result instanceof Function) {
+>result instanceof Function : boolean
+>result : EffectResult
+>Function : FunctionConstructor
+
+    await handleEffectResult(result());
+>await handleEffectResult(result()) : void
+>handleEffectResult(result()) : Promise<void>
+>handleEffectResult : (result: EffectResult) => Promise<void>
+>result() : EffectResult
+>result : () => EffectResult
+
+  } else if (result instanceof Promise) {
+>result instanceof Promise : boolean
+>result : Promise<EffectResult>
+>Promise : PromiseConstructor
+
+    await handleEffectResult(await result);
+>await handleEffectResult(await result) : void
+>handleEffectResult(await result) : Promise<void>
+>handleEffectResult : (result: EffectResult) => Promise<void>
+>await result : () => EffectResult
+>result : Promise<EffectResult>
+  }
+}
+

--- a/tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts
+++ b/tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts
@@ -1,4 +1,5 @@
 // @noEmit: true
+// @lib: esnext
 
 // repro #49646
 
@@ -16,4 +17,18 @@ type T1 = 1 | Promise<T1> | T1[];
 
 export async function myFunction(param: T1) {
   const awaited = await param
+}
+
+// repro #42948
+
+type EffectResult =
+  | (() => EffectResult)
+  | Promise<EffectResult>;
+
+export async function handleEffectResult(result: EffectResult) {
+  if (result instanceof Function) {
+    await handleEffectResult(result());
+  } else if (result instanceof Promise) {
+    await handleEffectResult(await result);
+  }
 }


### PR DESCRIPTION
this got fixed by https://github.com/microsoft/TypeScript/pull/49677 , this PR just adds a test case from an additional stale issue

closes https://github.com/microsoft/TypeScript/issues/42948