### PR TITLE
Improving Date.getTime documentation

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -741,7 +741,7 @@ interface Date {
     toLocaleTimeString(): string;
     /** Returns the stored time value in milliseconds since midnight, January 1, 1970 UTC. */
     valueOf(): number;
-    /** Gets the time value in milliseconds. */
+    /** Returns the stored time value in milliseconds since midnight, January 1, 1970 UTC. */
     getTime(): number;
     /** Gets the year, using local time. */
     getFullYear(): number;


### PR DESCRIPTION
Closes #51366 

Currently the `Date.getTime` documentation isn't very clear that it's the number of milliseconds since unix epoch. This PR makes that more clear.