### PR TITLE
Replace eslint-plugin-jsdoc by extending local jsdoc-format rule, saving ~20% of our linting time

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
         "es6": true
     },
     "plugins": [
-        "@typescript-eslint", "jsdoc", "no-null", "import", "eslint-plugin-local"
+        "@typescript-eslint", "no-null", "import", "eslint-plugin-local"
     ],
     "rules": {
         "@typescript-eslint/adjacent-overload-signatures": "error",
@@ -94,9 +94,6 @@
 
         // eslint-plugin-no-null
         "no-null/no-null": "error",
-
-        // eslint-plugin-jsdoc
-        "jsdoc/check-alignment": "error",
 
         // eslint
         "constructor-super": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,18 +56,36 @@
                 "node": ">=4.2.0"
             }
         },
-        "node_modules/@es-joy/jsdoccomment": {
-            "version": "0.36.0",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.0.tgz",
-            "integrity": "sha512-u0XZyvUF6Urb2cSivSXA8qXIpT/CxkHcdtZKoWusAzgzmsTWpg0F2FpWXsolHmMUyVY3dLWaoy+0ccJ5uf2QjA==",
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.13.tgz",
+            "integrity": "sha512-RY2fVI8O0iFUNvZirXaQ1vMvK0xhCcl0gqRj74Z6yEiO1zAUa7hbsdwZM1kzqbxHK7LFyMizipfXT3JME+12Hw==",
+            "cpu": [
+                "arm"
+            ],
             "dev": true,
-            "dependencies": {
-                "comment-parser": "1.3.1",
-                "esquery": "^1.4.0",
-                "jsdoc-type-pratt-parser": "~3.1.0"
-            },
+            "optional": true,
+            "os": [
+                "android"
+            ],
             "engines": {
-                "node": "^14 || ^16 || ^17 || ^18 || ^19"
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.13.tgz",
+            "integrity": "sha512-+BoyIm4I8uJmH/QDIH0fu7MG0AEx9OXEDXnqptXCwKOlOqZiS4iraH1Nr7/ObLMokW3sOCeBNyD68ATcV9b9Ag==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -341,9 +359,9 @@
             }
         },
         "node_modules/@types/chai": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-            "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+            "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
             "dev": true
         },
         "node_modules/@types/fs-extra": {
@@ -435,14 +453,14 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.0.tgz",
-            "integrity": "sha512-5TJh2AgL6+wpL8H/GTSjNb4WrjKoR2rqvFxR/DDTqYNk6uXn8BJMEcncLSpMbf/XV1aS0jAjYwn98uvVCiAywQ==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz",
+            "integrity": "sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.42.0",
-                "@typescript-eslint/type-utils": "5.42.0",
-                "@typescript-eslint/utils": "5.42.0",
+                "@typescript-eslint/scope-manager": "5.42.1",
+                "@typescript-eslint/type-utils": "5.42.1",
+                "@typescript-eslint/utils": "5.42.1",
                 "debug": "^4.3.4",
                 "ignore": "^5.2.0",
                 "natural-compare-lite": "^1.4.0",
@@ -468,14 +486,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.0.tgz",
-            "integrity": "sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.1.tgz",
+            "integrity": "sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.42.0",
-                "@typescript-eslint/types": "5.42.0",
-                "@typescript-eslint/typescript-estree": "5.42.0",
+                "@typescript-eslint/scope-manager": "5.42.1",
+                "@typescript-eslint/types": "5.42.1",
+                "@typescript-eslint/typescript-estree": "5.42.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -495,13 +513,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.0.tgz",
-            "integrity": "sha512-l5/3IBHLH0Bv04y+H+zlcLiEMEMjWGaCX6WyHE5Uk2YkSGAMlgdUPsT/ywTSKgu9D1dmmKMYgYZijObfA39Wow==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz",
+            "integrity": "sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.42.0",
-                "@typescript-eslint/visitor-keys": "5.42.0"
+                "@typescript-eslint/types": "5.42.1",
+                "@typescript-eslint/visitor-keys": "5.42.1"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -512,13 +530,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.0.tgz",
-            "integrity": "sha512-HW14TXC45dFVZxnVW8rnUGnvYyRC0E/vxXShFCthcC9VhVTmjqOmtqj6H5rm9Zxv+ORxKA/1aLGD7vmlLsdlOg==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz",
+            "integrity": "sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.42.0",
-                "@typescript-eslint/utils": "5.42.0",
+                "@typescript-eslint/typescript-estree": "5.42.1",
+                "@typescript-eslint/utils": "5.42.1",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -539,9 +557,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.0.tgz",
-            "integrity": "sha512-t4lzO9ZOAUcHY6bXQYRuu+3SSYdD9TS8ooApZft4WARt4/f2Cj/YpvbTe8A4GuhT4bNW72goDMOy7SW71mZwGw==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.1.tgz",
+            "integrity": "sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -552,13 +570,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.0.tgz",
-            "integrity": "sha512-2O3vSq794x3kZGtV7i4SCWZWCwjEtkWfVqX4m5fbUBomOsEOyd6OAD1qU2lbvV5S8tgy/luJnOYluNyYVeOTTg==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz",
+            "integrity": "sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.42.0",
-                "@typescript-eslint/visitor-keys": "5.42.0",
+                "@typescript-eslint/types": "5.42.1",
+                "@typescript-eslint/visitor-keys": "5.42.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -579,16 +597,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.0.tgz",
-            "integrity": "sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.1.tgz",
+            "integrity": "sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==",
             "dev": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.42.0",
-                "@typescript-eslint/types": "5.42.0",
-                "@typescript-eslint/typescript-estree": "5.42.0",
+                "@typescript-eslint/scope-manager": "5.42.1",
+                "@typescript-eslint/types": "5.42.1",
+                "@typescript-eslint/typescript-estree": "5.42.1",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0",
                 "semver": "^7.3.7"
@@ -605,12 +623,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.0.tgz",
-            "integrity": "sha512-QHbu5Hf/2lOEOwy+IUw0GoSCuAzByTAWWrOTKzTzsotiUnWFpuKnXcAhC9YztAf2EElQ0VvIK+pHJUPkM0q7jg==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz",
+            "integrity": "sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.42.0",
+                "@typescript-eslint/types": "5.42.1",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -671,6 +689,15 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -724,15 +751,15 @@
             }
         },
         "node_modules/array-includes": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-            "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+            "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
-                "es-abstract": "^1.19.5",
-                "get-intrinsic": "^1.1.1",
+                "es-abstract": "^1.20.4",
+                "get-intrinsic": "^1.1.3",
                 "is-string": "^1.0.7"
             },
             "engines": {
@@ -874,15 +901,27 @@
                 "node": ">=6"
             }
         },
+        "node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/chai": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-            "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+            "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
             "dev": true,
             "dependencies": {
                 "assertion-error": "^1.1.0",
                 "check-error": "^1.0.2",
-                "deep-eql": "^3.0.1",
+                "deep-eql": "^4.1.2",
                 "get-func-name": "^2.0.0",
                 "loupe": "^2.3.1",
                 "pathval": "^1.1.1",
@@ -944,6 +983,18 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/chokidar/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/clean-stack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -951,6 +1002,17 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
             }
         },
         "node_modules/color-convert": {
@@ -1090,15 +1152,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/comment-parser": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-            "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1151,16 +1204,28 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
+        "node_modules/decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/deep-eql": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.2.tgz",
+            "integrity": "sha512-gT18+YW4CcW/DBNTwAmqTtkJh7f9qqScu2qFVlx7kCoeY9tlBu9cUcr7+I+Z/noG8INehS3xQgLpTtd/QUTn4w==",
             "dev": true,
             "dependencies": {
                 "type-detect": "^4.0.0"
             },
             "engines": {
-                "node": ">=0.12"
+                "node": ">=6"
             }
         },
         "node_modules/deep-extend": {
@@ -1362,12 +1427,316 @@
                 "esbuild-windows-arm64": "0.15.13"
             }
         },
+        "node_modules/esbuild-android-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.13.tgz",
+            "integrity": "sha512-yRorukXBlokwTip+Sy4MYskLhJsO0Kn0/Fj43s1krVblfwP+hMD37a4Wmg139GEsMLl+vh8WXp2mq/cTA9J97g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-android-arm64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.13.tgz",
+            "integrity": "sha512-TKzyymLD6PiVeyYa4c5wdPw87BeAiTXNtK6amWUcXZxkV51gOk5u5qzmDaYSwiWeecSNHamFsaFjLoi32QR5/w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.13.tgz",
+            "integrity": "sha512-WAx7c2DaOS6CrRcoYCgXgkXDliLnFv3pQLV6GeW1YcGEZq2Gnl8s9Pg7ahValZkpOa0iE/ojRVQ87sbUhF1Cbg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-arm64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.13.tgz",
+            "integrity": "sha512-U6jFsPfSSxC3V1CLiQqwvDuj3GGrtQNB3P3nNC3+q99EKf94UGpsG9l4CQ83zBs1NHrk1rtCSYT0+KfK5LsD8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.13.tgz",
+            "integrity": "sha512-whItJgDiOXaDG/idy75qqevIpZjnReZkMGCgQaBWZuKHoElDJC1rh7MpoUgupMcdfOd+PgdEwNQW9DAE6i8wyA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-arm64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.13.tgz",
+            "integrity": "sha512-6pCSWt8mLUbPtygv7cufV0sZLeylaMwS5Fznj6Rsx9G2AJJsAjQ9ifA+0rQEIg7DwJmi9it+WjzNTEAzzdoM3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-32": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.13.tgz",
+            "integrity": "sha512-VbZdWOEdrJiYApm2kkxoTOgsoCO1krBZ3quHdYk3g3ivWaMwNIVPIfEE0f0XQQ0u5pJtBsnk2/7OPiCFIPOe/w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.13.tgz",
+            "integrity": "sha512-rXmnArVNio6yANSqDQlIO4WiP+Cv7+9EuAHNnag7rByAqFVuRusLbGi2697A5dFPNXoO//IiogVwi3AdcfPC6A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.13.tgz",
+            "integrity": "sha512-Ac6LpfmJO8WhCMQmO253xX2IU2B3wPDbl4IvR0hnqcPrdfCaUa2j/lLMGTjmQ4W5JsJIdHEdW12dG8lFS0MbxQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.13.tgz",
+            "integrity": "sha512-alEMGU4Z+d17U7KQQw2IV8tQycO6T+rOrgW8OS22Ua25x6kHxoG6Ngry6Aq6uranC+pNWNMB6aHFPh7aTQdORQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-mips64le": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.13.tgz",
+            "integrity": "sha512-47PgmyYEu+yN5rD/MbwS6DxP2FSGPo4Uxg5LwIdxTiyGC2XKwHhHyW7YYEDlSuXLQXEdTO7mYe8zQ74czP7W8A==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-ppc64le": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.13.tgz",
+            "integrity": "sha512-z6n28h2+PC1Ayle9DjKoBRcx/4cxHoOa2e689e2aDJSaKug3jXcQw7mM+GLg+9ydYoNzj8QxNL8ihOv/OnezhA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-riscv64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.13.tgz",
+            "integrity": "sha512-+Lu4zuuXuQhgLUGyZloWCqTslcCAjMZH1k3Xc9MSEJEpEFdpsSU0sRDXAnk18FKOfEjhu4YMGaykx9xjtpA6ow==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-s390x": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.13.tgz",
+            "integrity": "sha512-BMeXRljruf7J0TMxD5CIXS65y7puiZkAh+s4XFV9qy16SxOuMhxhVIXYLnbdfLrsYGFzx7U9mcdpFWkkvy/Uag==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-netbsd-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.13.tgz",
+            "integrity": "sha512-EHj9QZOTel581JPj7UO3xYbltFTYnHy+SIqJVq6yd3KkCrsHRbapiPb0Lx3EOOtybBEE9EyqbmfW1NlSDsSzvQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-openbsd-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.13.tgz",
+            "integrity": "sha512-nkuDlIjF/sfUhfx8SKq0+U+Fgx5K9JcPq1mUodnxI0x4kBdCv46rOGWbuJ6eof2n3wdoCLccOoJAbg9ba/bT2w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-sunos-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.13.tgz",
+            "integrity": "sha512-jVeu2GfxZQ++6lRdY43CS0Tm/r4WuQQ0Pdsrxbw+aOrHQPHV0+LNOLnvbN28M7BSUGnJnHkHm2HozGgNGyeIRw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-32": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.13.tgz",
+            "integrity": "sha512-XoF2iBf0wnqo16SDq+aDGi/+QbaLFpkiRarPVssMh9KYbFNCqPLlGAWwDvxEVz+ywX6Si37J2AKm+AXq1kC0JA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/esbuild-windows-64": {
             "version": "0.15.13",
             "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.13.tgz",
             "integrity": "sha512-Et6htEfGycjDrtqb2ng6nT+baesZPYQIW+HUEHK4D1ncggNrDNk3yoboYQ5KtiVrw/JaDMNttz8rrPubV/fvPQ==",
             "cpu": [
                 "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-arm64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.13.tgz",
+            "integrity": "sha512-3bv7tqntThQC9SWLRouMDmZnlOukBhOCTlkzNqzGCmrkCJI7io5LLjwJBOVY6kOUlIvdxbooNZwjtBvj+7uuVg==",
+            "cpu": [
+                "arm64"
             ],
             "dev": true,
             "optional": true,
@@ -1570,27 +1939,6 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
-        "node_modules/eslint-plugin-jsdoc": {
-            "version": "39.6.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.2.tgz",
-            "integrity": "sha512-dvgY/W7eUFoAIIiaWHERIMI61ZWqcz9YFjEeyTzdPlrZc3TY/3aZm5aB91NUoTLWYZmO/vFlYSuQi15tF7uE5A==",
-            "dev": true,
-            "dependencies": {
-                "@es-joy/jsdoccomment": "~0.36.0",
-                "comment-parser": "1.3.1",
-                "debug": "^4.3.4",
-                "escape-string-regexp": "^4.0.0",
-                "esquery": "^1.4.0",
-                "semver": "^7.3.8",
-                "spdx-expression-parse": "^3.0.1"
-            },
-            "engines": {
-                "node": "^14 || ^16 || ^17 || ^18 || ^19"
-            },
-            "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
-            }
-        },
         "node_modules/eslint-plugin-local": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-local/-/eslint-plugin-local-1.0.0.tgz",
@@ -1678,18 +2026,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4.0"
-            }
-        },
-        "node_modules/eslint/node_modules/glob-parent": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
-            "dependencies": {
-                "is-glob": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=10.13.0"
             }
         },
         "node_modules/espree": {
@@ -1789,6 +2125,18 @@
             },
             "engines": {
                 "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fast-glob/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/fast-json-stable-stringify": {
@@ -1986,6 +2334,20 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2017,6 +2379,15 @@
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
             }
         },
         "node_modules/get-func-name": {
@@ -2078,15 +2449,15 @@
             }
         },
         "node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "dependencies": {
-                "is-glob": "^4.0.1"
+                "is-glob": "^4.0.3"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
@@ -2255,12 +2626,6 @@
             "engines": {
                 "node": ">= 12.20"
             }
-        },
-        "node_modules/hereby/node_modules/picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-            "dev": true
         },
         "node_modules/ignore": {
             "version": "5.2.0",
@@ -2440,6 +2805,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-glob": {
@@ -2632,15 +3006,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsdoc-type-pratt-parser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-            "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2740,9 +3105,9 @@
             }
         },
         "node_modules/loupe": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.5.tgz",
-            "integrity": "sha512-KNGVjhsXDxvY/cYE8GNi7SBaJSfJIT+/+/8GlprqBXpoU6cSR7/RT7OBJOsoYtyxq0L3q6oIcO8tX7dbEEXr3A==",
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+            "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
             "dev": true,
             "dependencies": {
                 "get-func-name": "^2.0.0"
@@ -2849,26 +3214,6 @@
             "integrity": "sha512-nCf6dmCEHObJ8BBrcjW+UHYvVtHEL+FliYR/Mfc/v7dKenNmBQ0ZSuvlICgsyQy9Tt581ldvh+SReS4qp4LrQw==",
             "dev": true
         },
-        "node_modules/mocha/node_modules/ansi-colors": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/mocha/node_modules/cliui": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^7.0.0"
-            }
-        },
         "node_modules/mocha/node_modules/diff": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -2876,15 +3221,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
-            }
-        },
-        "node_modules/mocha/node_modules/get-caller-file": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
             }
         },
         "node_modules/mocha/node_modules/glob": {
@@ -2919,15 +3255,6 @@
                 "node": "*"
             }
         },
-        "node_modules/mocha/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/mocha/node_modules/minimatch": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -2949,20 +3276,6 @@
                 "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/mocha/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/mocha/node_modules/supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -2976,50 +3289,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/mocha/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/mocha/node_modules/y18n": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/mocha/node_modules/yargs": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-            "dev": true,
-            "dependencies": {
-                "cliui": "^7.0.2",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.0",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^20.2.2"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/ms": {
@@ -3135,14 +3404,14 @@
             }
         },
         "node_modules/object.values": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-            "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+            "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.19.1"
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3296,6 +3565,12 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -3555,10 +3830,24 @@
             }
         },
         "node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/safe-regex-test": {
             "version": "1.0.0",
@@ -3667,51 +3956,43 @@
                 "source-map": "^0.6.0"
             }
         },
-        "node_modules/spdx-exceptions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-            "dev": true
-        },
-        "node_modules/spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
-        "node_modules/spdx-license-ids": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-            "dev": true
-        },
         "node_modules/string.prototype.trimend": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-            "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+            "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
-                "es-abstract": "^1.19.5"
+                "es-abstract": "^1.20.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/string.prototype.trimstart": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-            "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+            "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
-                "es-abstract": "^1.19.5"
+                "es-abstract": "^1.20.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4083,17 +4364,61 @@
             "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
             "dev": true
         },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
         },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
+        },
+        "node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/yargs-parser": {
             "version": "20.2.4",
@@ -4119,30 +4444,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/yargs-unparser/node_modules/camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/yargs-unparser/node_modules/decamelize": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4157,16 +4458,19 @@
         }
     },
     "dependencies": {
-        "@es-joy/jsdoccomment": {
-            "version": "0.36.0",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.0.tgz",
-            "integrity": "sha512-u0XZyvUF6Urb2cSivSXA8qXIpT/CxkHcdtZKoWusAzgzmsTWpg0F2FpWXsolHmMUyVY3dLWaoy+0ccJ5uf2QjA==",
+        "@esbuild/android-arm": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.13.tgz",
+            "integrity": "sha512-RY2fVI8O0iFUNvZirXaQ1vMvK0xhCcl0gqRj74Z6yEiO1zAUa7hbsdwZM1kzqbxHK7LFyMizipfXT3JME+12Hw==",
             "dev": true,
-            "requires": {
-                "comment-parser": "1.3.1",
-                "esquery": "^1.4.0",
-                "jsdoc-type-pratt-parser": "~3.1.0"
-            }
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.13.tgz",
+            "integrity": "sha512-+BoyIm4I8uJmH/QDIH0fu7MG0AEx9OXEDXnqptXCwKOlOqZiS4iraH1Nr7/ObLMokW3sOCeBNyD68ATcV9b9Ag==",
+            "dev": true,
+            "optional": true
         },
         "@eslint/eslintrc": {
             "version": "1.3.3",
@@ -4370,9 +4674,9 @@
             }
         },
         "@types/chai": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-            "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+            "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
             "dev": true
         },
         "@types/fs-extra": {
@@ -4464,14 +4768,14 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.0.tgz",
-            "integrity": "sha512-5TJh2AgL6+wpL8H/GTSjNb4WrjKoR2rqvFxR/DDTqYNk6uXn8BJMEcncLSpMbf/XV1aS0jAjYwn98uvVCiAywQ==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz",
+            "integrity": "sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.42.0",
-                "@typescript-eslint/type-utils": "5.42.0",
-                "@typescript-eslint/utils": "5.42.0",
+                "@typescript-eslint/scope-manager": "5.42.1",
+                "@typescript-eslint/type-utils": "5.42.1",
+                "@typescript-eslint/utils": "5.42.1",
                 "debug": "^4.3.4",
                 "ignore": "^5.2.0",
                 "natural-compare-lite": "^1.4.0",
@@ -4481,53 +4785,53 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.0.tgz",
-            "integrity": "sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.1.tgz",
+            "integrity": "sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.42.0",
-                "@typescript-eslint/types": "5.42.0",
-                "@typescript-eslint/typescript-estree": "5.42.0",
+                "@typescript-eslint/scope-manager": "5.42.1",
+                "@typescript-eslint/types": "5.42.1",
+                "@typescript-eslint/typescript-estree": "5.42.1",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.0.tgz",
-            "integrity": "sha512-l5/3IBHLH0Bv04y+H+zlcLiEMEMjWGaCX6WyHE5Uk2YkSGAMlgdUPsT/ywTSKgu9D1dmmKMYgYZijObfA39Wow==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz",
+            "integrity": "sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.42.0",
-                "@typescript-eslint/visitor-keys": "5.42.0"
+                "@typescript-eslint/types": "5.42.1",
+                "@typescript-eslint/visitor-keys": "5.42.1"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.0.tgz",
-            "integrity": "sha512-HW14TXC45dFVZxnVW8rnUGnvYyRC0E/vxXShFCthcC9VhVTmjqOmtqj6H5rm9Zxv+ORxKA/1aLGD7vmlLsdlOg==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz",
+            "integrity": "sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "5.42.0",
-                "@typescript-eslint/utils": "5.42.0",
+                "@typescript-eslint/typescript-estree": "5.42.1",
+                "@typescript-eslint/utils": "5.42.1",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.0.tgz",
-            "integrity": "sha512-t4lzO9ZOAUcHY6bXQYRuu+3SSYdD9TS8ooApZft4WARt4/f2Cj/YpvbTe8A4GuhT4bNW72goDMOy7SW71mZwGw==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.1.tgz",
+            "integrity": "sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.0.tgz",
-            "integrity": "sha512-2O3vSq794x3kZGtV7i4SCWZWCwjEtkWfVqX4m5fbUBomOsEOyd6OAD1qU2lbvV5S8tgy/luJnOYluNyYVeOTTg==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz",
+            "integrity": "sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.42.0",
-                "@typescript-eslint/visitor-keys": "5.42.0",
+                "@typescript-eslint/types": "5.42.1",
+                "@typescript-eslint/visitor-keys": "5.42.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -4536,28 +4840,28 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.0.tgz",
-            "integrity": "sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.1.tgz",
+            "integrity": "sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.42.0",
-                "@typescript-eslint/types": "5.42.0",
-                "@typescript-eslint/typescript-estree": "5.42.0",
+                "@typescript-eslint/scope-manager": "5.42.1",
+                "@typescript-eslint/types": "5.42.1",
+                "@typescript-eslint/typescript-estree": "5.42.1",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0",
                 "semver": "^7.3.7"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.42.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.0.tgz",
-            "integrity": "sha512-QHbu5Hf/2lOEOwy+IUw0GoSCuAzByTAWWrOTKzTzsotiUnWFpuKnXcAhC9YztAf2EElQ0VvIK+pHJUPkM0q7jg==",
+            "version": "5.42.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz",
+            "integrity": "sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.42.0",
+                "@typescript-eslint/types": "5.42.1",
                 "eslint-visitor-keys": "^3.3.0"
             }
         },
@@ -4595,6 +4899,12 @@
                 "json-schema-traverse": "^0.4.1",
                 "uri-js": "^4.2.2"
             }
+        },
+        "ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+            "dev": true
         },
         "ansi-regex": {
             "version": "5.0.1",
@@ -4634,15 +4944,15 @@
             "dev": true
         },
         "array-includes": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-            "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+            "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
-                "es-abstract": "^1.19.5",
-                "get-intrinsic": "^1.1.1",
+                "es-abstract": "^1.20.4",
+                "get-intrinsic": "^1.1.3",
                 "is-string": "^1.0.7"
             }
         },
@@ -4751,15 +5061,21 @@
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
         },
+        "camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true
+        },
         "chai": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-            "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+            "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
             "dev": true,
             "requires": {
                 "assertion-error": "^1.1.0",
                 "check-error": "^1.0.2",
-                "deep-eql": "^3.0.1",
+                "deep-eql": "^4.1.2",
                 "get-func-name": "^2.0.0",
                 "loupe": "^2.3.1",
                 "pathval": "^1.1.1",
@@ -4796,6 +5112,17 @@
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
                 "readdirp": "~3.6.0"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                }
             }
         },
         "clean-stack": {
@@ -4803,6 +5130,17 @@
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "dev": true
+        },
+        "cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "requires": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
         },
         "color-convert": {
             "version": "2.0.1",
@@ -4913,12 +5251,6 @@
                 }
             }
         },
-        "comment-parser": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-            "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-            "dev": true
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4959,10 +5291,16 @@
                 }
             }
         },
+        "decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true
+        },
         "deep-eql": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.2.tgz",
+            "integrity": "sha512-gT18+YW4CcW/DBNTwAmqTtkJh7f9qqScu2qFVlx7kCoeY9tlBu9cUcr7+I+Z/noG8INehS3xQgLpTtd/QUTn4w==",
             "dev": true,
             "requires": {
                 "type-detect": "^4.0.0"
@@ -5124,10 +5462,143 @@
                 "esbuild-windows-arm64": "0.15.13"
             }
         },
+        "esbuild-android-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.13.tgz",
+            "integrity": "sha512-yRorukXBlokwTip+Sy4MYskLhJsO0Kn0/Fj43s1krVblfwP+hMD37a4Wmg139GEsMLl+vh8WXp2mq/cTA9J97g==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-android-arm64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.13.tgz",
+            "integrity": "sha512-TKzyymLD6PiVeyYa4c5wdPw87BeAiTXNtK6amWUcXZxkV51gOk5u5qzmDaYSwiWeecSNHamFsaFjLoi32QR5/w==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-darwin-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.13.tgz",
+            "integrity": "sha512-WAx7c2DaOS6CrRcoYCgXgkXDliLnFv3pQLV6GeW1YcGEZq2Gnl8s9Pg7ahValZkpOa0iE/ojRVQ87sbUhF1Cbg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-darwin-arm64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.13.tgz",
+            "integrity": "sha512-U6jFsPfSSxC3V1CLiQqwvDuj3GGrtQNB3P3nNC3+q99EKf94UGpsG9l4CQ83zBs1NHrk1rtCSYT0+KfK5LsD8A==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-freebsd-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.13.tgz",
+            "integrity": "sha512-whItJgDiOXaDG/idy75qqevIpZjnReZkMGCgQaBWZuKHoElDJC1rh7MpoUgupMcdfOd+PgdEwNQW9DAE6i8wyA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.13.tgz",
+            "integrity": "sha512-6pCSWt8mLUbPtygv7cufV0sZLeylaMwS5Fznj6Rsx9G2AJJsAjQ9ifA+0rQEIg7DwJmi9it+WjzNTEAzzdoM3Q==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-32": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.13.tgz",
+            "integrity": "sha512-VbZdWOEdrJiYApm2kkxoTOgsoCO1krBZ3quHdYk3g3ivWaMwNIVPIfEE0f0XQQ0u5pJtBsnk2/7OPiCFIPOe/w==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.13.tgz",
+            "integrity": "sha512-rXmnArVNio6yANSqDQlIO4WiP+Cv7+9EuAHNnag7rByAqFVuRusLbGi2697A5dFPNXoO//IiogVwi3AdcfPC6A==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-arm": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.13.tgz",
+            "integrity": "sha512-Ac6LpfmJO8WhCMQmO253xX2IU2B3wPDbl4IvR0hnqcPrdfCaUa2j/lLMGTjmQ4W5JsJIdHEdW12dG8lFS0MbxQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-arm64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.13.tgz",
+            "integrity": "sha512-alEMGU4Z+d17U7KQQw2IV8tQycO6T+rOrgW8OS22Ua25x6kHxoG6Ngry6Aq6uranC+pNWNMB6aHFPh7aTQdORQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-mips64le": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.13.tgz",
+            "integrity": "sha512-47PgmyYEu+yN5rD/MbwS6DxP2FSGPo4Uxg5LwIdxTiyGC2XKwHhHyW7YYEDlSuXLQXEdTO7mYe8zQ74czP7W8A==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.13.tgz",
+            "integrity": "sha512-z6n28h2+PC1Ayle9DjKoBRcx/4cxHoOa2e689e2aDJSaKug3jXcQw7mM+GLg+9ydYoNzj8QxNL8ihOv/OnezhA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-riscv64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.13.tgz",
+            "integrity": "sha512-+Lu4zuuXuQhgLUGyZloWCqTslcCAjMZH1k3Xc9MSEJEpEFdpsSU0sRDXAnk18FKOfEjhu4YMGaykx9xjtpA6ow==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-s390x": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.13.tgz",
+            "integrity": "sha512-BMeXRljruf7J0TMxD5CIXS65y7puiZkAh+s4XFV9qy16SxOuMhxhVIXYLnbdfLrsYGFzx7U9mcdpFWkkvy/Uag==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-netbsd-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.13.tgz",
+            "integrity": "sha512-EHj9QZOTel581JPj7UO3xYbltFTYnHy+SIqJVq6yd3KkCrsHRbapiPb0Lx3EOOtybBEE9EyqbmfW1NlSDsSzvQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-openbsd-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.13.tgz",
+            "integrity": "sha512-nkuDlIjF/sfUhfx8SKq0+U+Fgx5K9JcPq1mUodnxI0x4kBdCv46rOGWbuJ6eof2n3wdoCLccOoJAbg9ba/bT2w==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-sunos-64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.13.tgz",
+            "integrity": "sha512-jVeu2GfxZQ++6lRdY43CS0Tm/r4WuQQ0Pdsrxbw+aOrHQPHV0+LNOLnvbN28M7BSUGnJnHkHm2HozGgNGyeIRw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-32": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.13.tgz",
+            "integrity": "sha512-XoF2iBf0wnqo16SDq+aDGi/+QbaLFpkiRarPVssMh9KYbFNCqPLlGAWwDvxEVz+ywX6Si37J2AKm+AXq1kC0JA==",
+            "dev": true,
+            "optional": true
+        },
         "esbuild-windows-64": {
             "version": "0.15.13",
             "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.13.tgz",
             "integrity": "sha512-Et6htEfGycjDrtqb2ng6nT+baesZPYQIW+HUEHK4D1ncggNrDNk3yoboYQ5KtiVrw/JaDMNttz8rrPubV/fvPQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-arm64": {
+            "version": "0.15.13",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.13.tgz",
+            "integrity": "sha512-3bv7tqntThQC9SWLRouMDmZnlOukBhOCTlkzNqzGCmrkCJI7io5LLjwJBOVY6kOUlIvdxbooNZwjtBvj+7uuVg==",
             "dev": true,
             "optional": true
         },
@@ -5205,15 +5676,6 @@
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
                     "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
                     "dev": true
-                },
-                "glob-parent": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^4.0.3"
-                    }
                 }
             }
         },
@@ -5313,20 +5775,6 @@
                     "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
                     "dev": true
                 }
-            }
-        },
-        "eslint-plugin-jsdoc": {
-            "version": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.2.tgz",
-            "integrity": "sha512-dvgY/W7eUFoAIIiaWHERIMI61ZWqcz9YFjEeyTzdPlrZc3TY/3aZm5aB91NUoTLWYZmO/vFlYSuQi15tF7uE5A==",
-            "dev": true,
-            "requires": {
-                "@es-joy/jsdoccomment": "~0.36.0",
-                "comment-parser": "1.3.1",
-                "debug": "^4.3.4",
-                "escape-string-regexp": "^4.0.0",
-                "esquery": "^1.4.0",
-                "semver": "^7.3.8",
-                "spdx-expression-parse": "^3.0.1"
             }
         },
         "eslint-plugin-local": {
@@ -5449,6 +5897,17 @@
                 "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
                 "micromatch": "^4.0.4"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                }
             }
         },
         "fast-json-stable-stringify": {
@@ -5593,6 +6052,13 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
+        "fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "optional": true
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5615,6 +6081,12 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
         "get-func-name": {
@@ -5678,12 +6150,12 @@
             }
         },
         "glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "requires": {
-                "is-glob": "^4.0.1"
+                "is-glob": "^4.0.3"
             }
         },
         "globals": {
@@ -5785,14 +6257,6 @@
                 "import-meta-resolve": "^2.1.0",
                 "picocolors": "^1.0.0",
                 "pretty-ms": "^8.0.0"
-            },
-            "dependencies": {
-                "picocolors": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-                    "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-                    "dev": true
-                }
             }
         },
         "ignore": {
@@ -5918,6 +6382,12 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true
         },
         "is-glob": {
@@ -6047,12 +6517,6 @@
                 "argparse": "^2.0.1"
             }
         },
-        "jsdoc-type-pratt-parser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-            "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
-            "dev": true
-        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6132,9 +6596,9 @@
             }
         },
         "loupe": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.5.tgz",
-            "integrity": "sha512-KNGVjhsXDxvY/cYE8GNi7SBaJSfJIT+/+/8GlprqBXpoU6cSR7/RT7OBJOsoYtyxq0L3q6oIcO8tX7dbEEXr3A==",
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+            "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
             "dev": true,
             "requires": {
                 "get-func-name": "^2.0.0"
@@ -6209,33 +6673,10 @@
                 "yargs-unparser": "2.0.0"
             },
             "dependencies": {
-                "ansi-colors": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-                    "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-                    "dev": true
-                },
-                "cliui": {
-                    "version": "7.0.4",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-                    "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.0",
-                        "wrap-ansi": "^7.0.0"
-                    }
-                },
                 "diff": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
                     "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-                    "dev": true
-                },
-                "get-caller-file": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
                     "dev": true
                 },
                 "glob": {
@@ -6263,12 +6704,6 @@
                         }
                     }
                 },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-                    "dev": true
-                },
                 "minimatch": {
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -6289,17 +6724,6 @@
                         }
                     }
                 },
-                "string-width": {
-                    "version": "4.2.3",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.1"
-                    }
-                },
                 "supports-color": {
                     "version": "8.1.1",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -6307,38 +6731,6 @@
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
-                    }
-                },
-                "wrap-ansi": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.0.0",
-                        "string-width": "^4.1.0",
-                        "strip-ansi": "^6.0.0"
-                    }
-                },
-                "y18n": {
-                    "version": "5.0.8",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-                    "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "16.2.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-                    "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^7.0.2",
-                        "escalade": "^3.1.1",
-                        "get-caller-file": "^2.0.5",
-                        "require-directory": "^2.1.1",
-                        "string-width": "^4.2.0",
-                        "y18n": "^5.0.5",
-                        "yargs-parser": "^20.2.2"
                     }
                 }
             }
@@ -6421,14 +6813,14 @@
             }
         },
         "object.values": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-            "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+            "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.19.1"
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
             }
         },
         "once": {
@@ -6530,6 +6922,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
             "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+            "dev": true
+        },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
             "dev": true
         },
         "picomatch": {
@@ -6688,9 +7086,9 @@
             }
         },
         "safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true
         },
         "safe-regex-test": {
@@ -6776,48 +7174,37 @@
                 "source-map": "^0.6.0"
             }
         },
-        "spdx-exceptions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-            "dev": true
-        },
-        "spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+        "string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
             }
         },
-        "spdx-license-ids": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-            "dev": true
-        },
         "string.prototype.trimend": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-            "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+            "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
-                "es-abstract": "^1.19.5"
+                "es-abstract": "^1.20.4"
             }
         },
         "string.prototype.trimstart": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-            "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+            "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
-                "es-abstract": "^1.19.5"
+                "es-abstract": "^1.20.4"
             }
         },
         "strip-ansi": {
@@ -7099,10 +7486,27 @@
             "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
             "dev": true
         },
+        "wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            }
+        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
+        },
+        "y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true
         },
         "yallist": {
@@ -7110,6 +7514,21 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
+        },
+        "yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "requires": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            }
         },
         "yargs-parser": {
             "version": "20.2.4",
@@ -7127,20 +7546,6 @@
                 "decamelize": "^4.0.0",
                 "flat": "^5.0.2",
                 "is-plain-obj": "^2.1.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-                    "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-                    "dev": true
-                },
-                "decamelize": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-                    "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-                    "dev": true
-                }
             }
         },
         "yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
                 "eslint": "^8.22.0",
                 "eslint-formatter-autolinkable-stylish": "^1.2.0",
                 "eslint-plugin-import": "^2.26.0",
-                "eslint-plugin-jsdoc": "^39.3.6",
                 "eslint-plugin-local": "^1.0.0",
                 "eslint-plugin-no-null": "^1.0.2",
                 "fast-xml-parser": "^4.0.11",
@@ -55,20 +54,6 @@
             },
             "engines": {
                 "node": ">=4.2.0"
-            }
-        },
-        "node_modules/@es-joy/jsdoccomment": {
-            "version": "0.36.0",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.0.tgz",
-            "integrity": "sha512-u0XZyvUF6Urb2cSivSXA8qXIpT/CxkHcdtZKoWusAzgzmsTWpg0F2FpWXsolHmMUyVY3dLWaoy+0ccJ5uf2QjA==",
-            "dev": true,
-            "dependencies": {
-                "comment-parser": "1.3.1",
-                "esquery": "^1.4.0",
-                "jsdoc-type-pratt-parser": "~3.1.0"
-            },
-            "engines": {
-                "node": "^14 || ^16 || ^17 || ^18 || ^19"
             }
         },
         "node_modules/@esbuild/android-arm": {
@@ -1123,15 +1108,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/comment-parser": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-            "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1906,27 +1882,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
-        },
-        "node_modules/eslint-plugin-jsdoc": {
-            "version": "39.6.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.2.tgz",
-            "integrity": "sha512-dvgY/W7eUFoAIIiaWHERIMI61ZWqcz9YFjEeyTzdPlrZc3TY/3aZm5aB91NUoTLWYZmO/vFlYSuQi15tF7uE5A==",
-            "dev": true,
-            "dependencies": {
-                "@es-joy/jsdoccomment": "~0.36.0",
-                "comment-parser": "1.3.1",
-                "debug": "^4.3.4",
-                "escape-string-regexp": "^4.0.0",
-                "esquery": "^1.4.0",
-                "semver": "^7.3.8",
-                "spdx-expression-parse": "^3.0.1"
-            },
-            "engines": {
-                "node": "^14 || ^16 || ^17 || ^18 || ^19"
-            },
-            "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
-            }
         },
         "node_modules/eslint-plugin-local": {
             "version": "1.0.0",
@@ -2983,15 +2938,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsdoc-type-pratt-parser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-            "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4018,28 +3964,6 @@
                 "source-map": "^0.6.0"
             }
         },
-        "node_modules/spdx-exceptions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-            "dev": true
-        },
-        "node_modules/spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-license-ids": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-            "dev": true
-        },
         "node_modules/string.prototype.trimend": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
@@ -4508,17 +4432,6 @@
         }
     },
     "dependencies": {
-        "@es-joy/jsdoccomment": {
-            "version": "0.36.0",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.0.tgz",
-            "integrity": "sha512-u0XZyvUF6Urb2cSivSXA8qXIpT/CxkHcdtZKoWusAzgzmsTWpg0F2FpWXsolHmMUyVY3dLWaoy+0ccJ5uf2QjA==",
-            "dev": true,
-            "requires": {
-                "comment-parser": "1.3.1",
-                "esquery": "^1.4.0",
-                "jsdoc-type-pratt-parser": "~3.1.0"
-            }
-        },
         "@esbuild/android-arm": {
             "version": "0.15.13",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.13.tgz",
@@ -5278,12 +5191,6 @@
                 }
             }
         },
-        "comment-parser": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-            "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-            "dev": true
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5811,21 +5718,6 @@
                     "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
                     "dev": true
                 }
-            }
-        },
-        "eslint-plugin-jsdoc": {
-            "version": "39.6.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.2.tgz",
-            "integrity": "sha512-dvgY/W7eUFoAIIiaWHERIMI61ZWqcz9YFjEeyTzdPlrZc3TY/3aZm5aB91NUoTLWYZmO/vFlYSuQi15tF7uE5A==",
-            "dev": true,
-            "requires": {
-                "@es-joy/jsdoccomment": "~0.36.0",
-                "comment-parser": "1.3.1",
-                "debug": "^4.3.4",
-                "escape-string-regexp": "^4.0.0",
-                "esquery": "^1.4.0",
-                "semver": "^7.3.8",
-                "spdx-expression-parse": "^3.0.1"
             }
         },
         "eslint-plugin-local": {
@@ -6553,12 +6445,6 @@
                 "argparse": "^2.0.1"
             }
         },
-        "jsdoc-type-pratt-parser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-            "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
-            "dev": true
-        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -7281,28 +7167,6 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
-        },
-        "spdx-exceptions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-            "dev": true
-        },
-        "spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-license-ids": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-            "dev": true
         },
         "string.prototype.trimend": {
             "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
         "eslint": "^8.22.0",
         "eslint-formatter-autolinkable-stylish": "^1.2.0",
         "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-jsdoc": "^39.3.6",
         "eslint-plugin-local": "^1.0.0",
         "eslint-plugin-no-null": "^1.0.2",
         "fast-xml-parser": "^4.0.11",

--- a/scripts/eslint/rules/jsdoc-format.cjs
+++ b/scripts/eslint/rules/jsdoc-format.cjs
@@ -21,9 +21,6 @@ module.exports = createRule({
     },
     defaultOptions: [],
 
-    /**
-     *
-     */
     create(context) {
         const sourceCode = context.getSourceCode();
         const atInternal = "@internal";

--- a/scripts/eslint/rules/jsdoc-format.cjs
+++ b/scripts/eslint/rules/jsdoc-format.cjs
@@ -13,16 +13,26 @@ module.exports = createRule({
             internalCommentNotLastError: `@internal should only appear in final JSDoc comment for declaration.`,
             multipleJSDocError: `Declaration has multiple JSDoc comments.`,
             internalCommentOnParameterProperty: `@internal cannot appear on a JSDoc comment; use a declared property and an assignment in the constructor instead.`,
+            misalignedJSDocComment: `This JSDoc comment is misaligned.`,
         },
         schema: [],
         type: "problem",
+        fixable: "whitespace",
     },
     defaultOptions: [],
 
+    /**
+     *
+     */
     create(context) {
         const sourceCode = context.getSourceCode();
         const atInternal = "@internal";
         const jsdocStart = "/**";
+
+        /** @type {(text: string) => boolean} */
+        function isJSDocText(text) {
+            return text.startsWith(jsdocStart);
+        }
 
         /** @type {(c: TSESTree.Comment, indexInComment: number) => TSESTree.SourceLocation} */
         const getAtInternalLoc = (c, indexInComment) => {
@@ -51,7 +61,7 @@ module.exports = createRule({
         };
 
         /** @type {(node: TSESTree.Node) => void} */
-        const checkJSDocFormat = (node) => {
+        const checkDeclaration = (node) => {
             const blockComments = sourceCode.getCommentsBefore(node).filter(c => c.type === "Block");
             if (blockComments.length === 0) {
                 return;
@@ -63,7 +73,7 @@ module.exports = createRule({
                 const c = blockComments[i];
                 const rawComment = sourceCode.getText(c);
 
-                const isJSDoc = rawComment.startsWith(jsdocStart);
+                const isJSDoc = isJSDocText(rawComment);
                 if (isJSDoc && seenJSDoc) {
                     context.report({ messageId: "multipleJSDocError", node: c, loc: getJSDocStartLoc(c) });
                 }
@@ -86,25 +96,85 @@ module.exports = createRule({
             }
         };
 
+        /** @type {(node: TSESTree.Node) => void} */
+        const checkProgram = () => {
+            const comments = sourceCode.getAllComments();
+
+            for (const c of comments) {
+                if (c.type !== "Block") {
+                    continue;
+                }
+
+                const rawComment = sourceCode.getText(c);
+                if (!isJSDocText(rawComment)) {
+                    continue;
+                }
+
+                const expected = c.loc.start.column + 2;
+                const split = rawComment.split(/\r?\n/g);
+                for (let i = 1; i < split.length; i++) {
+                    const line = split[i];
+                    const match = /^ *\*/.exec(line);
+                    if (!match) {
+                        continue;
+                    }
+
+                    const actual = match[0].length;
+                    const diff = actual - expected;
+                    if (diff !== 0) {
+                        const line = c.loc.start.line + i;
+                        context.report({
+                            messageId: "misalignedJSDocComment",
+                            node: c,
+                            loc: {
+                                start: {
+                                    line,
+                                    column: 0,
+                                },
+                                end: {
+                                    line,
+                                    column: actual - 1,
+                                }
+                            },
+                            fix: (fixer) => {
+                                if (diff > 0) {
+                                    // Too many
+                                    const start = sourceCode.getIndexFromLoc({ line, column: expected - 1 });
+                                    return fixer.removeRange([start, start + diff]);
+                                }
+                                else {
+                                    // Too few
+                                    const start = sourceCode.getIndexFromLoc({ line, column: 0 });
+                                    return fixer.insertTextAfterRange([start, start], " ".repeat(-diff));
+                                }
+                            },
+                        });
+                        break;
+                    }
+                }
+            }
+        };
+
         return {
-            ClassDeclaration: checkJSDocFormat,
-            FunctionDeclaration: checkJSDocFormat,
-            TSEnumDeclaration: checkJSDocFormat,
-            TSModuleDeclaration: checkJSDocFormat,
-            VariableDeclaration: checkJSDocFormat,
-            TSInterfaceDeclaration: checkJSDocFormat,
-            TSTypeAliasDeclaration: checkJSDocFormat,
-            TSCallSignatureDeclaration: checkJSDocFormat,
-            ExportAllDeclaration: checkJSDocFormat,
-            ExportNamedDeclaration: checkJSDocFormat,
-            TSImportEqualsDeclaration: checkJSDocFormat,
-            TSNamespaceExportDeclaration: checkJSDocFormat,
-            TSConstructSignatureDeclaration: checkJSDocFormat,
-            ExportDefaultDeclaration: checkJSDocFormat,
-            TSPropertySignature: checkJSDocFormat,
-            TSIndexSignature: checkJSDocFormat,
-            TSMethodSignature: checkJSDocFormat,
-            TSParameterProperty: checkJSDocFormat,
+            Program: checkProgram,
+            ClassDeclaration: checkDeclaration,
+            FunctionDeclaration: checkDeclaration,
+            TSEnumDeclaration: checkDeclaration,
+            TSModuleDeclaration: checkDeclaration,
+            VariableDeclaration: checkDeclaration,
+            TSInterfaceDeclaration: checkDeclaration,
+            TSTypeAliasDeclaration: checkDeclaration,
+            TSCallSignatureDeclaration: checkDeclaration,
+            ExportAllDeclaration: checkDeclaration,
+            ExportNamedDeclaration: checkDeclaration,
+            TSImportEqualsDeclaration: checkDeclaration,
+            TSNamespaceExportDeclaration: checkDeclaration,
+            TSConstructSignatureDeclaration: checkDeclaration,
+            ExportDefaultDeclaration: checkDeclaration,
+            TSPropertySignature: checkDeclaration,
+            TSIndexSignature: checkDeclaration,
+            TSMethodSignature: checkDeclaration,
+            TSParameterProperty: checkDeclaration,
         };
     },
 });


### PR DESCRIPTION
I had to write an ESLint rule for our JSDoc comments in the module conversion anyway. Extend it to do some basic checking of the alignment of the comments, which is all we use the jsdoc plugin for. (To be clear, I wrote this logic from scratch; the jsdoc plugin probably does a lot more.)

Before:

```
npx eslint .  54.13s user 2.26s system 148% cpu 37.867 total
```

After:

```
npx eslint .  47.32s user 2.15s system 155% cpu 31.846 total
```

Probably deserves a test or two; I neglected writing any for my original rule.