### PR TITLE
Bump volta/packageManager in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,9 +101,9 @@
         "source-map-support": false,
         "inspector": false
     },
-    "packageManager": "npm@8.15.0",
+    "packageManager": "npm@8.19.3",
     "volta": {
-        "node": "14.20.0",
-        "npm": "8.15.0"
+        "node": "14.21.1",
+        "npm": "8.19.3"
     }
 }


### PR DESCRIPTION
These don't get automatically updated in CI (probably they should in the package-lock task). Bump them to their latest, but still Node 14 because we like stack frame restarting.