### PR TITLE
Depend on build-src in runtests

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -595,7 +595,7 @@ export const watchLocal = task({
 export const runTests = task({
     name: "runtests",
     description: "Runs the tests using the built run.js file.",
-    dependencies: [tests, generateLibs, dts],
+    dependencies: [tests, generateLibs, dts, buildSrc],
     run: () => runConsoleTests(testRunner, "mocha-fivemat-progress-reporter", /*runInParallel*/ false),
 });
 // task("runtests").flags = {
@@ -617,7 +617,7 @@ export const runTests = task({
 export const runTestsParallel = task({
     name: "runtests-parallel",
     description: "Runs all the tests in parallel using the built run.js file.",
-    dependencies: [tests, generateLibs, dts],
+    dependencies: [tests, generateLibs, dts, buildSrc],
     run: () => runConsoleTests(testRunner, "min", /*runInParallel*/ cmdLineOptions.workers > 1),
 });
 // task("runtests-parallel").flags = {

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -580,7 +580,7 @@ export const watchOtherOutputs = task({
 export const local = task({
     name: "local",
     description: "Builds the full compiler and services",
-    dependencies: [localize, tsc, tsserver, services, lssl, otherOutputs, dts],
+    dependencies: [localize, tsc, tsserver, services, lssl, otherOutputs, dts, buildSrc],
 });
 export default local;
 
@@ -588,7 +588,7 @@ export const watchLocal = task({
     name: "watch-local",
     description: "Watches the full compiler and services",
     hiddenFromTaskList: true,
-    dependencies: [localize, watchTsc, watchTsserver, watchServices, watchLssl, watchOtherOutputs, dts],
+    dependencies: [localize, watchTsc, watchTsserver, watchServices, watchLssl, watchOtherOutputs, dts, watchSrc],
 });
 
 


### PR DESCRIPTION
Right now when testing, you will only get typechecking errors for projects depended on by `typescript` and `tsserverlibrary`, but that omits the code for tsc, tsserver, etc, which is not shared.

Depend on the entire src build when running the tests, which on the whole shouldn't be much slower.