### PR TITLE
In for-await-of, only call return() for an abrupt completion in user code

### DIFF
--- a/src/testRunner/unittests/evaluation/forAwaitOf.ts
+++ b/src/testRunner/unittests/evaluation/forAwaitOf.ts
@@ -102,4 +102,31 @@ describe("unittests:: evaluation:: forAwaitOfEvaluation", () => {
         assert.instanceOf(result.output[1], Promise);
         assert.instanceOf(result.output[2], Promise);
     });
+
+    it("don't call return when non-user code throws (es2015)", async () => {
+        const result = evaluator.evaluateTypeScript(`
+        let returnCalled = false;
+        async function f() {
+            let i = 0;
+            const iterator = {
+                [Symbol.asyncIterator](): AsyncIterableIterator<any> { return this; },
+                async next() {
+                    i++;
+                    if (i < 2) return { value: undefined, done: false };
+                    throw new Error();
+                },
+                async return() {
+                    returnCalled = true;
+                }
+            };
+            for await (const item of iterator) {
+            }
+        }
+        export async function main() {
+            try { await f(); } catch { }
+            return returnCalled;
+        }
+        `, { target: ts.ScriptTarget.ES2015 });
+        assert.isFalse(await result.main());
+    });
 });

--- a/tests/baselines/reference/emitter.forAwait(target=es2015).js
+++ b/tests/baselines/reference/emitter.forAwait(target=es2015).js
@@ -68,18 +68,25 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 function f1() {
-    var e_1, _a;
+    var _a, e_1, _b, _c;
     return __awaiter(this, void 0, void 0, function* () {
         let y;
         try {
-            for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), !y_1_1.done;) {
-                const x = y_1_1.value;
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a;) {
+                _c = y_1_1.value;
+                _d = false;
+                try {
+                    const x = _c;
+                }
+                finally {
+                    _d = true;
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield _a.call(y_1);
+                if (!_d && !_a && (_b = y_1.return)) yield _b.call(y_1);
             }
             finally { if (e_1) throw e_1.error; }
         }
@@ -103,18 +110,25 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 function f2() {
-    var e_1, _a;
+    var _a, e_1, _b, _c;
     return __awaiter(this, void 0, void 0, function* () {
         let x, y;
         try {
-            for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), !y_1_1.done;) {
-                x = y_1_1.value;
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a;) {
+                _c = y_1_1.value;
+                _d = false;
+                try {
+                    x = _c;
+                }
+                finally {
+                    _d = true;
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield _a.call(y_1);
+                if (!_d && !_a && (_b = y_1.return)) yield _b.call(y_1);
             }
             finally { if (e_1) throw e_1.error; }
         }
@@ -142,17 +156,24 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function f3() {
     return __asyncGenerator(this, arguments, function* f3_1() {
-        var e_1, _a;
+        var _a, e_1, _b, _c;
         let y;
         try {
-            for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
-                const x = y_1_1.value;
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+                _c = y_1_1.value;
+                _d = false;
+                try {
+                    const x = _c;
+                }
+                finally {
+                    _d = true;
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield __await(_a.call(y_1));
+                if (!_d && !_a && (_b = y_1.return)) yield __await(_b.call(y_1));
             }
             finally { if (e_1) throw e_1.error; }
         }
@@ -180,17 +201,24 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function f4() {
     return __asyncGenerator(this, arguments, function* f4_1() {
-        var e_1, _a;
+        var _a, e_1, _b, _c;
         let x, y;
         try {
-            for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
-                x = y_1_1.value;
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+                _c = y_1_1.value;
+                _d = false;
+                try {
+                    x = _c;
+                }
+                finally {
+                    _d = true;
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield __await(_a.call(y_1));
+                if (!_d && !_a && (_b = y_1.return)) yield __await(_b.call(y_1));
             }
             finally { if (e_1) throw e_1.error; }
         }
@@ -215,19 +243,26 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 // https://github.com/Microsoft/TypeScript/issues/21363
 function f5() {
-    var e_1, _a;
+    var _a, e_1, _b, _c;
     return __awaiter(this, void 0, void 0, function* () {
         let y;
         try {
-            outer: for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), !y_1_1.done;) {
-                const x = y_1_1.value;
-                continue outer;
+            outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a;) {
+                _c = y_1_1.value;
+                _d = false;
+                try {
+                    const x = _c;
+                    continue outer;
+                }
+                finally {
+                    _d = true;
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield _a.call(y_1);
+                if (!_d && !_a && (_b = y_1.return)) yield _b.call(y_1);
             }
             finally { if (e_1) throw e_1.error; }
         }
@@ -256,18 +291,25 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 // https://github.com/Microsoft/TypeScript/issues/21363
 function f6() {
     return __asyncGenerator(this, arguments, function* f6_1() {
-        var e_1, _a;
+        var _a, e_1, _b, _c;
         let y;
         try {
-            outer: for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
-                const x = y_1_1.value;
-                continue outer;
+            outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+                _c = y_1_1.value;
+                _d = false;
+                try {
+                    const x = _c;
+                    continue outer;
+                }
+                finally {
+                    _d = true;
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield __await(_a.call(y_1));
+                if (!_d && !_a && (_b = y_1.return)) yield __await(_b.call(y_1));
             }
             finally { if (e_1) throw e_1.error; }
         }
@@ -296,18 +338,25 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 // https://github.com/microsoft/TypeScript/issues/36166
 function f7() {
     return __asyncGenerator(this, arguments, function* f7_1() {
-        var e_1, _a;
+        var _a, e_1, _b, _c;
         let y;
         for (;;) {
             try {
-                for (var y_1 = (e_1 = void 0, __asyncValues(y)), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
-                    const x = y_1_1.value;
+                for (var _d = true, y_1 = (e_1 = void 0, __asyncValues(y)), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+                    _c = y_1_1.value;
+                    _d = false;
+                    try {
+                        const x = _c;
+                    }
+                    finally {
+                        _d = true;
+                    }
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }
             finally {
                 try {
-                    if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield __await(_a.call(y_1));
+                    if (!_d && !_a && (_b = y_1.return)) yield __await(_b.call(y_1));
                 }
                 finally { if (e_1) throw e_1.error; }
             }

--- a/tests/baselines/reference/emitter.forAwait(target=es2017).js
+++ b/tests/baselines/reference/emitter.forAwait(target=es2017).js
@@ -59,17 +59,24 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 async function f1() {
-    var e_1, _a;
+    var _a, e_1, _b, _c;
     let y;
     try {
-        for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), !y_1_1.done;) {
-            const x = y_1_1.value;
+        for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a;) {
+            _c = y_1_1.value;
+            _d = false;
+            try {
+                const x = _c;
+            }
+            finally {
+                _d = true;
+            }
         }
     }
     catch (e_1_1) { e_1 = { error: e_1_1 }; }
     finally {
         try {
-            if (y_1_1 && !y_1_1.done && (_a = y_1.return)) await _a.call(y_1);
+            if (!_d && !_a && (_b = y_1.return)) await _b.call(y_1);
         }
         finally { if (e_1) throw e_1.error; }
     }
@@ -83,17 +90,24 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 async function f2() {
-    var e_1, _a;
+    var _a, e_1, _b, _c;
     let x, y;
     try {
-        for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), !y_1_1.done;) {
-            x = y_1_1.value;
+        for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a;) {
+            _c = y_1_1.value;
+            _d = false;
+            try {
+                x = _c;
+            }
+            finally {
+                _d = true;
+            }
         }
     }
     catch (e_1_1) { e_1 = { error: e_1_1 }; }
     finally {
         try {
-            if (y_1_1 && !y_1_1.done && (_a = y_1.return)) await _a.call(y_1);
+            if (!_d && !_a && (_b = y_1.return)) await _b.call(y_1);
         }
         finally { if (e_1) throw e_1.error; }
     }
@@ -120,17 +134,24 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function f3() {
     return __asyncGenerator(this, arguments, function* f3_1() {
-        var e_1, _a;
+        var _a, e_1, _b, _c;
         let y;
         try {
-            for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
-                const x = y_1_1.value;
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+                _c = y_1_1.value;
+                _d = false;
+                try {
+                    const x = _c;
+                }
+                finally {
+                    _d = true;
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield __await(_a.call(y_1));
+                if (!_d && !_a && (_b = y_1.return)) yield __await(_b.call(y_1));
             }
             finally { if (e_1) throw e_1.error; }
         }
@@ -158,17 +179,24 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function f4() {
     return __asyncGenerator(this, arguments, function* f4_1() {
-        var e_1, _a;
+        var _a, e_1, _b, _c;
         let x, y;
         try {
-            for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
-                x = y_1_1.value;
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+                _c = y_1_1.value;
+                _d = false;
+                try {
+                    x = _c;
+                }
+                finally {
+                    _d = true;
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield __await(_a.call(y_1));
+                if (!_d && !_a && (_b = y_1.return)) yield __await(_b.call(y_1));
             }
             finally { if (e_1) throw e_1.error; }
         }
@@ -184,18 +212,25 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 // https://github.com/Microsoft/TypeScript/issues/21363
 async function f5() {
-    var e_1, _a;
+    var _a, e_1, _b, _c;
     let y;
     try {
-        outer: for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), !y_1_1.done;) {
-            const x = y_1_1.value;
-            continue outer;
+        outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a;) {
+            _c = y_1_1.value;
+            _d = false;
+            try {
+                const x = _c;
+                continue outer;
+            }
+            finally {
+                _d = true;
+            }
         }
     }
     catch (e_1_1) { e_1 = { error: e_1_1 }; }
     finally {
         try {
-            if (y_1_1 && !y_1_1.done && (_a = y_1.return)) await _a.call(y_1);
+            if (!_d && !_a && (_b = y_1.return)) await _b.call(y_1);
         }
         finally { if (e_1) throw e_1.error; }
     }
@@ -223,18 +258,25 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 // https://github.com/Microsoft/TypeScript/issues/21363
 function f6() {
     return __asyncGenerator(this, arguments, function* f6_1() {
-        var e_1, _a;
+        var _a, e_1, _b, _c;
         let y;
         try {
-            outer: for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
-                const x = y_1_1.value;
-                continue outer;
+            outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+                _c = y_1_1.value;
+                _d = false;
+                try {
+                    const x = _c;
+                    continue outer;
+                }
+                finally {
+                    _d = true;
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield __await(_a.call(y_1));
+                if (!_d && !_a && (_b = y_1.return)) yield __await(_b.call(y_1));
             }
             finally { if (e_1) throw e_1.error; }
         }
@@ -263,18 +305,25 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 // https://github.com/microsoft/TypeScript/issues/36166
 function f7() {
     return __asyncGenerator(this, arguments, function* f7_1() {
-        var e_1, _a;
+        var _a, e_1, _b, _c;
         let y;
         for (;;) {
             try {
-                for (var y_1 = (e_1 = void 0, __asyncValues(y)), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
-                    const x = y_1_1.value;
+                for (var _d = true, y_1 = (e_1 = void 0, __asyncValues(y)), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+                    _c = y_1_1.value;
+                    _d = false;
+                    try {
+                        const x = _c;
+                    }
+                    finally {
+                        _d = true;
+                    }
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }
             finally {
                 try {
-                    if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield __await(_a.call(y_1));
+                    if (!_d && !_a && (_b = y_1.return)) yield __await(_b.call(y_1));
                 }
                 finally { if (e_1) throw e_1.error; }
             }

--- a/tests/baselines/reference/emitter.forAwait(target=es5).js
+++ b/tests/baselines/reference/emitter.forAwait(target=es5).js
@@ -95,33 +95,40 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 function f1() {
-    var e_1, _a;
+    var _a, e_1, _b, _c;
     return __awaiter(this, void 0, void 0, function () {
-        var y, y_1, y_1_1, x, e_1_1;
-        return __generator(this, function (_b) {
-            switch (_b.label) {
+        var y, _d, y_1, y_1_1, x, e_1_1;
+        return __generator(this, function (_e) {
+            switch (_e.label) {
                 case 0:
-                    _b.trys.push([0, 5, 6, 11]);
-                    y_1 = __asyncValues(y);
-                    _b.label = 1;
+                    _e.trys.push([0, 5, 6, 11]);
+                    _d = true, y_1 = __asyncValues(y);
+                    _e.label = 1;
                 case 1: return [4 /*yield*/, y_1.next()];
                 case 2:
-                    if (!(y_1_1 = _b.sent(), !y_1_1.done)) return [3 /*break*/, 4];
-                    x = y_1_1.value;
-                    _b.label = 3;
+                    if (!(y_1_1 = _e.sent(), _a = y_1_1.done, !_a)) return [3 /*break*/, 4];
+                    _c = y_1_1.value;
+                    _d = false;
+                    try {
+                        x = _c;
+                    }
+                    finally {
+                        _d = true;
+                    }
+                    _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
-                    e_1_1 = _b.sent();
+                    e_1_1 = _e.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 11];
                 case 6:
-                    _b.trys.push([6, , 9, 10]);
-                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 8];
-                    return [4 /*yield*/, _a.call(y_1)];
+                    _e.trys.push([6, , 9, 10]);
+                    if (!(!_d && !_a && (_b = y_1.return))) return [3 /*break*/, 8];
+                    return [4 /*yield*/, _b.call(y_1)];
                 case 7:
-                    _b.sent();
-                    _b.label = 8;
+                    _e.sent();
+                    _e.label = 8;
                 case 8: return [3 /*break*/, 10];
                 case 9:
                     if (e_1) throw e_1.error;
@@ -177,33 +184,40 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 function f2() {
-    var e_1, _a;
+    var _a, e_1, _b, _c;
     return __awaiter(this, void 0, void 0, function () {
-        var x, y, y_1, y_1_1, e_1_1;
-        return __generator(this, function (_b) {
-            switch (_b.label) {
+        var x, y, _d, y_1, y_1_1, e_1_1;
+        return __generator(this, function (_e) {
+            switch (_e.label) {
                 case 0:
-                    _b.trys.push([0, 5, 6, 11]);
-                    y_1 = __asyncValues(y);
-                    _b.label = 1;
+                    _e.trys.push([0, 5, 6, 11]);
+                    _d = true, y_1 = __asyncValues(y);
+                    _e.label = 1;
                 case 1: return [4 /*yield*/, y_1.next()];
                 case 2:
-                    if (!(y_1_1 = _b.sent(), !y_1_1.done)) return [3 /*break*/, 4];
-                    x = y_1_1.value;
-                    _b.label = 3;
+                    if (!(y_1_1 = _e.sent(), _a = y_1_1.done, !_a)) return [3 /*break*/, 4];
+                    _c = y_1_1.value;
+                    _d = false;
+                    try {
+                        x = _c;
+                    }
+                    finally {
+                        _d = true;
+                    }
+                    _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
-                    e_1_1 = _b.sent();
+                    e_1_1 = _e.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 11];
                 case 6:
-                    _b.trys.push([6, , 9, 10]);
-                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 8];
-                    return [4 /*yield*/, _a.call(y_1)];
+                    _e.trys.push([6, , 9, 10]);
+                    if (!(!_d && !_a && (_b = y_1.return))) return [3 /*break*/, 8];
+                    return [4 /*yield*/, _b.call(y_1)];
                 case 7:
-                    _b.sent();
-                    _b.label = 8;
+                    _e.sent();
+                    _e.label = 8;
                 case 8: return [3 /*break*/, 10];
                 case 9:
                     if (e_1) throw e_1.error;
@@ -263,32 +277,39 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function f3() {
     return __asyncGenerator(this, arguments, function f3_1() {
-        var y, y_1, y_1_1, x, e_1_1;
-        var e_1, _a;
-        return __generator(this, function (_b) {
-            switch (_b.label) {
+        var y, _a, y_1, y_1_1, x, e_1_1;
+        var _b, e_1, _c, _d;
+        return __generator(this, function (_e) {
+            switch (_e.label) {
                 case 0:
-                    _b.trys.push([0, 5, 6, 11]);
-                    y_1 = __asyncValues(y);
-                    _b.label = 1;
+                    _e.trys.push([0, 5, 6, 11]);
+                    _a = true, y_1 = __asyncValues(y);
+                    _e.label = 1;
                 case 1: return [4 /*yield*/, __await(y_1.next())];
                 case 2:
-                    if (!(y_1_1 = _b.sent(), !y_1_1.done)) return [3 /*break*/, 4];
-                    x = y_1_1.value;
-                    _b.label = 3;
+                    if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
+                    _d = y_1_1.value;
+                    _a = false;
+                    try {
+                        x = _d;
+                    }
+                    finally {
+                        _a = true;
+                    }
+                    _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
-                    e_1_1 = _b.sent();
+                    e_1_1 = _e.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 11];
                 case 6:
-                    _b.trys.push([6, , 9, 10]);
-                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 8];
-                    return [4 /*yield*/, __await(_a.call(y_1))];
+                    _e.trys.push([6, , 9, 10]);
+                    if (!(!_a && !_b && (_c = y_1.return))) return [3 /*break*/, 8];
+                    return [4 /*yield*/, __await(_c.call(y_1))];
                 case 7:
-                    _b.sent();
-                    _b.label = 8;
+                    _e.sent();
+                    _e.label = 8;
                 case 8: return [3 /*break*/, 10];
                 case 9:
                     if (e_1) throw e_1.error;
@@ -348,32 +369,39 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function f4() {
     return __asyncGenerator(this, arguments, function f4_1() {
-        var x, y, y_1, y_1_1, e_1_1;
-        var e_1, _a;
-        return __generator(this, function (_b) {
-            switch (_b.label) {
+        var x, y, _a, y_1, y_1_1, e_1_1;
+        var _b, e_1, _c, _d;
+        return __generator(this, function (_e) {
+            switch (_e.label) {
                 case 0:
-                    _b.trys.push([0, 5, 6, 11]);
-                    y_1 = __asyncValues(y);
-                    _b.label = 1;
+                    _e.trys.push([0, 5, 6, 11]);
+                    _a = true, y_1 = __asyncValues(y);
+                    _e.label = 1;
                 case 1: return [4 /*yield*/, __await(y_1.next())];
                 case 2:
-                    if (!(y_1_1 = _b.sent(), !y_1_1.done)) return [3 /*break*/, 4];
-                    x = y_1_1.value;
-                    _b.label = 3;
+                    if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
+                    _d = y_1_1.value;
+                    _a = false;
+                    try {
+                        x = _d;
+                    }
+                    finally {
+                        _a = true;
+                    }
+                    _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
-                    e_1_1 = _b.sent();
+                    e_1_1 = _e.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 11];
                 case 6:
-                    _b.trys.push([6, , 9, 10]);
-                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 8];
-                    return [4 /*yield*/, __await(_a.call(y_1))];
+                    _e.trys.push([6, , 9, 10]);
+                    if (!(!_a && !_b && (_c = y_1.return))) return [3 /*break*/, 8];
+                    return [4 /*yield*/, __await(_c.call(y_1))];
                 case 7:
-                    _b.sent();
-                    _b.label = 8;
+                    _e.sent();
+                    _e.label = 8;
                 case 8: return [3 /*break*/, 10];
                 case 9:
                     if (e_1) throw e_1.error;
@@ -430,33 +458,41 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 // https://github.com/Microsoft/TypeScript/issues/21363
 function f5() {
-    var e_1, _a;
+    var _a, e_1, _b, _c;
     return __awaiter(this, void 0, void 0, function () {
-        var y, y_1, y_1_1, x, e_1_1;
-        return __generator(this, function (_b) {
-            switch (_b.label) {
+        var y, _d, y_1, y_1_1, x, e_1_1;
+        return __generator(this, function (_e) {
+            switch (_e.label) {
                 case 0:
-                    _b.trys.push([0, 5, 6, 11]);
-                    y_1 = __asyncValues(y);
-                    _b.label = 1;
+                    _e.trys.push([0, 5, 6, 11]);
+                    _d = true, y_1 = __asyncValues(y);
+                    _e.label = 1;
                 case 1: return [4 /*yield*/, y_1.next()];
                 case 2:
-                    if (!(y_1_1 = _b.sent(), !y_1_1.done)) return [3 /*break*/, 4];
-                    x = y_1_1.value;
-                    return [3 /*break*/, 3];
+                    if (!(y_1_1 = _e.sent(), _a = y_1_1.done, !_a)) return [3 /*break*/, 4];
+                    _c = y_1_1.value;
+                    _d = false;
+                    try {
+                        x = _c;
+                        return [3 /*break*/, 3];
+                    }
+                    finally {
+                        _d = true;
+                    }
+                    _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
-                    e_1_1 = _b.sent();
+                    e_1_1 = _e.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 11];
                 case 6:
-                    _b.trys.push([6, , 9, 10]);
-                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 8];
-                    return [4 /*yield*/, _a.call(y_1)];
+                    _e.trys.push([6, , 9, 10]);
+                    if (!(!_d && !_a && (_b = y_1.return))) return [3 /*break*/, 8];
+                    return [4 /*yield*/, _b.call(y_1)];
                 case 7:
-                    _b.sent();
-                    _b.label = 8;
+                    _e.sent();
+                    _e.label = 8;
                 case 8: return [3 /*break*/, 10];
                 case 9:
                     if (e_1) throw e_1.error;
@@ -517,32 +553,40 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 // https://github.com/Microsoft/TypeScript/issues/21363
 function f6() {
     return __asyncGenerator(this, arguments, function f6_1() {
-        var y, y_1, y_1_1, x, e_1_1;
-        var e_1, _a;
-        return __generator(this, function (_b) {
-            switch (_b.label) {
+        var y, _a, y_1, y_1_1, x, e_1_1;
+        var _b, e_1, _c, _d;
+        return __generator(this, function (_e) {
+            switch (_e.label) {
                 case 0:
-                    _b.trys.push([0, 5, 6, 11]);
-                    y_1 = __asyncValues(y);
-                    _b.label = 1;
+                    _e.trys.push([0, 5, 6, 11]);
+                    _a = true, y_1 = __asyncValues(y);
+                    _e.label = 1;
                 case 1: return [4 /*yield*/, __await(y_1.next())];
                 case 2:
-                    if (!(y_1_1 = _b.sent(), !y_1_1.done)) return [3 /*break*/, 4];
-                    x = y_1_1.value;
-                    return [3 /*break*/, 3];
+                    if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
+                    _d = y_1_1.value;
+                    _a = false;
+                    try {
+                        x = _d;
+                        return [3 /*break*/, 3];
+                    }
+                    finally {
+                        _a = true;
+                    }
+                    _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
-                    e_1_1 = _b.sent();
+                    e_1_1 = _e.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 11];
                 case 6:
-                    _b.trys.push([6, , 9, 10]);
-                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 8];
-                    return [4 /*yield*/, __await(_a.call(y_1))];
+                    _e.trys.push([6, , 9, 10]);
+                    if (!(!_a && !_b && (_c = y_1.return))) return [3 /*break*/, 8];
+                    return [4 /*yield*/, __await(_c.call(y_1))];
                 case 7:
-                    _b.sent();
-                    _b.label = 8;
+                    _e.sent();
+                    _e.label = 8;
                 case 8: return [3 /*break*/, 10];
                 case 9:
                     if (e_1) throw e_1.error;
@@ -603,32 +647,39 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 // https://github.com/microsoft/TypeScript/issues/36166
 function f7() {
     return __asyncGenerator(this, arguments, function f7_1() {
-        var y, y_1, y_1_1, x, e_1_1;
-        var e_1, _a;
-        return __generator(this, function (_b) {
-            switch (_b.label) {
+        var y, _a, y_1, y_1_1, x, e_1_1;
+        var _b, e_1, _c, _d;
+        return __generator(this, function (_e) {
+            switch (_e.label) {
                 case 0:
-                    _b.trys.push([0, 5, 6, 11]);
-                    y_1 = (e_1 = void 0, __asyncValues(y));
-                    _b.label = 1;
+                    _e.trys.push([0, 5, 6, 11]);
+                    _a = true, y_1 = (e_1 = void 0, __asyncValues(y));
+                    _e.label = 1;
                 case 1: return [4 /*yield*/, __await(y_1.next())];
                 case 2:
-                    if (!(y_1_1 = _b.sent(), !y_1_1.done)) return [3 /*break*/, 4];
-                    x = y_1_1.value;
-                    _b.label = 3;
+                    if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
+                    _d = y_1_1.value;
+                    _a = false;
+                    try {
+                        x = _d;
+                    }
+                    finally {
+                        _a = true;
+                    }
+                    _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
-                    e_1_1 = _b.sent();
+                    e_1_1 = _e.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 11];
                 case 6:
-                    _b.trys.push([6, , 9, 10]);
-                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 8];
-                    return [4 /*yield*/, __await(_a.call(y_1))];
+                    _e.trys.push([6, , 9, 10]);
+                    if (!(!_a && !_b && (_c = y_1.return))) return [3 /*break*/, 8];
+                    return [4 /*yield*/, __await(_c.call(y_1))];
                 case 7:
-                    _b.sent();
-                    _b.label = 8;
+                    _e.sent();
+                    _e.label = 8;
                 case 8: return [3 /*break*/, 10];
                 case 9:
                     if (e_1) throw e_1.error;

--- a/tests/baselines/reference/forAwaitPerIterationBindingDownlevel.js
+++ b/tests/baselines/reference/forAwaitPerIterationBindingDownlevel.js
@@ -104,56 +104,63 @@ function gen() {
 }
 var log = console.log;
 (function () { return __awaiter(_this, void 0, void 0, function () {
-    var _loop_1, _a, _b, e_1_1;
+    var _loop_1, _a, _b, _c, e_1_1;
     var _this = this;
-    var e_1, _c;
-    return __generator(this, function (_d) {
-        switch (_d.label) {
+    var _d, e_1, _e, _f;
+    return __generator(this, function (_g) {
+        switch (_g.label) {
             case 0:
-                _d.trys.push([0, 5, 6, 11]);
+                _g.trys.push([0, 5, 6, 11]);
                 _loop_1 = function () {
-                    var outer = _b.value;
-                    log("I'm loop ".concat(outer));
-                    (function () { return __awaiter(_this, void 0, void 0, function () {
-                        var inner;
-                        return __generator(this, function (_a) {
-                            switch (_a.label) {
-                                case 0:
-                                    inner = outer;
-                                    return [4 /*yield*/, sleep(2000)];
-                                case 1:
-                                    _a.sent();
-                                    if (inner === outer) {
-                                        log("I'm loop ".concat(inner, " and I know I'm loop ").concat(outer));
-                                    }
-                                    else {
-                                        log("I'm loop ".concat(inner, ", but I think I'm loop ").concat(outer));
-                                    }
-                                    return [2 /*return*/];
-                            }
-                        });
-                    }); })();
+                    _f = _c.value;
+                    _a = false;
+                    try {
+                        var outer = _f;
+                        log("I'm loop ".concat(outer));
+                        (function () { return __awaiter(_this, void 0, void 0, function () {
+                            var inner;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0:
+                                        inner = outer;
+                                        return [4 /*yield*/, sleep(2000)];
+                                    case 1:
+                                        _a.sent();
+                                        if (inner === outer) {
+                                            log("I'm loop ".concat(inner, " and I know I'm loop ").concat(outer));
+                                        }
+                                        else {
+                                            log("I'm loop ".concat(inner, ", but I think I'm loop ").concat(outer));
+                                        }
+                                        return [2 /*return*/];
+                                }
+                            });
+                        }); })();
+                    }
+                    finally {
+                        _a = true;
+                    }
                 };
-                _a = __asyncValues(gen());
-                _d.label = 1;
-            case 1: return [4 /*yield*/, _a.next()];
+                _a = true, _b = __asyncValues(gen());
+                _g.label = 1;
+            case 1: return [4 /*yield*/, _b.next()];
             case 2:
-                if (!(_b = _d.sent(), !_b.done)) return [3 /*break*/, 4];
+                if (!(_c = _g.sent(), _d = _c.done, !_d)) return [3 /*break*/, 4];
                 _loop_1();
-                _d.label = 3;
+                _g.label = 3;
             case 3: return [3 /*break*/, 1];
             case 4: return [3 /*break*/, 11];
             case 5:
-                e_1_1 = _d.sent();
+                e_1_1 = _g.sent();
                 e_1 = { error: e_1_1 };
                 return [3 /*break*/, 11];
             case 6:
-                _d.trys.push([6, , 9, 10]);
-                if (!(_b && !_b.done && (_c = _a.return))) return [3 /*break*/, 8];
-                return [4 /*yield*/, _c.call(_a)];
+                _g.trys.push([6, , 9, 10]);
+                if (!(!_a && !_d && (_e = _b.return))) return [3 /*break*/, 8];
+                return [4 /*yield*/, _e.call(_b)];
             case 7:
-                _d.sent();
-                _d.label = 8;
+                _g.sent();
+                _g.label = 8;
             case 8: return [3 /*break*/, 10];
             case 9:
                 if (e_1) throw e_1.error;

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.js
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.js
@@ -83,12 +83,12 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     return to.concat(ar || Array.prototype.slice.call(from));
 };
 function fn(a, b, c, d, e, f, g) {
-    var c_1, c_1_1;
-    var e_1, _a;
+    var _a, c_1, c_1_1;
+    var _b, e_1, _c, _d;
     return __awaiter(this, void 0, void 0, function () {
         var _i, c_2, s, s, e_1_1;
-        return __generator(this, function (_b) {
-            switch (_b.label) {
+        return __generator(this, function (_e) {
+            switch (_e.label) {
                 case 0:
                     // All errors
                     a | b;
@@ -104,29 +104,36 @@ function fn(a, b, c, d, e, f, g) {
                         fn(b, b, c, d, e, f, g);
                         d.prop;
                     }
-                    _b.label = 1;
+                    _e.label = 1;
                 case 1:
-                    _b.trys.push([1, 6, 7, 12]);
-                    c_1 = __asyncValues(c);
-                    _b.label = 2;
+                    _e.trys.push([1, 6, 7, 12]);
+                    _a = true, c_1 = __asyncValues(c);
+                    _e.label = 2;
                 case 2: return [4 /*yield*/, c_1.next()];
                 case 3:
-                    if (!(c_1_1 = _b.sent(), !c_1_1.done)) return [3 /*break*/, 5];
-                    s = c_1_1.value;
-                    _b.label = 4;
+                    if (!(c_1_1 = _e.sent(), _b = c_1_1.done, !_b)) return [3 /*break*/, 5];
+                    _d = c_1_1.value;
+                    _a = false;
+                    try {
+                        s = _d;
+                    }
+                    finally {
+                        _a = true;
+                    }
+                    _e.label = 4;
                 case 4: return [3 /*break*/, 2];
                 case 5: return [3 /*break*/, 12];
                 case 6:
-                    e_1_1 = _b.sent();
+                    e_1_1 = _e.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 12];
                 case 7:
-                    _b.trys.push([7, , 10, 11]);
-                    if (!(c_1_1 && !c_1_1.done && (_a = c_1["return"]))) return [3 /*break*/, 9];
-                    return [4 /*yield*/, _a.call(c_1)];
+                    _e.trys.push([7, , 10, 11]);
+                    if (!(!_a && !_b && (_c = c_1["return"]))) return [3 /*break*/, 9];
+                    return [4 /*yield*/, _c.call(c_1)];
                 case 8:
-                    _b.sent();
-                    _b.label = 9;
+                    _e.sent();
+                    _e.label = 9;
                 case 9: return [3 /*break*/, 11];
                 case 10:
                     if (e_1) throw e_1.error;

--- a/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2015).js
@@ -81,22 +81,29 @@ for await (const item of arr) {
 
 
 //// [other.js]
-var e_1, _a;
+var _a, e_1, _b, _c;
 const _await = 1;
 // await allowed in aliased export
 export { _await as await };
 // for-await-of
 const arr = [Promise.resolve()];
 try {
-    for (var arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), !arr_1_1.done;) {
-        const item = arr_1_1.value;
-        item;
+    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+        _c = arr_1_1.value;
+        _d = false;
+        try {
+            const item = _c;
+            item;
+        }
+        finally {
+            _d = true;
+        }
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
 finally {
     try {
-        if (arr_1_1 && !arr_1_1.done && (_a = arr_1.return)) await _a.call(arr_1);
+        if (!_d && !_a && (_b = arr_1.return)) await _b.call(arr_1);
     }
     finally { if (e_1) throw e_1.error; }
 }

--- a/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2017).js
@@ -81,22 +81,29 @@ for await (const item of arr) {
 
 
 //// [other.js]
-var e_1, _a;
+var _a, e_1, _b, _c;
 const _await = 1;
 // await allowed in aliased export
 export { _await as await };
 // for-await-of
 const arr = [Promise.resolve()];
 try {
-    for (var arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), !arr_1_1.done;) {
-        const item = arr_1_1.value;
-        item;
+    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+        _c = arr_1_1.value;
+        _d = false;
+        try {
+            const item = _c;
+            item;
+        }
+        finally {
+            _d = true;
+        }
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
 finally {
     try {
-        if (arr_1_1 && !arr_1_1.done && (_a = arr_1.return)) await _a.call(arr_1);
+        if (!_d && !_a && (_b = arr_1.return)) await _b.call(arr_1);
     }
     finally { if (e_1) throw e_1.error; }
 }

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).js
@@ -81,22 +81,29 @@ for await (const item of arr) {
 
 
 //// [other.js]
-var e_1, _a;
+var _a, e_1, _b, _c;
 const _await = 1;
 // await allowed in aliased export
 export { _await as await };
 // for-await-of
 const arr = [Promise.resolve()];
 try {
-    for (var arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), !arr_1_1.done;) {
-        const item = arr_1_1.value;
-        item;
+    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+        _c = arr_1_1.value;
+        _d = false;
+        try {
+            const item = _c;
+            item;
+        }
+        finally {
+            _d = true;
+        }
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
 finally {
     try {
-        if (arr_1_1 && !arr_1_1.done && (_a = arr_1.return)) await _a.call(arr_1);
+        if (!_d && !_a && (_b = arr_1.return)) await _b.call(arr_1);
     }
     finally { if (e_1) throw e_1.error; }
 }

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).js
@@ -81,22 +81,29 @@ for await (const item of arr) {
 
 
 //// [other.js]
-var e_1, _a;
+var _a, e_1, _b, _c;
 const _await = 1;
 // await allowed in aliased export
 export { _await as await };
 // for-await-of
 const arr = [Promise.resolve()];
 try {
-    for (var arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), !arr_1_1.done;) {
-        const item = arr_1_1.value;
-        item;
+    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+        _c = arr_1_1.value;
+        _d = false;
+        try {
+            const item = _c;
+            item;
+        }
+        finally {
+            _d = true;
+        }
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
 finally {
     try {
-        if (arr_1_1 && !arr_1_1.done && (_a = arr_1.return)) await _a.call(arr_1);
+        if (!_d && !_a && (_b = arr_1.return)) await _b.call(arr_1);
     }
     finally { if (e_1) throw e_1.error; }
 }

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).js
@@ -83,7 +83,7 @@ for await (const item of arr) {
 //// [other.js]
 System.register([], function (exports_1, context_1) {
     "use strict";
-    var e_1, _a, _await, arr;
+    var _a, e_1, _b, _c, _await, arr;
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [],
@@ -93,15 +93,22 @@ System.register([], function (exports_1, context_1) {
             // for-await-of
             arr = [Promise.resolve()];
             try {
-                for (var arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), !arr_1_1.done;) {
-                    const item = arr_1_1.value;
-                    item;
+                for (var _a = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+                    _c = arr_1_1.value;
+                    _a = false;
+                    try {
+                        const item = _c;
+                        item;
+                    }
+                    finally {
+                        _a = true;
+                    }
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }
             finally {
                 try {
-                    if (arr_1_1 && !arr_1_1.done && (_a = arr_1.return)) await _a.call(arr_1);
+                    if (!_a && !_a && (_b = arr_1.return)) await _b.call(arr_1);
                 }
                 finally { if (e_1) throw e_1.error; }
             }

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).js
@@ -83,7 +83,7 @@ for await (const item of arr) {
 //// [other.js]
 System.register([], function (exports_1, context_1) {
     "use strict";
-    var e_1, _a, _await, arr;
+    var _a, e_1, _b, _c, _await, arr;
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [],
@@ -93,15 +93,22 @@ System.register([], function (exports_1, context_1) {
             // for-await-of
             arr = [Promise.resolve()];
             try {
-                for (var arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), !arr_1_1.done;) {
-                    const item = arr_1_1.value;
-                    item;
+                for (var _a = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+                    _c = arr_1_1.value;
+                    _a = false;
+                    try {
+                        const item = _c;
+                        item;
+                    }
+                    finally {
+                        _a = true;
+                    }
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }
             finally {
                 try {
-                    if (arr_1_1 && !arr_1_1.done && (_a = arr_1.return)) await _a.call(arr_1);
+                    if (!_a && !_a && (_b = arr_1.return)) await _b.call(arr_1);
                 }
                 finally { if (e_1) throw e_1.error; }
             }


### PR DESCRIPTION
This wraps user code in a `for-await-of` statement so that we only call `iter.return()` when user code exits abruptly. This better aligns with [ForIn/OfBodyEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset) which only calls IteratorClose when there is an abrupt completion in the body.

Fixes #50525
