### PR TITLE
feat: `Nullable<T>` lib type (Taylor's Version)

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1587,6 +1587,11 @@ type Extract<T, U> = T extends U ? T : never;
 type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
 
 /**
+ * Construct a union type from T and null.
+ */
+type Nullable<T> = null | { [P in keyof T]: null | T[P] };
+
+/**
  * Exclude null and undefined from T
  */
 type NonNullable<T> = T & {};


### PR DESCRIPTION
There is already a `NonNullable<T>`lib type, which does not seem specified in ECMA-262 and so should not be a valid basis for rejecting this PR, which I am sure many people will be thankful for as [a good chunk](https://www.google.com/search?q=%22Nullable%3CT%3E%22+includes%3Atypescript) of TS workspaces define this manually, usually as the `T | null` union.

This suggestion was resisted in #19944 (and many, *many* subsequent PRs and issues), presumably because it's hard to know whether to use `T | null` or the example provided under the [**old handbook**](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types), `{ [P in keyof T]: T[P] | null }` (all properties on `T` assignable to `null`).

There is nothing that stops us from doing both, and constructing a utility type `Nullable<T>` which can be assigned either to `null` *or* `T` with all properties assignable to `null`:

```ts
type Nullable<T> = null | { [P in keyof T]: null | T[P] };
```

This is not an existing utility type and so it is not as if it's breaking. It is not equivalent to `T | null` but is a superset of it, so there is more utility baked in than you can describe with `T | null` while still getting equivalent behavior for primitives. This would afford a lot of convenience without any apparent drawbacks as far as I can tell, and the other PRs seem to have been closed mostly on the basis of vibes only, despite lots of pushback in the RFC and several issues/PRs opened between 2016 and now.

Ultimately it does seem kind of ridiculous to leave a `NonNullable<T>` type without defining a `Nullable<T>` one, and I suggest we take a stab at it.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes: #51255