### PR TITLE
fix(51222): Go-to-definition on return statements should jump to the containing function declaration

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -26,6 +26,12 @@ namespace ts.GoToDefinition {
             return label ? [createDefinitionInfoFromName(typeChecker, label, ScriptElementKind.label, node.text, /*containerName*/ undefined!)] : undefined; // TODO: GH#18217
         }
 
+        if (node.kind === SyntaxKind.ReturnKeyword) {
+            const functionDeclaration = findAncestor(node.parent, n =>
+                isClassStaticBlockDeclaration(n) ? "quit" : isFunctionLikeDeclaration(n)) as FunctionLikeDeclaration;
+            return functionDeclaration ? [createDefinitionFromSignatureDeclaration(typeChecker, functionDeclaration)] : undefined;
+        }
+
         if (isStaticModifier(node) && isClassStaticBlockDeclaration(node.parent)) {
             const classDecl = node.parent.parent;
             const { symbol, failedAliasResolution } = getSymbol(classDecl, typeChecker, stopAtAlias);

--- a/tests/cases/fourslash/goToDefinitionReturn1.ts
+++ b/tests/cases/fourslash/goToDefinitionReturn1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////function /*end*/foo() {
+////    [|/*start*/return|] 10;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionReturn2.ts
+++ b/tests/cases/fourslash/goToDefinitionReturn2.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////function foo() {
+////    return /*end*/() => {
+////        [|/*start*/return|] 10;
+////    }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionReturn3.ts
+++ b/tests/cases/fourslash/goToDefinitionReturn3.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////class C {
+////    /*end*/m() {
+////        [|/*start*/return|] 1;
+////    }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionReturn4.ts
+++ b/tests/cases/fourslash/goToDefinitionReturn4.ts
@@ -1,0 +1,5 @@
+/// <reference path="fourslash.ts" />
+
+////[|/*start*/return|];
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionReturn5.ts
+++ b/tests/cases/fourslash/goToDefinitionReturn5.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////function foo() {
+////    class Foo {
+////        static { [|/*start*/return|]; }
+////    }
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionReturn6.ts
+++ b/tests/cases/fourslash/goToDefinitionReturn6.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////function foo() {
+////    return /*end*/function () {
+////        [|/*start*/return|] 10;
+////    }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionReturn7.ts
+++ b/tests/cases/fourslash/goToDefinitionReturn7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////function foo(a: string, b: string): string;
+////function foo(a: number, b: number): number;
+////function /*end*/foo(a: any, b: any): any {
+////    [|/*start*/return|] a + b;
+////}
+
+verify.goToDefinition("start", "end");


### PR DESCRIPTION
Fixes #51222