### PR TITLE
Fix super property transform in async arrow in method

### DIFF
--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -1013,7 +1013,7 @@ namespace ts {
 
             // Minor optimization, emit `_super` helper to capture `super` access in an arrow.
             // This step isn't needed if we eventually transform this to ES5.
-            const emitSuperHelpers = languageVersion >= ScriptTarget.ES2015 && resolver.getNodeCheckFlags(node) & (NodeCheckFlags.AsyncMethodWithSuperBinding | NodeCheckFlags.AsyncMethodWithSuper);
+            const emitSuperHelpers = languageVersion >= ScriptTarget.ES2015 && resolver.getNodeCheckFlags(node) & (NodeCheckFlags.MethodWithSuperPropertyAssignmentInAsync | NodeCheckFlags.MethodWithSuperPropertyAccessInAsync);
 
             if (emitSuperHelpers) {
                 enableSubstitutionForAsyncMethodsWithSuper();
@@ -1028,10 +1028,10 @@ namespace ts {
             const block = factory.updateBlock(node.body!, statements);
 
             if (emitSuperHelpers && hasSuperElementAccess) {
-                if (resolver.getNodeCheckFlags(node) & NodeCheckFlags.AsyncMethodWithSuperBinding) {
+                if (resolver.getNodeCheckFlags(node) & NodeCheckFlags.MethodWithSuperPropertyAssignmentInAsync) {
                     addEmitHelper(block, advancedAsyncSuperHelper);
                 }
-                else if (resolver.getNodeCheckFlags(node) & NodeCheckFlags.AsyncMethodWithSuper) {
+                else if (resolver.getNodeCheckFlags(node) & NodeCheckFlags.MethodWithSuperPropertyAccessInAsync) {
                     addEmitHelper(block, asyncSuperHelper);
                 }
             }
@@ -1185,7 +1185,7 @@ namespace ts {
             // If we need to support substitutions for `super` in an async method,
             // we should track it here.
             if (enabledSubstitutions & ESNextSubstitutionFlags.AsyncMethodsWithSuper && isSuperContainer(node)) {
-                const superContainerFlags = resolver.getNodeCheckFlags(node) & (NodeCheckFlags.AsyncMethodWithSuper | NodeCheckFlags.AsyncMethodWithSuperBinding);
+                const superContainerFlags = resolver.getNodeCheckFlags(node) & (NodeCheckFlags.MethodWithSuperPropertyAccessInAsync | NodeCheckFlags.MethodWithSuperPropertyAssignmentInAsync);
                 if (superContainerFlags !== enclosingSuperContainerFlags) {
                     const savedEnclosingSuperContainerFlags = enclosingSuperContainerFlags;
                     enclosingSuperContainerFlags = superContainerFlags;
@@ -1282,7 +1282,7 @@ namespace ts {
         }
 
         function createSuperElementAccessInAsyncMethod(argumentExpression: Expression, location: TextRange): LeftHandSideExpression {
-            if (enclosingSuperContainerFlags & NodeCheckFlags.AsyncMethodWithSuperBinding) {
+            if (enclosingSuperContainerFlags & NodeCheckFlags.MethodWithSuperPropertyAssignmentInAsync) {
                 return setTextRange(
                     factory.createPropertyAccessExpression(
                         factory.createCallExpression(

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5527,8 +5527,8 @@ namespace ts {
         SuperInstance                            = 0x00000100,  // Instance 'super' reference
         SuperStatic                              = 0x00000200,  // Static 'super' reference
         ContextChecked                           = 0x00000400,  // Contextual types have been assigned
-        AsyncMethodWithSuper                     = 0x00000800,  // An async method that reads a value from a member of 'super'.
-        AsyncMethodWithSuperBinding              = 0x00001000,  // An async method that assigns a value to a member of 'super'.
+        MethodWithSuperPropertyAccessInAsync     = 0x00000800,  // A method that contains a SuperProperty access in an async context.
+        MethodWithSuperPropertyAssignmentInAsync = 0x00001000,  // A method that contains a SuperProperty assignment in an async context.
         CaptureArguments                         = 0x00002000,  // Lexical 'arguments' used in body
         EnumValuesComputed                       = 0x00004000,  // Values for enum members have been computed, and any errors have been reported for them.
         LexicalModuleMergesWithClass             = 0x00008000,  // Instantiated lexical module declaration is merged with a previous class declaration.

--- a/tests/baselines/reference/asyncMethodWithSuper_es6.js
+++ b/tests/baselines/reference/asyncMethodWithSuper_es6.js
@@ -186,6 +186,32 @@ class B extends A {
     }
 }
 
+// https://github.com/microsoft/TypeScript/issues/46828
+class Base {
+    set setter(x: any) {}
+    get getter(): any { return; }
+    method(x: string): any {}
+
+    static set setter(x: any) {}
+    static get getter(): any { return; }
+    static method(x: string): any {}
+}
+
+class Derived extends Base {
+    a() { return async () => super.method('') }
+    b() { return async () => super.getter }
+    c() { return async () => super.setter = '' }
+    d() { return async () => super["method"]('') }
+    e() { return async () => super["getter"] }
+    f() { return async () => super["setter"] = '' }
+    static a() { return async () => super.method('') }
+    static b() { return async () => super.getter }
+    static c() { return async () => super.setter = '' }
+    static d() { return async () => super["method"]('') }
+    static e() { return async () => super["getter"] }
+    static f() { return async () => super["setter"] = '' }
+}
+
 
 //// [asyncMethodWithSuper_es6.js]
 class A {
@@ -375,5 +401,64 @@ class B extends A {
             // element access (assign) in async arrow
             (() => __awaiter(this, void 0, void 0, function* () { return _superIndex("x").value = f; }));
         });
+    }
+}
+// https://github.com/microsoft/TypeScript/issues/46828
+class Base {
+    set setter(x) { }
+    get getter() { return; }
+    method(x) { }
+    static set setter(x) { }
+    static get getter() { return; }
+    static method(x) { }
+}
+class Derived extends Base {
+    a() { const _super = Object.create(null, {
+        method: { get: () => super.method }
+    }); return () => __awaiter(this, void 0, void 0, function* () { return _super.method.call(this, ''); }); }
+    b() { const _super = Object.create(null, {
+        getter: { get: () => super.getter }
+    }); return () => __awaiter(this, void 0, void 0, function* () { return _super.getter; }); }
+    c() { const _super = Object.create(null, {
+        setter: { get: () => super.setter, set: v => super.setter = v }
+    }); return () => __awaiter(this, void 0, void 0, function* () { return _super.setter = ''; }); }
+    d() {
+        const _superIndex = name => super[name];
+        return () => __awaiter(this, void 0, void 0, function* () { return _superIndex("method").call(this, ''); });
+    }
+    e() {
+        const _superIndex = name => super[name];
+        return () => __awaiter(this, void 0, void 0, function* () { return _superIndex("getter"); });
+    }
+    f() {
+        const _superIndex = (function (geti, seti) {
+            const cache = Object.create(null);
+            return name => cache[name] || (cache[name] = { get value() { return geti(name); }, set value(v) { seti(name, v); } });
+        })(name => super[name], (name, value) => super[name] = value);
+        return () => __awaiter(this, void 0, void 0, function* () { return _superIndex("setter").value = ''; });
+    }
+    static a() { const _super = Object.create(null, {
+        method: { get: () => super.method }
+    }); return () => __awaiter(this, void 0, void 0, function* () { return _super.method.call(this, ''); }); }
+    static b() { const _super = Object.create(null, {
+        getter: { get: () => super.getter }
+    }); return () => __awaiter(this, void 0, void 0, function* () { return _super.getter; }); }
+    static c() { const _super = Object.create(null, {
+        setter: { get: () => super.setter, set: v => super.setter = v }
+    }); return () => __awaiter(this, void 0, void 0, function* () { return _super.setter = ''; }); }
+    static d() {
+        const _superIndex = name => super[name];
+        return () => __awaiter(this, void 0, void 0, function* () { return _superIndex("method").call(this, ''); });
+    }
+    static e() {
+        const _superIndex = name => super[name];
+        return () => __awaiter(this, void 0, void 0, function* () { return _superIndex("getter"); });
+    }
+    static f() {
+        const _superIndex = (function (geti, seti) {
+            const cache = Object.create(null);
+            return name => cache[name] || (cache[name] = { get value() { return geti(name); }, set value(v) { seti(name, v); } });
+        })(name => super[name], (name, value) => super[name] = value);
+        return () => __awaiter(this, void 0, void 0, function* () { return _superIndex("setter").value = ''; });
     }
 }

--- a/tests/baselines/reference/asyncMethodWithSuper_es6.symbols
+++ b/tests/baselines/reference/asyncMethodWithSuper_es6.symbols
@@ -376,3 +376,101 @@ class B extends A {
     }
 }
 
+// https://github.com/microsoft/TypeScript/issues/46828
+class Base {
+>Base : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+
+    set setter(x: any) {}
+>setter : Symbol(Base.setter, Decl(asyncMethodWithSuper_es6.ts, 188, 12))
+>x : Symbol(x, Decl(asyncMethodWithSuper_es6.ts, 189, 15))
+
+    get getter(): any { return; }
+>getter : Symbol(Base.getter, Decl(asyncMethodWithSuper_es6.ts, 189, 25))
+
+    method(x: string): any {}
+>method : Symbol(Base.method, Decl(asyncMethodWithSuper_es6.ts, 190, 33))
+>x : Symbol(x, Decl(asyncMethodWithSuper_es6.ts, 191, 11))
+
+    static set setter(x: any) {}
+>setter : Symbol(Base.setter, Decl(asyncMethodWithSuper_es6.ts, 191, 29))
+>x : Symbol(x, Decl(asyncMethodWithSuper_es6.ts, 193, 22))
+
+    static get getter(): any { return; }
+>getter : Symbol(Base.getter, Decl(asyncMethodWithSuper_es6.ts, 193, 32))
+
+    static method(x: string): any {}
+>method : Symbol(Base.method, Decl(asyncMethodWithSuper_es6.ts, 194, 40))
+>x : Symbol(x, Decl(asyncMethodWithSuper_es6.ts, 195, 18))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(asyncMethodWithSuper_es6.ts, 196, 1))
+>Base : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+
+    a() { return async () => super.method('') }
+>a : Symbol(Derived.a, Decl(asyncMethodWithSuper_es6.ts, 198, 28))
+>super.method : Symbol(Base.method, Decl(asyncMethodWithSuper_es6.ts, 190, 33))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>method : Symbol(Base.method, Decl(asyncMethodWithSuper_es6.ts, 190, 33))
+
+    b() { return async () => super.getter }
+>b : Symbol(Derived.b, Decl(asyncMethodWithSuper_es6.ts, 199, 47))
+>super.getter : Symbol(Base.getter, Decl(asyncMethodWithSuper_es6.ts, 189, 25))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>getter : Symbol(Base.getter, Decl(asyncMethodWithSuper_es6.ts, 189, 25))
+
+    c() { return async () => super.setter = '' }
+>c : Symbol(Derived.c, Decl(asyncMethodWithSuper_es6.ts, 200, 43))
+>super.setter : Symbol(Base.setter, Decl(asyncMethodWithSuper_es6.ts, 188, 12))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>setter : Symbol(Base.setter, Decl(asyncMethodWithSuper_es6.ts, 188, 12))
+
+    d() { return async () => super["method"]('') }
+>d : Symbol(Derived.d, Decl(asyncMethodWithSuper_es6.ts, 201, 48))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>"method" : Symbol(Base.method, Decl(asyncMethodWithSuper_es6.ts, 190, 33))
+
+    e() { return async () => super["getter"] }
+>e : Symbol(Derived.e, Decl(asyncMethodWithSuper_es6.ts, 202, 50))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>"getter" : Symbol(Base.getter, Decl(asyncMethodWithSuper_es6.ts, 189, 25))
+
+    f() { return async () => super["setter"] = '' }
+>f : Symbol(Derived.f, Decl(asyncMethodWithSuper_es6.ts, 203, 46))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>"setter" : Symbol(Base.setter, Decl(asyncMethodWithSuper_es6.ts, 188, 12))
+
+    static a() { return async () => super.method('') }
+>a : Symbol(Derived.a, Decl(asyncMethodWithSuper_es6.ts, 204, 51))
+>super.method : Symbol(Base.method, Decl(asyncMethodWithSuper_es6.ts, 194, 40))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>method : Symbol(Base.method, Decl(asyncMethodWithSuper_es6.ts, 194, 40))
+
+    static b() { return async () => super.getter }
+>b : Symbol(Derived.b, Decl(asyncMethodWithSuper_es6.ts, 205, 54))
+>super.getter : Symbol(Base.getter, Decl(asyncMethodWithSuper_es6.ts, 193, 32))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>getter : Symbol(Base.getter, Decl(asyncMethodWithSuper_es6.ts, 193, 32))
+
+    static c() { return async () => super.setter = '' }
+>c : Symbol(Derived.c, Decl(asyncMethodWithSuper_es6.ts, 206, 50))
+>super.setter : Symbol(Base.setter, Decl(asyncMethodWithSuper_es6.ts, 191, 29))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>setter : Symbol(Base.setter, Decl(asyncMethodWithSuper_es6.ts, 191, 29))
+
+    static d() { return async () => super["method"]('') }
+>d : Symbol(Derived.d, Decl(asyncMethodWithSuper_es6.ts, 207, 55))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>"method" : Symbol(Base.method, Decl(asyncMethodWithSuper_es6.ts, 194, 40))
+
+    static e() { return async () => super["getter"] }
+>e : Symbol(Derived.e, Decl(asyncMethodWithSuper_es6.ts, 208, 57))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>"getter" : Symbol(Base.getter, Decl(asyncMethodWithSuper_es6.ts, 193, 32))
+
+    static f() { return async () => super["setter"] = '' }
+>f : Symbol(Derived.f, Decl(asyncMethodWithSuper_es6.ts, 209, 53))
+>super : Symbol(Base, Decl(asyncMethodWithSuper_es6.ts, 185, 1))
+>"setter" : Symbol(Base.setter, Decl(asyncMethodWithSuper_es6.ts, 191, 29))
+}
+

--- a/tests/baselines/reference/asyncMethodWithSuper_es6.types
+++ b/tests/baselines/reference/asyncMethodWithSuper_es6.types
@@ -504,3 +504,135 @@ class B extends A {
     }
 }
 
+// https://github.com/microsoft/TypeScript/issues/46828
+class Base {
+>Base : Base
+
+    set setter(x: any) {}
+>setter : any
+>x : any
+
+    get getter(): any { return; }
+>getter : any
+
+    method(x: string): any {}
+>method : (x: string) => any
+>x : string
+
+    static set setter(x: any) {}
+>setter : any
+>x : any
+
+    static get getter(): any { return; }
+>getter : any
+
+    static method(x: string): any {}
+>method : (x: string) => any
+>x : string
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    a() { return async () => super.method('') }
+>a : () => () => Promise<any>
+>async () => super.method('') : () => Promise<any>
+>super.method('') : any
+>super.method : (x: string) => any
+>super : Base
+>method : (x: string) => any
+>'' : ""
+
+    b() { return async () => super.getter }
+>b : () => () => Promise<any>
+>async () => super.getter : () => Promise<any>
+>super.getter : any
+>super : Base
+>getter : any
+
+    c() { return async () => super.setter = '' }
+>c : () => () => Promise<string>
+>async () => super.setter = '' : () => Promise<string>
+>super.setter = '' : ""
+>super.setter : any
+>super : Base
+>setter : any
+>'' : ""
+
+    d() { return async () => super["method"]('') }
+>d : () => () => Promise<any>
+>async () => super["method"]('') : () => Promise<any>
+>super["method"]('') : any
+>super["method"] : (x: string) => any
+>super : Base
+>"method" : "method"
+>'' : ""
+
+    e() { return async () => super["getter"] }
+>e : () => () => Promise<any>
+>async () => super["getter"] : () => Promise<any>
+>super["getter"] : any
+>super : Base
+>"getter" : "getter"
+
+    f() { return async () => super["setter"] = '' }
+>f : () => () => Promise<string>
+>async () => super["setter"] = '' : () => Promise<string>
+>super["setter"] = '' : ""
+>super["setter"] : any
+>super : Base
+>"setter" : "setter"
+>'' : ""
+
+    static a() { return async () => super.method('') }
+>a : () => () => Promise<any>
+>async () => super.method('') : () => Promise<any>
+>super.method('') : any
+>super.method : (x: string) => any
+>super : typeof Base
+>method : (x: string) => any
+>'' : ""
+
+    static b() { return async () => super.getter }
+>b : () => () => Promise<any>
+>async () => super.getter : () => Promise<any>
+>super.getter : any
+>super : typeof Base
+>getter : any
+
+    static c() { return async () => super.setter = '' }
+>c : () => () => Promise<string>
+>async () => super.setter = '' : () => Promise<string>
+>super.setter = '' : ""
+>super.setter : any
+>super : typeof Base
+>setter : any
+>'' : ""
+
+    static d() { return async () => super["method"]('') }
+>d : () => () => Promise<any>
+>async () => super["method"]('') : () => Promise<any>
+>super["method"]('') : any
+>super["method"] : (x: string) => any
+>super : typeof Base
+>"method" : "method"
+>'' : ""
+
+    static e() { return async () => super["getter"] }
+>e : () => () => Promise<any>
+>async () => super["getter"] : () => Promise<any>
+>super["getter"] : any
+>super : typeof Base
+>"getter" : "getter"
+
+    static f() { return async () => super["setter"] = '' }
+>f : () => () => Promise<string>
+>async () => super["setter"] = '' : () => Promise<string>
+>super["setter"] = '' : ""
+>super["setter"] : any
+>super : typeof Base
+>"setter" : "setter"
+>'' : ""
+}
+

--- a/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
@@ -187,3 +187,29 @@ class B extends A {
         (async () => super["x"] = f);
     }
 }
+
+// https://github.com/microsoft/TypeScript/issues/46828
+class Base {
+    set setter(x: any) {}
+    get getter(): any { return; }
+    method(x: string): any {}
+
+    static set setter(x: any) {}
+    static get getter(): any { return; }
+    static method(x: string): any {}
+}
+
+class Derived extends Base {
+    a() { return async () => super.method('') }
+    b() { return async () => super.getter }
+    c() { return async () => super.setter = '' }
+    d() { return async () => super["method"]('') }
+    e() { return async () => super["getter"] }
+    f() { return async () => super["setter"] = '' }
+    static a() { return async () => super.method('') }
+    static b() { return async () => super.getter }
+    static c() { return async () => super.setter = '' }
+    static d() { return async () => super["method"]('') }
+    static e() { return async () => super["getter"] }
+    static f() { return async () => super["setter"] = '' }
+}


### PR DESCRIPTION
Previously we were only checking if `super.x` (or `super[x]`) was referenced in an async method, but were not properly transforming non-async methods that contain async arrow functions that contain `super.x`.

Fixes #46828
