### PR TITLE
Remove some unnecessary code discovered by rollup

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -41414,18 +41414,6 @@ namespace ts {
                     if (isGlobalAugmentation) {
                         return;
                     }
-                    const symbol = getSymbolOfNode(node);
-                    if (symbol) {
-                        // module augmentations cannot introduce new names on the top level scope of the module
-                        // this is done it two steps
-                        // 1. quick check - if symbol for node is not merged - this is local symbol to this augmentation - report error
-                        // 2. main check - report error if value declaration of the parent symbol is module augmentation)
-                        let reportError = !(symbol.flags & SymbolFlags.Transient);
-                        if (!reportError) {
-                            // symbol should not originate in augmentation
-                            reportError = !!symbol.parent?.declarations && isExternalModuleAugmentation(symbol.parent.declarations[0]);
-                        }
-                    }
                     break;
             }
         }


### PR DESCRIPTION
While working on the module branch, I enabled the "smallest" preset of Rollup to see what it'd do; it deleted a block of code, which appears to do nothing after the code that used `reportError` was removed in #8485. Rollup's static analysis appears to have understood that. Neat.