### PR TITLE
`--annotateTransforms` switch to add transformer diagnostics to Source Maps

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -318,6 +318,13 @@ namespace ts {
             description: Diagnostics.Set_the_language_of_the_messaging_from_TypeScript_This_does_not_affect_emit,
             defaultValueDescription: Diagnostics.Platform_specific
         },
+        {
+            name: "annotateTransforms",
+            type: "boolean",
+            affectsEmit: true,
+            category: Diagnostics.Compiler_Diagnostics,
+            defaultValueDescription: false
+        }
     ];
 
     /* @internal */

--- a/src/compiler/sourcemapPublic.ts
+++ b/src/compiler/sourcemapPublic.ts
@@ -1,0 +1,146 @@
+namespace ts {
+    export interface DecodedSourceMapAnnotation {
+        generatedLine: number;
+        generatedCharacter: number;
+        annotations: SourceMapAnnotation[];
+    }
+
+    /**
+     * Decodes the custom `x_ms_ts_annotations` field of a SourceMap.
+     */
+    export function decodeSourceMapAnnotations(annotations: string, names: readonly string[]): Iterator<DecodedSourceMapAnnotation> {
+        const reader = createCharCodeReader(annotations);
+        let done = false;
+        let generatedLine = 0;
+        let generatedCharacter = 0;
+        let nameIndex = 0;
+
+        return {
+            next() {
+                debugger;
+                while (!done && reader.pos < reader.length) {
+                    const ch = reader.peek();
+                    if (ch === CharacterCodes.semicolon) {
+                        generatedLine++;
+                        generatedCharacter = 0;
+                        reader.read();
+                        continue;
+                    }
+                    if (ch === CharacterCodes.comma) {
+                        reader.read();
+                        continue;
+                    }
+
+                    generatedCharacter += base64VLQFormatDecode(reader, noop);
+                    if (generatedCharacter < 0) break;
+                    if (isSegmentEnd()) continue;
+
+                    nameIndex += base64VLQFormatDecode(reader, noop);
+                    const name = elementAt(names, nameIndex);
+                    if (name) {
+                        const annotations = decodeAnnotations(createCharCodeReader(name));
+                        if (annotations) {
+                            return { value: { generatedLine, generatedCharacter, annotations }, done };
+                        }
+                    }
+                }
+
+                done = true;
+                return { value: undefined!, done: true } as { value: never, done: true };
+            }
+        };
+
+        function isSegmentEnd() {
+            return (reader.pos === reader.length ||
+                reader.peek() === CharacterCodes.comma ||
+                reader.peek() === CharacterCodes.semicolon);
+        }
+
+        function decodeAnnotations(reader: CharCodeReader): SourceMapAnnotation[] | undefined {
+            let nameIndex = 0;
+            const annotations = decodeAnnotationWorker();
+            if (Array.isArray(annotations) && annotations.every(isSourceMapAnnotation)) {
+                return annotations;
+            }
+
+            function decodeAnnotationWorker(): unknown {
+                if (reader.pos < reader.length) {
+                    let ch = reader.peek();
+                    if (ch === CharacterCodes.hash) {
+                        reader.read();
+                        return base64VLQFormatDecode(reader, noop);
+                    }
+                    else if (ch === CharacterCodes.at) {
+                        reader.read();
+                        nameIndex += base64VLQFormatDecode(reader, noop);
+                        return elementAt(names, nameIndex);
+                    }
+                    else if (ch === CharacterCodes.t || ch === CharacterCodes.f) {
+                        reader.read();
+                        return ch === CharacterCodes.t;
+                    }
+                    else if (ch === CharacterCodes.exclamation) {
+                        reader.read();
+                        return null; // eslint-disable-line no-null/no-null
+                    }
+                    else if (ch === CharacterCodes.openBracket) {
+                        const array: unknown[] = [];
+                        reader.read();
+                        while (reader.pos < reader.length) {
+                            ch = reader.peek();
+                            if (ch === CharacterCodes.closeBracket) {
+                                reader.read();
+                                return array;
+                            }
+                            if (array.length > 0) {
+                                if (ch !== CharacterCodes.comma) {
+                                    return;
+                                }
+                                reader.read();
+                            }
+                            array.push(decodeAnnotationWorker());
+                        }
+                    }
+                    else if (ch === CharacterCodes.openBrace) {
+                        const obj: any = {};
+                        let hasReadProperty = false;
+                        reader.read();
+                        while (reader.pos < reader.length) {
+                            ch = reader.peek();
+                            if (ch === CharacterCodes.closeBrace) {
+                                reader.read();
+                                return obj;
+                            }
+
+                            if (hasReadProperty) {
+                                if (ch !== CharacterCodes.comma) {
+                                    return;
+                                }
+                                reader.read();
+                                if (reader.pos >= reader.length) return;
+                            }
+
+                            const key = decodeAnnotationWorker();
+                            if (typeof key !== "string") return;
+                            if (reader.pos >= reader.length) return;
+
+                            ch = reader.peek();
+                            if (ch !== CharacterCodes.colon) return;
+
+                            reader.read();
+                            if (reader.pos >= reader.length) return;
+
+                            const value = decodeAnnotationWorker();
+                            obj[key] = value;
+                            hasReadProperty = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    function isSourceMapAnnotation(value: unknown): value is SourceMapAnnotation {
+        return typeof value === "object" && !!value && typeof (value as SourceMapAnnotation).name === "string";
+    }
+}

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -43,6 +43,7 @@
         "checker.ts",
         "visitorPublic.ts",
         "sourcemap.ts",
+        "sourcemapPublic.ts",
         "transformers/utilities.ts",
         "transformers/destructuring.ts",
         "transformers/taggedTemplate.ts",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -885,6 +885,7 @@ namespace ts {
         /* @internal */ emitNode?: EmitNode;                  // Associated EmitNode (initialized by transforms)
         /* @internal */ contextualType?: Type;                // Used to temporarily assign a contextual type during overload resolution
         /* @internal */ inferenceContext?: InferenceContext;  // Inference context for contextual type
+        /* @internal */ transformer?: TransformerFactory<Node>; // Source transformer that created the node
     }
 
     export interface JSDocContainer {
@@ -6669,6 +6670,7 @@ namespace ts {
         esModuleInterop?: boolean;
         /* @internal */ showConfig?: boolean;
         useDefineForClassFields?: boolean;
+        annotateTransforms?: boolean;
 
         [option: string]: CompilerOptionsValue | TsConfigSourceFile | undefined;
     }
@@ -8786,6 +8788,7 @@ namespace ts {
         /*@internal*/ stripInternal?: boolean;
         /*@internal*/ preserveSourceNewlines?: boolean;
         /*@internal*/ terminateUnterminatedLiterals?: boolean;
+        /*@internal*/ annotateTransforms?: boolean;
         /*@internal*/ relativeToBuildInfo?: (path: string) => string;
     }
 
@@ -8798,6 +8801,8 @@ namespace ts {
         sourcesContent?: (string | null)[] | null;
         mappings: string;
         names?: string[] | null;
+        [key: `x_${string}`]: unknown;
+        x_ms_ts_annotations?: string;
     }
 
     /**
@@ -8831,6 +8836,10 @@ namespace ts {
          */
         appendSourceMap(generatedLine: number, generatedCharacter: number, sourceMap: RawSourceMap, sourceMapPath: string, start?: LineAndCharacter, end?: LineAndCharacter): void;
         /**
+         * Adds a JSON annotation at the specified line and character.
+         */
+        addAnnotation(generatedLine: number, generatedCharacter: number, annotationName: string, annotationValue: unknown): void;
+        /**
          * Gets the source map as a `RawSourceMap` object.
          */
         toJSON(): RawSourceMap;
@@ -8838,6 +8847,11 @@ namespace ts {
          * Gets the string representation of the source map.
          */
         toString(): string;
+    }
+
+    export interface SourceMapAnnotation {
+        name: string;
+        value: unknown;
     }
 
     /* @internal */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3088,6 +3088,7 @@ declare namespace ts {
         typeRoots?: string[];
         esModuleInterop?: boolean;
         useDefineForClassFields?: boolean;
+        annotateTransforms?: boolean;
         [option: string]: CompilerOptionsValue | TsConfigSourceFile | undefined;
     }
     export interface WatchOptions {
@@ -4051,6 +4052,10 @@ declare namespace ts {
         newLine?: NewLineKind;
         omitTrailingSemicolon?: boolean;
         noEmitHelpers?: boolean;
+    }
+    export interface SourceMapAnnotation {
+        name: string;
+        value: unknown;
     }
     export interface GetEffectiveTypeRootsHost {
         directoryExists?(directoryName: string): boolean;
@@ -5140,6 +5145,17 @@ declare namespace ts {
      * @param context A lexical environment context for the visitor.
      */
     function visitEachChild<T extends Node>(node: T | undefined, visitor: Visitor, context: TransformationContext, nodesVisitor?: typeof visitNodes, tokenVisitor?: Visitor): T | undefined;
+}
+declare namespace ts {
+    interface DecodedSourceMapAnnotation {
+        generatedLine: number;
+        generatedCharacter: number;
+        annotations: SourceMapAnnotation[];
+    }
+    /**
+     * Decodes the custom `x_ms_ts_annotations` field of a SourceMap.
+     */
+    function decodeSourceMapAnnotations(annotations: string, names: readonly string[]): Iterator<DecodedSourceMapAnnotation>;
 }
 declare namespace ts {
     function getTsBuildInfoEmitOutputFilePath(options: CompilerOptions): string | undefined;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3088,6 +3088,7 @@ declare namespace ts {
         typeRoots?: string[];
         esModuleInterop?: boolean;
         useDefineForClassFields?: boolean;
+        annotateTransforms?: boolean;
         [option: string]: CompilerOptionsValue | TsConfigSourceFile | undefined;
     }
     export interface WatchOptions {
@@ -4051,6 +4052,10 @@ declare namespace ts {
         newLine?: NewLineKind;
         omitTrailingSemicolon?: boolean;
         noEmitHelpers?: boolean;
+    }
+    export interface SourceMapAnnotation {
+        name: string;
+        value: unknown;
     }
     export interface GetEffectiveTypeRootsHost {
         directoryExists?(directoryName: string): boolean;
@@ -5140,6 +5145,17 @@ declare namespace ts {
      * @param context A lexical environment context for the visitor.
      */
     function visitEachChild<T extends Node>(node: T | undefined, visitor: Visitor, context: TransformationContext, nodesVisitor?: typeof visitNodes, tokenVisitor?: Visitor): T | undefined;
+}
+declare namespace ts {
+    interface DecodedSourceMapAnnotation {
+        generatedLine: number;
+        generatedCharacter: number;
+        annotations: SourceMapAnnotation[];
+    }
+    /**
+     * Decodes the custom `x_ms_ts_annotations` field of a SourceMap.
+     */
+    function decodeSourceMapAnnotations(annotations: string, names: readonly string[]): Iterator<DecodedSourceMapAnnotation>;
 }
 declare namespace ts {
     function getTsBuildInfoEmitOutputFilePath(options: CompilerOptions): string | undefined;

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/annotateTransforms/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/annotateTransforms/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "annotateTransforms": true
+    }
+}


### PR DESCRIPTION
This adds an `--annotateTransforms` compiler option that can (eventually) be used as a debugging tool for compiler transforms. When `--annotateTransforms` is set, along with `--sourceMap` (and/or `--declarationMap`), an extra `x_ms_ts_annotations` property is added to the output source map containing annotations associated with a line/character in the generated output. 

However, this isn't extremely useful on its own. In addition to this, we would need to publish a VS Code extension capable of reading the source map that can then add hovers or text editor decorations to display the diagnostic information. The end result would be something not unlike VS Code's own "Developer: Inspect Editor Tokens and Scopes" command, allowing you to inspect which transformers lead to a specific node being included in the output.

Most of this was originally part of #50820, but I'm pulling the functionality out of that PR. The original version injected comments into the output, but that made the output file difficult to read and thus defeated the purpose.

The format of the `x_ms_ts_annotations` field is not yet set in stone and is likely to change before (if) this becomes available. The information stored in `x_ms_ts_annotations` is intentionally generic: an "Annotation" is an object consisting of a name (a string) and a value (any valid JSON). One or more annotations can be associated with a generated line/character:

```ts
interface SourceMapAnnotation {
  name: string;
  value: unknown;
}

interface DecodedSourceMapAnnotation {
  generatedLine: number;
  generatedCharacter: number;
  annotations: SourceMapAnnotation[];
}
```

The provided name need not be unique. All annotations will be included at the generated position since multiple nodes can share the same generated start and end positions.

In addition, this adds a public `decodeSourceMapAnnotations` function that can be used to deserialize the `x_ms_ts_annotations` property into each `DecodedSourceMapAnnotation` entry.

When `--annotateTransforms` is enabled, the following annotations are written before and after each `Node`:
```
{ name: "typescript.transformers", value: { kind: "start", transformers: ["ts", "es2022", ...] } }
{ name: "typescript.transformers", value: { kind: "end" } }
```

Since this can be fairly chatty, this information is only written to the source map when `--annotateTransforms` is enabled.