### PR TITLE
Fix for broken baseline in yieldInForInInDownlevelGenerator

### DIFF
--- a/tests/baselines/reference/yieldInForInInDownlevelGenerator.js
+++ b/tests/baselines/reference/yieldInForInInDownlevelGenerator.js
@@ -15,7 +15,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     function verb(n) { return function (v) { return step([n, v]); }; }
     function step(op) {
         if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
             if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
             if (y = 0, t) op = [op[0] & 2, t.value];
             switch (op[0]) {


### PR DESCRIPTION
This fixes a broken baseline due to overlapping emit changes from two different PRs.
