### PR TITLE
Remove no-unnecessary-qualifier from eslintrc

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -5,7 +5,6 @@
         "project": "./tsconfig-base.json"
     },
     "rules": {
-        "@typescript-eslint/no-unnecessary-qualifier": "error",
         "@typescript-eslint/no-unnecessary-type-assertion": "error",
         "no-restricted-globals": ["error",
             { "name": "setTimeout" },

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -5,8 +5,6 @@ import {
     TodoComment, TodoCommentDescriptor, TypeAcquisition,
 } from "./_namespaces/ts";
 
-/* eslint-disable @typescript-eslint/no-unnecessary-qualifier */
-
 /**
  * Declaration module describing the TypeScript Server protocol
  */

--- a/src/testRunner/unittests/tsserver/helpers.ts
+++ b/src/testRunner/unittests/tsserver/helpers.ts
@@ -320,7 +320,7 @@ export class TestServerEventManager {
             configFileName: "tsconfig.json",
             projectType: "configured",
             languageServiceEnabled: true,
-            version: ts.version, // eslint-disable-line @typescript-eslint/no-unnecessary-qualifier
+            version: ts.version,
             ...partial,
         });
     }

--- a/src/testRunner/unittests/tsserver/session.ts
+++ b/src/testRunner/unittests/tsserver/session.ts
@@ -186,7 +186,7 @@ describe("unittests:: tsserver:: Session:: General functionality", () => {
             };
 
             const expected: ts.server.protocol.StatusResponseBody = {
-                version: ts.version, // eslint-disable-line @typescript-eslint/no-unnecessary-qualifier
+                version: ts.version,
             };
             assert.deepEqual(session.executeCommand(req).response, expected);
         });

--- a/src/typingsInstallerCore/typingsInstaller.ts
+++ b/src/typingsInstallerCore/typingsInstaller.ts
@@ -350,8 +350,6 @@ export abstract class TypingsInstaller {
         this.sendResponse({
             kind: EventBeginInstallTypes,
             eventId: requestId,
-            // qualified explicitly to prevent occasional shadowing
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-qualifier
             typingsInstallerVersion: version,
             projectName: req.projectName
         } as BeginInstallTypes);
@@ -401,8 +399,6 @@ export abstract class TypingsInstaller {
                     projectName: req.projectName,
                     packagesToInstall: scopedTypings,
                     installSuccess: ok,
-                    // qualified explicitly to prevent occasional shadowing
-                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-qualifier
                     typingsInstallerVersion: version
                 };
                 this.sendResponse(response);


### PR DESCRIPTION
For discussion; this saves a lot of lint time.

I don't think we need `no-unnecessary-qualifier` at all post-modules. `no-unnecessary-type-assertion` is kinda useful, but does create LKG friction in main.