### PR TITLE
Fix apparent typo in getStringMappingType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15709,7 +15709,7 @@ namespace ts {
                 type.flags & TypeFlags.TemplateLiteral ? getTemplateLiteralType(...applyTemplateStringMapping(symbol, (type as TemplateLiteralType).texts, (type as TemplateLiteralType).types)) :
                 // Mapping<Mapping<T>> === Mapping<T>
                 type.flags & TypeFlags.StringMapping && symbol === type.symbol ? type :
-                type.flags & (TypeFlags.Any | TypeFlags.String || type.flags & TypeFlags.StringMapping) || isGenericIndexType(type) ? getStringMappingTypeForGenericType(symbol, type) :
+                type.flags & (TypeFlags.Any | TypeFlags.String | TypeFlags.StringMapping) || isGenericIndexType(type) ? getStringMappingTypeForGenericType(symbol, type) :
                 // This handles Mapping<`${number}`> and Mapping<`${bigint}`>
                 isPatternLiteralPlaceholderType(type) ? getStringMappingTypeForGenericType(symbol, getTemplateLiteralType(["", ""], [type])) :
                 type;


### PR DESCRIPTION
I've been running rollup on our output looking for dead code; this expression (introduced in #51050) ended getting simplified and that seemed wrong, because `TypeFlags.Any | TypeFlags.String` is always truthy so the latter condition is never checked.

Doesn't seem to change any tests though, so I have no idea.