### PR TITLE
Remove old tslint comments

### DIFF
--- a/src/compiler/factory/baseNodeFactory.ts
+++ b/src/compiler/factory/baseNodeFactory.ts
@@ -17,13 +17,11 @@ namespace ts {
      * Creates a `BaseNodeFactory` which can be used to create `Node` instances from the constructors provided by the object allocator.
      */
     export function createBaseNodeFactory(): BaseNodeFactory {
-        // tslint:disable variable-name
         let NodeConstructor: new (kind: SyntaxKind, pos?: number, end?: number) => Node;
         let TokenConstructor: new (kind: SyntaxKind, pos?: number, end?: number) => Node;
         let IdentifierConstructor: new (kind: SyntaxKind, pos?: number, end?: number) => Node;
         let PrivateIdentifierConstructor: new (kind: SyntaxKind, pos?: number, end?: number) => Node;
         let SourceFileConstructor: new (kind: SyntaxKind, pos?: number, end?: number) => Node;
-        // tslint:enable variable-name
 
         return {
             createBaseSourceFileNode,

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -6407,11 +6407,9 @@ namespace ts {
                 rawTextScanner.setText("`" + rawText + "`");
                 break;
             case SyntaxKind.TemplateHead:
-                // tslint:disable-next-line no-invalid-template-strings
                 rawTextScanner.setText("`" + rawText + "${");
                 break;
             case SyntaxKind.TemplateMiddle:
-                // tslint:disable-next-line no-invalid-template-strings
                 rawTextScanner.setText("}" + rawText + "${");
                 break;
             case SyntaxKind.TemplateTail:
@@ -6840,7 +6838,6 @@ namespace ts {
         return node;
     }
 
-    // tslint:disable-next-line variable-name
     let SourceMapSource: new (fileName: string, text: string, skipTrivia?: (pos: number) => number) => SourceMapSource;
 
     /**

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1027,13 +1027,11 @@ namespace ts {
         const disallowInAndDecoratorContext = NodeFlags.DisallowInContext | NodeFlags.DecoratorContext;
 
         // capture constructors in 'initializeState' to avoid null checks
-        // tslint:disable variable-name
         let NodeConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
         let TokenConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
         let IdentifierConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
         let PrivateIdentifierConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
         let SourceFileConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
-        // tslint:enable variable-name
 
         function countNode(node: Node) {
             nodeCount++;


### PR DESCRIPTION
Found via `@typescript-eslint/ban-tslint-comment`, which I won't add into our config as nobody's going to introduce one of these intentionally or otherwise.