### PR TITLE
Use base constraint when testing whether a type needs an `Awaited<T>` wrapper

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36985,7 +36985,7 @@ namespace ts {
             }
 
             // primitives with a `{ then() }` won't be unwrapped/adopted.
-            if (allTypesAssignableToKind(type, TypeFlags.Primitive | TypeFlags.Never)) {
+            if (allTypesAssignableToKind(getBaseConstraintOrType(type), TypeFlags.Primitive | TypeFlags.Never)) {
                 return undefined;
             }
 
@@ -37060,7 +37060,7 @@ namespace ts {
          * Determines whether a type is an object with a callable `then` member.
          */
         function isThenableType(type: Type): boolean {
-            if (allTypesAssignableToKind(type, TypeFlags.Primitive | TypeFlags.Never)) {
+            if (allTypesAssignableToKind(getBaseConstraintOrType(type), TypeFlags.Primitive | TypeFlags.Never)) {
                 // primitive types cannot be considered "thenable" since they are not objects.
                 return false;
             }

--- a/tests/baselines/reference/asyncFunctionReturnType.2.js
+++ b/tests/baselines/reference/asyncFunctionReturnType.2.js
@@ -1,0 +1,11 @@
+//// [asyncFunctionReturnType.2.ts]
+// https://github.com/microsoft/TypeScript/issues/47291
+class X {
+    f = async (): Promise<this> => this;
+}
+
+//// [asyncFunctionReturnType.2.js]
+// https://github.com/microsoft/TypeScript/issues/47291
+class X {
+    f = async () => this;
+}

--- a/tests/baselines/reference/asyncFunctionReturnType.2.symbols
+++ b/tests/baselines/reference/asyncFunctionReturnType.2.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/asyncFunctionReturnType.2.ts ===
+// https://github.com/microsoft/TypeScript/issues/47291
+class X {
+>X : Symbol(X, Decl(asyncFunctionReturnType.2.ts, 0, 0))
+
+    f = async (): Promise<this> => this;
+>f : Symbol(X.f, Decl(asyncFunctionReturnType.2.ts, 1, 9))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>this : Symbol(X, Decl(asyncFunctionReturnType.2.ts, 0, 0))
+}

--- a/tests/baselines/reference/asyncFunctionReturnType.2.types
+++ b/tests/baselines/reference/asyncFunctionReturnType.2.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/asyncFunctionReturnType.2.ts ===
+// https://github.com/microsoft/TypeScript/issues/47291
+class X {
+>X : X
+
+    f = async (): Promise<this> => this;
+>f : () => Promise<this>
+>async (): Promise<this> => this : () => Promise<this>
+>this : this
+}

--- a/tests/cases/compiler/asyncFunctionReturnType.2.ts
+++ b/tests/cases/compiler/asyncFunctionReturnType.2.ts
@@ -1,0 +1,6 @@
+// @target: esnext
+
+// https://github.com/microsoft/TypeScript/issues/47291
+class X {
+    f = async (): Promise<this> => this;
+}


### PR DESCRIPTION
When we updated `await` to use `Awaited<T>` in 4.5, we avoided introducing a new `Awaited<T>` wrapper when `T` is a generic primitive by calling `allTypesAssignableToKind`. However, when `T` is a `this` type, it triggers a circularity error. This change ensures we check against the base constraint of `T` rather than `T` itself, which avoids the circularity.

Fixes #47291
