### PR TITLE
`markAliasReferenced` should include `ExportValue` as well

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26035,13 +26035,13 @@ namespace ts {
         function markAliasReferenced(symbol: Symbol, location: Node) {
             if (isNonLocalAlias(symbol, /*excludes*/ SymbolFlags.Value) && !isInTypeQuery(location) && !getTypeOnlyAliasDeclaration(symbol, SymbolFlags.Value)) {
                 const target = resolveAlias(symbol);
-                if (getAllSymbolFlags(target) & SymbolFlags.Value) {
+                if (getAllSymbolFlags(target) & (SymbolFlags.Value | SymbolFlags.ExportValue)) {
                     // An alias resolving to a const enum cannot be elided if (1) 'isolatedModules' is enabled
                     // (because the const enum value will not be inlined), or if (2) the alias is an export
                     // of a const enum declaration that will be preserved.
                     if (compilerOptions.isolatedModules ||
                         shouldPreserveConstEnums(compilerOptions) && isExportOrExportExpression(location) ||
-                        !isConstEnumOrConstEnumOnlyModule(target)
+                        !isConstEnumOrConstEnumOnlyModule(getExportSymbolOfValueSymbolIfExported(target))
                     ) {
                         markAliasSymbolAsReferenced(symbol);
                     }

--- a/tests/baselines/reference/importElisionExportNonExportAndDefault.js
+++ b/tests/baselines/reference/importElisionExportNonExportAndDefault.js
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/importElisionExportNonExportAndDefault.ts] ////
+
+//// [main.ts]
+import MyFunction from "./MyComponent";
+
+MyFunction({msg: "Hello World"});
+
+
+//// [MyComponent.ts]
+interface MyFunction { msg: string; }
+
+export const MyFunction = ({ msg }: MyFunction) => console.log(`Got message "${msg}"`);
+export default MyFunction;
+
+//// [MyComponent.js]
+export const MyFunction = ({ msg }) => console.log(`Got message "${msg}"`);
+export default MyFunction;
+//// [main.js]
+import MyFunction from "./MyComponent";
+MyFunction({ msg: "Hello World" });

--- a/tests/baselines/reference/importElisionExportNonExportAndDefault.symbols
+++ b/tests/baselines/reference/importElisionExportNonExportAndDefault.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/main.ts ===
+import MyFunction from "./MyComponent";
+>MyFunction : Symbol(MyFunction, Decl(main.ts, 0, 6))
+
+MyFunction({msg: "Hello World"});
+>msg : Symbol(msg, Decl(main.ts, 2, 12))
+
+
+=== tests/cases/compiler/MyComponent.ts ===
+interface MyFunction { msg: string; }
+>MyFunction : Symbol(MyFunction, Decl(MyComponent.ts, 0, 0), Decl(MyComponent.ts, 2, 12))
+>msg : Symbol(MyFunction.msg, Decl(MyComponent.ts, 0, 22))
+
+export const MyFunction = ({ msg }: MyFunction) => console.log(`Got message "${msg}"`);
+>MyFunction : Symbol(MyFunction, Decl(MyComponent.ts, 2, 12))
+>msg : Symbol(msg, Decl(MyComponent.ts, 2, 28))
+>MyFunction : Symbol(MyFunction, Decl(MyComponent.ts, 0, 0), Decl(MyComponent.ts, 2, 12))
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>msg : Symbol(msg, Decl(MyComponent.ts, 2, 28))
+
+export default MyFunction;
+>MyFunction : Symbol(MyFunction, Decl(MyComponent.ts, 0, 0), Decl(MyComponent.ts, 2, 12))
+

--- a/tests/baselines/reference/importElisionExportNonExportAndDefault.types
+++ b/tests/baselines/reference/importElisionExportNonExportAndDefault.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/main.ts ===
+import MyFunction from "./MyComponent";
+>MyFunction : any
+
+MyFunction({msg: "Hello World"});
+>MyFunction({msg: "Hello World"}) : error
+>MyFunction : error
+>{msg: "Hello World"} : { msg: string; }
+>msg : string
+>"Hello World" : "Hello World"
+
+
+=== tests/cases/compiler/MyComponent.ts ===
+interface MyFunction { msg: string; }
+>msg : string
+
+export const MyFunction = ({ msg }: MyFunction) => console.log(`Got message "${msg}"`);
+>MyFunction : ({ msg }: MyFunction) => void
+>({ msg }: MyFunction) => console.log(`Got message "${msg}"`) : ({ msg }: MyFunction) => void
+>msg : string
+>console.log(`Got message "${msg}"`) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>`Got message "${msg}"` : string
+>msg : string
+
+export default MyFunction;
+>MyFunction : MyFunction
+

--- a/tests/cases/compiler/importElisionExportNonExportAndDefault.ts
+++ b/tests/cases/compiler/importElisionExportNonExportAndDefault.ts
@@ -1,0 +1,13 @@
+// @target: esnext
+// @module: esnext
+// @filename: main.ts
+import MyFunction from "./MyComponent";
+
+MyFunction({msg: "Hello World"});
+
+
+// @filename: MyComponent.ts
+interface MyFunction { msg: string; }
+
+export const MyFunction = ({ msg }: MyFunction) => console.log(`Got message "${msg}"`);
+export default MyFunction;


### PR DESCRIPTION
In `markAliasReferenced` we check that the `SymbolFlags` of the resolved symbol includes `SymbolFlags.Value`. However, if the default export points to a variable that is also exported, and that variable merges with a type that is not, the alias we create when importing the default export points to the local symbol (which has `SymbolFlags.Interface | SymbolFlags.ExportValue`) and not the export symbol (which has `SymbolFlags.Value`).

Since you can only end up with `SymbolFlags.ExportValue` if the export symbol is a value, this change considers such a local symbol to also be a value for the purpose of marking the import alias as referenced.

Fixes #47598
