### PR TITLE
Convert debug namespace into a module, direct import

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -157,6 +157,7 @@ export default tseslint.config(
             "local/jsdoc-format": "error",
             "local/js-extensions": "error",
             "local/no-array-mutating-method-expressions": "error",
+            "local/prefer-direct-import": "error",
         },
     },
     {
@@ -220,6 +221,12 @@ export default tseslint.config(
         files: ["src/**/_namespaces/**"],
         rules: {
             "local/no-direct-import": "off",
+        },
+    },
+    {
+        files: ["src/harness/**", "src/testRunner/**", "src/tsserver/**", "src/typingsInstaller/**"],
+        rules: {
+            "local/prefer-direct-import": "off",
         },
     },
     {

--- a/scripts/eslint/rules/no-direct-import.cjs
+++ b/scripts/eslint/rules/no-direct-import.cjs
@@ -45,6 +45,9 @@ module.exports = createRule({
 
             // These appear in place of public API imports.
             if (p.endsWith("../typescript/typescript.js")) return;
+            // Okay to direct import, for now.
+            // TODO(jakebailey): we should consider where this is safe to ignore
+            if (p.endsWith("/debug.js")) return;
 
             // The below is similar to https://github.com/microsoft/DefinitelyTyped-tools/blob/main/packages/eslint-plugin/src/rules/no-bad-reference.ts
 

--- a/scripts/eslint/rules/prefer-direct-import.cjs
+++ b/scripts/eslint/rules/prefer-direct-import.cjs
@@ -1,0 +1,124 @@
+const { AST_NODE_TYPES } = require("@typescript-eslint/utils");
+const { createRule } = require("./utils.cjs");
+const path = require("path");
+
+const srcRoot = path.resolve(__dirname, "../../../src");
+
+const tsNamespaceBarrelRegex = /_namespaces\/ts(?:\.ts|\.js|\.mts|\.mjs|\.cts|\.cjs)?$/;
+
+/**
+ * @type {Array<{ name: string; path: string; }>}
+ */
+const modules = [
+    {
+        name: "Debug",
+        path: "compiler/debug",
+    },
+];
+
+module.exports = createRule({
+    name: "prefer-direct-import",
+    meta: {
+        docs: {
+            description: ``,
+        },
+        messages: {
+            importError: `{{ name }} should be imported directly from {{ path }}`,
+        },
+        schema: [],
+        type: "problem",
+        fixable: "code",
+    },
+    defaultOptions: [],
+
+    create(context) {
+        /**
+         * @param {string} p
+         */
+        function getImportPath(p) {
+            let out = path.relative(path.dirname(context.filename), path.join(srcRoot, p)).replace(/\\/g, "/");
+            if (!out.startsWith(".")) out = "./" + out;
+            return out;
+        }
+
+        /** @type {any} */
+        let program;
+        let addedImport = false;
+
+        return {
+            Program: node => {
+                program = node;
+            },
+            ImportDeclaration: node => {
+                if (node.importKind !== "value" || !tsNamespaceBarrelRegex.test(node.source.value)) return;
+
+                for (const specifier of node.specifiers) {
+                    if (specifier.type !== AST_NODE_TYPES.ImportSpecifier || specifier.importKind !== "value") continue;
+
+                    for (const mod of modules) {
+                        if (specifier.imported.name !== mod.name) continue;
+
+                        context.report({
+                            messageId: "importError",
+                            data: { name: mod.name, path: mod.path },
+                            node: specifier,
+                            fix: fixer => {
+                                const newCode = `import * as ${mod.name} from "${getImportPath(mod.path)}";`;
+                                const fixes = [];
+                                if (node.specifiers.length === 1) {
+                                    if (addedImport) {
+                                        fixes.push(fixer.remove(node));
+                                    }
+                                    else {
+                                        fixes.push(fixer.replaceText(node, newCode));
+                                        addedImport = true;
+                                    }
+                                }
+                                else {
+                                    const comma = context.sourceCode.getTokenAfter(specifier, token => token.value === ",");
+                                    if (!comma) throw new Error("comma is null");
+                                    const prevNode = context.sourceCode.getTokenBefore(specifier);
+                                    if (!prevNode) throw new Error("prevNode is null");
+                                    fixes.push(
+                                        fixer.removeRange([prevNode.range[1], specifier.range[0]]),
+                                        fixer.remove(specifier),
+                                        fixer.remove(comma),
+                                    );
+                                    if (!addedImport) {
+                                        fixes.push(fixer.insertTextBefore(node, newCode + "\r\n"));
+                                        addedImport = true;
+                                    }
+                                }
+
+                                return fixes;
+                            },
+                        });
+                    }
+                }
+            },
+            MemberExpression: node => {
+                if (node.object.type !== AST_NODE_TYPES.Identifier || node.object.name !== "ts") return;
+
+                for (const mod of modules) {
+                    if (node.property.type !== AST_NODE_TYPES.Identifier || node.property.name !== mod.name) continue;
+
+                    context.report({
+                        messageId: "importError",
+                        data: { name: mod.name, path: mod.path },
+                        node,
+                        fix: fixer => {
+                            const fixes = [fixer.replaceText(node, mod.name)];
+
+                            if (!addedImport) {
+                                fixes.push(fixer.insertTextBefore(program, `import * as ${mod.name} from "${getImportPath(mod.path)}";\r\n`));
+                                addedImport = true;
+                            }
+
+                            return fixes;
+                        },
+                    });
+                }
+            },
+        };
+    },
+});

--- a/scripts/eslint/tests/prefer-direct-import.cjs
+++ b/scripts/eslint/tests/prefer-direct-import.cjs
@@ -1,0 +1,79 @@
+const { RuleTester } = require("./support/RuleTester.cjs");
+const rule = require("../rules/prefer-direct-import.cjs");
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            warnOnUnsupportedTypeScriptVersion: false,
+        },
+    },
+});
+
+ruleTester.run("no-ts-debug", rule, {
+    valid: [
+        {
+            code: `
+import * as Debug from "./debug";
+        `,
+        },
+        {
+            code: `
+import type { Debug } from "./_namespaces/ts";
+            `,
+        },
+        {
+            code: `
+import { type Debug } from "./_namespaces/ts";
+            `,
+        },
+    ],
+
+    invalid: [
+        {
+            filename: "src/compiler/checker.ts",
+            code: `
+import { Debug } from "./_namespaces/ts";
+            `.replace(/\r?\n/g, "\r\n"),
+            errors: [{ messageId: "importError", data: { name: "Debug", path: "compiler/debug" } }],
+            output: `
+import * as Debug from "./debug";
+            `.replace(/\r?\n/g, "\r\n"),
+        },
+        {
+            filename: "src/compiler/transformers/ts.ts",
+            code: `
+import { Debug } from "../_namespaces/ts";
+            `.replace(/\r?\n/g, "\r\n"),
+            errors: [{ messageId: "importError", data: { name: "Debug", path: "compiler/debug" } }],
+            output: `
+import * as Debug from "../debug";
+            `.replace(/\r?\n/g, "\r\n"),
+        },
+        // TODO(jakebailey): the rule probably needs to handle .js extensions
+        {
+            filename: "src/compiler/checker.ts",
+            code: `
+import { Debug } from "./_namespaces/ts.js";
+            `.replace(/\r?\n/g, "\r\n"),
+            errors: [{ messageId: "importError", data: { name: "Debug", path: "compiler/debug" } }],
+            output: `
+import * as Debug from "./debug";
+            `.replace(/\r?\n/g, "\r\n"),
+        },
+        {
+            filename: "src/compiler/checker.ts",
+            code: `
+import * as ts from "./_namespaces/ts";
+
+ts.Debug.assert(true);
+            `.replace(/\r?\n/g, "\r\n"),
+            errors: [{ messageId: "importError", data: { name: "Debug", path: "compiler/debug" } }],
+            output: `
+import * as Debug from "./debug";
+import * as ts from "./_namespaces/ts";
+
+Debug.assert(true);
+            `.replace(/\r?\n/g, "\r\n"),
+        },
+    ],
+});

--- a/src/compiler/_namespaces/ts.ts
+++ b/src/compiler/_namespaces/ts.ts
@@ -2,7 +2,8 @@
 
 export * from "../corePublic.js";
 export * from "../core.js";
-export * from "../debug.js";
+import * as Debug from "../debug.js";
+export { Debug };
 export * from "../semver.js";
 export * from "../performanceCore.js";
 export * from "../tracing.js";

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -39,7 +39,6 @@ import {
     createFileDiagnostic,
     createQueue,
     createSymbolTable,
-    Debug,
     Declaration,
     declarationNameToString,
     DeleteExpression,
@@ -321,6 +320,7 @@ import {
     WithStatement,
 } from "./_namespaces/ts.js";
 import * as performance from "./_namespaces/ts.performance.js";
+import * as Debug from "./debug.js";
 
 /** @internal */
 export const enum ModuleInstanceState {

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -26,7 +26,6 @@ import {
     createModuleNotFoundChain,
     createProgram,
     CustomTransformers,
-    Debug,
     Diagnostic,
     DiagnosticCategory,
     DiagnosticMessageChain,
@@ -90,6 +89,7 @@ import {
     WriteFileCallback,
     WriteFileCallbackData,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /** @internal */
 export interface ReusableDiagnostic extends ReusableDiagnosticRelatedInformation {

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -4,7 +4,6 @@ import {
     CompilerOptions,
     computeSignatureWithDiagnostics,
     CustomTransformers,
-    Debug,
     EmitOnly,
     EmitOutput,
     emptyArray,
@@ -34,6 +33,7 @@ import {
     toPath,
     TypeChecker,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /** @internal */
 export function getFileEmitOutput(

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -130,7 +130,6 @@ import {
     createSymbolTable,
     createSyntacticTypeNodeBuilder,
     createTextWriter,
-    Debug,
     Declaration,
     DeclarationName,
     declarationNameToString,
@@ -1124,6 +1123,7 @@ import {
 } from "./_namespaces/ts.js";
 import * as moduleSpecifiers from "./_namespaces/ts.moduleSpecifiers.js";
 import * as performance from "./_namespaces/ts.performance.js";
+import * as Debug from "./debug.js";
 
 const ambientModuleSymbolRegex = /^".+"$/;
 const anon = "(anonymous)" as __String & string;

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -22,7 +22,6 @@ import {
     createCompilerDiagnostic,
     createDiagnosticForNodeInSourceFile,
     createGetCanonicalFileName,
-    Debug,
     Diagnostic,
     DiagnosticArguments,
     DiagnosticMessage,
@@ -122,6 +121,7 @@ import {
     WatchFileKind,
     WatchOptions,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 const compileOnSaveCommandLineOption: CommandLineOption = {
     name: "compileOnSave",

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2,7 +2,6 @@ import {
     CharacterCodes,
     Comparer,
     Comparison,
-    Debug,
     EqualityComparer,
     MapLike,
     Queue,
@@ -10,6 +9,7 @@ import {
     SortedReadonlyArray,
     TextSpan,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /* eslint-disable @typescript-eslint/prefer-for-of */
 

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1917,7 +1917,7 @@ export function memoizeOne<A extends string | number | boolean | undefined, T>(c
     };
 }
 
-/** @internal */
+/** @internal @knipignore */
 export const enum AssertionLevel {
     None = 0,
     Normal = 1,

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -1,7 +1,6 @@
 import * as ts from "./_namespaces/ts.js";
 import {
     AnyFunction,
-    AssertionLevel,
     BigIntLiteralType,
     CheckMode,
     compareValues,
@@ -13,7 +12,6 @@ import {
     FlowSwitchClause,
     getEffectiveModifierFlagsNoCache,
     getEmitFlags,
-    getOwnKeys,
     getParseTreeNode,
     getSourceFileOfNode,
     getSourceTextOfNodeFromSourceFile,
@@ -60,7 +58,6 @@ import {
     isUnionTypeNode,
     LiteralType,
     map,
-    MatchingKeys,
     maxBy,
     ModifierFlags,
     Node,
@@ -68,7 +65,6 @@ import {
     NodeCheckFlags,
     NodeFlags,
     nodeIsSynthesized,
-    noop,
     objectAllocator,
     ObjectFlags,
     ObjectType,
@@ -110,1145 +106,1205 @@ export interface LoggingHost {
 }
 
 /** @internal */
-export namespace Debug {
-    /* eslint-disable prefer-const */
-    let currentAssertionLevel = AssertionLevel.None;
-    export let currentLogLevel: LogLevel = LogLevel.Warning;
-    export let isDebugging = false;
-    export let loggingHost: LoggingHost | undefined;
-    /* eslint-enable prefer-const */
+export const enum AssertionLevel {
+    None = 0,
+    Normal = 1,
+    Aggressive = 2,
+    VeryAggressive = 3,
+}
 
-    type AssertionKeys = MatchingKeys<typeof Debug, AnyFunction>;
+let currentAssertionLevel = AssertionLevel.None;
 
-    export function shouldLog(level: LogLevel): boolean {
-        return currentLogLevel <= level;
+/** @internal */
+export let currentLogLevel: LogLevel = LogLevel.Warning;
+
+/** @internal */
+export function setCurrentLogLevel(newCurrentLogLevel: LogLevel): void {
+    currentLogLevel = newCurrentLogLevel;
+}
+
+/** @internal */
+export let isDebugging = false;
+
+/** @internal */
+export function setIsDebugging(newIsDebugging: boolean): void {
+    isDebugging = newIsDebugging;
+}
+
+/** @internal */
+export let loggingHost: LoggingHost | undefined;
+
+/** @internal */
+export function setLoggingHost(newLoggingHost: LoggingHost | undefined): void {
+    loggingHost = newLoggingHost;
+}
+
+/** @internal */
+export function shouldLog(level: LogLevel): boolean {
+    return currentLogLevel <= level;
+}
+
+function logMessage(level: LogLevel, s: string): void {
+    if (loggingHost && shouldLog(level)) {
+        loggingHost.log(level, s);
+    }
+}
+
+/** @internal */
+export function log(s: string): void {
+    logMessage(LogLevel.Info, s);
+}
+
+/** @internal */
+export namespace log {
+    export function error(s: string): void {
+        logMessage(LogLevel.Error, s);
     }
 
-    function logMessage(level: LogLevel, s: string): void {
-        if (loggingHost && shouldLog(level)) {
-            loggingHost.log(level, s);
-        }
+    export function warn(s: string): void {
+        logMessage(LogLevel.Warning, s);
     }
 
     export function log(s: string): void {
         logMessage(LogLevel.Info, s);
     }
 
-    export namespace log {
-        export function error(s: string): void {
-            logMessage(LogLevel.Error, s);
-        }
-
-        export function warn(s: string): void {
-            logMessage(LogLevel.Warning, s);
-        }
-
-        export function log(s: string): void {
-            logMessage(LogLevel.Info, s);
-        }
-
-        export function trace(s: string): void {
-            logMessage(LogLevel.Verbose, s);
-        }
+    export function trace(s: string): void {
+        logMessage(LogLevel.Verbose, s);
     }
+}
 
-    const assertionCache: Partial<Record<AssertionKeys, { level: AssertionLevel; assertion: AnyFunction; }>> = {};
+/** @internal */
+export function getAssertionLevel(): AssertionLevel {
+    return currentAssertionLevel;
+}
 
-    export function getAssertionLevel(): AssertionLevel {
-        return currentAssertionLevel;
+/** @internal */
+export function setAssertionLevel(level: AssertionLevel): void {
+    currentAssertionLevel = level;
+}
+
+/** @internal */
+export function shouldAssert(level: AssertionLevel): boolean {
+    return currentAssertionLevel >= level;
+}
+
+/** @internal */
+export function fail(message?: string, stackCrawlMark?: AnyFunction): never {
+    // eslint-disable-next-line no-debugger
+    debugger;
+    const e = new Error(message ? `Debug Failure. ${message}` : "Debug Failure.");
+    if ((Error as any).captureStackTrace) {
+        (Error as any).captureStackTrace(e, stackCrawlMark || fail);
     }
+    throw e;
+}
 
-    export function setAssertionLevel(level: AssertionLevel): void {
-        const prevAssertionLevel = currentAssertionLevel;
-        currentAssertionLevel = level;
+/** @internal */
+export function failBadSyntaxKind(node: Node, message?: string, stackCrawlMark?: AnyFunction): never {
+    return fail(
+        `${message || "Unexpected node."}\r\nNode ${formatSyntaxKind(node.kind)} was unexpected.`,
+        stackCrawlMark || failBadSyntaxKind,
+    );
+}
 
-        if (level > prevAssertionLevel) {
-            // restore assertion functions for the current assertion level (see `shouldAssertFunction`).
-            for (const key of getOwnKeys(assertionCache) as AssertionKeys[]) {
-                const cachedFunc = assertionCache[key];
-                if (cachedFunc !== undefined && Debug[key] !== cachedFunc.assertion && level >= cachedFunc.level) {
-                    (Debug as any)[key] = cachedFunc;
-                    assertionCache[key] = undefined;
-                }
-            }
+/** @internal */
+export function assert(expression: unknown, message?: string, verboseDebugInfo?: string | (() => string), stackCrawlMark?: AnyFunction): asserts expression {
+    if (!expression) {
+        message = message ? `False expression: ${message}` : "False expression.";
+        if (verboseDebugInfo) {
+            message += "\r\nVerbose Debug Information: " + (typeof verboseDebugInfo === "string" ? verboseDebugInfo : verboseDebugInfo());
         }
+        fail(message, stackCrawlMark || assert);
     }
+}
 
-    export function shouldAssert(level: AssertionLevel): boolean {
-        return currentAssertionLevel >= level;
+/** @internal */
+export function assertEqual<T>(a: T, b: T, msg?: string, msg2?: string, stackCrawlMark?: AnyFunction): void {
+    if (a !== b) {
+        const message = msg ? msg2 ? `${msg} ${msg2}` : msg : "";
+        fail(`Expected ${a} === ${b}. ${message}`, stackCrawlMark || assertEqual);
     }
+}
 
-    /**
-     * Tests whether an assertion function should be executed. If it shouldn't, it is cached and replaced with `ts.noop`.
-     * Replaced assertion functions are restored when `Debug.setAssertionLevel` is set to a high enough level.
-     * @param level The minimum assertion level required.
-     * @param name The name of the current assertion function.
-     */
-    function shouldAssertFunction<K extends AssertionKeys>(level: AssertionLevel, name: K): boolean {
-        if (!shouldAssert(level)) {
-            assertionCache[name] = { level, assertion: Debug[name] };
-            (Debug as any)[name] = noop;
-            return false;
-        }
-        return true;
+/** @internal */
+export function assertLessThan(a: number, b: number, msg?: string, stackCrawlMark?: AnyFunction): void {
+    if (a >= b) {
+        fail(`Expected ${a} < ${b}. ${msg || ""}`, stackCrawlMark || assertLessThan);
     }
+}
 
-    export function fail(message?: string, stackCrawlMark?: AnyFunction): never {
-        // eslint-disable-next-line no-debugger
-        debugger;
-        const e = new Error(message ? `Debug Failure. ${message}` : "Debug Failure.");
-        if ((Error as any).captureStackTrace) {
-            (Error as any).captureStackTrace(e, stackCrawlMark || fail);
-        }
-        throw e;
+/** @internal */
+export function assertLessThanOrEqual(a: number, b: number, stackCrawlMark?: AnyFunction): void {
+    if (a > b) {
+        fail(`Expected ${a} <= ${b}`, stackCrawlMark || assertLessThanOrEqual);
     }
+}
 
-    export function failBadSyntaxKind(node: Node, message?: string, stackCrawlMark?: AnyFunction): never {
-        return fail(
-            `${message || "Unexpected node."}\r\nNode ${formatSyntaxKind(node.kind)} was unexpected.`,
-            stackCrawlMark || failBadSyntaxKind,
+/** @internal */
+export function assertGreaterThanOrEqual(a: number, b: number, stackCrawlMark?: AnyFunction): void {
+    if (a < b) {
+        fail(`Expected ${a} >= ${b}`, stackCrawlMark || assertGreaterThanOrEqual);
+    }
+}
+
+/** @internal */
+export function assertIsDefined<T>(value: T, message?: string, stackCrawlMark?: AnyFunction): asserts value is NonNullable<T> {
+    // eslint-disable-next-line no-restricted-syntax
+    if (value === undefined || value === null) {
+        fail(message, stackCrawlMark || assertIsDefined);
+    }
+}
+
+/** @internal */
+export function checkDefined<T>(value: T | null | undefined, message?: string, stackCrawlMark?: AnyFunction): T { // eslint-disable-line no-restricted-syntax
+    assertIsDefined(value, message, stackCrawlMark || checkDefined);
+    return value;
+}
+
+/** @internal */
+export function assertEachIsDefined<T extends Node>(value: NodeArray<T>, message?: string, stackCrawlMark?: AnyFunction): asserts value is NodeArray<T>;
+/** @internal */
+export function assertEachIsDefined<T>(value: readonly T[], message?: string, stackCrawlMark?: AnyFunction): asserts value is readonly NonNullable<T>[];
+export function assertEachIsDefined<T>(value: readonly T[], message?: string, stackCrawlMark?: AnyFunction) {
+    for (const v of value) {
+        assertIsDefined(v, message, stackCrawlMark || assertEachIsDefined);
+    }
+}
+
+/** @internal */
+export function checkEachDefined<T, A extends readonly T[]>(value: A, message?: string, stackCrawlMark?: AnyFunction): A {
+    assertEachIsDefined(value, message, stackCrawlMark || checkEachDefined);
+    return value;
+}
+
+/** @internal */
+export function assertNever(member: never, message = "Illegal value:", stackCrawlMark?: AnyFunction): never {
+    const detail = typeof member === "object" && hasProperty(member, "kind") && hasProperty(member, "pos") ? "SyntaxKind: " + formatSyntaxKind((member as Node).kind) : JSON.stringify(member);
+    return fail(`${message} ${detail}`, stackCrawlMark || assertNever);
+}
+
+/** @internal */
+export function assertEachNode<T extends Node, U extends T>(nodes: NodeArray<T>, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts nodes is NodeArray<U>;
+/** @internal */
+export function assertEachNode<T extends Node, U extends T>(nodes: readonly T[], test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts nodes is readonly U[];
+/** @internal */
+export function assertEachNode<T extends Node, U extends T>(nodes: NodeArray<T> | undefined, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts nodes is NodeArray<U> | undefined;
+/** @internal */
+export function assertEachNode<T extends Node, U extends T>(nodes: readonly T[] | undefined, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts nodes is readonly U[] | undefined;
+/** @internal */
+export function assertEachNode(nodes: readonly Node[], test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
+export function assertEachNode(nodes: readonly Node[] | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction) {
+    if (shouldAssert(AssertionLevel.Normal)) {
+        assert(
+            test === undefined || every(nodes, test),
+            message || "Unexpected node.",
+            () => `Node array did not pass test '${getFunctionName(test!)}'.`,
+            stackCrawlMark || assertEachNode,
         );
     }
+}
 
-    export function assert(expression: unknown, message?: string, verboseDebugInfo?: string | (() => string), stackCrawlMark?: AnyFunction): asserts expression {
-        if (!expression) {
-            message = message ? `False expression: ${message}` : "False expression.";
-            if (verboseDebugInfo) {
-                message += "\r\nVerbose Debug Information: " + (typeof verboseDebugInfo === "string" ? verboseDebugInfo : verboseDebugInfo());
+/** @internal */
+export function assertNode<T extends Node, U extends T>(node: T | undefined, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts node is U;
+/** @internal */
+export function assertNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
+export function assertNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction) {
+    if (shouldAssert(AssertionLevel.Normal)) {
+        assert(
+            node !== undefined && (test === undefined || test(node)),
+            message || "Unexpected node.",
+            () => `Node ${formatSyntaxKind(node?.kind)} did not pass test '${getFunctionName(test!)}'.`,
+            stackCrawlMark || assertNode,
+        );
+    }
+}
+
+/** @internal */
+export function assertNotNode<T extends Node, U extends T>(node: T | undefined, test: (node: Node) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts node is Exclude<T, U>;
+/** @internal */
+export function assertNotNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
+export function assertNotNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction) {
+    if (shouldAssert(AssertionLevel.Normal)) {
+        assert(
+            node === undefined || test === undefined || !test(node),
+            message || "Unexpected node.",
+            () => `Node ${formatSyntaxKind(node!.kind)} should not have passed test '${getFunctionName(test!)}'.`,
+            stackCrawlMark || assertNotNode,
+        );
+    }
+}
+
+/** @internal */
+export function assertOptionalNode<T extends Node, U extends T>(node: T, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts node is U;
+/** @internal */
+export function assertOptionalNode<T extends Node, U extends T>(node: T | undefined, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts node is U | undefined;
+/** @internal */
+export function assertOptionalNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
+export function assertOptionalNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction) {
+    if (shouldAssert(AssertionLevel.Normal)) {
+        assert(
+            test === undefined || node === undefined || test(node),
+            message || "Unexpected node.",
+            () => `Node ${formatSyntaxKind(node?.kind)} did not pass test '${getFunctionName(test!)}'.`,
+            stackCrawlMark || assertOptionalNode,
+        );
+    }
+}
+
+/** @internal */
+export function assertOptionalToken<T extends Node, K extends SyntaxKind>(node: T, kind: K, message?: string, stackCrawlMark?: AnyFunction): asserts node is Extract<T, { readonly kind: K; }>;
+/** @internal */
+export function assertOptionalToken<T extends Node, K extends SyntaxKind>(node: T | undefined, kind: K, message?: string, stackCrawlMark?: AnyFunction): asserts node is Extract<T, { readonly kind: K; }> | undefined;
+/** @internal */
+export function assertOptionalToken(node: Node | undefined, kind: SyntaxKind | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
+export function assertOptionalToken(node: Node | undefined, kind: SyntaxKind | undefined, message?: string, stackCrawlMark?: AnyFunction) {
+    if (shouldAssert(AssertionLevel.Normal)) {
+        assert(
+            kind === undefined || node === undefined || node.kind === kind,
+            message || "Unexpected node.",
+            () => `Node ${formatSyntaxKind(node?.kind)} was not a '${formatSyntaxKind(kind)}' token.`,
+            stackCrawlMark || assertOptionalToken,
+        );
+    }
+}
+
+/** @internal */
+export function assertMissingNode(node: Node | undefined, message?: string, stackCrawlMark?: AnyFunction): void {
+    if (shouldAssert(AssertionLevel.Normal)) {
+        assert(
+            node === undefined,
+            message || "Unexpected node.",
+            () => `Node ${formatSyntaxKind(node!.kind)} was unexpected'.`,
+            stackCrawlMark || assertMissingNode,
+        );
+    }
+}
+
+/**
+ * Asserts a value has the specified type in typespace only (does not perform a runtime assertion).
+ * This is useful in cases where we switch on `node.kind` and can be reasonably sure the type is accurate, and
+ * as a result can reduce the number of unnecessary casts.
+ *
+ * @internal
+ */
+export function assertType<T>(value: unknown): asserts value is T;
+export function assertType(_value: unknown) {}
+
+/** @internal */
+export function getFunctionName(func: AnyFunction): string {
+    if (typeof func !== "function") {
+        return "";
+    }
+    else if (hasProperty(func, "name")) {
+        return (func as any).name;
+    }
+    else {
+        const text = Function.prototype.toString.call(func);
+        const match = /^function\s+([\w$]+)\s*\(/.exec(text);
+        return match ? match[1] : "";
+    }
+}
+
+/** @internal */
+export function formatSymbol(symbol: Symbol): string {
+    return `{ name: ${unescapeLeadingUnderscores(symbol.escapedName)}; flags: ${formatSymbolFlags(symbol.flags)}; declarations: ${map(symbol.declarations, node => formatSyntaxKind(node.kind))} }`;
+}
+
+/**
+ * Formats an enum value as a string for debugging and debug assertions.
+ *
+ * @internal
+ */
+export function formatEnum(value = 0, enumObject: any, isFlags?: boolean): string {
+    const members = getEnumMembers(enumObject);
+    if (value === 0) {
+        return members.length > 0 && members[0][0] === 0 ? members[0][1] : "0";
+    }
+    if (isFlags) {
+        const result: string[] = [];
+        let remainingFlags = value;
+        for (const [enumValue, enumName] of members) {
+            if (enumValue > value) {
+                break;
             }
-            fail(message, stackCrawlMark || assert);
+            if (enumValue !== 0 && enumValue & value) {
+                result.push(enumName);
+                remainingFlags &= ~enumValue;
+            }
+        }
+        if (remainingFlags === 0) {
+            return result.join("|");
+        }
+    }
+    else {
+        for (const [enumValue, enumName] of members) {
+            if (enumValue === value) {
+                return enumName;
+            }
+        }
+    }
+    return value.toString();
+}
+
+const enumMemberCache = new Map<any, SortedReadonlyArray<[number, string]>>();
+
+function getEnumMembers(enumObject: any) {
+    // Assuming enum objects do not change at runtime, we can cache the enum members list
+    // to reuse later. This saves us from reconstructing this each and every time we call
+    // a formatting function (which can be expensive for large enums like SyntaxKind).
+    const existing = enumMemberCache.get(enumObject);
+    if (existing) {
+        return existing;
+    }
+
+    const result: [number, string][] = [];
+    for (const name in enumObject) {
+        const value = enumObject[name];
+        if (typeof value === "number") {
+            result.push([value, name]);
         }
     }
 
-    export function assertEqual<T>(a: T, b: T, msg?: string, msg2?: string, stackCrawlMark?: AnyFunction): void {
-        if (a !== b) {
-            const message = msg ? msg2 ? `${msg} ${msg2}` : msg : "";
-            fail(`Expected ${a} === ${b}. ${message}`, stackCrawlMark || assertEqual);
-        }
+    const sorted = toSorted<[number, string]>(result, (x, y) => compareValues(x[0], y[0]));
+    enumMemberCache.set(enumObject, sorted);
+    return sorted;
+}
+
+/** @internal */
+export function formatSyntaxKind(kind: SyntaxKind | undefined): string {
+    return formatEnum(kind, (ts as any).SyntaxKind, /*isFlags*/ false);
+}
+
+/** @internal */
+export function formatSnippetKind(kind: SnippetKind | undefined): string {
+    return formatEnum(kind, (ts as any).SnippetKind, /*isFlags*/ false);
+}
+
+/** @internal */
+export function formatScriptKind(kind: ScriptKind | undefined): string {
+    return formatEnum(kind, (ts as any).ScriptKind, /*isFlags*/ false);
+}
+
+/** @internal */
+export function formatNodeFlags(flags: NodeFlags | undefined): string {
+    return formatEnum(flags, (ts as any).NodeFlags, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatNodeCheckFlags(flags: NodeCheckFlags | undefined): string {
+    return formatEnum(flags, (ts as any).NodeCheckFlags, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatModifierFlags(flags: ModifierFlags | undefined): string {
+    return formatEnum(flags, (ts as any).ModifierFlags, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatTransformFlags(flags: TransformFlags | undefined): string {
+    return formatEnum(flags, (ts as any).TransformFlags, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatEmitFlags(flags: EmitFlags | undefined): string {
+    return formatEnum(flags, (ts as any).EmitFlags, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatSymbolFlags(flags: SymbolFlags | undefined): string {
+    return formatEnum(flags, (ts as any).SymbolFlags, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatTypeFlags(flags: TypeFlags | undefined): string {
+    return formatEnum(flags, (ts as any).TypeFlags, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatSignatureFlags(flags: SignatureFlags | undefined): string {
+    return formatEnum(flags, (ts as any).SignatureFlags, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatObjectFlags(flags: ObjectFlags | undefined): string {
+    return formatEnum(flags, (ts as any).ObjectFlags, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatFlowFlags(flags: FlowFlags | undefined): string {
+    return formatEnum(flags, (ts as any).FlowFlags, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatRelationComparisonResult(result: RelationComparisonResult | undefined): string {
+    return formatEnum(result, (ts as any).RelationComparisonResult, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatCheckMode(mode: CheckMode | undefined): string {
+    return formatEnum(mode, (ts as any).CheckMode, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatSignatureCheckMode(mode: SignatureCheckMode | undefined): string {
+    return formatEnum(mode, (ts as any).SignatureCheckMode, /*isFlags*/ true);
+}
+
+/** @internal */
+export function formatTypeFacts(facts: TypeFacts | undefined): string {
+    return formatEnum(facts, (ts as any).TypeFacts, /*isFlags*/ true);
+}
+
+let isDebugInfoEnabled = false;
+
+let flowNodeProto: FlowNode | undefined;
+
+function attachFlowNodeDebugInfoWorker(flowNode: FlowNode) {
+    if (!("__debugFlowFlags" in flowNode)) { // eslint-disable-line local/no-in-operator
+        Object.defineProperties(flowNode, {
+            // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
+            __tsDebuggerDisplay: {
+                value(this: FlowNode) {
+                    const flowHeader = this.flags & FlowFlags.Start ? "FlowStart" :
+                        this.flags & FlowFlags.BranchLabel ? "FlowBranchLabel" :
+                        this.flags & FlowFlags.LoopLabel ? "FlowLoopLabel" :
+                        this.flags & FlowFlags.Assignment ? "FlowAssignment" :
+                        this.flags & FlowFlags.TrueCondition ? "FlowTrueCondition" :
+                        this.flags & FlowFlags.FalseCondition ? "FlowFalseCondition" :
+                        this.flags & FlowFlags.SwitchClause ? "FlowSwitchClause" :
+                        this.flags & FlowFlags.ArrayMutation ? "FlowArrayMutation" :
+                        this.flags & FlowFlags.Call ? "FlowCall" :
+                        this.flags & FlowFlags.ReduceLabel ? "FlowReduceLabel" :
+                        this.flags & FlowFlags.Unreachable ? "FlowUnreachable" :
+                        "UnknownFlow";
+                    const remainingFlags = this.flags & ~(FlowFlags.Referenced - 1);
+                    return `${flowHeader}${remainingFlags ? ` (${formatFlowFlags(remainingFlags)})` : ""}`;
+                },
+            },
+            __debugFlowFlags: {
+                get(this: FlowNode) {
+                    return formatEnum(this.flags, (ts as any).FlowFlags, /*isFlags*/ true);
+                },
+            },
+            __debugToString: {
+                value(this: FlowNode) {
+                    return formatControlFlowGraph(this);
+                },
+            },
+        });
     }
+}
 
-    export function assertLessThan(a: number, b: number, msg?: string, stackCrawlMark?: AnyFunction): void {
-        if (a >= b) {
-            fail(`Expected ${a} < ${b}. ${msg || ""}`, stackCrawlMark || assertLessThan);
-        }
-    }
-
-    export function assertLessThanOrEqual(a: number, b: number, stackCrawlMark?: AnyFunction): void {
-        if (a > b) {
-            fail(`Expected ${a} <= ${b}`, stackCrawlMark || assertLessThanOrEqual);
-        }
-    }
-
-    export function assertGreaterThanOrEqual(a: number, b: number, stackCrawlMark?: AnyFunction): void {
-        if (a < b) {
-            fail(`Expected ${a} >= ${b}`, stackCrawlMark || assertGreaterThanOrEqual);
-        }
-    }
-
-    export function assertIsDefined<T>(value: T, message?: string, stackCrawlMark?: AnyFunction): asserts value is NonNullable<T> {
-        // eslint-disable-next-line no-restricted-syntax
-        if (value === undefined || value === null) {
-            fail(message, stackCrawlMark || assertIsDefined);
-        }
-    }
-
-    export function checkDefined<T>(value: T | null | undefined, message?: string, stackCrawlMark?: AnyFunction): T { // eslint-disable-line no-restricted-syntax
-        assertIsDefined(value, message, stackCrawlMark || checkDefined);
-        return value;
-    }
-
-    export function assertEachIsDefined<T extends Node>(value: NodeArray<T>, message?: string, stackCrawlMark?: AnyFunction): asserts value is NodeArray<T>;
-    export function assertEachIsDefined<T>(value: readonly T[], message?: string, stackCrawlMark?: AnyFunction): asserts value is readonly NonNullable<T>[];
-    export function assertEachIsDefined<T>(value: readonly T[], message?: string, stackCrawlMark?: AnyFunction) {
-        for (const v of value) {
-            assertIsDefined(v, message, stackCrawlMark || assertEachIsDefined);
-        }
-    }
-
-    export function checkEachDefined<T, A extends readonly T[]>(value: A, message?: string, stackCrawlMark?: AnyFunction): A {
-        assertEachIsDefined(value, message, stackCrawlMark || checkEachDefined);
-        return value;
-    }
-
-    export function assertNever(member: never, message = "Illegal value:", stackCrawlMark?: AnyFunction): never {
-        const detail = typeof member === "object" && hasProperty(member, "kind") && hasProperty(member, "pos") ? "SyntaxKind: " + formatSyntaxKind((member as Node).kind) : JSON.stringify(member);
-        return fail(`${message} ${detail}`, stackCrawlMark || assertNever);
-    }
-
-    export function assertEachNode<T extends Node, U extends T>(nodes: NodeArray<T>, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts nodes is NodeArray<U>;
-    export function assertEachNode<T extends Node, U extends T>(nodes: readonly T[], test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts nodes is readonly U[];
-    export function assertEachNode<T extends Node, U extends T>(nodes: NodeArray<T> | undefined, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts nodes is NodeArray<U> | undefined;
-    export function assertEachNode<T extends Node, U extends T>(nodes: readonly T[] | undefined, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts nodes is readonly U[] | undefined;
-    export function assertEachNode(nodes: readonly Node[], test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
-    export function assertEachNode(nodes: readonly Node[] | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction) {
-        if (shouldAssertFunction(AssertionLevel.Normal, "assertEachNode")) {
-            assert(
-                test === undefined || every(nodes, test),
-                message || "Unexpected node.",
-                () => `Node array did not pass test '${getFunctionName(test!)}'.`,
-                stackCrawlMark || assertEachNode,
-            );
-        }
-    }
-
-    export function assertNode<T extends Node, U extends T>(node: T | undefined, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts node is U;
-    export function assertNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
-    export function assertNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction) {
-        if (shouldAssertFunction(AssertionLevel.Normal, "assertNode")) {
-            assert(
-                node !== undefined && (test === undefined || test(node)),
-                message || "Unexpected node.",
-                () => `Node ${formatSyntaxKind(node?.kind)} did not pass test '${getFunctionName(test!)}'.`,
-                stackCrawlMark || assertNode,
-            );
-        }
-    }
-
-    export function assertNotNode<T extends Node, U extends T>(node: T | undefined, test: (node: Node) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts node is Exclude<T, U>;
-    export function assertNotNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
-    export function assertNotNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction) {
-        if (shouldAssertFunction(AssertionLevel.Normal, "assertNotNode")) {
-            assert(
-                node === undefined || test === undefined || !test(node),
-                message || "Unexpected node.",
-                () => `Node ${formatSyntaxKind(node!.kind)} should not have passed test '${getFunctionName(test!)}'.`,
-                stackCrawlMark || assertNotNode,
-            );
-        }
-    }
-
-    export function assertOptionalNode<T extends Node, U extends T>(node: T, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts node is U;
-    export function assertOptionalNode<T extends Node, U extends T>(node: T | undefined, test: (node: T) => node is U, message?: string, stackCrawlMark?: AnyFunction): asserts node is U | undefined;
-    export function assertOptionalNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
-    export function assertOptionalNode(node: Node | undefined, test: ((node: Node) => boolean) | undefined, message?: string, stackCrawlMark?: AnyFunction) {
-        if (shouldAssertFunction(AssertionLevel.Normal, "assertOptionalNode")) {
-            assert(
-                test === undefined || node === undefined || test(node),
-                message || "Unexpected node.",
-                () => `Node ${formatSyntaxKind(node?.kind)} did not pass test '${getFunctionName(test!)}'.`,
-                stackCrawlMark || assertOptionalNode,
-            );
-        }
-    }
-
-    export function assertOptionalToken<T extends Node, K extends SyntaxKind>(node: T, kind: K, message?: string, stackCrawlMark?: AnyFunction): asserts node is Extract<T, { readonly kind: K; }>;
-    export function assertOptionalToken<T extends Node, K extends SyntaxKind>(node: T | undefined, kind: K, message?: string, stackCrawlMark?: AnyFunction): asserts node is Extract<T, { readonly kind: K; }> | undefined;
-    export function assertOptionalToken(node: Node | undefined, kind: SyntaxKind | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
-    export function assertOptionalToken(node: Node | undefined, kind: SyntaxKind | undefined, message?: string, stackCrawlMark?: AnyFunction) {
-        if (shouldAssertFunction(AssertionLevel.Normal, "assertOptionalToken")) {
-            assert(
-                kind === undefined || node === undefined || node.kind === kind,
-                message || "Unexpected node.",
-                () => `Node ${formatSyntaxKind(node?.kind)} was not a '${formatSyntaxKind(kind)}' token.`,
-                stackCrawlMark || assertOptionalToken,
-            );
-        }
-    }
-
-    export function assertMissingNode(node: Node | undefined, message?: string, stackCrawlMark?: AnyFunction): asserts node is undefined;
-    export function assertMissingNode(node: Node | undefined, message?: string, stackCrawlMark?: AnyFunction) {
-        if (shouldAssertFunction(AssertionLevel.Normal, "assertMissingNode")) {
-            assert(
-                node === undefined,
-                message || "Unexpected node.",
-                () => `Node ${formatSyntaxKind(node!.kind)} was unexpected'.`,
-                stackCrawlMark || assertMissingNode,
-            );
-        }
-    }
-
-    /**
-     * Asserts a value has the specified type in typespace only (does not perform a runtime assertion).
-     * This is useful in cases where we switch on `node.kind` and can be reasonably sure the type is accurate, and
-     * as a result can reduce the number of unnecessary casts.
-     */
-    export function type<T>(value: unknown): asserts value is T;
-    export function type(_value: unknown) {}
-
-    export function getFunctionName(func: AnyFunction): string {
-        if (typeof func !== "function") {
-            return "";
-        }
-        else if (hasProperty(func, "name")) {
-            return (func as any).name;
+/** @internal */
+export function attachFlowNodeDebugInfo(flowNode: FlowNode): FlowNode {
+    if (isDebugInfoEnabled) {
+        if (typeof Object.setPrototypeOf === "function") {
+            // if we're in es2015, attach the method to a shared prototype for `FlowNode`
+            // so the method doesn't show up in the watch window.
+            if (!flowNodeProto) {
+                flowNodeProto = Object.create(Object.prototype) as FlowNode;
+                attachFlowNodeDebugInfoWorker(flowNodeProto);
+            }
+            Object.setPrototypeOf(flowNode, flowNodeProto);
         }
         else {
-            const text = Function.prototype.toString.call(func);
-            const match = /^function\s+([\w$]+)\s*\(/.exec(text);
-            return match ? match[1] : "";
+            // not running in an es2015 environment, attach the method directly.
+            attachFlowNodeDebugInfoWorker(flowNode);
         }
     }
+    return flowNode;
+}
 
-    export function formatSymbol(symbol: Symbol): string {
-        return `{ name: ${unescapeLeadingUnderscores(symbol.escapedName)}; flags: ${formatSymbolFlags(symbol.flags)}; declarations: ${map(symbol.declarations, node => formatSyntaxKind(node.kind))} }`;
+let nodeArrayProto: NodeArray<Node> | undefined;
+
+function attachNodeArrayDebugInfoWorker(array: NodeArray<Node>) {
+    if (!("__tsDebuggerDisplay" in array)) { // eslint-disable-line local/no-in-operator
+        Object.defineProperties(array, {
+            __tsDebuggerDisplay: {
+                value(this: NodeArray<Node>, defaultValue: string) {
+                    // An `Array` with extra properties is rendered as `[A, B, prop1: 1, prop2: 2]`. Most of
+                    // these aren't immediately useful so we trim off the `prop1: ..., prop2: ...` part from the
+                    // formatted string.
+                    // This regex can trigger slow backtracking because of overlapping potential captures.
+                    // We don't care, this is debug code that's only enabled with a debugger attached -
+                    // we're just taking note of it for anyone checking regex performance in the future.
+                    defaultValue = String(defaultValue).replace(/(?:,[\s\w]+:[^,]+)+\]$/, "]");
+                    return `NodeArray ${defaultValue}`;
+                },
+            },
+        });
     }
+}
 
-    /**
-     * Formats an enum value as a string for debugging and debug assertions.
-     */
-    export function formatEnum(value = 0, enumObject: any, isFlags?: boolean): string {
-        const members = getEnumMembers(enumObject);
-        if (value === 0) {
-            return members.length > 0 && members[0][0] === 0 ? members[0][1] : "0";
-        }
-        if (isFlags) {
-            const result: string[] = [];
-            let remainingFlags = value;
-            for (const [enumValue, enumName] of members) {
-                if (enumValue > value) {
-                    break;
-                }
-                if (enumValue !== 0 && enumValue & value) {
-                    result.push(enumName);
-                    remainingFlags &= ~enumValue;
-                }
+/** @internal */
+export function attachNodeArrayDebugInfo(array: NodeArray<Node>): void {
+    if (isDebugInfoEnabled) {
+        if (typeof Object.setPrototypeOf === "function") {
+            // if we're in es2015, attach the method to a shared prototype for `NodeArray`
+            // so the method doesn't show up in the watch window.
+            if (!nodeArrayProto) {
+                nodeArrayProto = Object.create(Array.prototype) as NodeArray<Node>;
+                attachNodeArrayDebugInfoWorker(nodeArrayProto);
             }
-            if (remainingFlags === 0) {
-                return result.join("|");
-            }
+            Object.setPrototypeOf(array, nodeArrayProto);
         }
         else {
-            for (const [enumValue, enumName] of members) {
-                if (enumValue === value) {
-                    return enumName;
+            // not running in an es2015 environment, attach the method directly.
+            attachNodeArrayDebugInfoWorker(array);
+        }
+    }
+}
+
+/**
+ * Injects debug information into frequently used types.
+ *
+ * @internal
+ */
+export function enableDebugInfo(): void {
+    if (isDebugInfoEnabled) return;
+
+    // avoid recomputing
+    const weakTypeTextMap = new WeakMap<Type, string>();
+    const weakNodeTextMap = new WeakMap<Node, string>();
+
+    // Add additional properties in debug mode to assist with debugging.
+    Object.defineProperties(objectAllocator.getSymbolConstructor().prototype, {
+        // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
+        __tsDebuggerDisplay: {
+            value(this: Symbol) {
+                const symbolHeader = this.flags & SymbolFlags.Transient ? "TransientSymbol" :
+                    "Symbol";
+                const remainingSymbolFlags = this.flags & ~SymbolFlags.Transient;
+                return `${symbolHeader} '${symbolName(this)}'${remainingSymbolFlags ? ` (${formatSymbolFlags(remainingSymbolFlags)})` : ""}`;
+            },
+        },
+        __debugFlags: {
+            get(this: Symbol) {
+                return formatSymbolFlags(this.flags);
+            },
+        },
+    });
+
+    Object.defineProperties(objectAllocator.getTypeConstructor().prototype, {
+        // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
+        __tsDebuggerDisplay: {
+            value(this: Type) {
+                const typeHeader = this.flags & TypeFlags.Intrinsic ? `IntrinsicType ${(this as IntrinsicType).intrinsicName}${(this as IntrinsicType).debugIntrinsicName ? ` (${(this as IntrinsicType).debugIntrinsicName})` : ""}` :
+                    this.flags & TypeFlags.Nullable ? "NullableType" :
+                    this.flags & TypeFlags.StringOrNumberLiteral ? `LiteralType ${JSON.stringify((this as LiteralType).value)}` :
+                    this.flags & TypeFlags.BigIntLiteral ? `LiteralType ${(this as BigIntLiteralType).value.negative ? "-" : ""}${(this as BigIntLiteralType).value.base10Value}n` :
+                    this.flags & TypeFlags.UniqueESSymbol ? "UniqueESSymbolType" :
+                    this.flags & TypeFlags.Enum ? "EnumType" :
+                    this.flags & TypeFlags.Union ? "UnionType" :
+                    this.flags & TypeFlags.Intersection ? "IntersectionType" :
+                    this.flags & TypeFlags.Index ? "IndexType" :
+                    this.flags & TypeFlags.IndexedAccess ? "IndexedAccessType" :
+                    this.flags & TypeFlags.Conditional ? "ConditionalType" :
+                    this.flags & TypeFlags.Substitution ? "SubstitutionType" :
+                    this.flags & TypeFlags.TypeParameter ? "TypeParameter" :
+                    this.flags & TypeFlags.Object ?
+                    (this as ObjectType).objectFlags & ObjectFlags.ClassOrInterface ? "InterfaceType" :
+                        (this as ObjectType).objectFlags & ObjectFlags.Reference ? "TypeReference" :
+                        (this as ObjectType).objectFlags & ObjectFlags.Tuple ? "TupleType" :
+                        (this as ObjectType).objectFlags & ObjectFlags.Anonymous ? "AnonymousType" :
+                        (this as ObjectType).objectFlags & ObjectFlags.Mapped ? "MappedType" :
+                        (this as ObjectType).objectFlags & ObjectFlags.ReverseMapped ? "ReverseMappedType" :
+                        (this as ObjectType).objectFlags & ObjectFlags.EvolvingArray ? "EvolvingArrayType" :
+                        "ObjectType" :
+                    "Type";
+                const remainingObjectFlags = this.flags & TypeFlags.Object ? (this as ObjectType).objectFlags & ~ObjectFlags.ObjectTypeKindMask : 0;
+                return `${typeHeader}${this.symbol ? ` '${symbolName(this.symbol)}'` : ""}${remainingObjectFlags ? ` (${formatObjectFlags(remainingObjectFlags)})` : ""}`;
+            },
+        },
+        __debugFlags: {
+            get(this: Type) {
+                return formatTypeFlags(this.flags);
+            },
+        },
+        __debugObjectFlags: {
+            get(this: Type) {
+                return this.flags & TypeFlags.Object ? formatObjectFlags((this as ObjectType).objectFlags) : "";
+            },
+        },
+        __debugTypeToString: {
+            value(this: Type) {
+                // avoid recomputing
+                let text = weakTypeTextMap.get(this);
+                if (text === undefined) {
+                    text = this.checker.typeToString(this);
+                    weakTypeTextMap.set(this, text);
                 }
-            }
-        }
-        return value.toString();
-    }
+                return text;
+            },
+        },
+    });
 
-    const enumMemberCache = new Map<any, SortedReadonlyArray<[number, string]>>();
+    Object.defineProperties(objectAllocator.getSignatureConstructor().prototype, {
+        __debugFlags: {
+            get(this: Signature) {
+                return formatSignatureFlags(this.flags);
+            },
+        },
+        __debugSignatureToString: {
+            value(this: Signature) {
+                return this.checker?.signatureToString(this);
+            },
+        },
+    });
 
-    function getEnumMembers(enumObject: any) {
-        // Assuming enum objects do not change at runtime, we can cache the enum members list
-        // to reuse later. This saves us from reconstructing this each and every time we call
-        // a formatting function (which can be expensive for large enums like SyntaxKind).
-        const existing = enumMemberCache.get(enumObject);
-        if (existing) {
-            return existing;
-        }
+    const nodeConstructors = [
+        objectAllocator.getNodeConstructor(),
+        objectAllocator.getIdentifierConstructor(),
+        objectAllocator.getTokenConstructor(),
+        objectAllocator.getSourceFileConstructor(),
+    ];
 
-        const result: [number, string][] = [];
-        for (const name in enumObject) {
-            const value = enumObject[name];
-            if (typeof value === "number") {
-                result.push([value, name]);
-            }
-        }
-
-        const sorted = toSorted<[number, string]>(result, (x, y) => compareValues(x[0], y[0]));
-        enumMemberCache.set(enumObject, sorted);
-        return sorted;
-    }
-
-    export function formatSyntaxKind(kind: SyntaxKind | undefined): string {
-        return formatEnum(kind, (ts as any).SyntaxKind, /*isFlags*/ false);
-    }
-
-    export function formatSnippetKind(kind: SnippetKind | undefined): string {
-        return formatEnum(kind, (ts as any).SnippetKind, /*isFlags*/ false);
-    }
-
-    export function formatScriptKind(kind: ScriptKind | undefined): string {
-        return formatEnum(kind, (ts as any).ScriptKind, /*isFlags*/ false);
-    }
-
-    export function formatNodeFlags(flags: NodeFlags | undefined): string {
-        return formatEnum(flags, (ts as any).NodeFlags, /*isFlags*/ true);
-    }
-
-    export function formatNodeCheckFlags(flags: NodeCheckFlags | undefined): string {
-        return formatEnum(flags, (ts as any).NodeCheckFlags, /*isFlags*/ true);
-    }
-
-    export function formatModifierFlags(flags: ModifierFlags | undefined): string {
-        return formatEnum(flags, (ts as any).ModifierFlags, /*isFlags*/ true);
-    }
-
-    export function formatTransformFlags(flags: TransformFlags | undefined): string {
-        return formatEnum(flags, (ts as any).TransformFlags, /*isFlags*/ true);
-    }
-
-    export function formatEmitFlags(flags: EmitFlags | undefined): string {
-        return formatEnum(flags, (ts as any).EmitFlags, /*isFlags*/ true);
-    }
-
-    export function formatSymbolFlags(flags: SymbolFlags | undefined): string {
-        return formatEnum(flags, (ts as any).SymbolFlags, /*isFlags*/ true);
-    }
-
-    export function formatTypeFlags(flags: TypeFlags | undefined): string {
-        return formatEnum(flags, (ts as any).TypeFlags, /*isFlags*/ true);
-    }
-
-    export function formatSignatureFlags(flags: SignatureFlags | undefined): string {
-        return formatEnum(flags, (ts as any).SignatureFlags, /*isFlags*/ true);
-    }
-
-    export function formatObjectFlags(flags: ObjectFlags | undefined): string {
-        return formatEnum(flags, (ts as any).ObjectFlags, /*isFlags*/ true);
-    }
-
-    export function formatFlowFlags(flags: FlowFlags | undefined): string {
-        return formatEnum(flags, (ts as any).FlowFlags, /*isFlags*/ true);
-    }
-
-    export function formatRelationComparisonResult(result: RelationComparisonResult | undefined): string {
-        return formatEnum(result, (ts as any).RelationComparisonResult, /*isFlags*/ true);
-    }
-
-    export function formatCheckMode(mode: CheckMode | undefined): string {
-        return formatEnum(mode, (ts as any).CheckMode, /*isFlags*/ true);
-    }
-
-    export function formatSignatureCheckMode(mode: SignatureCheckMode | undefined): string {
-        return formatEnum(mode, (ts as any).SignatureCheckMode, /*isFlags*/ true);
-    }
-
-    export function formatTypeFacts(facts: TypeFacts | undefined): string {
-        return formatEnum(facts, (ts as any).TypeFacts, /*isFlags*/ true);
-    }
-
-    let isDebugInfoEnabled = false;
-
-    let flowNodeProto: FlowNode | undefined;
-
-    function attachFlowNodeDebugInfoWorker(flowNode: FlowNode) {
-        if (!("__debugFlowFlags" in flowNode)) { // eslint-disable-line local/no-in-operator
-            Object.defineProperties(flowNode, {
+    for (const ctor of nodeConstructors) {
+        if (!hasProperty(ctor.prototype, "__debugKind")) {
+            Object.defineProperties(ctor.prototype, {
                 // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
                 __tsDebuggerDisplay: {
-                    value(this: FlowNode) {
-                        const flowHeader = this.flags & FlowFlags.Start ? "FlowStart" :
-                            this.flags & FlowFlags.BranchLabel ? "FlowBranchLabel" :
-                            this.flags & FlowFlags.LoopLabel ? "FlowLoopLabel" :
-                            this.flags & FlowFlags.Assignment ? "FlowAssignment" :
-                            this.flags & FlowFlags.TrueCondition ? "FlowTrueCondition" :
-                            this.flags & FlowFlags.FalseCondition ? "FlowFalseCondition" :
-                            this.flags & FlowFlags.SwitchClause ? "FlowSwitchClause" :
-                            this.flags & FlowFlags.ArrayMutation ? "FlowArrayMutation" :
-                            this.flags & FlowFlags.Call ? "FlowCall" :
-                            this.flags & FlowFlags.ReduceLabel ? "FlowReduceLabel" :
-                            this.flags & FlowFlags.Unreachable ? "FlowUnreachable" :
-                            "UnknownFlow";
-                        const remainingFlags = this.flags & ~(FlowFlags.Referenced - 1);
-                        return `${flowHeader}${remainingFlags ? ` (${formatFlowFlags(remainingFlags)})` : ""}`;
+                    value(this: Node) {
+                        const nodeHeader = isGeneratedIdentifier(this) ? "GeneratedIdentifier" :
+                            isIdentifier(this) ? `Identifier '${idText(this)}'` :
+                            isPrivateIdentifier(this) ? `PrivateIdentifier '${idText(this)}'` :
+                            isStringLiteral(this) ? `StringLiteral ${JSON.stringify(this.text.length < 10 ? this.text : this.text.slice(10) + "...")}` :
+                            isNumericLiteral(this) ? `NumericLiteral ${this.text}` :
+                            isBigIntLiteral(this) ? `BigIntLiteral ${this.text}n` :
+                            isTypeParameterDeclaration(this) ? "TypeParameterDeclaration" :
+                            isParameter(this) ? "ParameterDeclaration" :
+                            isConstructorDeclaration(this) ? "ConstructorDeclaration" :
+                            isGetAccessorDeclaration(this) ? "GetAccessorDeclaration" :
+                            isSetAccessorDeclaration(this) ? "SetAccessorDeclaration" :
+                            isCallSignatureDeclaration(this) ? "CallSignatureDeclaration" :
+                            isConstructSignatureDeclaration(this) ? "ConstructSignatureDeclaration" :
+                            isIndexSignatureDeclaration(this) ? "IndexSignatureDeclaration" :
+                            isTypePredicateNode(this) ? "TypePredicateNode" :
+                            isTypeReferenceNode(this) ? "TypeReferenceNode" :
+                            isFunctionTypeNode(this) ? "FunctionTypeNode" :
+                            isConstructorTypeNode(this) ? "ConstructorTypeNode" :
+                            isTypeQueryNode(this) ? "TypeQueryNode" :
+                            isTypeLiteralNode(this) ? "TypeLiteralNode" :
+                            isArrayTypeNode(this) ? "ArrayTypeNode" :
+                            isTupleTypeNode(this) ? "TupleTypeNode" :
+                            isOptionalTypeNode(this) ? "OptionalTypeNode" :
+                            isRestTypeNode(this) ? "RestTypeNode" :
+                            isUnionTypeNode(this) ? "UnionTypeNode" :
+                            isIntersectionTypeNode(this) ? "IntersectionTypeNode" :
+                            isConditionalTypeNode(this) ? "ConditionalTypeNode" :
+                            isInferTypeNode(this) ? "InferTypeNode" :
+                            isParenthesizedTypeNode(this) ? "ParenthesizedTypeNode" :
+                            isThisTypeNode(this) ? "ThisTypeNode" :
+                            isTypeOperatorNode(this) ? "TypeOperatorNode" :
+                            isIndexedAccessTypeNode(this) ? "IndexedAccessTypeNode" :
+                            isMappedTypeNode(this) ? "MappedTypeNode" :
+                            isLiteralTypeNode(this) ? "LiteralTypeNode" :
+                            isNamedTupleMember(this) ? "NamedTupleMember" :
+                            isImportTypeNode(this) ? "ImportTypeNode" :
+                            formatSyntaxKind(this.kind);
+                        return `${nodeHeader}${this.flags ? ` (${formatNodeFlags(this.flags)})` : ""}`;
                     },
                 },
-                __debugFlowFlags: {
-                    get(this: FlowNode) {
-                        return formatEnum(this.flags, (ts as any).FlowFlags, /*isFlags*/ true);
+                __debugKind: {
+                    get(this: Node) {
+                        return formatSyntaxKind(this.kind);
                     },
                 },
-                __debugToString: {
-                    value(this: FlowNode) {
-                        return formatControlFlowGraph(this);
+                __debugNodeFlags: {
+                    get(this: Node) {
+                        return formatNodeFlags(this.flags);
+                    },
+                },
+                __debugModifierFlags: {
+                    get(this: Node) {
+                        return formatModifierFlags(getEffectiveModifierFlagsNoCache(this));
+                    },
+                },
+                __debugTransformFlags: {
+                    get(this: Node) {
+                        return formatTransformFlags(this.transformFlags);
+                    },
+                },
+                __debugIsParseTreeNode: {
+                    get(this: Node) {
+                        return isParseTreeNode(this);
+                    },
+                },
+                __debugEmitFlags: {
+                    get(this: Node) {
+                        return formatEmitFlags(getEmitFlags(this));
+                    },
+                },
+                __debugGetText: {
+                    value(this: Node, includeTrivia?: boolean) {
+                        if (nodeIsSynthesized(this)) return "";
+                        // avoid recomputing
+                        let text = weakNodeTextMap.get(this);
+                        if (text === undefined) {
+                            const parseNode = getParseTreeNode(this);
+                            const sourceFile = parseNode && getSourceFileOfNode(parseNode);
+                            text = sourceFile ? getSourceTextOfNodeFromSourceFile(sourceFile, parseNode, includeTrivia) : "";
+                            weakNodeTextMap.set(this, text);
+                        }
+                        return text;
                     },
                 },
             });
         }
     }
 
-    export function attachFlowNodeDebugInfo(flowNode: FlowNode): FlowNode {
-        if (isDebugInfoEnabled) {
-            if (typeof Object.setPrototypeOf === "function") {
-                // if we're in es2015, attach the method to a shared prototype for `FlowNode`
-                // so the method doesn't show up in the watch window.
-                if (!flowNodeProto) {
-                    flowNodeProto = Object.create(Object.prototype) as FlowNode;
-                    attachFlowNodeDebugInfoWorker(flowNodeProto);
-                }
-                Object.setPrototypeOf(flowNode, flowNodeProto);
-            }
-            else {
-                // not running in an es2015 environment, attach the method directly.
-                attachFlowNodeDebugInfoWorker(flowNode);
-            }
-        }
-        return flowNode;
+    isDebugInfoEnabled = true;
+}
+
+/** @internal */
+export function formatVariance(varianceFlags: VarianceFlags): string {
+    const variance = varianceFlags & VarianceFlags.VarianceMask;
+    let result = variance === VarianceFlags.Invariant ? "in out" :
+        variance === VarianceFlags.Bivariant ? "[bivariant]" :
+        variance === VarianceFlags.Contravariant ? "in" :
+        variance === VarianceFlags.Covariant ? "out" :
+        variance === VarianceFlags.Independent ? "[independent]" : "";
+    if (varianceFlags & VarianceFlags.Unmeasurable) {
+        result += " (unmeasurable)";
     }
-
-    let nodeArrayProto: NodeArray<Node> | undefined;
-
-    function attachNodeArrayDebugInfoWorker(array: NodeArray<Node>) {
-        if (!("__tsDebuggerDisplay" in array)) { // eslint-disable-line local/no-in-operator
-            Object.defineProperties(array, {
-                __tsDebuggerDisplay: {
-                    value(this: NodeArray<Node>, defaultValue: string) {
-                        // An `Array` with extra properties is rendered as `[A, B, prop1: 1, prop2: 2]`. Most of
-                        // these aren't immediately useful so we trim off the `prop1: ..., prop2: ...` part from the
-                        // formatted string.
-                        // This regex can trigger slow backtracking because of overlapping potential captures.
-                        // We don't care, this is debug code that's only enabled with a debugger attached -
-                        // we're just taking note of it for anyone checking regex performance in the future.
-                        defaultValue = String(defaultValue).replace(/(?:,[\s\w]+:[^,]+)+\]$/, "]");
-                        return `NodeArray ${defaultValue}`;
-                    },
-                },
-            });
-        }
+    else if (varianceFlags & VarianceFlags.Unreliable) {
+        result += " (unreliable)";
     }
+    return result;
+}
 
-    export function attachNodeArrayDebugInfo(array: NodeArray<Node>): void {
-        if (isDebugInfoEnabled) {
-            if (typeof Object.setPrototypeOf === "function") {
-                // if we're in es2015, attach the method to a shared prototype for `NodeArray`
-                // so the method doesn't show up in the watch window.
-                if (!nodeArrayProto) {
-                    nodeArrayProto = Object.create(Array.prototype) as NodeArray<Node>;
-                    attachNodeArrayDebugInfoWorker(nodeArrayProto);
-                }
-                Object.setPrototypeOf(array, nodeArrayProto);
-            }
-            else {
-                // not running in an es2015 environment, attach the method directly.
-                attachNodeArrayDebugInfoWorker(array);
-            }
-        }
-    }
-
-    /**
-     * Injects debug information into frequently used types.
-     */
-    export function enableDebugInfo(): void {
-        if (isDebugInfoEnabled) return;
-
-        // avoid recomputing
-        const weakTypeTextMap = new WeakMap<Type, string>();
-        const weakNodeTextMap = new WeakMap<Node, string>();
-
-        // Add additional properties in debug mode to assist with debugging.
-        Object.defineProperties(objectAllocator.getSymbolConstructor().prototype, {
-            // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
-            __tsDebuggerDisplay: {
-                value(this: Symbol) {
-                    const symbolHeader = this.flags & SymbolFlags.Transient ? "TransientSymbol" :
-                        "Symbol";
-                    const remainingSymbolFlags = this.flags & ~SymbolFlags.Transient;
-                    return `${symbolHeader} '${symbolName(this)}'${remainingSymbolFlags ? ` (${formatSymbolFlags(remainingSymbolFlags)})` : ""}`;
-                },
-            },
-            __debugFlags: {
-                get(this: Symbol) {
-                    return formatSymbolFlags(this.flags);
-                },
-            },
-        });
-
-        Object.defineProperties(objectAllocator.getTypeConstructor().prototype, {
-            // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
-            __tsDebuggerDisplay: {
-                value(this: Type) {
-                    const typeHeader = this.flags & TypeFlags.Intrinsic ? `IntrinsicType ${(this as IntrinsicType).intrinsicName}${(this as IntrinsicType).debugIntrinsicName ? ` (${(this as IntrinsicType).debugIntrinsicName})` : ""}` :
-                        this.flags & TypeFlags.Nullable ? "NullableType" :
-                        this.flags & TypeFlags.StringOrNumberLiteral ? `LiteralType ${JSON.stringify((this as LiteralType).value)}` :
-                        this.flags & TypeFlags.BigIntLiteral ? `LiteralType ${(this as BigIntLiteralType).value.negative ? "-" : ""}${(this as BigIntLiteralType).value.base10Value}n` :
-                        this.flags & TypeFlags.UniqueESSymbol ? "UniqueESSymbolType" :
-                        this.flags & TypeFlags.Enum ? "EnumType" :
-                        this.flags & TypeFlags.Union ? "UnionType" :
-                        this.flags & TypeFlags.Intersection ? "IntersectionType" :
-                        this.flags & TypeFlags.Index ? "IndexType" :
-                        this.flags & TypeFlags.IndexedAccess ? "IndexedAccessType" :
-                        this.flags & TypeFlags.Conditional ? "ConditionalType" :
-                        this.flags & TypeFlags.Substitution ? "SubstitutionType" :
-                        this.flags & TypeFlags.TypeParameter ? "TypeParameter" :
-                        this.flags & TypeFlags.Object ?
-                        (this as ObjectType).objectFlags & ObjectFlags.ClassOrInterface ? "InterfaceType" :
-                            (this as ObjectType).objectFlags & ObjectFlags.Reference ? "TypeReference" :
-                            (this as ObjectType).objectFlags & ObjectFlags.Tuple ? "TupleType" :
-                            (this as ObjectType).objectFlags & ObjectFlags.Anonymous ? "AnonymousType" :
-                            (this as ObjectType).objectFlags & ObjectFlags.Mapped ? "MappedType" :
-                            (this as ObjectType).objectFlags & ObjectFlags.ReverseMapped ? "ReverseMappedType" :
-                            (this as ObjectType).objectFlags & ObjectFlags.EvolvingArray ? "EvolvingArrayType" :
-                            "ObjectType" :
-                        "Type";
-                    const remainingObjectFlags = this.flags & TypeFlags.Object ? (this as ObjectType).objectFlags & ~ObjectFlags.ObjectTypeKindMask : 0;
-                    return `${typeHeader}${this.symbol ? ` '${symbolName(this.symbol)}'` : ""}${remainingObjectFlags ? ` (${formatObjectFlags(remainingObjectFlags)})` : ""}`;
-                },
-            },
-            __debugFlags: {
-                get(this: Type) {
-                    return formatTypeFlags(this.flags);
-                },
-            },
-            __debugObjectFlags: {
-                get(this: Type) {
-                    return this.flags & TypeFlags.Object ? formatObjectFlags((this as ObjectType).objectFlags) : "";
-                },
-            },
-            __debugTypeToString: {
-                value(this: Type) {
-                    // avoid recomputing
-                    let text = weakTypeTextMap.get(this);
-                    if (text === undefined) {
-                        text = this.checker.typeToString(this);
-                        weakTypeTextMap.set(this, text);
-                    }
-                    return text;
-                },
-            },
-        });
-
-        Object.defineProperties(objectAllocator.getSignatureConstructor().prototype, {
-            __debugFlags: {
-                get(this: Signature) {
-                    return formatSignatureFlags(this.flags);
-                },
-            },
-            __debugSignatureToString: {
-                value(this: Signature) {
-                    return this.checker?.signatureToString(this);
-                },
-            },
-        });
-
-        const nodeConstructors = [
-            objectAllocator.getNodeConstructor(),
-            objectAllocator.getIdentifierConstructor(),
-            objectAllocator.getTokenConstructor(),
-            objectAllocator.getSourceFileConstructor(),
-        ];
-
-        for (const ctor of nodeConstructors) {
-            if (!hasProperty(ctor.prototype, "__debugKind")) {
-                Object.defineProperties(ctor.prototype, {
-                    // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
-                    __tsDebuggerDisplay: {
-                        value(this: Node) {
-                            const nodeHeader = isGeneratedIdentifier(this) ? "GeneratedIdentifier" :
-                                isIdentifier(this) ? `Identifier '${idText(this)}'` :
-                                isPrivateIdentifier(this) ? `PrivateIdentifier '${idText(this)}'` :
-                                isStringLiteral(this) ? `StringLiteral ${JSON.stringify(this.text.length < 10 ? this.text : this.text.slice(10) + "...")}` :
-                                isNumericLiteral(this) ? `NumericLiteral ${this.text}` :
-                                isBigIntLiteral(this) ? `BigIntLiteral ${this.text}n` :
-                                isTypeParameterDeclaration(this) ? "TypeParameterDeclaration" :
-                                isParameter(this) ? "ParameterDeclaration" :
-                                isConstructorDeclaration(this) ? "ConstructorDeclaration" :
-                                isGetAccessorDeclaration(this) ? "GetAccessorDeclaration" :
-                                isSetAccessorDeclaration(this) ? "SetAccessorDeclaration" :
-                                isCallSignatureDeclaration(this) ? "CallSignatureDeclaration" :
-                                isConstructSignatureDeclaration(this) ? "ConstructSignatureDeclaration" :
-                                isIndexSignatureDeclaration(this) ? "IndexSignatureDeclaration" :
-                                isTypePredicateNode(this) ? "TypePredicateNode" :
-                                isTypeReferenceNode(this) ? "TypeReferenceNode" :
-                                isFunctionTypeNode(this) ? "FunctionTypeNode" :
-                                isConstructorTypeNode(this) ? "ConstructorTypeNode" :
-                                isTypeQueryNode(this) ? "TypeQueryNode" :
-                                isTypeLiteralNode(this) ? "TypeLiteralNode" :
-                                isArrayTypeNode(this) ? "ArrayTypeNode" :
-                                isTupleTypeNode(this) ? "TupleTypeNode" :
-                                isOptionalTypeNode(this) ? "OptionalTypeNode" :
-                                isRestTypeNode(this) ? "RestTypeNode" :
-                                isUnionTypeNode(this) ? "UnionTypeNode" :
-                                isIntersectionTypeNode(this) ? "IntersectionTypeNode" :
-                                isConditionalTypeNode(this) ? "ConditionalTypeNode" :
-                                isInferTypeNode(this) ? "InferTypeNode" :
-                                isParenthesizedTypeNode(this) ? "ParenthesizedTypeNode" :
-                                isThisTypeNode(this) ? "ThisTypeNode" :
-                                isTypeOperatorNode(this) ? "TypeOperatorNode" :
-                                isIndexedAccessTypeNode(this) ? "IndexedAccessTypeNode" :
-                                isMappedTypeNode(this) ? "MappedTypeNode" :
-                                isLiteralTypeNode(this) ? "LiteralTypeNode" :
-                                isNamedTupleMember(this) ? "NamedTupleMember" :
-                                isImportTypeNode(this) ? "ImportTypeNode" :
-                                formatSyntaxKind(this.kind);
-                            return `${nodeHeader}${this.flags ? ` (${formatNodeFlags(this.flags)})` : ""}`;
-                        },
-                    },
-                    __debugKind: {
-                        get(this: Node) {
-                            return formatSyntaxKind(this.kind);
-                        },
-                    },
-                    __debugNodeFlags: {
-                        get(this: Node) {
-                            return formatNodeFlags(this.flags);
-                        },
-                    },
-                    __debugModifierFlags: {
-                        get(this: Node) {
-                            return formatModifierFlags(getEffectiveModifierFlagsNoCache(this));
-                        },
-                    },
-                    __debugTransformFlags: {
-                        get(this: Node) {
-                            return formatTransformFlags(this.transformFlags);
-                        },
-                    },
-                    __debugIsParseTreeNode: {
-                        get(this: Node) {
-                            return isParseTreeNode(this);
-                        },
-                    },
-                    __debugEmitFlags: {
-                        get(this: Node) {
-                            return formatEmitFlags(getEmitFlags(this));
-                        },
-                    },
-                    __debugGetText: {
-                        value(this: Node, includeTrivia?: boolean) {
-                            if (nodeIsSynthesized(this)) return "";
-                            // avoid recomputing
-                            let text = weakNodeTextMap.get(this);
-                            if (text === undefined) {
-                                const parseNode = getParseTreeNode(this);
-                                const sourceFile = parseNode && getSourceFileOfNode(parseNode);
-                                text = sourceFile ? getSourceTextOfNodeFromSourceFile(sourceFile, parseNode, includeTrivia) : "";
-                                weakNodeTextMap.set(this, text);
-                            }
-                            return text;
-                        },
-                    },
-                });
-            }
-        }
-
-        isDebugInfoEnabled = true;
-    }
-
-    export function formatVariance(varianceFlags: VarianceFlags): string {
-        const variance = varianceFlags & VarianceFlags.VarianceMask;
-        let result = variance === VarianceFlags.Invariant ? "in out" :
-            variance === VarianceFlags.Bivariant ? "[bivariant]" :
-            variance === VarianceFlags.Contravariant ? "in" :
-            variance === VarianceFlags.Covariant ? "out" :
-            variance === VarianceFlags.Independent ? "[independent]" : "";
-        if (varianceFlags & VarianceFlags.Unmeasurable) {
-            result += " (unmeasurable)";
-        }
-        else if (varianceFlags & VarianceFlags.Unreliable) {
-            result += " (unreliable)";
-        }
-        return result;
-    }
-
-    export type DebugType = Type & { __debugTypeToString(): string; }; // eslint-disable-line @typescript-eslint/naming-convention
-    export class DebugTypeMapper {
-        declare kind: TypeMapKind;
-        __debugToString(): string { // eslint-disable-line @typescript-eslint/naming-convention
-            type<TypeMapper>(this);
-            switch (this.kind) {
-                case TypeMapKind.Function:
-                    return this.debugInfo?.() || "(function mapper)";
-                case TypeMapKind.Simple:
-                    return `${(this.source as DebugType).__debugTypeToString()} -> ${(this.target as DebugType).__debugTypeToString()}`;
-                case TypeMapKind.Array:
-                    return zipWith<DebugType, DebugType | string, unknown>(
-                        this.sources as readonly DebugType[],
-                        this.targets as readonly DebugType[] || map(this.sources, () => "any"),
-                        (s, t) => `${s.__debugTypeToString()} -> ${typeof t === "string" ? t : t.__debugTypeToString()}`,
-                    ).join(", ");
-                case TypeMapKind.Deferred:
-                    return zipWith(
-                        this.sources,
-                        this.targets,
-                        (s, t) => `${(s as DebugType).__debugTypeToString()} -> ${(t() as DebugType).__debugTypeToString()}`,
-                    ).join(", ");
-                case TypeMapKind.Merged:
-                case TypeMapKind.Composite:
-                    return `m1: ${(this.mapper1 as unknown as DebugTypeMapper).__debugToString().split("\n").join("\n    ")}
+/** @internal */
+export type DebugType = Type & { __debugTypeToString(): string; }; // eslint-disable-line @typescript-eslint/naming-convention
+/** @internal */
+export class DebugTypeMapper {
+    declare kind: TypeMapKind;
+    __debugToString(): string { // eslint-disable-line @typescript-eslint/naming-convention
+        assertType<TypeMapper>(this);
+        switch (this.kind) {
+            case TypeMapKind.Function:
+                return this.debugInfo?.() || "(function mapper)";
+            case TypeMapKind.Simple:
+                return `${(this.source as DebugType).__debugTypeToString()} -> ${(this.target as DebugType).__debugTypeToString()}`;
+            case TypeMapKind.Array:
+                return zipWith<DebugType, DebugType | string, unknown>(
+                    this.sources as readonly DebugType[],
+                    this.targets as readonly DebugType[] || map(this.sources, () => "any"),
+                    (s, t) => `${s.__debugTypeToString()} -> ${typeof t === "string" ? t : t.__debugTypeToString()}`,
+                ).join(", ");
+            case TypeMapKind.Deferred:
+                return zipWith(
+                    this.sources,
+                    this.targets,
+                    (s, t) => `${(s as DebugType).__debugTypeToString()} -> ${(t() as DebugType).__debugTypeToString()}`,
+                ).join(", ");
+            case TypeMapKind.Merged:
+            case TypeMapKind.Composite:
+                return `m1: ${(this.mapper1 as unknown as DebugTypeMapper).__debugToString().split("\n").join("\n    ")}
 m2: ${(this.mapper2 as unknown as DebugTypeMapper).__debugToString().split("\n").join("\n    ")}`;
-                default:
-                    return assertNever(this);
-            }
+            default:
+                return assertNever(this);
         }
     }
+}
 
-    export function attachDebugPrototypeIfDebug(mapper: TypeMapper): TypeMapper {
-        if (isDebugging) {
-            return Object.setPrototypeOf(mapper, DebugTypeMapper.prototype);
+/** @internal */
+export function attachDebugPrototypeIfDebug(mapper: TypeMapper): TypeMapper {
+    if (isDebugging) {
+        return Object.setPrototypeOf(mapper, DebugTypeMapper.prototype);
+    }
+    return mapper;
+}
+
+/** @internal */
+export function printControlFlowGraph(flowNode: FlowNode): void {
+    return console.log(formatControlFlowGraph(flowNode));
+}
+
+/** @internal */
+export function formatControlFlowGraph(flowNode: FlowNode): string {
+    let nextDebugFlowId = -1;
+
+    function getDebugFlowNodeId(f: FlowNode) {
+        if (!f.id) {
+            f.id = nextDebugFlowId;
+            nextDebugFlowId--;
         }
-        return mapper;
+        return f.id;
     }
 
-    export function printControlFlowGraph(flowNode: FlowNode): void {
-        return console.log(formatControlFlowGraph(flowNode));
+    const enum BoxCharacter {
+        lr = "─",
+        ud = "│",
+        dr = "╭",
+        dl = "╮",
+        ul = "╯",
+        ur = "╰",
+        udr = "├",
+        udl = "┤",
+        dlr = "┬",
+        ulr = "┴",
+        udlr = "╫",
     }
 
-    export function formatControlFlowGraph(flowNode: FlowNode): string {
-        let nextDebugFlowId = -1;
+    const enum Connection {
+        None = 0,
+        Up = 1 << 0,
+        Down = 1 << 1,
+        Left = 1 << 2,
+        Right = 1 << 3,
 
-        function getDebugFlowNodeId(f: FlowNode) {
-            if (!f.id) {
-                f.id = nextDebugFlowId;
-                nextDebugFlowId--;
+        UpDown = Up | Down,
+        LeftRight = Left | Right,
+        UpLeft = Up | Left,
+        UpRight = Up | Right,
+        DownLeft = Down | Left,
+        DownRight = Down | Right,
+        UpDownLeft = UpDown | Left,
+        UpDownRight = UpDown | Right,
+        UpLeftRight = Up | LeftRight,
+        DownLeftRight = Down | LeftRight,
+        UpDownLeftRight = UpDown | LeftRight,
+
+        NoChildren = 1 << 4,
+    }
+
+    interface FlowGraphNode {
+        id: number;
+        flowNode: FlowNode;
+        edges: FlowGraphEdge[];
+        text: string;
+        lane: number;
+        endLane: number;
+        level: number;
+        circular: boolean | "circularity";
+    }
+
+    interface FlowGraphEdge {
+        source: FlowGraphNode;
+        target: FlowGraphNode;
+    }
+
+    const hasAntecedentFlags = FlowFlags.Assignment |
+        FlowFlags.Condition |
+        FlowFlags.SwitchClause |
+        FlowFlags.ArrayMutation |
+        FlowFlags.Call |
+        FlowFlags.ReduceLabel;
+
+    const hasNodeFlags = FlowFlags.Start |
+        FlowFlags.Assignment |
+        FlowFlags.Call |
+        FlowFlags.Condition |
+        FlowFlags.ArrayMutation;
+
+    const links: Record<number, FlowGraphNode> = Object.create(/*o*/ null); // eslint-disable-line no-restricted-syntax
+    const nodes: FlowGraphNode[] = [];
+    const edges: FlowGraphEdge[] = [];
+    const root = buildGraphNode(flowNode, new Set());
+    for (const node of nodes) {
+        node.text = renderFlowNode(node.flowNode, node.circular);
+        computeLevel(node);
+    }
+
+    const height = computeHeight(root);
+    const columnWidths = computeColumnWidths(height);
+    computeLanes(root, 0);
+    return renderGraph();
+
+    function isFlowSwitchClause(f: FlowNode): f is FlowSwitchClause {
+        return !!(f.flags & FlowFlags.SwitchClause);
+    }
+
+    function hasAntecedents(f: FlowNode): f is FlowLabel & { antecedent: FlowNode[]; } {
+        return !!(f.flags & FlowFlags.Label) && !!(f as FlowLabel).antecedent;
+    }
+
+    function hasAntecedent(f: FlowNode): f is Extract<FlowNode, { antecedent: FlowNode; }> {
+        return !!(f.flags & hasAntecedentFlags);
+    }
+
+    function hasNode(f: FlowNode): f is Extract<FlowNode, { node?: Node; }> {
+        return !!(f.flags & hasNodeFlags);
+    }
+
+    function getChildren(node: FlowGraphNode) {
+        const children: FlowGraphNode[] = [];
+        for (const edge of node.edges) {
+            if (edge.source === node) {
+                children.push(edge.target);
             }
-            return f.id;
         }
+        return children;
+    }
 
-        const enum BoxCharacter {
-            lr = "─",
-            ud = "│",
-            dr = "╭",
-            dl = "╮",
-            ul = "╯",
-            ur = "╰",
-            udr = "├",
-            udl = "┤",
-            dlr = "┬",
-            ulr = "┴",
-            udlr = "╫",
-        }
-
-        const enum Connection {
-            None = 0,
-            Up = 1 << 0,
-            Down = 1 << 1,
-            Left = 1 << 2,
-            Right = 1 << 3,
-
-            UpDown = Up | Down,
-            LeftRight = Left | Right,
-            UpLeft = Up | Left,
-            UpRight = Up | Right,
-            DownLeft = Down | Left,
-            DownRight = Down | Right,
-            UpDownLeft = UpDown | Left,
-            UpDownRight = UpDown | Right,
-            UpLeftRight = Up | LeftRight,
-            DownLeftRight = Down | LeftRight,
-            UpDownLeftRight = UpDown | LeftRight,
-
-            NoChildren = 1 << 4,
-        }
-
-        interface FlowGraphNode {
-            id: number;
-            flowNode: FlowNode;
-            edges: FlowGraphEdge[];
-            text: string;
-            lane: number;
-            endLane: number;
-            level: number;
-            circular: boolean | "circularity";
-        }
-
-        interface FlowGraphEdge {
-            source: FlowGraphNode;
-            target: FlowGraphNode;
-        }
-
-        const hasAntecedentFlags = FlowFlags.Assignment |
-            FlowFlags.Condition |
-            FlowFlags.SwitchClause |
-            FlowFlags.ArrayMutation |
-            FlowFlags.Call |
-            FlowFlags.ReduceLabel;
-
-        const hasNodeFlags = FlowFlags.Start |
-            FlowFlags.Assignment |
-            FlowFlags.Call |
-            FlowFlags.Condition |
-            FlowFlags.ArrayMutation;
-
-        const links: Record<number, FlowGraphNode> = Object.create(/*o*/ null); // eslint-disable-line no-restricted-syntax
-        const nodes: FlowGraphNode[] = [];
-        const edges: FlowGraphEdge[] = [];
-        const root = buildGraphNode(flowNode, new Set());
-        for (const node of nodes) {
-            node.text = renderFlowNode(node.flowNode, node.circular);
-            computeLevel(node);
-        }
-
-        const height = computeHeight(root);
-        const columnWidths = computeColumnWidths(height);
-        computeLanes(root, 0);
-        return renderGraph();
-
-        function isFlowSwitchClause(f: FlowNode): f is FlowSwitchClause {
-            return !!(f.flags & FlowFlags.SwitchClause);
-        }
-
-        function hasAntecedents(f: FlowNode): f is FlowLabel & { antecedent: FlowNode[]; } {
-            return !!(f.flags & FlowFlags.Label) && !!(f as FlowLabel).antecedent;
-        }
-
-        function hasAntecedent(f: FlowNode): f is Extract<FlowNode, { antecedent: FlowNode; }> {
-            return !!(f.flags & hasAntecedentFlags);
-        }
-
-        function hasNode(f: FlowNode): f is Extract<FlowNode, { node?: Node; }> {
-            return !!(f.flags & hasNodeFlags);
-        }
-
-        function getChildren(node: FlowGraphNode) {
-            const children: FlowGraphNode[] = [];
-            for (const edge of node.edges) {
-                if (edge.source === node) {
-                    children.push(edge.target);
-                }
+    function getParents(node: FlowGraphNode) {
+        const parents: FlowGraphNode[] = [];
+        for (const edge of node.edges) {
+            if (edge.target === node) {
+                parents.push(edge.source);
             }
-            return children;
         }
+        return parents;
+    }
 
-        function getParents(node: FlowGraphNode) {
-            const parents: FlowGraphNode[] = [];
-            for (const edge of node.edges) {
-                if (edge.target === node) {
-                    parents.push(edge.source);
-                }
-            }
-            return parents;
-        }
-
-        function buildGraphNode(flowNode: FlowNode, seen: Set<FlowNode>): FlowGraphNode {
-            const id = getDebugFlowNodeId(flowNode);
-            let graphNode = links[id];
-            if (graphNode && seen.has(flowNode)) {
-                graphNode.circular = true;
-                graphNode = {
-                    id: -1,
-                    flowNode,
-                    edges: [],
-                    text: "",
-                    lane: -1,
-                    endLane: -1,
-                    level: -1,
-                    circular: "circularity",
-                };
-                nodes.push(graphNode);
-                return graphNode;
-            }
-            seen.add(flowNode);
-            if (!graphNode) {
-                links[id] = graphNode = { id, flowNode, edges: [], text: "", lane: -1, endLane: -1, level: -1, circular: false };
-                nodes.push(graphNode);
-                if (hasAntecedents(flowNode)) {
-                    for (const antecedent of flowNode.antecedent) {
-                        buildGraphEdge(graphNode, antecedent, seen);
-                    }
-                }
-                else if (hasAntecedent(flowNode)) {
-                    buildGraphEdge(graphNode, flowNode.antecedent, seen);
-                }
-            }
-            seen.delete(flowNode);
+    function buildGraphNode(flowNode: FlowNode, seen: Set<FlowNode>): FlowGraphNode {
+        const id = getDebugFlowNodeId(flowNode);
+        let graphNode = links[id];
+        if (graphNode && seen.has(flowNode)) {
+            graphNode.circular = true;
+            graphNode = {
+                id: -1,
+                flowNode,
+                edges: [],
+                text: "",
+                lane: -1,
+                endLane: -1,
+                level: -1,
+                circular: "circularity",
+            };
+            nodes.push(graphNode);
             return graphNode;
         }
+        seen.add(flowNode);
+        if (!graphNode) {
+            links[id] = graphNode = { id, flowNode, edges: [], text: "", lane: -1, endLane: -1, level: -1, circular: false };
+            nodes.push(graphNode);
+            if (hasAntecedents(flowNode)) {
+                for (const antecedent of flowNode.antecedent) {
+                    buildGraphEdge(graphNode, antecedent, seen);
+                }
+            }
+            else if (hasAntecedent(flowNode)) {
+                buildGraphEdge(graphNode, flowNode.antecedent, seen);
+            }
+        }
+        seen.delete(flowNode);
+        return graphNode;
+    }
 
-        function buildGraphEdge(source: FlowGraphNode, antecedent: FlowNode, seen: Set<FlowNode>) {
-            const target = buildGraphNode(antecedent, seen);
-            const edge: FlowGraphEdge = { source, target };
-            edges.push(edge);
-            source.edges.push(edge);
-            target.edges.push(edge);
+    function buildGraphEdge(source: FlowGraphNode, antecedent: FlowNode, seen: Set<FlowNode>) {
+        const target = buildGraphNode(antecedent, seen);
+        const edge: FlowGraphEdge = { source, target };
+        edges.push(edge);
+        source.edges.push(edge);
+        target.edges.push(edge);
+    }
+
+    function computeLevel(node: FlowGraphNode): number {
+        if (node.level !== -1) {
+            return node.level;
+        }
+        let level = 0;
+        for (const parent of getParents(node)) {
+            level = Math.max(level, computeLevel(parent) + 1);
+        }
+        return node.level = level;
+    }
+
+    function computeHeight(node: FlowGraphNode): number {
+        let height = 0;
+        for (const child of getChildren(node)) {
+            height = Math.max(height, computeHeight(child));
+        }
+        return height + 1;
+    }
+
+    function computeColumnWidths(height: number) {
+        const columns: number[] = fill(Array(height), 0);
+        for (const node of nodes) {
+            columns[node.level] = Math.max(columns[node.level], node.text.length);
+        }
+        return columns;
+    }
+
+    function computeLanes(node: FlowGraphNode, lane: number) {
+        if (node.lane === -1) {
+            node.lane = lane;
+            node.endLane = lane;
+            const children = getChildren(node);
+            for (let i = 0; i < children.length; i++) {
+                if (i > 0) lane++;
+                const child = children[i];
+                computeLanes(child, lane);
+                if (child.endLane > node.endLane) {
+                    lane = child.endLane;
+                }
+            }
+            node.endLane = lane;
+        }
+    }
+
+    function getHeader(flags: FlowFlags) {
+        if (flags & FlowFlags.Start) return "Start";
+        if (flags & FlowFlags.BranchLabel) return "Branch";
+        if (flags & FlowFlags.LoopLabel) return "Loop";
+        if (flags & FlowFlags.Assignment) return "Assignment";
+        if (flags & FlowFlags.TrueCondition) return "True";
+        if (flags & FlowFlags.FalseCondition) return "False";
+        if (flags & FlowFlags.SwitchClause) return "SwitchClause";
+        if (flags & FlowFlags.ArrayMutation) return "ArrayMutation";
+        if (flags & FlowFlags.Call) return "Call";
+        if (flags & FlowFlags.ReduceLabel) return "ReduceLabel";
+        if (flags & FlowFlags.Unreachable) return "Unreachable";
+        throw new Error();
+    }
+
+    function getNodeText(node: Node) {
+        const sourceFile = getSourceFileOfNode(node);
+        return getSourceTextOfNodeFromSourceFile(sourceFile, node, /*includeTrivia*/ false);
+    }
+
+    function renderFlowNode(flowNode: FlowNode, circular: boolean | "circularity") {
+        let text = getHeader(flowNode.flags);
+        if (circular) {
+            text = `${text}#${getDebugFlowNodeId(flowNode)}`;
+        }
+        if (isFlowSwitchClause(flowNode)) {
+            const clauses: string[] = [];
+            const { switchStatement, clauseStart, clauseEnd } = flowNode.node;
+            for (let i = clauseStart; i < clauseEnd; i++) {
+                const clause = switchStatement.caseBlock.clauses[i];
+                if (isDefaultClause(clause)) {
+                    clauses.push("default");
+                }
+                else {
+                    clauses.push(getNodeText(clause.expression));
+                }
+            }
+            text += ` (${clauses.join(", ")})`;
+        }
+        else if (hasNode(flowNode)) {
+            if (flowNode.node) {
+                text += ` (${getNodeText(flowNode.node)})`;
+            }
+        }
+        return circular === "circularity" ? `Circular(${text})` : text;
+    }
+
+    function renderGraph() {
+        const columnCount = columnWidths.length;
+        const laneCount = maxBy(nodes, 0, n => n.lane) + 1;
+        const lanes: string[] = fill(Array(laneCount), "");
+        const grid: (FlowGraphNode | undefined)[][] = columnWidths.map(() => Array(laneCount));
+        const connectors: Connection[][] = columnWidths.map(() => fill(Array(laneCount), 0));
+
+        // build connectors
+        for (const node of nodes) {
+            grid[node.level][node.lane] = node;
+            const children = getChildren(node);
+            for (let i = 0; i < children.length; i++) {
+                const child = children[i];
+                let connector: Connection = Connection.Right;
+                if (child.lane === node.lane) connector |= Connection.Left;
+                if (i > 0) connector |= Connection.Up;
+                if (i < children.length - 1) connector |= Connection.Down;
+                connectors[node.level][child.lane] |= connector;
+            }
+            if (children.length === 0) {
+                connectors[node.level][node.lane] |= Connection.NoChildren;
+            }
+            const parents = getParents(node);
+            for (let i = 0; i < parents.length; i++) {
+                const parent = parents[i];
+                let connector: Connection = Connection.Left;
+                if (i > 0) connector |= Connection.Up;
+                if (i < parents.length - 1) connector |= Connection.Down;
+                connectors[node.level - 1][parent.lane] |= connector;
+            }
         }
 
-        function computeLevel(node: FlowGraphNode): number {
-            if (node.level !== -1) {
-                return node.level;
+        // fill in missing connectors
+        for (let column = 0; column < columnCount; column++) {
+            for (let lane = 0; lane < laneCount; lane++) {
+                const left = column > 0 ? connectors[column - 1][lane] : 0;
+                const above = lane > 0 ? connectors[column][lane - 1] : 0;
+                let connector = connectors[column][lane];
+                if (!connector) {
+                    if (left & Connection.Right) connector |= Connection.LeftRight;
+                    if (above & Connection.Down) connector |= Connection.UpDown;
+                    connectors[column][lane] = connector;
+                }
             }
-            let level = 0;
-            for (const parent of getParents(node)) {
-                level = Math.max(level, computeLevel(parent) + 1);
-            }
-            return node.level = level;
         }
 
-        function computeHeight(node: FlowGraphNode): number {
-            let height = 0;
-            for (const child of getChildren(node)) {
-                height = Math.max(height, computeHeight(child));
-            }
-            return height + 1;
-        }
-
-        function computeColumnWidths(height: number) {
-            const columns: number[] = fill(Array(height), 0);
-            for (const node of nodes) {
-                columns[node.level] = Math.max(columns[node.level], node.text.length);
-            }
-            return columns;
-        }
-
-        function computeLanes(node: FlowGraphNode, lane: number) {
-            if (node.lane === -1) {
-                node.lane = lane;
-                node.endLane = lane;
-                const children = getChildren(node);
-                for (let i = 0; i < children.length; i++) {
-                    if (i > 0) lane++;
-                    const child = children[i];
-                    computeLanes(child, lane);
-                    if (child.endLane > node.endLane) {
-                        lane = child.endLane;
+        for (let column = 0; column < columnCount; column++) {
+            for (let lane = 0; lane < lanes.length; lane++) {
+                const connector = connectors[column][lane];
+                const fill = connector & Connection.Left ? BoxCharacter.lr : " ";
+                const node = grid[column][lane];
+                if (!node) {
+                    if (column < columnCount - 1) {
+                        writeLane(lane, repeat(fill, columnWidths[column] + 1));
                     }
                 }
-                node.endLane = lane;
-            }
-        }
-
-        function getHeader(flags: FlowFlags) {
-            if (flags & FlowFlags.Start) return "Start";
-            if (flags & FlowFlags.BranchLabel) return "Branch";
-            if (flags & FlowFlags.LoopLabel) return "Loop";
-            if (flags & FlowFlags.Assignment) return "Assignment";
-            if (flags & FlowFlags.TrueCondition) return "True";
-            if (flags & FlowFlags.FalseCondition) return "False";
-            if (flags & FlowFlags.SwitchClause) return "SwitchClause";
-            if (flags & FlowFlags.ArrayMutation) return "ArrayMutation";
-            if (flags & FlowFlags.Call) return "Call";
-            if (flags & FlowFlags.ReduceLabel) return "ReduceLabel";
-            if (flags & FlowFlags.Unreachable) return "Unreachable";
-            throw new Error();
-        }
-
-        function getNodeText(node: Node) {
-            const sourceFile = getSourceFileOfNode(node);
-            return getSourceTextOfNodeFromSourceFile(sourceFile, node, /*includeTrivia*/ false);
-        }
-
-        function renderFlowNode(flowNode: FlowNode, circular: boolean | "circularity") {
-            let text = getHeader(flowNode.flags);
-            if (circular) {
-                text = `${text}#${getDebugFlowNodeId(flowNode)}`;
-            }
-            if (isFlowSwitchClause(flowNode)) {
-                const clauses: string[] = [];
-                const { switchStatement, clauseStart, clauseEnd } = flowNode.node;
-                for (let i = clauseStart; i < clauseEnd; i++) {
-                    const clause = switchStatement.caseBlock.clauses[i];
-                    if (isDefaultClause(clause)) {
-                        clauses.push("default");
-                    }
-                    else {
-                        clauses.push(getNodeText(clause.expression));
+                else {
+                    writeLane(lane, node.text);
+                    if (column < columnCount - 1) {
+                        writeLane(lane, " ");
+                        writeLane(lane, repeat(fill, columnWidths[column] - node.text.length));
                     }
                 }
-                text += ` (${clauses.join(", ")})`;
-            }
-            else if (hasNode(flowNode)) {
-                if (flowNode.node) {
-                    text += ` (${getNodeText(flowNode.node)})`;
-                }
-            }
-            return circular === "circularity" ? `Circular(${text})` : text;
-        }
-
-        function renderGraph() {
-            const columnCount = columnWidths.length;
-            const laneCount = maxBy(nodes, 0, n => n.lane) + 1;
-            const lanes: string[] = fill(Array(laneCount), "");
-            const grid: (FlowGraphNode | undefined)[][] = columnWidths.map(() => Array(laneCount));
-            const connectors: Connection[][] = columnWidths.map(() => fill(Array(laneCount), 0));
-
-            // build connectors
-            for (const node of nodes) {
-                grid[node.level][node.lane] = node;
-                const children = getChildren(node);
-                for (let i = 0; i < children.length; i++) {
-                    const child = children[i];
-                    let connector: Connection = Connection.Right;
-                    if (child.lane === node.lane) connector |= Connection.Left;
-                    if (i > 0) connector |= Connection.Up;
-                    if (i < children.length - 1) connector |= Connection.Down;
-                    connectors[node.level][child.lane] |= connector;
-                }
-                if (children.length === 0) {
-                    connectors[node.level][node.lane] |= Connection.NoChildren;
-                }
-                const parents = getParents(node);
-                for (let i = 0; i < parents.length; i++) {
-                    const parent = parents[i];
-                    let connector: Connection = Connection.Left;
-                    if (i > 0) connector |= Connection.Up;
-                    if (i < parents.length - 1) connector |= Connection.Down;
-                    connectors[node.level - 1][parent.lane] |= connector;
-                }
-            }
-
-            // fill in missing connectors
-            for (let column = 0; column < columnCount; column++) {
-                for (let lane = 0; lane < laneCount; lane++) {
-                    const left = column > 0 ? connectors[column - 1][lane] : 0;
-                    const above = lane > 0 ? connectors[column][lane - 1] : 0;
-                    let connector = connectors[column][lane];
-                    if (!connector) {
-                        if (left & Connection.Right) connector |= Connection.LeftRight;
-                        if (above & Connection.Down) connector |= Connection.UpDown;
-                        connectors[column][lane] = connector;
-                    }
-                }
-            }
-
-            for (let column = 0; column < columnCount; column++) {
-                for (let lane = 0; lane < lanes.length; lane++) {
-                    const connector = connectors[column][lane];
-                    const fill = connector & Connection.Left ? BoxCharacter.lr : " ";
-                    const node = grid[column][lane];
-                    if (!node) {
-                        if (column < columnCount - 1) {
-                            writeLane(lane, repeat(fill, columnWidths[column] + 1));
-                        }
-                    }
-                    else {
-                        writeLane(lane, node.text);
-                        if (column < columnCount - 1) {
-                            writeLane(lane, " ");
-                            writeLane(lane, repeat(fill, columnWidths[column] - node.text.length));
-                        }
-                    }
-                    writeLane(lane, getBoxCharacter(connector));
-                    writeLane(lane, connector & Connection.Right && column < columnCount - 1 && !grid[column + 1][lane] ? BoxCharacter.lr : " ");
-                }
-            }
-
-            return `\n${lanes.join("\n")}\n`;
-
-            function writeLane(lane: number, text: string) {
-                lanes[lane] += text;
+                writeLane(lane, getBoxCharacter(connector));
+                writeLane(lane, connector & Connection.Right && column < columnCount - 1 && !grid[column + 1][lane] ? BoxCharacter.lr : " ");
             }
         }
 
-        function getBoxCharacter(connector: Connection) {
-            switch (connector) {
-                case Connection.UpDown:
-                    return BoxCharacter.ud;
-                case Connection.LeftRight:
-                    return BoxCharacter.lr;
-                case Connection.UpLeft:
-                    return BoxCharacter.ul;
-                case Connection.UpRight:
-                    return BoxCharacter.ur;
-                case Connection.DownLeft:
-                    return BoxCharacter.dl;
-                case Connection.DownRight:
-                    return BoxCharacter.dr;
-                case Connection.UpDownLeft:
-                    return BoxCharacter.udl;
-                case Connection.UpDownRight:
-                    return BoxCharacter.udr;
-                case Connection.UpLeftRight:
-                    return BoxCharacter.ulr;
-                case Connection.DownLeftRight:
-                    return BoxCharacter.dlr;
-                case Connection.UpDownLeftRight:
-                    return BoxCharacter.udlr;
-            }
-            return " ";
-        }
+        return `\n${lanes.join("\n")}\n`;
 
-        function fill<T>(array: T[], value: T) {
-            if (array.fill) {
-                array.fill(value);
-            }
-            else {
-                for (let i = 0; i < array.length; i++) {
-                    array[i] = value;
-                }
-            }
-            return array;
+        function writeLane(lane: number, text: string) {
+            lanes[lane] += text;
         }
+    }
 
-        function repeat(ch: string, length: number) {
-            if (ch.repeat) {
-                return length > 0 ? ch.repeat(length) : "";
-            }
-            let s = "";
-            while (s.length < length) {
-                s += ch;
-            }
-            return s;
+    function getBoxCharacter(connector: Connection) {
+        switch (connector) {
+            case Connection.UpDown:
+                return BoxCharacter.ud;
+            case Connection.LeftRight:
+                return BoxCharacter.lr;
+            case Connection.UpLeft:
+                return BoxCharacter.ul;
+            case Connection.UpRight:
+                return BoxCharacter.ur;
+            case Connection.DownLeft:
+                return BoxCharacter.dl;
+            case Connection.DownRight:
+                return BoxCharacter.dr;
+            case Connection.UpDownLeft:
+                return BoxCharacter.udl;
+            case Connection.UpDownRight:
+                return BoxCharacter.udr;
+            case Connection.UpLeftRight:
+                return BoxCharacter.ulr;
+            case Connection.DownLeftRight:
+                return BoxCharacter.dlr;
+            case Connection.UpDownLeftRight:
+                return BoxCharacter.udlr;
         }
+        return " ";
+    }
+
+    function fill<T>(array: T[], value: T) {
+        if (array.fill) {
+            array.fill(value);
+        }
+        else {
+            for (let i = 0; i < array.length; i++) {
+                array[i] = value;
+            }
+        }
+        return array;
+    }
+
+    function repeat(ch: string, length: number) {
+        if (ch.repeat) {
+            return length > 0 ? ch.repeat(length) : "";
+        }
+        let s = "";
+        while (s.length < length) {
+            s += ch;
+        }
+        return s;
     }
 }

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -115,10 +115,10 @@ export const enum AssertionLevel {
 
 let currentAssertionLevel = AssertionLevel.None;
 
-/** @internal */
+/** @internal @knipignore */
 export let currentLogLevel: LogLevel = LogLevel.Warning;
 
-/** @internal */
+/** @internal @knipignore */
 export function setCurrentLogLevel(newCurrentLogLevel: LogLevel): void {
     currentLogLevel = newCurrentLogLevel;
 }
@@ -139,7 +139,7 @@ export function setLoggingHost(newLoggingHost: LoggingHost | undefined): void {
     loggingHost = newLoggingHost;
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function shouldLog(level: LogLevel): boolean {
     return currentLogLevel <= level;
 }
@@ -174,7 +174,7 @@ export namespace log {
     }
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function getAssertionLevel(): AssertionLevel {
     return currentAssertionLevel;
 }
@@ -352,11 +352,11 @@ export function assertOptionalNode(node: Node | undefined, test: ((node: Node) =
     }
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function assertOptionalToken<T extends Node, K extends SyntaxKind>(node: T, kind: K, message?: string, stackCrawlMark?: AnyFunction): asserts node is Extract<T, { readonly kind: K; }>;
-/** @internal */
+/** @internal @knipignore */
 export function assertOptionalToken<T extends Node, K extends SyntaxKind>(node: T | undefined, kind: K, message?: string, stackCrawlMark?: AnyFunction): asserts node is Extract<T, { readonly kind: K; }> | undefined;
-/** @internal */
+/** @internal @knipignore */
 export function assertOptionalToken(node: Node | undefined, kind: SyntaxKind | undefined, message?: string, stackCrawlMark?: AnyFunction): void;
 export function assertOptionalToken(node: Node | undefined, kind: SyntaxKind | undefined, message?: string, stackCrawlMark?: AnyFunction) {
     if (shouldAssert(AssertionLevel.Normal)) {
@@ -476,7 +476,7 @@ export function formatSyntaxKind(kind: SyntaxKind | undefined): string {
     return formatEnum(kind, (ts as any).SyntaxKind, /*isFlags*/ false);
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatSnippetKind(kind: SnippetKind | undefined): string {
     return formatEnum(kind, (ts as any).SnippetKind, /*isFlags*/ false);
 }
@@ -496,17 +496,17 @@ export function formatNodeCheckFlags(flags: NodeCheckFlags | undefined): string 
     return formatEnum(flags, (ts as any).NodeCheckFlags, /*isFlags*/ true);
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatModifierFlags(flags: ModifierFlags | undefined): string {
     return formatEnum(flags, (ts as any).ModifierFlags, /*isFlags*/ true);
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatTransformFlags(flags: TransformFlags | undefined): string {
     return formatEnum(flags, (ts as any).TransformFlags, /*isFlags*/ true);
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatEmitFlags(flags: EmitFlags | undefined): string {
     return formatEnum(flags, (ts as any).EmitFlags, /*isFlags*/ true);
 }
@@ -521,7 +521,7 @@ export function formatTypeFlags(flags: TypeFlags | undefined): string {
     return formatEnum(flags, (ts as any).TypeFlags, /*isFlags*/ true);
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatSignatureFlags(flags: SignatureFlags | undefined): string {
     return formatEnum(flags, (ts as any).SignatureFlags, /*isFlags*/ true);
 }
@@ -531,27 +531,27 @@ export function formatObjectFlags(flags: ObjectFlags | undefined): string {
     return formatEnum(flags, (ts as any).ObjectFlags, /*isFlags*/ true);
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatFlowFlags(flags: FlowFlags | undefined): string {
     return formatEnum(flags, (ts as any).FlowFlags, /*isFlags*/ true);
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatRelationComparisonResult(result: RelationComparisonResult | undefined): string {
     return formatEnum(result, (ts as any).RelationComparisonResult, /*isFlags*/ true);
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatCheckMode(mode: CheckMode | undefined): string {
     return formatEnum(mode, (ts as any).CheckMode, /*isFlags*/ true);
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatSignatureCheckMode(mode: SignatureCheckMode | undefined): string {
     return formatEnum(mode, (ts as any).SignatureCheckMode, /*isFlags*/ true);
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatTypeFacts(facts: TypeFacts | undefined): string {
     return formatEnum(facts, (ts as any).TypeFacts, /*isFlags*/ true);
 }
@@ -876,7 +876,7 @@ export function formatVariance(varianceFlags: VarianceFlags): string {
 
 /** @internal */
 export type DebugType = Type & { __debugTypeToString(): string; }; // eslint-disable-line @typescript-eslint/naming-convention
-/** @internal */
+/** @internal @knipignore */
 export class DebugTypeMapper {
     declare kind: TypeMapKind;
     __debugToString(): string { // eslint-disable-line @typescript-eslint/naming-convention
@@ -916,12 +916,12 @@ export function attachDebugPrototypeIfDebug(mapper: TypeMapper): TypeMapper {
     return mapper;
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function printControlFlowGraph(flowNode: FlowNode): void {
     return console.log(formatControlFlowGraph(flowNode));
 }
 
-/** @internal */
+/** @internal @knipignore */
 export function formatControlFlowGraph(flowNode: FlowNode): string {
     let nextDebugFlowId = -1;
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -54,7 +54,6 @@ import {
     createGetCanonicalFileName,
     createSourceMapGenerator,
     createTextWriter,
-    Debug,
     DebuggerStatement,
     DeclarationName,
     Decorator,
@@ -424,6 +423,7 @@ import {
     YieldExpression,
 } from "./_namespaces/ts.js";
 import * as performance from "./_namespaces/ts.performance.js";
+import * as Debug from "./debug.js";
 
 const brackets = createBracketsMap();
 

--- a/src/compiler/executeCommandLine.ts
+++ b/src/compiler/executeCommandLine.ts
@@ -29,7 +29,6 @@ import {
     createWatchCompilerHostOfFilesAndCompilerOptions,
     createWatchProgram,
     createWatchStatusReporter as ts_createWatchStatusReporter,
-    Debug,
     Diagnostic,
     DiagnosticMessage,
     DiagnosticReporter,
@@ -88,6 +87,7 @@ import {
     WatchOfConfigFile,
     WatchOptions,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 import * as performance from "./performance.js";
 
 interface Statistic {

--- a/src/compiler/expressionToTypeNode.ts
+++ b/src/compiler/expressionToTypeNode.ts
@@ -8,7 +8,6 @@ import {
     BindingElement,
     ClassExpression,
     CompilerOptions,
-    Debug,
     ElementAccessExpression,
     ExportAssignment,
     Expression,
@@ -65,6 +64,7 @@ import {
     UnionTypeNode,
     VariableDeclaration,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /** @internal */
 export function createSyntacticTypeNodeBuilder(

--- a/src/compiler/factory/emitHelpers.ts
+++ b/src/compiler/factory/emitHelpers.ts
@@ -6,7 +6,6 @@ import {
     compareValues,
     Comparison,
     createExpressionFromEntityName,
-    Debug,
     EmitFlags,
     EmitHelper,
     EmitHelperUniqueNameCallback,
@@ -36,6 +35,7 @@ import {
     TransformationContext,
     UnscopedEmitHelper,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 /** @internal */
 export const enum PrivateIdentifierKind {

--- a/src/compiler/factory/emitNode.ts
+++ b/src/compiler/factory/emitNode.ts
@@ -3,7 +3,6 @@ import {
     append,
     appendIfUnique,
     AutoGenerateInfo,
-    Debug,
     EmitFlags,
     EmitHelper,
     EmitNode,
@@ -27,6 +26,7 @@ import {
     TypeNode,
     TypeParameterDeclaration,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 /**
  * Associates a node with the current transformation, initializing

--- a/src/compiler/factory/nodeChildren.ts
+++ b/src/compiler/factory/nodeChildren.ts
@@ -1,5 +1,4 @@
 import {
-    Debug,
     emptyArray,
     isNodeKind,
     Node,
@@ -7,6 +6,7 @@ import {
     SyntaxKind,
     SyntaxList,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 const sourceFileToNodeChildren = new WeakMap<SourceFileLike, WeakMap<Node, readonly Node[] | undefined>>();
 

--- a/src/compiler/factory/nodeConverters.ts
+++ b/src/compiler/factory/nodeConverters.ts
@@ -8,7 +8,6 @@ import {
     cast,
     ClassDeclaration,
     ConciseBody,
-    Debug,
     Expression,
     FunctionDeclaration,
     getModifiers,
@@ -36,6 +35,7 @@ import {
     setTextRange,
     SyntaxKind,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 /** @internal */
 export function createNodeConverters(factory: NodeFactory): NodeConverters {

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -59,7 +59,6 @@ import {
     createNodeConverters,
     createParenthesizerRules,
     createScanner,
-    Debug,
     DebuggerStatement,
     Declaration,
     DeclarationName,
@@ -458,6 +457,7 @@ import {
     WithStatement,
     YieldExpression,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 let nextAutoGenerateId = 0;
 

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -4,7 +4,6 @@ import {
     addInternalEmitFlags,
     AdditiveOperator,
     AdditiveOperatorOrHigher,
-    AssertionLevel,
     AssignmentExpression,
     AssignmentOperatorOrHigher,
     AssignmentPattern,
@@ -1396,7 +1395,7 @@ namespace BinaryExpressionState {
     }
 
     function checkCircularity(stackIndex: number, nodeStack: BinaryExpression[], node: BinaryExpression) {
-        if (Debug.shouldAssert(AssertionLevel.Aggressive)) {
+        if (Debug.shouldAssert(Debug.AssertionLevel.Aggressive)) {
             while (stackIndex >= 0) {
                 Debug.assert(nodeStack[stackIndex] !== node, "Circular traversal detected.");
                 stackIndex--;

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -21,7 +21,6 @@ import {
     compareStringsCaseSensitive,
     CompilerOptions,
     ComputedPropertyName,
-    Debug,
     Declaration,
     DefaultKeyword,
     EmitFlags,
@@ -175,6 +174,7 @@ import {
     UnscopedEmitHelper,
     WrappedExpression,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 // Compound nodes
 

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -15,7 +15,6 @@ import {
     contains,
     containsPath,
     createCompilerDiagnostic,
-    Debug,
     deduplicate,
     Diagnostic,
     DiagnosticMessage,
@@ -109,6 +108,7 @@ import {
     versionMajorMinor,
     VersionRange,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /** @internal */
 export function trace(host: ModuleResolutionHost, message: DiagnosticMessage, ...args: any[]): void {

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -16,7 +16,6 @@ import {
     containsIgnoredPath,
     containsPath,
     createGetCanonicalFileName,
-    Debug,
     directorySeparator,
     emptyArray,
     endsWith,
@@ -129,6 +128,7 @@ import {
     TypeChecker,
     UserPreferences,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 const stringToRegex = memoizeOne((pattern: string) => {
     try {

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -812,7 +812,7 @@ function getAllModulePathsWorker(info: Info, importedFileName: string, host: Mod
     const cache = host.getModuleResolutionCache?.();
     const links = host.getSymlinkCache?.();
     if (cache && links && host.readFile && !pathContainsNodeModules(info.importingSourceFileName)) {
-        Debug.type<ModuleResolutionHost>(host);
+        Debug.assertType<ModuleResolutionHost>(host);
         // Cache resolutions for all `dependencies` of the `package.json` context of the input file.
         // This should populate all the relevant symlinks in the symlink cache, and most, if not all, of these resolutions
         // should get (re)used.

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -56,7 +56,6 @@ import {
     createScanner,
     createTextChangeRange,
     createTextSpanFromBounds,
-    Debug,
     Decorator,
     DefaultClause,
     DeleteExpression,
@@ -399,6 +398,7 @@ import {
     YieldExpression,
 } from "./_namespaces/ts.js";
 import * as performance from "./_namespaces/ts.performance.js";
+import * as Debug from "./debug.js";
 
 const enum SignatureFlags {
     None = 0,

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -9,7 +9,6 @@ import {
     ArrayTypeNode,
     ArrowFunction,
     AsExpression,
-    AssertionLevel,
     AsteriskToken,
     attachFileToDiagnostics,
     AwaitExpression,
@@ -9898,7 +9897,7 @@ function markAsIntersectingIncrementalChange(node: Node | NodeArray<Node>) {
 
 namespace IncrementalParser {
     export function updateSourceFile(sourceFile: SourceFile, newText: string, textChangeRange: TextChangeRange, aggressiveChecks: boolean): SourceFile {
-        aggressiveChecks = aggressiveChecks || Debug.shouldAssert(AssertionLevel.Aggressive);
+        aggressiveChecks = aggressiveChecks || Debug.shouldAssert(Debug.AssertionLevel.Aggressive);
 
         checkChangeRange(sourceFile, newText, textChangeRange, aggressiveChecks);
         if (textChangeRangeIsUnchanged(textChangeRange)) {
@@ -10380,7 +10379,7 @@ namespace IncrementalParser {
         if (textChangeRange) {
             Debug.assert((oldText.length - textChangeRange.span.length + textChangeRange.newLength) === newText.length);
 
-            if (aggressiveChecks || Debug.shouldAssert(AssertionLevel.VeryAggressive)) {
+            if (aggressiveChecks || Debug.shouldAssert(Debug.AssertionLevel.VeryAggressive)) {
                 const oldTextPrefix = oldText.substr(0, textChangeRange.span.start);
                 const newTextPrefix = newText.substr(0, textChangeRange.span.start);
                 Debug.assert(oldTextPrefix === newTextPrefix);

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -4,7 +4,6 @@ import {
     compareStringsCaseSensitive,
     compareValues,
     Comparison,
-    Debug,
     endsWith,
     equateStringsCaseInsensitive,
     equateStringsCaseSensitive,
@@ -17,6 +16,7 @@ import {
     some,
     startsWith,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /**
  * Internally, we represent paths as strings with '/' as the directory separator.

--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -1,5 +1,4 @@
 import {
-    Debug,
     noop,
     Performance,
     PerformanceHooks,
@@ -8,6 +7,7 @@ import {
     timestamp,
     tryGetNativePerformanceHooks,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /** Performance measurements for the compiler. */
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -52,7 +52,6 @@ import {
     createTypeChecker,
     createTypeReferenceDirectiveResolutionCache,
     CustomTransformers,
-    Debug,
     DeclarationWithTypeParameterChildren,
     Diagnostic,
     DiagnosticArguments,
@@ -335,6 +334,7 @@ import {
     writeFileEnsuringDirectories,
 } from "./_namespaces/ts.js";
 import * as performance from "./_namespaces/ts.performance.js";
+import * as Debug from "./debug.js";
 
 export function findConfigFile(searchPath: string, fileExists: (fileName: string) => boolean, configName = "tsconfig.json"): string | undefined {
     return forEachAncestorDirectory(searchPath, ancestor => {

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -8,7 +8,6 @@ import {
     createModuleResolutionCache,
     createTypeReferenceDirectiveResolutionCache,
     createTypeReferenceResolutionLoader,
-    Debug,
     Diagnostics,
     directorySeparator,
     DirectoryWatcherCallback,
@@ -76,6 +75,7 @@ import {
     updateResolutionField,
     WatchDirectoryFlags,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /** @internal */
 export interface HasInvalidatedFromResolutionCache {

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -8,7 +8,6 @@ import {
     CommentKind,
     CommentRange,
     compareValues,
-    Debug,
     DiagnosticMessage,
     Diagnostics,
     forEach,
@@ -35,6 +34,7 @@ import {
     TextRange,
     TokenFlags,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 export type ErrorCallback = (message: DiagnosticMessage, length: number, arg0?: any) => void;
 

--- a/src/compiler/semver.ts
+++ b/src/compiler/semver.ts
@@ -2,13 +2,13 @@ import {
     compareStringsCaseSensitive,
     compareValues,
     Comparison,
-    Debug,
     emptyArray,
     every,
     isArray,
     map,
     some,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 // https://semver.org/#spec-item-2
 // > A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -4,7 +4,6 @@ import {
     CharacterCodes,
     combinePaths,
     compareValues,
-    Debug,
     DocumentPosition,
     DocumentPositionMapper,
     DocumentPositionMapperHost,
@@ -26,6 +25,7 @@ import {
     SourceMapGenerator,
 } from "./_namespaces/ts.js";
 import * as performance from "./_namespaces/ts.performance.js";
+import * as Debug from "./debug.js";
 
 /** @internal */
 export interface SourceMapGeneratorOptions {

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -7,7 +7,6 @@ import {
     containsPath,
     createGetCanonicalFileName,
     createMultiMap,
-    Debug,
     directorySeparator,
     emptyArray,
     emptyFileSystemEntries,
@@ -45,6 +44,7 @@ import {
     WatchOptions,
     writeFileEnsuringDirectories,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 declare function setTimeout(handler: (...args: any[]) => void, timeout: number): any;
 declare function clearTimeout(handle: any): void;

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1,5 +1,4 @@
 import {
-    AssertionLevel,
     closeFileWatcher,
     closeFileWatcherOf,
     combinePaths,
@@ -2005,10 +2004,10 @@ if (sys && sys.getEnvironmentVariable) {
     setCustomPollingValues(sys);
     Debug.setAssertionLevel(
         /^development$/i.test(sys.getEnvironmentVariable("NODE_ENV"))
-            ? AssertionLevel.Normal
-            : AssertionLevel.None,
+            ? Debug.AssertionLevel.Normal
+            : Debug.AssertionLevel.None,
     );
 }
 if (sys && sys.debugMode) {
-    Debug.isDebugging = true;
+    Debug.setIsDebugging(true);
 }

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -1,7 +1,6 @@
 import {
     combinePaths,
     ConditionalType,
-    Debug,
     EvolvingArrayType,
     getLineAndCharacterOfPosition,
     getSourceFileOfNode,
@@ -22,6 +21,7 @@ import {
     UnionType,
 } from "./_namespaces/ts.js";
 import * as performance from "./_namespaces/ts.performance.js";
+import * as Debug from "./debug.js";
 
 /* Tracing events for the compiler. */
 

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -8,7 +8,6 @@ import {
     CustomTransformer,
     CustomTransformerFactory,
     CustomTransformers,
-    Debug,
     DiagnosticWithLocation,
     disposeEmitNodes,
     EmitFlags,
@@ -74,6 +73,7 @@ import {
     VariableDeclaration,
 } from "./_namespaces/ts.js";
 import * as performance from "./_namespaces/ts.performance.js";
+import * as Debug from "./debug.js";
 
 function getModuleTransformer(moduleKind: ModuleKind): TransformerFactory<SourceFile | Bundle> {
     switch (moduleKind) {

--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -33,7 +33,6 @@ import {
     createAccessorPropertyGetRedirector,
     createAccessorPropertySetRedirector,
     createMemberAccessForPropertyName,
-    Debug,
     ElementAccessExpression,
     EmitFlags,
     EmitHint,
@@ -226,6 +225,7 @@ import {
     visitParameterList,
     VisitResult,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 const enum ClassPropertySubstitutionFlags {
     None = 0,

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -25,7 +25,6 @@ import {
     createGetSymbolAccessibilityDiagnosticForNode,
     createGetSymbolAccessibilityDiagnosticForNodeName,
     createSymbolTable,
-    Debug,
     Declaration,
     DeclarationDiagnosticProducing,
     DeclarationName,
@@ -214,6 +213,7 @@ import {
     visitNodes,
     VisitResult,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 /** @internal */
 export function getDeclarationDiagnostics(

--- a/src/compiler/transformers/declarations/diagnostics.ts
+++ b/src/compiler/transformers/declarations/diagnostics.ts
@@ -11,7 +11,6 @@ import {
     ConstructorDeclaration,
     ConstructSignatureDeclaration,
     createDiagnosticForNode,
-    Debug,
     Declaration,
     DeclarationName,
     DiagnosticMessage,
@@ -96,6 +95,7 @@ import {
     TypeParameterDeclaration,
     VariableDeclaration,
 } from "../../_namespaces/ts.js";
+import * as Debug from "../../debug.js";
 
 /** @internal */
 export type GetSymbolAccessibilityDiagnostic = (symbolAccessibilityResult: SymbolAccessibilityResult) => SymbolAccessibilityDiagnostic | undefined;

--- a/src/compiler/transformers/declarations/diagnostics.ts
+++ b/src/compiler/transformers/declarations/diagnostics.ts
@@ -669,7 +669,7 @@ export function createGetIsolatedDeclarationErrors(resolver: EmitResolver): (nod
         if ((isPartOfTypeNode(node) || isTypeQueryNode(node.parent)) && (isEntityName(node) || isEntityNameExpression(node))) {
             return createEntityInTypeNodeError(node);
         }
-        Debug.type<WithIsolatedDeclarationDiagnostic>(node);
+        Debug.assertType<WithIsolatedDeclarationDiagnostic>(node);
         switch (node.kind) {
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:

--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -7,7 +7,6 @@ import {
     BindingOrAssignmentElement,
     BindingOrAssignmentElementTarget,
     BindingOrAssignmentPattern,
-    Debug,
     DestructuringAssignment,
     ElementAccessExpression,
     every,
@@ -62,6 +61,7 @@ import {
     visitNode,
     VisitResult,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 interface FlattenContext {
     context: TransformationContext;

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -34,7 +34,6 @@ import {
     createMemberAccessForPropertyName,
     createRange,
     createTokenRange,
-    Debug,
     Declaration,
     DoStatement,
     elementAt,
@@ -216,6 +215,7 @@ import {
     WhileStatement,
     YieldExpression,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 const enum ES2015SubstitutionFlags {
     None = 0,

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -17,7 +17,6 @@ import {
     ClassDeclaration,
     ConciseBody,
     ConstructorDeclaration,
-    Debug,
     ElementAccessExpression,
     EmitFlags,
     EmitHint,
@@ -100,6 +99,7 @@ import {
     visitParameterList,
     VisitResult,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 type SuperContainer = ClassDeclaration | MethodDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | ConstructorDeclaration;
 

--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -22,7 +22,6 @@ import {
     containsObjectRestOrSpread,
     createForOfBindingStatement,
     createSuperAccessVariableStatement,
-    Debug,
     ElementAccessExpression,
     EmitFlags,
     EmitHint,
@@ -111,6 +110,7 @@ import {
     VoidExpression,
     YieldExpression,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 const enum ESNextSubstitutionFlags {
     None = 0,

--- a/src/compiler/transformers/es2020.ts
+++ b/src/compiler/transformers/es2020.ts
@@ -6,7 +6,6 @@ import {
     CallExpression,
     cast,
     chainBundle,
-    Debug,
     DeleteExpression,
     EmitFlags,
     Expression,
@@ -37,6 +36,7 @@ import {
     visitNodes,
     VisitResult,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 /** @internal */
 export function transformES2020(context: TransformationContext): (x: SourceFile | Bundle) => SourceFile | Bundle {

--- a/src/compiler/transformers/esDecorators.ts
+++ b/src/compiler/transformers/esDecorators.ts
@@ -26,7 +26,6 @@ import {
     ComputedPropertyName,
     ConstructorDeclaration,
     createAccessorPropertyBackingField,
-    Debug,
     Decorator,
     ElementAccessExpression,
     EmitFlags,
@@ -189,6 +188,7 @@ import {
     VisitResult,
     WrappedExpression,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 // Class/Decorator evaluation order, as it pertains to this transformer:
 //

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -9,7 +9,6 @@ import {
     CaseOrDefaultClause,
     chainBundle,
     ClassDeclaration,
-    Debug,
     EmitFlags,
     ExportAssignment,
     ExportSpecifier,
@@ -63,6 +62,7 @@ import {
     visitNodes,
     VisitResult,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 const enum UsingKind {
     None,

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -15,7 +15,6 @@ import {
     ConditionalExpression,
     ContinueStatement,
     createExpressionForObjectLiteralElementLike,
-    Debug,
     DoStatement,
     ElementAccessExpression,
     EmitFlags,
@@ -96,6 +95,7 @@ import {
     WithStatement,
     YieldExpression,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 // Transforms generator functions into a compatible ES5 representation with similar runtime
 // semantics. This is accomplished by first transforming the body of each generator

--- a/src/compiler/transformers/jsx.ts
+++ b/src/compiler/transformers/jsx.ts
@@ -7,7 +7,6 @@ import {
     createExpressionForJsxFragment,
     createExpressionFromEntityName,
     createJsxFactoryExpression,
-    Debug,
     emptyArray,
     Expression,
     filter,
@@ -85,6 +84,7 @@ import {
     visitNode,
     VisitResult,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 /** @internal */
 export function transformJsx(context: TransformationContext): (x: SourceFile | Bundle) => SourceFile | Bundle {

--- a/src/compiler/transformers/legacyDecorators.ts
+++ b/src/compiler/transformers/legacyDecorators.ts
@@ -14,7 +14,6 @@ import {
     ClassLikeDeclaration,
     classOrConstructorParameterIsDecorated,
     ConstructorDeclaration,
-    Debug,
     Decorator,
     elideNodes,
     EmitFlags,
@@ -83,6 +82,7 @@ import {
     visitNodes,
     VisitResult,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 /** @internal */
 export function transformLegacyDecorators(context: TransformationContext): (x: SourceFile | Bundle) => SourceFile | Bundle {

--- a/src/compiler/transformers/module/esnextAnd2015.ts
+++ b/src/compiler/transformers/module/esnextAnd2015.ts
@@ -5,7 +5,6 @@ import {
     chainBundle,
     createEmptyExports,
     createExternalHelpersImportDeclarationIfNeeded,
-    Debug,
     EmitFlags,
     EmitHint,
     ExportAssignment,
@@ -54,6 +53,7 @@ import {
     visitNodes,
     VisitResult,
 } from "../../_namespaces/ts.js";
+import * as Debug from "../../debug.js";
 
 /** @internal */
 export function transformECMAScriptModule(context: TransformationContext): (x: SourceFile | Bundle) => SourceFile | Bundle {

--- a/src/compiler/transformers/module/impliedNodeFormatDependent.ts
+++ b/src/compiler/transformers/module/impliedNodeFormatDependent.ts
@@ -1,6 +1,5 @@
 import {
     Bundle,
-    Debug,
     EmitHint,
     isSourceFile,
     map,
@@ -13,6 +12,7 @@ import {
     Transformer,
     transformModule,
 } from "../../_namespaces/ts.js";
+import * as Debug from "../../debug.js";
 
 /** @internal */
 export function transformImpliedNodeFormatDependentModule(context: TransformationContext): Transformer<SourceFile | Bundle> {

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -17,7 +17,6 @@ import {
     chainBundle,
     ClassDeclaration,
     collectExternalModuleInfo,
-    Debug,
     Declaration,
     DefaultClause,
     DestructuringAssignment,
@@ -165,6 +164,7 @@ import {
     WhileStatement,
     WithStatement,
 } from "../../_namespaces/ts.js";
+import * as Debug from "../../debug.js";
 
 /** @internal */
 export function transformModule(context: TransformationContext): (x: SourceFile | Bundle) => SourceFile | Bundle {

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -12,7 +12,6 @@ import {
     chainBundle,
     ClassDeclaration,
     collectExternalModuleInfo,
-    Debug,
     Declaration,
     DefaultClause,
     DestructuringAssignment,
@@ -132,6 +131,7 @@ import {
     WhileStatement,
     WithStatement,
 } from "../../_namespaces/ts.js";
+import * as Debug from "../../debug.js";
 
 /** @internal */
 export function transformSystemModule(context: TransformationContext): (x: SourceFile | Bundle) => SourceFile | Bundle {

--- a/src/compiler/transformers/taggedTemplate.ts
+++ b/src/compiler/transformers/taggedTemplate.ts
@@ -1,6 +1,5 @@
 import {
     CallExpression,
-    Debug,
     Expression,
     getSourceTextOfNodeFromSourceFile,
     hasInvalidEscape,
@@ -24,6 +23,7 @@ import {
     visitNode,
     Visitor,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 /** @internal */
 export enum ProcessLevel {

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -25,7 +25,6 @@ import {
     createRange,
     createRuntimeTypeSerializer,
     createTokenRange,
-    Debug,
     Declaration,
     Decorator,
     ElementAccessExpression,
@@ -202,6 +201,7 @@ import {
     visitParameterList,
     VisitResult,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 /**
  * Indicates whether to emit type metadata in the new format.

--- a/src/compiler/transformers/typeSerializer.ts
+++ b/src/compiler/transformers/typeSerializer.ts
@@ -8,7 +8,6 @@ import {
     ClassLikeDeclaration,
     ConditionalExpression,
     ConditionalTypeNode,
-    Debug,
     EntityName,
     Expression,
     findAncestor,
@@ -68,6 +67,7 @@ import {
     UnionOrIntersectionTypeNode,
     VoidExpression,
 } from "../_namespaces/ts.js";
+import * as Debug from "../debug.js";
 
 /** @internal */
 export type SerializedEntityName =

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -30,7 +30,6 @@ import {
     createWatchFactory,
     createWatchHost,
     CustomTransformers,
-    Debug,
     Diagnostic,
     DiagnosticArguments,
     DiagnosticMessage,
@@ -129,6 +128,7 @@ import {
     WriteFileCallback,
 } from "./_namespaces/ts.js";
 import * as performance from "./_namespaces/ts.performance.js";
+import * as Debug from "./debug.js";
 
 const minimumDate = new Date(-8640000000000000);
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -84,7 +84,6 @@ import {
     createScanner,
     createTextSpan,
     createTextSpanFromBounds,
-    Debug,
     Declaration,
     DeclarationName,
     DeclarationWithTypeParameterChildren,
@@ -590,6 +589,7 @@ import {
     WriteFileCallbackData,
     YieldExpression,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /** @internal */
 export const resolvingEmptyArray: never[] = [];

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2083,7 +2083,7 @@ export function isBlockScope(node: Node, parentNode: Node | undefined): boolean 
 
 /** @internal */
 export function isDeclarationWithTypeParameters(node: Node): node is DeclarationWithTypeParameters {
-    Debug.type<DeclarationWithTypeParameters>(node);
+    Debug.assertType<DeclarationWithTypeParameters>(node);
     switch (node.kind) {
         case SyntaxKind.JSDocCallbackTag:
         case SyntaxKind.JSDocTypedefTag:
@@ -2097,7 +2097,7 @@ export function isDeclarationWithTypeParameters(node: Node): node is Declaration
 
 /** @internal */
 export function isDeclarationWithTypeParameterChildren(node: Node): node is DeclarationWithTypeParameterChildren {
-    Debug.type<DeclarationWithTypeParameterChildren>(node);
+    Debug.assertType<DeclarationWithTypeParameterChildren>(node);
     switch (node.kind) {
         case SyntaxKind.CallSignature:
         case SyntaxKind.ConstructSignature:
@@ -11798,7 +11798,7 @@ export function createNameResolver({
 
 /** @internal */
 export function isPrimitiveLiteralValue(node: Expression, includeBigInt = true): node is PrimitiveLiteral {
-    Debug.type<PrimitiveLiteral>(node);
+    Debug.assertType<PrimitiveLiteral>(node);
     switch (node.kind) {
         case SyntaxKind.TrueKeyword:
         case SyntaxKind.FalseKeyword:
@@ -11832,7 +11832,7 @@ export function unwrapParenthesizedExpression(o: Expression): Expression {
 
 /** @internal */
 export function hasInferredType(node: Node): node is HasInferredType {
-    Debug.type<HasInferredType>(node);
+    Debug.assertType<HasInferredType>(node);
     switch (node.kind) {
         case SyntaxKind.Parameter:
         case SyntaxKind.PropertySignature:

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -41,7 +41,6 @@ import {
     ConstructorTypeNode,
     contains,
     createCompilerDiagnostic,
-    Debug,
     Declaration,
     DeclarationName,
     DeclarationStatement,
@@ -291,6 +290,7 @@ import {
     UnaryExpression,
     VariableDeclaration,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 export function isExternalModuleNameRelative(moduleName: string): boolean {
     // TypeScript 1.0 spec (April 2014): 11.2.1

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -1,6 +1,5 @@
 import {
     ConciseBody,
-    Debug,
     EmitFlags,
     Expression,
     factory,
@@ -104,6 +103,7 @@ import {
     TransformationContext,
     Visitor,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /**
  * Visits a Node using the supplied visitor, possibly returning a new Node in its place.

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -20,7 +20,6 @@ import {
     CreateProgram,
     createWriteFileMeasuringIO,
     CustomTransformers,
-    Debug,
     Diagnostic,
     DiagnosticAndArguments,
     DiagnosticCategory,
@@ -109,6 +108,7 @@ import {
     whitespaceOrMapCommentRegExp,
     WriteFileCallback,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 const sysFormatDiagnosticsHost: FormatDiagnosticsHost | undefined = sys ? {
     getCurrentDirectory: () => sys.getCurrentDirectory(),

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -24,7 +24,6 @@ import {
     createWatchCompilerHostOfConfigFile,
     createWatchCompilerHostOfFilesAndCompilerOptions,
     createWatchFactory,
-    Debug,
     Diagnostic,
     DiagnosticMessage,
     DiagnosticReporter,
@@ -95,6 +94,7 @@ import {
     WatchTypeRegistry,
     WildcardDirectoryWatcher,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 export interface ReadBuildProgramHost {
     useCaseSensitiveFileNames(): boolean;

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -7,7 +7,6 @@ import {
     compareStringsCaseSensitive,
     CompilerOptions,
     createGetCanonicalFileName,
-    Debug,
     DirectoryWatcherCallback,
     emptyArray,
     emptyFileSystemEntries,
@@ -59,6 +58,7 @@ import {
     WatchFileKind,
     WatchOptions,
 } from "./_namespaces/ts.js";
+import * as Debug from "./debug.js";
 
 /**
  * Partial interface of the System thats needed to support the caching of directory structure

--- a/src/deprecatedCompat/deprecate.ts
+++ b/src/deprecatedCompat/deprecate.ts
@@ -1,5 +1,5 @@
+import * as Debug from "../compiler/debug.js";
 import {
-    Debug,
     DeprecationOptions,
     formatStringFromArgs,
     noop,

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -1,9 +1,9 @@
+import * as Debug from "../compiler/debug.js";
 import {
     CharacterCodes,
     combinePaths,
     compareStringsCaseSensitive,
     CompilerOptions,
-    Debug,
     deduplicate,
     equateStringsCaseSensitive,
     Extension,

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     addToSeen,
     arrayFrom,
@@ -20,7 +21,6 @@ import {
     createDocumentRegistryInternal,
     createGetCanonicalFileName,
     createMultiMap,
-    Debug,
     Diagnostic,
     directorySeparator,
     DirectoryStructureHost,

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1,7 +1,6 @@
 import {
     addToSeen,
     arrayFrom,
-    AssertionLevel,
     CachedDirectoryStructureHost,
     canJsonReportNoInputFiles,
     canWatchDirectoryOrFilePath,
@@ -2057,7 +2056,7 @@ export class ProjectService {
         project.print(/*writeProjectFileNames*/ true, /*writeFileExplaination*/ true, /*writeFileVersionAndText*/ false);
 
         project.close();
-        if (Debug.shouldAssert(AssertionLevel.Normal)) {
+        if (Debug.shouldAssert(Debug.AssertionLevel.Normal)) {
             this.filenameToScriptInfo.forEach(info =>
                 Debug.assert(
                     !info.isAttached(project),

--- a/src/server/moduleSpecifierCache.ts
+++ b/src/server/moduleSpecifierCache.ts
@@ -1,6 +1,6 @@
+import * as Debug from "../compiler/debug.js";
 import {
     closeFileWatcher,
-    Debug,
     FileWatcher,
     ModulePath,
     ModuleSpecifierCache,

--- a/src/server/packageJsonCache.ts
+++ b/src/server/packageJsonCache.ts
@@ -1,7 +1,7 @@
+import * as Debug from "../compiler/debug.js";
 import {
     combinePaths,
     createPackageJsonInfo,
-    Debug,
     forEachAncestorDirectoryStoppingAtGlobalCache,
     getDirectoryPath,
     Path,

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import * as ts from "./_namespaces/ts.js";
 import {
     addRange,
@@ -24,7 +25,6 @@ import {
     createLanguageService,
     createResolutionCache,
     createSymlinkCache,
-    Debug,
     Diagnostic,
     directorySeparator,
     DirectoryStructureHost,

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     assign,
     clear,
@@ -7,7 +8,6 @@ import {
     computePositionOfLineAndCharacter,
     contains,
     createTextSpanFromBounds,
-    Debug,
     directorySeparator,
     DocumentPositionMapper,
     DocumentRegistryBucketKeyWithMode,

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -1,9 +1,9 @@
+import * as Debug from "../compiler/debug.js";
 import {
     collapseTextChangeRangesAcrossMultipleVersions,
     computeLineStarts,
     createTextChangeRange,
     createTextSpan,
-    Debug,
     IScriptSnapshot,
     TextChangeRange,
     TextSpan,

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     arrayFrom,
     arrayReverseIterator,
@@ -22,7 +23,6 @@ import {
     createSet,
     createTextSpan,
     createTextSpanFromBounds,
-    Debug,
     decodedTextSpanIntersectsWith,
     deduplicate,
     DefinitionInfo,

--- a/src/server/typingInstallerAdapter.ts
+++ b/src/server/typingInstallerAdapter.ts
@@ -1,8 +1,8 @@
+import * as Debug from "../compiler/debug.js";
 import {
     ApplyCodeActionCommandResult,
     assertType,
     createQueue,
-    Debug,
     JsTyping,
     MapLike,
     server,

--- a/src/services/breakpoints.ts
+++ b/src/services/breakpoints.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     ArrayLiteralExpression,
     BinaryExpression,
@@ -10,7 +11,6 @@ import {
     CatchClause,
     ClassDeclaration,
     createTextSpanFromBounds,
-    Debug,
     DestructuringPattern,
     DoStatement,
     EnumDeclaration,

--- a/src/services/callHierarchy.ts
+++ b/src/services/callHierarchy.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     AccessExpression,
     append,
@@ -18,7 +19,6 @@ import {
     createTextRangeFromNode,
     createTextSpanFromBounds,
     createTextSpanFromRange,
-    Debug,
     Decorator,
     ElementAccessExpression,
     EmitHint,

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     __String,
     arrayToNumericMap,
@@ -15,7 +16,6 @@ import {
     couldStartTrivia,
     createScanner,
     createTextSpan,
-    Debug,
     decodedTextSpanIntersectsWith,
     EndOfLineState,
     EnumDeclaration,

--- a/src/services/classifier2020.ts
+++ b/src/services/classifier2020.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../compiler/debug.js";
 import {
     BindingElement,
     CancellationToken,
     Classifications,
     ClassifiedSpan2020,
     createTextSpan,
-    Debug,
     Declaration,
     EndOfLineState,
     forEachChild,

--- a/src/services/codeFixProvider.ts
+++ b/src/services/codeFixProvider.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     arrayFrom,
     cast,
@@ -11,7 +12,6 @@ import {
     computeSuggestionDiagnostics,
     contains,
     createMultiMap,
-    Debug,
     Diagnostic,
     DiagnosticOrDiagnosticAndArguments,
     diagnosticToString,

--- a/src/services/codefixes/addMissingInvocationForDecorator.ts
+++ b/src/services/codefixes/addMissingInvocationForDecorator.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
     registerCodeFix,
 } from "../_namespaces/ts.codefix.js";
 import {
-    Debug,
     Diagnostics,
     factory,
     findAncestor,

--- a/src/services/codefixes/addMissingResolutionModeImportAttribute.ts
+++ b/src/services/codefixes/addMissingResolutionModeImportAttribute.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
     registerCodeFix,
 } from "../_namespaces/ts.codefix.js";
 import {
-    Debug,
     Diagnostics,
     factory,
     findAncestor,

--- a/src/services/codefixes/addNameToNamelessParameter.ts
+++ b/src/services/codefixes/addNameToNamelessParameter.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -5,7 +6,6 @@ import {
 } from "../_namespaces/ts.codefix.js";
 import {
     createRange,
-    Debug,
     Diagnostics,
     factory,
     findNextToken,

--- a/src/services/codefixes/annotateWithTypeFromJSDoc.ts
+++ b/src/services/codefixes/annotateWithTypeFromJSDoc.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
     registerCodeFix,
 } from "../_namespaces/ts.codefix.js";
 import {
-    Debug,
     Diagnostics,
     EmitFlags,
     emptyArray,

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -15,7 +16,6 @@ import {
     CodeFixContext,
     concatenate,
     createMultiMap,
-    Debug,
     Diagnostics,
     elementAt,
     emptyArray,

--- a/src/services/codefixes/convertToEsModule.ts
+++ b/src/services/codefixes/convertToEsModule.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     createCodeFixActionWithoutFixAll,
     registerCodeFix,
@@ -15,7 +16,6 @@ import {
     copyEntries,
     createMultiMap,
     createRange,
-    Debug,
     Diagnostics,
     emptyMap,
     ExportDeclaration,

--- a/src/services/codefixes/correctQualifiedNameToIndexedAccessType.ts
+++ b/src/services/codefixes/correctQualifiedNameToIndexedAccessType.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
     registerCodeFix,
 } from "../_namespaces/ts.codefix.js";
 import {
-    Debug,
     Diagnostics,
     factory,
     findAncestor,

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     createCodeFixAction,
     createCodeFixActionWithoutFixAll,
@@ -25,7 +26,6 @@ import {
     CodeFixContextBase,
     concatenate,
     createPropertyNameNodeForIdentifierOrLiteral,
-    Debug,
     Diagnostics,
     emptyArray,
     EnumDeclaration,

--- a/src/services/codefixes/fixAddModuleReferTypeMissingTypeof.ts
+++ b/src/services/codefixes/fixAddModuleReferTypeMissingTypeof.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
     registerCodeFix,
 } from "../_namespaces/ts.codefix.js";
 import {
-    Debug,
     Diagnostics,
     factory,
     getTokenAtPosition,

--- a/src/services/codefixes/fixCannotFindModule.ts
+++ b/src/services/codefixes/fixCannotFindModule.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
     registerCodeFix,
 } from "../_namespaces/ts.codefix.js";
 import {
-    Debug,
     Diagnostics,
     getTokenAtPosition,
     getTypesPackageName,

--- a/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
+++ b/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -14,7 +15,6 @@ import {
     ClassLikeDeclaration,
     CodeFixAction,
     createSymbolTable,
-    Debug,
     Diagnostics,
     ExpressionWithTypeArguments,
     find,

--- a/src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts
+++ b/src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -5,7 +6,6 @@ import {
 } from "../_namespaces/ts.codefix.js";
 import {
     ConstructorDeclaration,
-    Debug,
     Diagnostics,
     emptyArray,
     factory,

--- a/src/services/codefixes/fixImplicitThis.ts
+++ b/src/services/codefixes/fixImplicitThis.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -5,7 +6,6 @@ import {
 } from "../_namespaces/ts.codefix.js";
 import {
     ANONYMOUS,
-    Debug,
     DiagnosticOrDiagnosticAndArguments,
     Diagnostics,
     emptyArray,

--- a/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
+++ b/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     createCodeFixAction,
     createCombinedCodeActions,
@@ -20,7 +21,6 @@ import {
     CodeFixAllContext,
     CodeFixContext,
     createPrinter,
-    Debug,
     Declaration,
     defaultMaximumTruncationLength,
     DiagnosticAndArguments,

--- a/src/services/codefixes/fixOverrideModifier.ts
+++ b/src/services/codefixes/fixOverrideModifier.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixActionMaybeFixAll,
@@ -7,7 +8,6 @@ import {
     CodeFixAllContext,
     CodeFixContext,
     ConstructorDeclaration,
-    Debug,
     DiagnosticMessage,
     Diagnostics,
     emptyArray,

--- a/src/services/codefixes/fixPropertyOverrideAccessor.ts
+++ b/src/services/codefixes/fixPropertyOverrideAccessor.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -8,7 +9,6 @@ import {
 import {
     CodeFixAllContext,
     CodeFixContext,
-    Debug,
     Diagnostics,
     getSourceFileOfNode,
     getTextOfPropertyName,

--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -5,7 +6,6 @@ import {
 } from "../_namespaces/ts.codefix.js";
 import {
     CodeFixContextBase,
-    Debug,
     Diagnostics,
     factory,
     findAncestor,

--- a/src/services/codefixes/fixStrictClassInitialization.ts
+++ b/src/services/codefixes/fixStrictClassInitialization.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -8,7 +9,6 @@ import {
     BigIntLiteralType,
     CodeFixAction,
     CodeFixContext,
-    Debug,
     Diagnostics,
     Expression,
     factory,

--- a/src/services/codefixes/fixUnreachableCode.ts
+++ b/src/services/codefixes/fixUnreachableCode.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
     registerCodeFix,
 } from "../_namespaces/ts.codefix.js";
 import {
-    Debug,
     Diagnostics,
     emptyArray,
     factory,

--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -9,7 +10,6 @@ import {
     cast,
     CodeFixAction,
     CodeFixContext,
-    Debug,
     DiagnosticMessage,
     DiagnosticOrDiagnosticAndArguments,
     Diagnostics,

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import { ImportAdder } from "../_namespaces/ts.codefix.js";
 import {
     AccessorDeclaration,
@@ -11,7 +12,6 @@ import {
     ClassLikeDeclaration,
     CodeFixContextBase,
     combine,
-    Debug,
     Declaration,
     Diagnostics,
     emptyArray,

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     createCodeFixAction,
     createCombinedCodeActions,
@@ -26,7 +27,6 @@ import {
     createModuleSpecifierResolutionHost,
     createMultiMap,
     createPackageJsonImportFilter,
-    Debug,
     DiagnosticOrDiagnosticAndArguments,
     Diagnostics,
     DiagnosticWithLocation,

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -16,7 +17,6 @@ import {
     cast,
     createMultiMap,
     createSymbolTable,
-    Debug,
     Declaration,
     DiagnosticMessage,
     Diagnostics,

--- a/src/services/codefixes/requireInTs.ts
+++ b/src/services/codefixes/requireInTs.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -5,7 +6,6 @@ import {
 } from "../_namespaces/ts.codefix.js";
 import {
     cast,
-    Debug,
     Diagnostics,
     factory,
     first,

--- a/src/services/codefixes/returnValueCorrect.ts
+++ b/src/services/codefixes/returnValueCorrect.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -9,7 +10,6 @@ import {
     CodeFixContext,
     copyComments,
     createSymbolTable,
-    Debug,
     Diagnostics,
     Expression,
     factory,

--- a/src/services/codefixes/splitTypeOnlyImport.ts
+++ b/src/services/codefixes/splitTypeOnlyImport.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
@@ -5,7 +6,6 @@ import {
 } from "../_namespaces/ts.codefix.js";
 import {
     CodeFixContextBase,
-    Debug,
     Diagnostics,
     factory,
     findAncestor,

--- a/src/services/codefixes/wrapDecoratorInParentheses.ts
+++ b/src/services/codefixes/wrapDecoratorInParentheses.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     codeFixAll,
     createCodeFixAction,
     registerCodeFix,
 } from "../_namespaces/ts.codefix.js";
 import {
-    Debug,
     Diagnostics,
     factory,
     findAncestor,

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import { StringCompletions } from "./_namespaces/ts.Completions.js";
 import {
     __String,
@@ -45,7 +46,6 @@ import {
     createTextSpanFromBounds,
     createTextSpanFromNode,
     createTextSpanFromRange,
-    Debug,
     Declaration,
     Decorator,
     Diagnostics,

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     __String,
     arrayFrom,
@@ -14,7 +15,6 @@ import {
     createGetCanonicalFileName,
     createTextSpanFromBounds,
     createTextSpanFromNode,
-    Debug,
     DefaultClause,
     find,
     FindAllReferences,

--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../compiler/debug.js";
 import {
     arrayFrom,
     CompilerOptions,
     createGetCanonicalFileName,
     createLanguageServiceSourceFile,
     CreateSourceFileOptions,
-    Debug,
     ensureScriptKind,
     firstDefinedIterator,
     forEachEntry,

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     __String,
     addToSeen,
@@ -6,7 +7,6 @@ import {
     CancellationToken,
     consumesNodeCoreModules,
     createMultiMap,
-    Debug,
     emptyArray,
     ensureTrailingDirectorySeparator,
     findIndex,

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     createImportTracker,
     ExportInfo,
@@ -32,7 +33,6 @@ import {
     createTextSpan,
     createTextSpanFromBounds,
     createTextSpanFromRange,
-    Debug,
     Declaration,
     displayPart,
     DocumentSpan,

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     FormattingContext,
     FormattingRequestKind,
@@ -19,7 +20,6 @@ import {
     CommentRange,
     concatenate,
     createTextChangeFromStartLength,
-    Debug,
     Declaration,
     Diagnostic,
     EditorSettings,

--- a/src/services/formatting/formattingContext.ts
+++ b/src/services/formatting/formattingContext.ts
@@ -1,6 +1,6 @@
+import * as Debug from "../../compiler/debug.js";
 import { TextRangeWithKind } from "../_namespaces/ts.formatting.js";
 import {
-    Debug,
     findChildOfKind,
     FormatCodeSettings,
     Node,

--- a/src/services/formatting/formattingScanner.ts
+++ b/src/services/formatting/formattingScanner.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     createTextRangeWithKind,
     TextRangeWithKind,
@@ -7,7 +8,6 @@ import {
 import {
     append,
     createScanner,
-    Debug,
     isJsxAttribute,
     isJsxElement,
     isJsxText,

--- a/src/services/formatting/rulesMap.ts
+++ b/src/services/formatting/rulesMap.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     anyContext,
     FormatContext,
@@ -8,7 +9,6 @@ import {
     RuleSpec,
 } from "../_namespaces/ts.formatting.js";
 import {
-    Debug,
     every,
     FormatCodeSettings,
     FormattingHost,

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     getRangeOfEnclosingComment,
     TextRangeWithKind,
@@ -11,7 +12,6 @@ import {
     ClassExpression,
     CommentRange,
     contains,
-    Debug,
     EditorSettings,
     find,
     findChildOfKind,

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -1,9 +1,9 @@
+import * as Debug from "../compiler/debug.js";
 import {
     combinePaths,
     createGetCanonicalFileName,
     createModuleSpecifierResolutionHost,
     createRange,
-    Debug,
     emptyArray,
     endsWith,
     ensurePathIsNonModuleName,

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     __String,
     AnyImportOrJsDocImport,
@@ -10,7 +11,6 @@ import {
     canHaveModifiers,
     canHaveSymbol,
     cast,
-    Debug,
     ExportAssignment,
     ExportDeclaration,
     FileReference,

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     __String,
     ArrowFunction,
@@ -5,7 +6,6 @@ import {
     CharacterCodes,
     createPrinterWithRemoveComments,
     createTextSpanFromNode,
-    Debug,
     ElementFlags,
     EmitHint,
     EnumMember,

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     ArrowFunction,
     AssignmentDeclarationKind,
@@ -18,7 +19,6 @@ import {
     contains,
     createTextSpanFromNode,
     createTextSpanFromRange,
-    Debug,
     Declaration,
     DeclarationName,
     declarationNameToString,

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     ArrowFunction,
     Block,
@@ -7,7 +8,6 @@ import {
     createTextSpanFromBounds,
     createTextSpanFromNode,
     createTextSpanFromRange,
-    Debug,
     DefaultClause,
     findChildOfKind,
     getLeadingCommentRanges,

--- a/src/services/pasteEdits.ts
+++ b/src/services/pasteEdits.ts
@@ -1,7 +1,7 @@
+import * as Debug from "../compiler/debug.js";
 import {
     CancellationToken,
     codefix,
-    Debug,
     fileShouldUseJavaScriptRequire,
     findAncestor,
     findIndex,

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ApplicableRefactorInfo,
     ArrowFunction,
@@ -5,7 +6,6 @@ import {
     copyLeadingComments,
     copyTrailingAsLeadingComments,
     copyTrailingComments,
-    Debug,
     Diagnostics,
     emptyArray,
     Expression,

--- a/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
+++ b/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ApplicableRefactorInfo,
     ArrowFunction,
@@ -5,7 +6,6 @@ import {
     ConciseBody,
     copyComments,
     copyTrailingAsLeadingComments,
-    Debug,
     Diagnostics,
     emptyArray,
     factory,

--- a/src/services/refactors/convertExport.ts
+++ b/src/services/refactors/convertExport.ts
@@ -1,8 +1,8 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ApplicableRefactorInfo,
     CancellationToken,
     ClassDeclaration,
-    Debug,
     Diagnostics,
     emptyArray,
     EnumDeclaration,

--- a/src/services/refactors/convertImport.ts
+++ b/src/services/refactors/convertImport.ts
@@ -1,7 +1,7 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ApplicableRefactorInfo,
     arrayFrom,
-    Debug,
     Diagnostics,
     emptyArray,
     Expression,

--- a/src/services/refactors/convertOverloadListToSingleSignature.ts
+++ b/src/services/refactors/convertOverloadListToSingleSignature.ts
@@ -1,9 +1,9 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ApplicableRefactorInfo,
     CallSignatureDeclaration,
     ConstructorDeclaration,
     ConstructSignatureDeclaration,
-    Debug,
     Diagnostics,
     displayPartsToString,
     EmitFlags,

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     addEmitFlags,
     ApplicableRefactorInfo,
@@ -12,7 +13,6 @@ import {
     ConstructorDeclaration,
     contains,
     copyComments,
-    Debug,
     deduplicate,
     Diagnostics,
     ElementAccessExpression,

--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ApplicableRefactorInfo,
     BinaryExpression,
     BinaryOperator,
     copyTrailingAsLeadingComments,
     copyTrailingComments,
-    Debug,
     Diagnostics,
     emptyArray,
     Expression,

--- a/src/services/refactors/convertToOptionalChainExpression.ts
+++ b/src/services/refactors/convertToOptionalChainExpression.ts
@@ -1,10 +1,10 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ApplicableRefactorInfo,
     BinaryExpression,
     CallExpression,
     ConditionalExpression,
     createTextSpanFromBounds,
-    Debug,
     Diagnostics,
     ElementAccessExpression,
     emptyArray,

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     __String,
     ANONYMOUS,
@@ -20,7 +21,6 @@ import {
     ContinueStatement,
     createDiagnosticForNode,
     createFileDiagnostic,
-    Debug,
     Declaration,
     Diagnostic,
     DiagnosticCategory,

--- a/src/services/refactors/extractType.ts
+++ b/src/services/refactors/extractType.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     addRange,
     addToSeen,
@@ -6,7 +7,6 @@ import {
     cast,
     concatenate,
     createTextRangeFromSpan,
-    Debug,
     Diagnostics,
     EmitFlags,
     emptyArray,

--- a/src/services/refactors/generateGetAccessorAndSetAccessor.ts
+++ b/src/services/refactors/generateGetAccessorAndSetAccessor.ts
@@ -1,7 +1,7 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ApplicableRefactorInfo,
     codefix,
-    Debug,
     Diagnostics,
     emptyArray,
     getLocaleSpecificMessage,

--- a/src/services/refactors/helpers.ts
+++ b/src/services/refactors/helpers.ts
@@ -1,7 +1,7 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ClassLikeDeclaration,
     codefix,
-    Debug,
     findAncestor,
     FunctionLikeDeclaration,
     getUniqueName,

--- a/src/services/refactors/inlineVariable.ts
+++ b/src/services/refactors/inlineVariable.ts
@@ -1,6 +1,6 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     cast,
-    Debug,
     Diagnostics,
     emptyArray,
     Expression,

--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ApplicableRefactorInfo,
     arrayFrom,
@@ -19,7 +20,6 @@ import {
     createFutureSourceFile,
     createModuleSpecifierResolutionHost,
     createTextRangeFromSpan,
-    Debug,
     Declaration,
     DeclarationStatement,
     Diagnostics,

--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -1,8 +1,8 @@
+import * as Debug from "../../compiler/debug.js";
 import {
     ApplicableRefactorInfo,
     codefix,
     createFutureSourceFile,
-    Debug,
     Diagnostics,
     emptyArray,
     findAncestor,

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     __String,
     ApplicableRefactorInfo,
@@ -46,7 +47,6 @@ import {
     createTextSpanFromBounds,
     createTextSpanFromNode,
     createTextSpanFromRange,
-    Debug,
     Declaration,
     deduplicate,
     DefinitionInfo,

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     ArrowFunction,
     BinaryExpression,
@@ -10,7 +11,6 @@ import {
     createTextSpan,
     createTextSpanFromBounds,
     createTextSpanFromNode,
-    Debug,
     ElementFlags,
     EmitHint,
     emptyArray,

--- a/src/services/smartSelection.ts
+++ b/src/services/smartSelection.ts
@@ -1,9 +1,9 @@
+import * as Debug from "../compiler/debug.js";
 import {
     CharacterCodes,
     compact,
     contains,
     createTextSpanFromBounds,
-    Debug,
     findIndex,
     first,
     getTokenPosOfNode,

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     CompletionKind,
     createCompletionDetails,
@@ -33,7 +34,6 @@ import {
     createSortedArray,
     createTextSpan,
     createTextSpanFromStringLiteralLikeContent,
-    Debug,
     deduplicate,
     directorySeparator,
     ElementAccessExpression,

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     addRange,
     arrayFrom,
@@ -6,7 +7,6 @@ import {
     CheckFlags,
     contains,
     createPrinterWithRemoveComments,
-    Debug,
     displayPart,
     EmitHint,
     emptyArray,

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     addToSeen,
     ArrowFunction,
@@ -20,7 +21,6 @@ import {
     createTextSpan,
     createTextSpanFromRange,
     createTextWriter,
-    Debug,
     DeclarationStatement,
     EmitHint,
     EmitTextWriter,

--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     addRange,
     cloneCompilerOptions,
@@ -8,7 +9,6 @@ import {
     createProgram,
     createSourceFile,
     CustomTransformers,
-    Debug,
     Diagnostic,
     fileExtensionIs,
     filter,

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1,3 +1,4 @@
+import * as Debug from "../compiler/debug.js";
 import {
     __String,
     addEmitFlags,
@@ -34,7 +35,6 @@ import {
     createScanner,
     createTextSpan,
     createTextSpanFromBounds,
-    Debug,
     Declaration,
     Decorator,
     DefaultClause,

--- a/src/testRunner/runner.ts
+++ b/src/testRunner/runner.ts
@@ -228,11 +228,11 @@ function handleTestConfig() {
 }
 
 function beginTests() {
-    ts.Debug.loggingHost = {
+    ts.Debug.setLoggingHost({
         log(_level, s) {
             console.log(s || "");
         },
-    };
+    });
 
     if (ts.Debug.isDebugging) {
         ts.Debug.enableDebugInfo();

--- a/src/testRunner/unittests/debugDeprecation.ts
+++ b/src/testRunner/unittests/debugDeprecation.ts
@@ -2,12 +2,12 @@ import { deprecate } from "../../deprecatedCompat/deprecate.js";
 import * as ts from "../_namespaces/ts.js";
 
 describe("unittests:: debugDeprecation", () => {
-    let loggingHost: ts.LoggingHost | undefined;
+    let loggingHost: ts.Debug.LoggingHost | undefined;
     beforeEach(() => {
         loggingHost = ts.Debug.loggingHost;
     });
     afterEach(() => {
-        ts.Debug.loggingHost = loggingHost;
+        ts.Debug.setLoggingHost(loggingHost);
         loggingHost = undefined;
     });
     describe("deprecateFunction", () => {
@@ -17,11 +17,11 @@ describe("unittests:: debugDeprecation", () => {
                 typeScriptVersion: "3.8",
             });
             let logWritten = false;
-            ts.Debug.loggingHost = {
+            ts.Debug.setLoggingHost({
                 log() {
                     logWritten = true;
                 },
-            };
+            });
             deprecation();
             assert.isFalse(logWritten);
         });
@@ -31,11 +31,11 @@ describe("unittests:: debugDeprecation", () => {
                 typeScriptVersion: "3.9",
             });
             let logWritten = false;
-            ts.Debug.loggingHost = {
+            ts.Debug.setLoggingHost({
                 log() {
                     logWritten = true;
                 },
-            };
+            });
             deprecation();
             assert.isTrue(logWritten);
         });
@@ -44,11 +44,11 @@ describe("unittests:: debugDeprecation", () => {
                 typeScriptVersion: "3.9",
             });
             let logWritten = false;
-            ts.Debug.loggingHost = {
+            ts.Debug.setLoggingHost({
                 log() {
                     logWritten = true;
                 },
-            };
+            });
             deprecation();
             assert.isTrue(logWritten);
         });
@@ -57,11 +57,11 @@ describe("unittests:: debugDeprecation", () => {
                 typeScriptVersion: "3.9",
             });
             let logWrites = 0;
-            ts.Debug.loggingHost = {
+            ts.Debug.setLoggingHost({
                 log() {
                     logWrites++;
                 },
-            };
+            });
             deprecation();
             deprecation();
             assert.equal(logWrites, 1);
@@ -73,11 +73,11 @@ describe("unittests:: debugDeprecation", () => {
                 typeScriptVersion: "3.9",
             });
             let logWritten = false;
-            ts.Debug.loggingHost = {
+            ts.Debug.setLoggingHost({
                 log() {
                     logWritten = true;
                 },
-            };
+            });
             expect(deprecation).throws();
             assert.isFalse(logWritten);
         });
@@ -86,11 +86,11 @@ describe("unittests:: debugDeprecation", () => {
                 error: true,
             });
             let logWritten = false;
-            ts.Debug.loggingHost = {
+            ts.Debug.setLoggingHost({
                 log() {
                     logWritten = true;
                 },
-            };
+            });
             expect(deprecation).throws();
             assert.isFalse(logWritten);
         });

--- a/src/tsc/tsc.ts
+++ b/src/tsc/tsc.ts
@@ -3,11 +3,11 @@ import * as ts from "./_namespaces/ts.js";
 // This file actually uses arguments passed on commandline and executes it
 
 // enable deprecation logging
-ts.Debug.loggingHost = {
+ts.Debug.setLoggingHost({
     log(_level, s) {
         ts.sys.write(`${s || ""}${ts.sys.newLine}`);
     },
-};
+});
 
 if (ts.Debug.isDebugging) {
     ts.Debug.enableDebugInfo();

--- a/src/tsc/tsc.ts
+++ b/src/tsc/tsc.ts
@@ -1,16 +1,17 @@
+import * as Debug from "../compiler/debug.js";
 import * as ts from "./_namespaces/ts.js";
 
 // This file actually uses arguments passed on commandline and executes it
 
 // enable deprecation logging
-ts.Debug.setLoggingHost({
+Debug.setLoggingHost({
     log(_level, s) {
         ts.sys.write(`${s || ""}${ts.sys.newLine}`);
     },
 });
 
-if (ts.Debug.isDebugging) {
-    ts.Debug.enableDebugInfo();
+if (Debug.isDebugging) {
+    Debug.enableDebugInfo();
 }
 
 if (ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -197,18 +197,18 @@ export function initializeNodeSystem(): StartInput {
     const logger = createLogger();
 
     // enable deprecation logging
-    Debug.loggingHost = {
+    Debug.setLoggingHost({
         log(level, s) {
             switch (level) {
-                case ts.LogLevel.Error:
-                case ts.LogLevel.Warning:
+                case ts.Debug.LogLevel.Error:
+                case ts.Debug.LogLevel.Warning:
                     return logger.msg(s, ts.server.Msg.Err);
-                case ts.LogLevel.Info:
-                case ts.LogLevel.Verbose:
+                case ts.Debug.LogLevel.Info:
+                case ts.Debug.LogLevel.Verbose:
                     return logger.msg(s, ts.server.Msg.Info);
             }
         },
-    };
+    });
 
     const pending = createQueue<Buffer>();
     let canWrite = true;

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -1,25 +1,22 @@
-import {
-    Debug,
-    LogLevel,
-} from "./_namespaces/ts.js";
+import { Debug } from "./_namespaces/ts.js";
 
 // enable deprecation logging
 declare const console: any;
 if (typeof console !== "undefined") {
-    Debug.loggingHost = {
+    Debug.setLoggingHost({
         log(level, s) {
             switch (level) {
-                case LogLevel.Error:
+                case Debug.LogLevel.Error:
                     return console.error(s);
-                case LogLevel.Warning:
+                case Debug.LogLevel.Warning:
                     return console.warn(s);
-                case LogLevel.Info:
+                case Debug.LogLevel.Info:
                     return console.log(s);
-                case LogLevel.Verbose:
+                case Debug.LogLevel.Verbose:
                     return console.log(s);
             }
         },
-    };
+    });
 }
 
 export * from "./_namespaces/ts.js";

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -1,4 +1,4 @@
-import { Debug } from "./_namespaces/ts.js";
+import * as Debug from "../compiler/debug.js";
 
 // enable deprecation logging
 declare const console: any;

--- a/src/typingsInstallerCore/typingsInstaller.ts
+++ b/src/typingsInstallerCore/typingsInstaller.ts
@@ -1,6 +1,6 @@
+import * as Debug from "../compiler/debug.js";
 import {
     combinePaths,
-    Debug,
     forEachAncestorDirectory,
     forEachKey,
     getBaseFileName,


### PR DESCRIPTION
For #51441.

This is best viewed without whitespace: https://github.com/microsoft/TypeScript/pull/51455/files?w=1

All of the real changes are in `src/compiler/debug.ts`.

## Overall package size

|  | Before | After | Diff | Diff (percent) |
| - | - | - | - | - |
| Packed | 4.00 MiB | 4.00 MiB | -3.92 KiB | -0.10% |
| Unpacked | 21.47 MiB | 21.44 MiB | -32.89 KiB | -0.15% |

## Files

|  | Before | After | Diff | Diff (percent) |
| - | - | - | - | - |
| `lib/tsc.js` | 5.82 MiB | 5.80 MiB | -21.63 KiB | -0.36% |
| `lib/tsserver.js` | 25.94 KiB | 25.96 KiB | +26.00 B | +0.10% |
| `lib/typescript.js` | 8.55 MiB | 8.54 MiB | -11.29 KiB | -0.13% |

