### PR TITLE
Rename internal functions to `narrowTypeBySwitchOnTypeOf` and `narrowTypeByInKeyword`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25037,7 +25037,7 @@ namespace ts {
                     type = narrowTypeBySwitchOnDiscriminant(type, flow.switchStatement, flow.clauseStart, flow.clauseEnd);
                 }
                 else if (expr.kind === SyntaxKind.TypeOfExpression && isMatchingReference(reference, (expr as TypeOfExpression).expression)) {
-                    type = narrowBySwitchOnTypeOf(type, flow.switchStatement, flow.clauseStart, flow.clauseEnd);
+                    type = narrowTypeBySwitchOnTypeOf(type, flow.switchStatement, flow.clauseStart, flow.clauseEnd);
                 }
                 else {
                     if (strictNullChecks) {
@@ -25329,7 +25329,7 @@ namespace ts {
                     !!getApplicableIndexInfoForName(type, propName) || !assumeTrue;
             }
 
-            function narrowByInKeyword(type: Type, nameType: StringLiteralType | NumberLiteralType | UniqueESSymbolType, assumeTrue: boolean) {
+            function narrowTypeByInKeyword(type: Type, nameType: StringLiteralType | NumberLiteralType | UniqueESSymbolType, assumeTrue: boolean) {
                 const name = getPropertyNameFromType(nameType);
                 const isKnownProperty = someType(type, t => isTypePresencePossible(t, name, /*assumeTrue*/ true));
                 if (isKnownProperty) {
@@ -25411,7 +25411,7 @@ namespace ts {
                                 return getTypeWithFacts(type, assumeTrue ? TypeFacts.NEUndefined : TypeFacts.EQUndefined);
                             }
                             if (isMatchingReference(reference, target)) {
-                                return narrowByInKeyword(type, leftType as StringLiteralType | NumberLiteralType | UniqueESSymbolType, assumeTrue);
+                                return narrowTypeByInKeyword(type, leftType as StringLiteralType | NumberLiteralType | UniqueESSymbolType, assumeTrue);
                             }
                         }
                         break;
@@ -25611,7 +25611,7 @@ namespace ts {
                     neverType);
             }
 
-            function narrowBySwitchOnTypeOf(type: Type, switchStatement: SwitchStatement, clauseStart: number, clauseEnd: number): Type {
+            function narrowTypeBySwitchOnTypeOf(type: Type, switchStatement: SwitchStatement, clauseStart: number, clauseEnd: number): Type {
                 const witnesses = getSwitchClauseTypeOfWitnesses(switchStatement);
                 if (!witnesses) {
                     return type;


### PR DESCRIPTION
This aligns the naming scheme of those two outliers with the rest of the functions from the same "family". I genuinely was looking for a `narrowTypeByInKeyword` at first and couldn't find it because the fuzzy search in the IDE wasn't able to find it once i put "type" in my query~

<img width="606" alt="Screenshot 2022-10-18 at 15 03 52" src="https://user-images.githubusercontent.com/9800850/196482557-1030ee40-72ab-41b9-8e3a-62f809227dd0.png">
