### PR TITLE
fix for-in enumeration containing yield in generator

### DIFF
--- a/tests/baselines/reference/es5-asyncFunctionForInStatements.js
+++ b/tests/baselines/reference/es5-asyncFunctionForInStatements.js
@@ -50,22 +50,24 @@ function forInStatement0() {
 }
 function forInStatement1() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _b, _i;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
-                case 0:
-                    _a = [];
-                    return [4 /*yield*/, y];
+        var _a, _b, _c, _i;
+        return __generator(this, function (_d) {
+            switch (_d.label) {
+                case 0: return [4 /*yield*/, y];
                 case 1:
-                    for (_b in _c.sent())
-                        _a.push(_b);
+                    _a = _d.sent();
+                    _b = [];
+                    for (_c in _a)
+                        _b.push(_c);
                     _i = 0;
-                    _c.label = 2;
+                    _d.label = 2;
                 case 2:
-                    if (!(_i < _a.length)) return [3 /*break*/, 4];
-                    x = _a[_i];
+                    if (!(_i < _b.length)) return [3 /*break*/, 4];
+                    _c = _b[_i];
+                    if (!(_c in _a)) return [3 /*break*/, 3];
+                    x = _c;
                     z;
-                    _c.label = 3;
+                    _d.label = 3;
                 case 3:
                     _i++;
                     return [3 /*break*/, 2];
@@ -76,22 +78,25 @@ function forInStatement1() {
 }
 function forInStatement2() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _b, _i;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
+        var _a, _b, _c, _i;
+        return __generator(this, function (_d) {
+            switch (_d.label) {
                 case 0:
-                    _a = [];
-                    for (_b in y)
-                        _a.push(_b);
+                    _a = y;
+                    _b = [];
+                    for (_c in _a)
+                        _b.push(_c);
                     _i = 0;
-                    _c.label = 1;
+                    _d.label = 1;
                 case 1:
-                    if (!(_i < _a.length)) return [3 /*break*/, 4];
-                    x = _a[_i];
+                    if (!(_i < _b.length)) return [3 /*break*/, 4];
+                    _c = _b[_i];
+                    if (!(_c in _a)) return [3 /*break*/, 3];
+                    x = _c;
                     return [4 /*yield*/, z];
                 case 2:
-                    _c.sent();
-                    _c.label = 3;
+                    _d.sent();
+                    _d.label = 3;
                 case 3:
                     _i++;
                     return [3 /*break*/, 1];
@@ -102,22 +107,25 @@ function forInStatement2() {
 }
 function forInStatement3() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _b, _i;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
+        var _a, _b, _c, _i;
+        return __generator(this, function (_d) {
+            switch (_d.label) {
                 case 0:
-                    _a = [];
-                    for (_b in y)
-                        _a.push(_b);
+                    _a = y;
+                    _b = [];
+                    for (_c in _a)
+                        _b.push(_c);
                     _i = 0;
-                    _c.label = 1;
+                    _d.label = 1;
                 case 1:
-                    if (!(_i < _a.length)) return [3 /*break*/, 4];
+                    if (!(_i < _b.length)) return [3 /*break*/, 4];
+                    _c = _b[_i];
+                    if (!(_c in _a)) return [3 /*break*/, 3];
                     return [4 /*yield*/, x];
                 case 2:
-                    (_c.sent()).a = _a[_i];
+                    (_d.sent()).a = _c;
                     z;
-                    _c.label = 3;
+                    _d.label = 3;
                 case 3:
                     _i++;
                     return [3 /*break*/, 1];
@@ -128,22 +136,24 @@ function forInStatement3() {
 }
 function forInStatement4() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _b, _i;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
-                case 0:
-                    _a = [];
-                    return [4 /*yield*/, y];
+        var _a, _b, _c, _i;
+        return __generator(this, function (_d) {
+            switch (_d.label) {
+                case 0: return [4 /*yield*/, y];
                 case 1:
-                    for (_b in _c.sent())
-                        _a.push(_b);
+                    _a = _d.sent();
+                    _b = [];
+                    for (_c in _a)
+                        _b.push(_c);
                     _i = 0;
-                    _c.label = 2;
+                    _d.label = 2;
                 case 2:
-                    if (!(_i < _a.length)) return [3 /*break*/, 4];
-                    x.a = _a[_i];
+                    if (!(_i < _b.length)) return [3 /*break*/, 4];
+                    _c = _b[_i];
+                    if (!(_c in _a)) return [3 /*break*/, 3];
+                    x.a = _c;
                     z;
-                    _c.label = 3;
+                    _d.label = 3;
                 case 3:
                     _i++;
                     return [3 /*break*/, 2];
@@ -154,22 +164,25 @@ function forInStatement4() {
 }
 function forInStatement5() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _b, _i;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
+        var _a, _b, _c, _i;
+        return __generator(this, function (_d) {
+            switch (_d.label) {
                 case 0:
-                    _a = [];
-                    for (_b in y)
-                        _a.push(_b);
+                    _a = y;
+                    _b = [];
+                    for (_c in _a)
+                        _b.push(_c);
                     _i = 0;
-                    _c.label = 1;
+                    _d.label = 1;
                 case 1:
-                    if (!(_i < _a.length)) return [3 /*break*/, 4];
-                    x.a = _a[_i];
+                    if (!(_i < _b.length)) return [3 /*break*/, 4];
+                    _c = _b[_i];
+                    if (!(_c in _a)) return [3 /*break*/, 3];
+                    x.a = _c;
                     return [4 /*yield*/, z];
                 case 2:
-                    _c.sent();
-                    _c.label = 3;
+                    _d.sent();
+                    _d.label = 3;
                 case 3:
                     _i++;
                     return [3 /*break*/, 1];
@@ -191,22 +204,24 @@ function forInStatement6() {
 }
 function forInStatement7() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _b, _i, b;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
-                case 0:
-                    _a = [];
-                    return [4 /*yield*/, y];
+        var _a, _b, _c, _i, b;
+        return __generator(this, function (_d) {
+            switch (_d.label) {
+                case 0: return [4 /*yield*/, y];
                 case 1:
-                    for (_b in _c.sent())
-                        _a.push(_b);
+                    _a = _d.sent();
+                    _b = [];
+                    for (_c in _a)
+                        _b.push(_c);
                     _i = 0;
-                    _c.label = 2;
+                    _d.label = 2;
                 case 2:
-                    if (!(_i < _a.length)) return [3 /*break*/, 4];
-                    b = _a[_i];
+                    if (!(_i < _b.length)) return [3 /*break*/, 4];
+                    _c = _b[_i];
+                    if (!(_c in _a)) return [3 /*break*/, 3];
+                    b = _c;
                     z;
-                    _c.label = 3;
+                    _d.label = 3;
                 case 3:
                     _i++;
                     return [3 /*break*/, 2];
@@ -217,22 +232,25 @@ function forInStatement7() {
 }
 function forInStatement8() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _b, _i, c;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
+        var _a, _b, _c, _i, c;
+        return __generator(this, function (_d) {
+            switch (_d.label) {
                 case 0:
-                    _a = [];
-                    for (_b in y)
-                        _a.push(_b);
+                    _a = y;
+                    _b = [];
+                    for (_c in _a)
+                        _b.push(_c);
                     _i = 0;
-                    _c.label = 1;
+                    _d.label = 1;
                 case 1:
-                    if (!(_i < _a.length)) return [3 /*break*/, 4];
-                    c = _a[_i];
+                    if (!(_i < _b.length)) return [3 /*break*/, 4];
+                    _c = _b[_i];
+                    if (!(_c in _a)) return [3 /*break*/, 3];
+                    c = _c;
                     return [4 /*yield*/, z];
                 case 2:
-                    _c.sent();
-                    _c.label = 3;
+                    _d.sent();
+                    _d.label = 3;
                 case 3:
                     _i++;
                     return [3 /*break*/, 1];

--- a/tests/baselines/reference/yieldInForInInDownlevelGenerator.js
+++ b/tests/baselines/reference/yieldInForInInDownlevelGenerator.js
@@ -1,0 +1,68 @@
+//// [yieldInForInInDownlevelGenerator.ts]
+// https://github.com/microsoft/TypeScript/issues/49808
+function* gen() {
+  var obj: any = { foo: 1, bar: 2 };
+  for (var key in obj) {
+      yield key;
+      delete obj.bar;
+  }
+}
+
+//// [yieldInForInInDownlevelGenerator.js]
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+// https://github.com/microsoft/TypeScript/issues/49808
+function gen() {
+    var obj, _a, _b, _c, _i, key;
+    return __generator(this, function (_d) {
+        switch (_d.label) {
+            case 0:
+                obj = { foo: 1, bar: 2 };
+                _a = obj;
+                _b = [];
+                for (_c in _a)
+                    _b.push(_c);
+                _i = 0;
+                _d.label = 1;
+            case 1:
+                if (!(_i < _b.length)) return [3 /*break*/, 4];
+                _c = _b[_i];
+                if (!(_c in _a)) return [3 /*break*/, 3];
+                key = _c;
+                return [4 /*yield*/, key];
+            case 2:
+                _d.sent();
+                delete obj.bar;
+                _d.label = 3;
+            case 3:
+                _i++;
+                return [3 /*break*/, 1];
+            case 4: return [2 /*return*/];
+        }
+    });
+}

--- a/tests/baselines/reference/yieldInForInInDownlevelGenerator.symbols
+++ b/tests/baselines/reference/yieldInForInInDownlevelGenerator.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/yieldInForInInDownlevelGenerator.ts ===
+// https://github.com/microsoft/TypeScript/issues/49808
+function* gen() {
+>gen : Symbol(gen, Decl(yieldInForInInDownlevelGenerator.ts, 0, 0))
+
+  var obj: any = { foo: 1, bar: 2 };
+>obj : Symbol(obj, Decl(yieldInForInInDownlevelGenerator.ts, 2, 5))
+>foo : Symbol(foo, Decl(yieldInForInInDownlevelGenerator.ts, 2, 18))
+>bar : Symbol(bar, Decl(yieldInForInInDownlevelGenerator.ts, 2, 26))
+
+  for (var key in obj) {
+>key : Symbol(key, Decl(yieldInForInInDownlevelGenerator.ts, 3, 10))
+>obj : Symbol(obj, Decl(yieldInForInInDownlevelGenerator.ts, 2, 5))
+
+      yield key;
+>key : Symbol(key, Decl(yieldInForInInDownlevelGenerator.ts, 3, 10))
+
+      delete obj.bar;
+>obj : Symbol(obj, Decl(yieldInForInInDownlevelGenerator.ts, 2, 5))
+  }
+}

--- a/tests/baselines/reference/yieldInForInInDownlevelGenerator.types
+++ b/tests/baselines/reference/yieldInForInInDownlevelGenerator.types
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/yieldInForInInDownlevelGenerator.ts ===
+// https://github.com/microsoft/TypeScript/issues/49808
+function* gen() {
+>gen : () => Generator<string, void, unknown>
+
+  var obj: any = { foo: 1, bar: 2 };
+>obj : any
+>{ foo: 1, bar: 2 } : { foo: number; bar: number; }
+>foo : number
+>1 : 1
+>bar : number
+>2 : 2
+
+  for (var key in obj) {
+>key : string
+>obj : any
+
+      yield key;
+>yield key : any
+>key : string
+
+      delete obj.bar;
+>delete obj.bar : boolean
+>obj.bar : any
+>obj : any
+>bar : any
+  }
+}

--- a/tests/cases/compiler/yieldInForInInDownlevelGenerator.ts
+++ b/tests/cases/compiler/yieldInForInInDownlevelGenerator.ts
@@ -1,0 +1,10 @@
+// @target: es5
+// @lib: esnext
+// https://github.com/microsoft/TypeScript/issues/49808
+function* gen() {
+  var obj: any = { foo: 1, bar: 2 };
+  for (var key in obj) {
+      yield key;
+      delete obj.bar;
+  }
+}


### PR DESCRIPTION
This updates the emit for a `for..in` statement containing a `yield` when emitting a downlevel generator to more accurately align with [EnumerateObjectProperties](https://tc39.es/ecma262/#sec-enumerate-object-properties), which states (emphasis added):

> The iterator's `throw` and `return` methods are `null` and are never invoked. The iterator's `next` method processes object properties to determine whether the [property key](https://tc39.es/ecma262/#sec-object-type) should be returned as an iterator value. Returned [property keys](https://tc39.es/ecma262/#sec-object-type) do not include keys that are Symbols. _**Properties of the target object may be deleted during enumeration. A property that is deleted before it is processed by the iterator's `next` method is ignored.**_ If new properties are added to the target object during enumeration, the newly added properties are not guaranteed to be processed in the active enumeration.

This is achieved by adding an extra `if (!(key in obj)) continue` test at the top of the transformed loop body so that we can skip over deleted properties. We don't make any changes to handle newly added properties since that is spec'd to be implementation defined behavior (per the "not guaranteed" statement in the above condition).

Fixes #49808
