### PR TITLE
Generate shortest `rootDirs` module specifier instead of first possible

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1937,8 +1937,14 @@ namespace ts {
         return compareValues(a?.start, b?.start) || compareValues(a?.length, b?.length);
     }
 
-    export function min<T>(a: T, b: T, compare: Comparer<T>): T {
-        return compare(a, b) === Comparison.LessThan ? a : b;
+    export function min<T>(a: readonly T[], compare: Comparer<T>): T | undefined;
+    export function min<T>(a: T, b: T, compare: Comparer<T>): T;
+    export function min<T>(a: T | readonly T[], b: T | Comparer<T>, compare?: Comparer<T>): T | undefined {
+        if (compare !== undefined) {
+            return compare(a as T, b as T) === Comparison.LessThan ? a as T : b as T;
+        }
+        compare = b as Comparer<T>;
+        return reduceLeft(a as readonly T[], (x, y) => compare!(x, y) === Comparison.LessThan ? x : y);
     }
 
     /**

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1937,14 +1937,10 @@ namespace ts {
         return compareValues(a?.start, b?.start) || compareValues(a?.length, b?.length);
     }
 
-    export function min<T>(a: readonly T[], compare: Comparer<T>): T | undefined;
-    export function min<T>(a: T, b: T, compare: Comparer<T>): T;
-    export function min<T>(a: T | readonly T[], b: T | Comparer<T>, compare?: Comparer<T>): T | undefined {
-        if (compare !== undefined) {
-            return compare(a as T, b as T) === Comparison.LessThan ? a as T : b as T;
-        }
-        compare = b as Comparer<T>;
-        return reduceLeft(a as readonly T[], (x, y) => compare!(x, y) === Comparison.LessThan ? x : y);
+    export function min<T>(items: readonly [T, ...T[]], compare: Comparer<T>): T;
+    export function min<T>(items: readonly T[], compare: Comparer<T>): T | undefined;
+    export function min<T>(items: readonly T[], compare: Comparer<T>): T | undefined {
+        return reduceLeft(items, (x, y) => compare(x, y) === Comparison.LessThan ? x : y);
     }
 
     /**

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -726,16 +726,23 @@ namespace ts.moduleSpecifiers {
     }
 
     function tryGetModuleNameFromRootDirs(rootDirs: readonly string[], moduleFileName: string, sourceDirectory: string, getCanonicalFileName: (file: string) => string, ending: Ending, compilerOptions: CompilerOptions): string | undefined {
-        const normalizedTargetPath = getPathRelativeToRootDirs(moduleFileName, rootDirs, getCanonicalFileName);
-        if (normalizedTargetPath === undefined) {
+        const normalizedTargetPaths = getPathsRelativeToRootDirs(moduleFileName, rootDirs, getCanonicalFileName);
+        if (normalizedTargetPaths === undefined) {
             return undefined;
         }
 
-        const normalizedSourcePath = getPathRelativeToRootDirs(sourceDirectory, rootDirs, getCanonicalFileName);
-        const relativePath = normalizedSourcePath !== undefined ? ensurePathIsNonModuleName(getRelativePathFromDirectory(normalizedSourcePath, normalizedTargetPath, getCanonicalFileName)) : normalizedTargetPath;
+        const normalizedSourcePaths = getPathsRelativeToRootDirs(sourceDirectory, rootDirs, getCanonicalFileName);
+        const relativePaths = flatMap(normalizedSourcePaths, sourcePath => {
+            return map(normalizedTargetPaths, targetPath => ensurePathIsNonModuleName(getRelativePathFromDirectory(sourcePath, targetPath, getCanonicalFileName)));
+        });
+        const shortest = min(relativePaths, compareNumberOfDirectorySeparators);
+        if (!shortest) {
+            return undefined;
+        }
+
         return getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.NodeJs
-            ? removeExtensionAndIndexPostFix(relativePath, ending, compilerOptions)
-            : removeFileExtension(relativePath);
+            ? removeExtensionAndIndexPostFix(shortest, ending, compilerOptions)
+            : removeFileExtension(shortest);
     }
 
     function tryGetModuleNameAsNodeModule({ path, isRedirect }: ModulePath, { getCanonicalFileName, sourceDirectory }: Info, importingSourceFile: SourceFile , host: ModuleSpecifierResolutionHost, options: CompilerOptions, userPreferences: UserPreferences, packageNameOnly?: boolean, overrideMode?: ModuleKind.ESNext | ModuleKind.CommonJS): string | undefined {
@@ -882,8 +889,8 @@ namespace ts.moduleSpecifiers {
         }
     }
 
-    function getPathRelativeToRootDirs(path: string, rootDirs: readonly string[], getCanonicalFileName: GetCanonicalFileName): string | undefined {
-        return firstDefined(rootDirs, rootDir => {
+    function getPathsRelativeToRootDirs(path: string, rootDirs: readonly string[], getCanonicalFileName: GetCanonicalFileName): string[] | undefined {
+        return mapDefined(rootDirs, rootDir => {
             const relativePath = getRelativePathIfInDirectory(path, rootDir, getCanonicalFileName);
             return relativePath !== undefined && isPathRelativeToParent(relativePath) ? undefined : relativePath;
         });

--- a/src/services/patternMatcher.ts
+++ b/src/services/patternMatcher.ts
@@ -259,7 +259,7 @@ namespace ts {
     }
 
     function betterMatch(a: PatternMatch | undefined, b: PatternMatch | undefined): PatternMatch | undefined {
-        return min(a, b, compareMatches);
+        return min([a, b], compareMatches);
     }
     function compareMatches(a: PatternMatch | undefined, b: PatternMatch | undefined): Comparison {
         return a === undefined ? Comparison.GreaterThan : b === undefined ? Comparison.LessThan

--- a/tests/cases/fourslash/autoImportRootDirs.ts
+++ b/tests/cases/fourslash/autoImportRootDirs.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "module": "commonjs",
+////         "rootDirs": [".", "./some/other/root"]
+////     }
+//// }
+
+// @Filename: /some/other/root/types.ts
+//// export type Something = {};
+
+// @Filename: /index.ts
+//// const s: Something/**/
+
+verify.importFixModuleSpecifiers("", ["./types"]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

It might be preferable to provide multiple options in auto-imports, but it would require a lot more plumbing as many functions assume only one local/relative module specifier will be generated. Additionally, it might be a nuisance for every local auto import to be duplicated for every `rootDirs`, so let’s try continuing to provide just one, but having it be the shortest path, rather than the one generated from the first `rootDirs` entry that contains the target.

Fixes #51209
