### PR TITLE
Fix nightly post-#50528 merge

### DIFF
--- a/src/debug/dbg.ts
+++ b/src/debug/dbg.ts
@@ -431,7 +431,7 @@ namespace Debug {
                     const above = lane > 0 ? connectors[column][lane - 1] : 0;
                     let connector = connectors[column][lane];
                     if (!connector) {
-                        if (left & Connection.Right) connector |= Connection.LeftRight;
+                        if (left & Connection.Right) connector = Connection.LeftRight;
                         if (above & Connection.Down) connector |= Connection.UpDown;
                         connectors[column][lane] = connector;
                     }


### PR DESCRIPTION
Fixes our nightly publish, which requires a clean post-LKG build. Looks like #50528 missed an instance of enum narrowing behaviors changing a bit in our own codebase between when it was made and when it was merged.