### PR TITLE
Fix missed errors in switch when using union of literal and non-literal types (#38686)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40048,7 +40048,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let hasDuplicateDefaultClause = false;
 
         const expressionType = checkExpression(node.expression);
-        
+
         forEach(node.caseBlock.clauses, clause => {
             // Grammar check for duplicate default clauses, skip if we already report duplicate default clause
             if (clause.kind === SyntaxKind.DefaultClause && !hasDuplicateDefaultClause) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40048,7 +40048,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let hasDuplicateDefaultClause = false;
 
         const expressionType = checkExpression(node.expression);
-        const expressionIsLiteral = isLiteralType(expressionType);
+        
         forEach(node.caseBlock.clauses, clause => {
             // Grammar check for duplicate default clauses, skip if we already report duplicate default clause
             if (clause.kind === SyntaxKind.DefaultClause && !hasDuplicateDefaultClause) {
@@ -40074,16 +40074,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // TypeScript 1.0 spec (April 2014): 5.9
                     // In a 'switch' statement, each 'case' expression must be of a type that is comparable
                     // to or from the type of the 'switch' expression.
-                    let caseType = checkExpression(clause.expression);
-                    const caseIsLiteral = isLiteralType(caseType);
-                    let comparedExpressionType = expressionType;
-                    if (!caseIsLiteral || !expressionIsLiteral) {
-                        caseType = caseIsLiteral ? getBaseTypeOfLiteralType(caseType) : caseType;
-                        comparedExpressionType = getBaseTypeOfLiteralType(expressionType);
-                    }
-                    if (!isTypeEqualityComparableTo(comparedExpressionType, caseType)) {
+                    const caseType = checkExpression(clause.expression);
+
+                    if (!isTypeEqualityComparableTo(expressionType, caseType)) {
                         // expressionType is not comparable to caseType, try the reversed check and report errors if it fails
-                        checkTypeComparableTo(caseType, comparedExpressionType, clause.expression, /*headMessage*/ undefined);
+                        checkTypeComparableTo(caseType, expressionType, clause.expression, /*headMessage*/ undefined);
                     }
                 };
             }

--- a/tests/baselines/reference/switchAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/switchAssignmentCompat.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/switchAssignmentCompat.ts(4,10): error TS2678: Type 'typeof Foo' is not comparable to type 'number'.
+tests/cases/compiler/switchAssignmentCompat.ts(4,10): error TS2678: Type 'typeof Foo' is not comparable to type '0'.
 
 
 ==== tests/cases/compiler/switchAssignmentCompat.ts (1 errors) ====
@@ -7,6 +7,6 @@ tests/cases/compiler/switchAssignmentCompat.ts(4,10): error TS2678: Type 'typeof
     switch (0) {
         case Foo: break; // Error expected
              ~~~
-!!! error TS2678: Type 'typeof Foo' is not comparable to type 'number'.
+!!! error TS2678: Type 'typeof Foo' is not comparable to type '0'.
     }
     

--- a/tests/baselines/reference/switchCaseCircularRefeference.errors.txt
+++ b/tests/baselines/reference/switchCaseCircularRefeference.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/switchCaseCircularRefeference.ts(5,10): error TS2678: Type '{ a: "A"; b: any; } | { a: "C"; e: any; }' is not comparable to type 'string'.
-  Type '{ a: "C"; e: any; }' is not comparable to type 'string'.
+tests/cases/compiler/switchCaseCircularRefeference.ts(5,10): error TS2678: Type '{ a: "A"; b: any; } | { a: "C"; e: any; }' is not comparable to type '"A" | "C"'.
+  Type '{ a: "C"; e: any; }' is not comparable to type '"A" | "C"'.
 
 
 ==== tests/cases/compiler/switchCaseCircularRefeference.ts (1 errors) ====
@@ -9,8 +9,8 @@ tests/cases/compiler/switchCaseCircularRefeference.ts(5,10): error TS2678: Type 
         switch (x.a) {
         case x:
              ~
-!!! error TS2678: Type '{ a: "A"; b: any; } | { a: "C"; e: any; }' is not comparable to type 'string'.
-!!! error TS2678:   Type '{ a: "C"; e: any; }' is not comparable to type 'string'.
+!!! error TS2678: Type '{ a: "A"; b: any; } | { a: "C"; e: any; }' is not comparable to type '"A" | "C"'.
+!!! error TS2678:   Type '{ a: "C"; e: any; }' is not comparable to type '"A" | "C"'.
             break;
         }
     }

--- a/tests/baselines/reference/switchCasesExpressionTypeMismatch.errors.txt
+++ b/tests/baselines/reference/switchCasesExpressionTypeMismatch.errors.txt
@@ -1,16 +1,18 @@
-tests/cases/compiler/switchCasesExpressionTypeMismatch.ts(4,10): error TS2678: Type 'typeof Foo' is not comparable to type 'number'.
+tests/cases/compiler/switchCasesExpressionTypeMismatch.ts(4,10): error TS2678: Type 'typeof Foo' is not comparable to type '0'.
 tests/cases/compiler/switchCasesExpressionTypeMismatch.ts(5,10): error TS2678: Type '"sss"' is not comparable to type '0'.
 tests/cases/compiler/switchCasesExpressionTypeMismatch.ts(6,10): error TS2678: Type '123' is not comparable to type '0'.
 tests/cases/compiler/switchCasesExpressionTypeMismatch.ts(7,10): error TS2678: Type 'true' is not comparable to type '0'.
+tests/cases/compiler/switchCasesExpressionTypeMismatch.ts(16,10): error TS2678: Type 'true' is not comparable to type 'number | "hello"'.
+tests/cases/compiler/switchCasesExpressionTypeMismatch.ts(18,10): error TS2678: Type '"world"' is not comparable to type 'number | "hello"'.
 
 
-==== tests/cases/compiler/switchCasesExpressionTypeMismatch.ts (4 errors) ====
+==== tests/cases/compiler/switchCasesExpressionTypeMismatch.ts (6 errors) ====
     class Foo { }
     
     switch (0) {
         case Foo: break;    // Error
              ~~~
-!!! error TS2678: Type 'typeof Foo' is not comparable to type 'number'.
+!!! error TS2678: Type 'typeof Foo' is not comparable to type '0'.
         case "sss": break;  // Error
              ~~~~~
 !!! error TS2678: Type '"sss"' is not comparable to type '0'.
@@ -20,6 +22,21 @@ tests/cases/compiler/switchCasesExpressionTypeMismatch.ts(7,10): error TS2678: T
         case true: break;   // Error
              ~~~~
 !!! error TS2678: Type 'true' is not comparable to type '0'.
+    }
+    
+    declare var q: string
+    declare var r: number | "hello"
+    
+    switch (r) {
+        case q: break
+        case 42: break
+        case true: break // Error
+             ~~~~
+!!! error TS2678: Type 'true' is not comparable to type 'number | "hello"'.
+        case "hello": break
+        case "world": break // Error
+             ~~~~~~~
+!!! error TS2678: Type '"world"' is not comparable to type 'number | "hello"'.
     }
     
     var s: any = 0;

--- a/tests/baselines/reference/switchCasesExpressionTypeMismatch.js
+++ b/tests/baselines/reference/switchCasesExpressionTypeMismatch.js
@@ -8,6 +8,17 @@ switch (0) {
     case true: break;   // Error
 }
 
+declare var q: string
+declare var r: number | "hello"
+
+switch (r) {
+    case q: break
+    case 42: break
+    case true: break // Error
+    case "hello": break
+    case "world": break // Error
+}
+
 var s: any = 0;
 
 // No error for all
@@ -30,6 +41,13 @@ switch (0) {
     case "sss": break; // Error
     case 123: break; // Error
     case true: break; // Error
+}
+switch (r) {
+    case q: break;
+    case 42: break;
+    case true: break; // Error
+    case "hello": break;
+    case "world": break; // Error
 }
 var s = 0;
 // No error for all

--- a/tests/baselines/reference/switchCasesExpressionTypeMismatch.symbols
+++ b/tests/baselines/reference/switchCasesExpressionTypeMismatch.symbols
@@ -11,12 +11,30 @@ switch (0) {
     case true: break;   // Error
 }
 
+declare var q: string
+>q : Symbol(q, Decl(switchCasesExpressionTypeMismatch.ts, 9, 11))
+
+declare var r: number | "hello"
+>r : Symbol(r, Decl(switchCasesExpressionTypeMismatch.ts, 10, 11))
+
+switch (r) {
+>r : Symbol(r, Decl(switchCasesExpressionTypeMismatch.ts, 10, 11))
+
+    case q: break
+>q : Symbol(q, Decl(switchCasesExpressionTypeMismatch.ts, 9, 11))
+
+    case 42: break
+    case true: break // Error
+    case "hello": break
+    case "world": break // Error
+}
+
 var s: any = 0;
->s : Symbol(s, Decl(switchCasesExpressionTypeMismatch.ts, 9, 3))
+>s : Symbol(s, Decl(switchCasesExpressionTypeMismatch.ts, 20, 3))
 
 // No error for all
 switch (s) {
->s : Symbol(s, Decl(switchCasesExpressionTypeMismatch.ts, 9, 3))
+>s : Symbol(s, Decl(switchCasesExpressionTypeMismatch.ts, 20, 3))
 
     case Foo: break;
 >Foo : Symbol(Foo, Decl(switchCasesExpressionTypeMismatch.ts, 0, 0))

--- a/tests/baselines/reference/switchCasesExpressionTypeMismatch.types
+++ b/tests/baselines/reference/switchCasesExpressionTypeMismatch.types
@@ -18,6 +18,31 @@ switch (0) {
 >true : true
 }
 
+declare var q: string
+>q : string
+
+declare var r: number | "hello"
+>r : number | "hello"
+
+switch (r) {
+>r : number | "hello"
+
+    case q: break
+>q : string
+
+    case 42: break
+>42 : 42
+
+    case true: break // Error
+>true : true
+
+    case "hello": break
+>"hello" : "hello"
+
+    case "world": break // Error
+>"world" : "world"
+}
+
 var s: any = 0;
 >s : any
 >0 : 0

--- a/tests/cases/compiler/switchCasesExpressionTypeMismatch.ts
+++ b/tests/cases/compiler/switchCasesExpressionTypeMismatch.ts
@@ -7,6 +7,17 @@ switch (0) {
     case true: break;   // Error
 }
 
+declare var q: string
+declare var r: number | "hello"
+
+switch (r) {
+    case q: break
+    case 42: break
+    case true: break // Error
+    case "hello": break
+    case "world": break // Error
+}
+
 var s: any = 0;
 
 // No error for all


### PR DESCRIPTION
This commit makes it so we don’t use the base type of literals when checking comparability in switch. The comparability checks handle that case already, is my understanding, so we don’t need to clobber the type before actually doing the check, causing missed errors.

When comparing the types in switch, if a union with a literal and a non-literal was used, the compiler in `checker.ts` would automatically get the base type of all parts of the union, resulting in missed errors. For example, if the union of the non-literal `number` and literal `"hello"` was compared to the literal `"world"` in a switch case, the compiler would miss that they’re actually not comparable.

Maybe someone can tell me why we were getting the base type before checking comparability, rather than relying on the logic within the comparability checks to handle literal/base type comparability?

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #38686
