### PR TITLE
Add a GH Action to file a new issue if we go a week without seeing a typescript-error-deltas issue

### DIFF
--- a/.github/workflows/error-deltas-watchdog.yaml
+++ b/.github/workflows/error-deltas-watchdog.yaml
@@ -1,0 +1,36 @@
+name: "typescript-error-deltas Watchdog"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 3' # Every Wednesday
+
+jobs:
+  check-for-recent:
+    runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/TypeScript'
+    permissions:
+      contents: read # Apparently required to create issues
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAGS: "@RyanCavanaugh @DanielRosenwasser @amcasey"
+    steps:
+    - name: NewErrors
+      run: | # --json and --jq prints exactly one issue number per line of output
+        DATE=$(date --date="7 days ago" --iso-8601)
+        gh issue list --repo microsoft/typescript --search "[NewErrors] created:>=$DATE" --state all --json number --jq ".[].number" \
+        | grep -qe "[0-9]" \
+        || gh issue create --repo ${{ github.repository }} --title "No [NewErrors] issue since $DATE" --body "$TAGS Please check the [pipeline](https://typescript.visualstudio.com/TypeScript/_build?definitionId=48)."
+    - name: ServerErrors TS
+      run: |
+        DATE=$(date --date="7 days ago" --iso-8601)
+        gh issue list --repo microsoft/typescript --search "[ServerErrors][TypeScript] created:>=$DATE" --state all --json number --jq ".[].number" \
+        | grep -qe "[0-9]" \
+        || gh issue create --repo ${{ github.repository }} --title "No [ServerErrors][TypeScript] issue since $DATE" --body "$TAGS Please check the [pipeline](https://typescript.visualstudio.com/TypeScript/_build?definitionId=59)."
+    - name: ServerErrors JS
+      run: |
+        DATE=$(date --date="7 days ago" --iso-8601)
+        gh issue list --repo microsoft/typescript --search "[ServerErrors][JavaScript] created:>=$DATE" --state all --json number --jq ".[].number" \
+        | grep -qe "[0-9]" \
+        || gh issue create --repo ${{ github.repository }} --title "No [ServerErrors][JavaScript] issue since $DATE" --body "$TAGS Please check the [pipeline](https://typescript.visualstudio.com/TypeScript/_build?definitionId=58)."

--- a/.github/workflows/error-deltas-watchdog.yaml
+++ b/.github/workflows/error-deltas-watchdog.yaml
@@ -21,16 +21,16 @@ jobs:
         DATE=$(date --date="7 days ago" --iso-8601)
         gh issue list --repo microsoft/typescript --search "[NewErrors] created:>=$DATE" --state all --json number --jq ".[].number" \
         | grep -qe "[0-9]" \
-        || gh issue create --repo ${{ github.repository }} --title "No [NewErrors] issue since $DATE" --body "$TAGS Please check the [pipeline](https://typescript.visualstudio.com/TypeScript/_build?definitionId=48)."
+        || gh issue create --repo ${{ github.repository }} --title "No NewErrors issue since $DATE" --body "$TAGS Please check the [pipeline](https://typescript.visualstudio.com/TypeScript/_build?definitionId=48)."
     - name: ServerErrors TS
       run: |
         DATE=$(date --date="7 days ago" --iso-8601)
         gh issue list --repo microsoft/typescript --search "[ServerErrors][TypeScript] created:>=$DATE" --state all --json number --jq ".[].number" \
         | grep -qe "[0-9]" \
-        || gh issue create --repo ${{ github.repository }} --title "No [ServerErrors][TypeScript] issue since $DATE" --body "$TAGS Please check the [pipeline](https://typescript.visualstudio.com/TypeScript/_build?definitionId=59)."
+        || gh issue create --repo ${{ github.repository }} --title "No TypeScript ServerErrors issue since $DATE" --body "$TAGS Please check the [pipeline](https://typescript.visualstudio.com/TypeScript/_build?definitionId=59)."
     - name: ServerErrors JS
       run: |
         DATE=$(date --date="7 days ago" --iso-8601)
         gh issue list --repo microsoft/typescript --search "[ServerErrors][JavaScript] created:>=$DATE" --state all --json number --jq ".[].number" \
         | grep -qe "[0-9]" \
-        || gh issue create --repo ${{ github.repository }} --title "No [ServerErrors][JavaScript] issue since $DATE" --body "$TAGS Please check the [pipeline](https://typescript.visualstudio.com/TypeScript/_build?definitionId=58)."
+        || gh issue create --repo ${{ github.repository }} --title "No JavaScript ServerErrors issue since $DATE" --body "$TAGS Please check the [pipeline](https://typescript.visualstudio.com/TypeScript/_build?definitionId=58)."


### PR DESCRIPTION
Covers [NewErrors], [ServerErrors][TypeScript], and [ServerErrors][JavaScript].