### PR TITLE
More explicit error message for function signature length mismatches

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18480,6 +18480,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const sourceHasMoreParameters = !hasEffectiveRestParameter(target) &&
             (checkMode & SignatureCheckMode.StrictArity ? hasEffectiveRestParameter(source) || getParameterCount(source) > targetCount : getMinArgumentCount(source) > targetCount);
         if (sourceHasMoreParameters) {
+            if (reportErrors) {
+                errorReporter!(Diagnostics.Call_signature_0_expects_more_arguments_than_call_signature_1, signatureToString(source), signatureToString(target));
+            }
             return Ternary.False;
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18442,7 +18442,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         target: Signature,
         ignoreReturnTypes: boolean): boolean {
         return compareSignaturesRelated(source, target, ignoreReturnTypes ? SignatureCheckMode.IgnoreReturnTypes : 0, /*reportErrors*/ false,
-            /*errorReporter*/ undefined, /*errorReporter*/ undefined, compareTypesAssignable, /*reportUnreliableMarkers*/ undefined) !== Ternary.False;
+            /*errorReporter*/ undefined, /*incompatibleErrorReporter*/ undefined, /*signatureKindForErrors*/ undefined, compareTypesAssignable, /*reportUnreliableMarkers*/ undefined) !== Ternary.False;
     }
 
     type ErrorReporter = (message: DiagnosticMessage, arg0?: string, arg1?: string) => void;
@@ -18465,6 +18465,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         reportErrors: boolean,
         errorReporter: ErrorReporter | undefined,
         incompatibleErrorReporter: ((source: Type, target: Type) => void) | undefined,
+        signatureKindForErrors: SignatureKind | undefined,
         compareTypes: TypeComparer,
         reportUnreliableMarkers: TypeMapper | undefined): Ternary {
         // TODO (drosen): De-duplicate code between related functions.
@@ -18481,7 +18482,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             (checkMode & SignatureCheckMode.StrictArity ? hasEffectiveRestParameter(source) || getParameterCount(source) > targetCount : getMinArgumentCount(source) > targetCount);
         if (sourceHasMoreParameters) {
             if (reportErrors) {
-                errorReporter!(Diagnostics.Call_signature_0_expects_more_arguments_than_call_signature_1, signatureToString(source), signatureToString(target));
+                const diagnostic = signatureKindForErrors! === SignatureKind.Call ? Diagnostics.Call_signature_0_expects_more_arguments_than_call_signature_1 : Diagnostics.Construct_signature_0_expects_more_arguments_than_construct_signature_1;
+                errorReporter!(diagnostic, signatureToString(source), signatureToString(target));
             }
             return Ternary.False;
         }
@@ -18540,7 +18542,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const callbacks = sourceSig && targetSig && !getTypePredicateOfSignature(sourceSig) && !getTypePredicateOfSignature(targetSig) &&
                     (getTypeFacts(sourceType) & TypeFacts.IsUndefinedOrNull) === (getTypeFacts(targetType) & TypeFacts.IsUndefinedOrNull);
                 let related = callbacks ?
-                    compareSignaturesRelated(targetSig, sourceSig, (checkMode & SignatureCheckMode.StrictArity) | (strictVariance ? SignatureCheckMode.StrictCallback : SignatureCheckMode.BivariantCallback), reportErrors, errorReporter, incompatibleErrorReporter, compareTypes, reportUnreliableMarkers) :
+                    compareSignaturesRelated(targetSig, sourceSig, (checkMode & SignatureCheckMode.StrictArity) | (strictVariance ? SignatureCheckMode.StrictCallback : SignatureCheckMode.BivariantCallback), reportErrors, errorReporter, incompatibleErrorReporter, signatureKindForErrors, compareTypes, reportUnreliableMarkers) :
                     !(checkMode & SignatureCheckMode.Callback) && !strictVariance && compareTypes(sourceType, targetType, /*reportErrors*/ false) || compareTypes(targetType, sourceType, reportErrors);
                 // With strict arity, (x: number | undefined) => void is a subtype of (x?: number | undefined) => void
                 if (related && checkMode & SignatureCheckMode.StrictArity && i >= getMinArgumentCount(source) && i < getMinArgumentCount(target) && compareTypes(sourceType, targetType, /*reportErrors*/ false)) {
@@ -20914,7 +20916,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // of the much more expensive N * M comparison matrix we explore below. We erase type parameters
                 // as they are known to always be the same.
                 for (let i = 0; i < targetSignatures.length; i++) {
-                    const related = signatureRelatedTo(sourceSignatures[i], targetSignatures[i], /*erase*/ true, reportErrors, incompatibleReporter(sourceSignatures[i], targetSignatures[i]));
+                    const related = signatureRelatedTo(sourceSignatures[i], targetSignatures[i], /*erase*/ true, reportErrors, incompatibleReporter(sourceSignatures[i], targetSignatures[i]), kind);
                     if (!related) {
                         return Ternary.False;
                     }
@@ -20930,7 +20932,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const eraseGenerics = relation === comparableRelation || !!compilerOptions.noStrictGenericChecks;
                 const sourceSignature = first(sourceSignatures);
                 const targetSignature = first(targetSignatures);
-                result = signatureRelatedTo(sourceSignature, targetSignature, eraseGenerics, reportErrors, incompatibleReporter(sourceSignature, targetSignature));
+                result = signatureRelatedTo(sourceSignature, targetSignature, eraseGenerics, reportErrors, incompatibleReporter(sourceSignature, targetSignature), kind);
                 if (!result && reportErrors && kind === SignatureKind.Construct && (sourceObjectFlags & targetObjectFlags) &&
                     (targetSignature.declaration?.kind === SyntaxKind.Constructor || sourceSignature.declaration?.kind === SyntaxKind.Constructor)) {
                     const constructSignatureToString = (signature: Signature) =>
@@ -20946,7 +20948,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // Only elaborate errors from the first failure
                     let shouldElaborateErrors = reportErrors;
                     for (const s of sourceSignatures) {
-                        const related = signatureRelatedTo(s, t, /*erase*/ true, shouldElaborateErrors, incompatibleReporter(s, t));
+                        const related = signatureRelatedTo(s, t, /*erase*/ true, shouldElaborateErrors, incompatibleReporter(s, t), kind);
                         if (related) {
                             result &= related;
                             resetErrorInfo(saveErrorInfo);
@@ -20996,9 +20998,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         /**
          * See signatureAssignableTo, compareSignaturesIdentical
          */
-        function signatureRelatedTo(source: Signature, target: Signature, erase: boolean, reportErrors: boolean, incompatibleReporter: (source: Type, target: Type) => void): Ternary {
+        function signatureRelatedTo(source: Signature, target: Signature, erase: boolean, reportErrors: boolean, incompatibleReporter: (source: Type, target: Type) => void, signatureKind: SignatureKind): Ternary {
             return compareSignaturesRelated(erase ? getErasedSignature(source) : source, erase ? getErasedSignature(target) : target,
-                relation === strictSubtypeRelation ? SignatureCheckMode.StrictArity : 0, reportErrors, reportError, incompatibleReporter, isRelatedToWorker, reportUnreliableMapper);
+                relation === strictSubtypeRelation ? SignatureCheckMode.StrictArity : 0, reportErrors, reportError, incompatibleReporter, signatureKind, isRelatedToWorker, reportUnreliableMapper);
         }
 
         function signaturesIdenticalTo(source: Type, target: Type, kind: SignatureKind): Ternary {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3567,6 +3567,10 @@
         "category": "Error",
         "code": 2846
     },
+    "Construct signature '{0}' expects more arguments than construct signature '{1}'.": {
+        "category": "Error",
+        "code": 2847
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3563,6 +3563,10 @@
         "category": "Error",
         "code": 2845
     },
+    "Call signature '{0}' expects more arguments than call signature '{1}'.": {
+        "category": "Error",
+        "code": 2846
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/addMoreOverloadsToBaseSignature.errors.txt
+++ b/tests/baselines/reference/addMoreOverloadsToBaseSignature.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/addMoreOverloadsToBaseSignature.ts(5,11): error TS2430: Interface 'Bar' incorrectly extends interface 'Foo'.
   Types of property 'f' are incompatible.
     Type '(key: string) => string' is not assignable to type '() => string'.
+      Call signature '(key: string): string' expects more arguments than call signature '(): string'.
 
 
 ==== tests/cases/compiler/addMoreOverloadsToBaseSignature.ts (1 errors) ====
@@ -13,6 +14,7 @@ tests/cases/compiler/addMoreOverloadsToBaseSignature.ts(5,11): error TS2430: Int
 !!! error TS2430: Interface 'Bar' incorrectly extends interface 'Foo'.
 !!! error TS2430:   Types of property 'f' are incompatible.
 !!! error TS2430:     Type '(key: string) => string' is not assignable to type '() => string'.
+!!! error TS2430:       Call signature '(key: string): string' expects more arguments than call signature '(): string'.
         f(key: string): string;
     }
     

--- a/tests/baselines/reference/arrowFunctionErrorSpan.errors.txt
+++ b/tests/baselines/reference/arrowFunctionErrorSpan.errors.txt
@@ -8,6 +8,7 @@ tests/cases/compiler/arrowFunctionErrorSpan.ts(17,3): error TS2345: Argument of 
   Type 'void' is not assignable to type 'number'.
 tests/cases/compiler/arrowFunctionErrorSpan.ts(18,5): error TS1200: Line terminator not permitted before arrow.
 tests/cases/compiler/arrowFunctionErrorSpan.ts(21,3): error TS2345: Argument of type '(a: any, b: any, c: any, d: any) => void' is not assignable to parameter of type '() => number'.
+  Call signature '(a: any, b: any, c: any, d: any): void' expects more arguments than call signature '(): number'.
 tests/cases/compiler/arrowFunctionErrorSpan.ts(28,7): error TS2345: Argument of type '() => void' is not assignable to parameter of type '() => number'.
   Type 'void' is not assignable to type 'number'.
 tests/cases/compiler/arrowFunctionErrorSpan.ts(32,7): error TS2345: Argument of type '() => void' is not assignable to parameter of type '() => number'.
@@ -17,6 +18,7 @@ tests/cases/compiler/arrowFunctionErrorSpan.ts(36,7): error TS2345: Argument of 
 tests/cases/compiler/arrowFunctionErrorSpan.ts(43,5): error TS2345: Argument of type '() => void' is not assignable to parameter of type '() => number'.
   Type 'void' is not assignable to type 'number'.
 tests/cases/compiler/arrowFunctionErrorSpan.ts(52,3): error TS2345: Argument of type '(_: any) => number' is not assignable to parameter of type '() => number'.
+  Call signature '(_: any): number' expects more arguments than call signature '(): number'.
 
 
 ==== tests/cases/compiler/arrowFunctionErrorSpan.ts (11 errors) ====
@@ -64,6 +66,7 @@ tests/cases/compiler/arrowFunctionErrorSpan.ts(52,3): error TS2345: Argument of 
         d) => { });
     ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(a: any, b: any, c: any, d: any) => void' is not assignable to parameter of type '() => number'.
+!!! error TS2345:   Call signature '(a: any, b: any, c: any, d: any): void' expects more arguments than call signature '(): number'.
     
     // single line with a comment
     f(/*
@@ -108,4 +111,5 @@ tests/cases/compiler/arrowFunctionErrorSpan.ts(52,3): error TS2345: Argument of 
         2);
     ~~~~~
 !!! error TS2345: Argument of type '(_: any) => number' is not assignable to parameter of type '() => number'.
+!!! error TS2345:   Call signature '(_: any): number' expects more arguments than call signature '(): number'.
     

--- a/tests/baselines/reference/assignmentCompatWithCallSignaturesWithOptionalParameters.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithCallSignaturesWithOptionalParameters.errors.txt
@@ -1,10 +1,17 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts(16,5): error TS2322: Type '(x: number) => number' is not assignable to type '() => number'.
+  Call signature '(x: number): number' expects more arguments than call signature '(): number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts(19,5): error TS2322: Type '(x: number) => number' is not assignable to type '() => number'.
+  Call signature '(x: number): number' expects more arguments than call signature '(): number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts(20,5): error TS2322: Type '(x: number, y?: number) => number' is not assignable to type '() => number'.
+  Call signature '(x: number, y?: number): number' expects more arguments than call signature '(): number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts(22,5): error TS2322: Type '(x: number, y: number) => number' is not assignable to type '() => number'.
+  Call signature '(x: number, y: number): number' expects more arguments than call signature '(): number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts(33,5): error TS2322: Type '(x: number, y: number) => number' is not assignable to type '(x?: number) => number'.
+  Call signature '(x: number, y: number): number' expects more arguments than call signature '(x?: number): number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts(39,5): error TS2322: Type '(x: number, y: number) => number' is not assignable to type '(x: number) => number'.
+  Call signature '(x: number, y: number): number' expects more arguments than call signature '(x: number): number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts(45,5): error TS2322: Type '(x: number, y: number) => number' is not assignable to type '(x: number) => number'.
+  Call signature '(x: number, y: number): number' expects more arguments than call signature '(x: number): number'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithOptionalParameters.ts (7 errors) ====
@@ -26,18 +33,22 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         a = (x: number) => 1; // error, too many required params
         ~
 !!! error TS2322: Type '(x: number) => number' is not assignable to type '() => number'.
+!!! error TS2322:   Call signature '(x: number): number' expects more arguments than call signature '(): number'.
         a = b.a; // ok
         a = b.a2; // ok
         a = b.a3; // error
         ~
 !!! error TS2322: Type '(x: number) => number' is not assignable to type '() => number'.
+!!! error TS2322:   Call signature '(x: number): number' expects more arguments than call signature '(): number'.
         a = b.a4; // error
         ~
 !!! error TS2322: Type '(x: number, y?: number) => number' is not assignable to type '() => number'.
+!!! error TS2322:   Call signature '(x: number, y?: number): number' expects more arguments than call signature '(): number'.
         a = b.a5; // ok
         a = b.a6; // error
         ~
 !!! error TS2322: Type '(x: number, y: number) => number' is not assignable to type '() => number'.
+!!! error TS2322:   Call signature '(x: number, y: number): number' expects more arguments than call signature '(): number'.
     
     var a2: (x?: number) => number; 
         a2 = () => 1; // ok, same number of required params
@@ -51,6 +62,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         a2 = b.a6; // error
         ~~
 !!! error TS2322: Type '(x: number, y: number) => number' is not assignable to type '(x?: number) => number'.
+!!! error TS2322:   Call signature '(x: number, y: number): number' expects more arguments than call signature '(x?: number): number'.
     
     var a3: (x: number) => number; 
         a3 = () => 1; // ok, fewer required params
@@ -59,6 +71,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         a3 = (x: number, y: number) => 1;  // error, too many required params
         ~~
 !!! error TS2322: Type '(x: number, y: number) => number' is not assignable to type '(x: number) => number'.
+!!! error TS2322:   Call signature '(x: number, y: number): number' expects more arguments than call signature '(x: number): number'.
         a3 = b.a; // ok
         a3 = b.a2; // ok
         a3 = b.a3; // ok
@@ -67,6 +80,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         a3 = b.a6; // error
         ~~
 !!! error TS2322: Type '(x: number, y: number) => number' is not assignable to type '(x: number) => number'.
+!!! error TS2322:   Call signature '(x: number, y: number): number' expects more arguments than call signature '(x: number): number'.
     
     var a4: (x: number, y?: number) => number;
         a4 = () => 1; // ok, fewer required params

--- a/tests/baselines/reference/assignmentCompatWithConstructSignaturesWithOptionalParameters.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignaturesWithOptionalParameters.errors.txt
@@ -1,8 +1,13 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignaturesWithOptionalParameters.ts(16,5): error TS2322: Type 'new (x: number) => number' is not assignable to type 'new () => number'.
+  Construct signature '(x: number): number' expects more arguments than construct signature '(): number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignaturesWithOptionalParameters.ts(17,5): error TS2322: Type 'new (x: number, y?: number) => number' is not assignable to type 'new () => number'.
+  Construct signature '(x: number, y?: number): number' expects more arguments than construct signature '(): number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignaturesWithOptionalParameters.ts(19,5): error TS2322: Type 'new (x: number, y: number) => number' is not assignable to type 'new () => number'.
+  Construct signature '(x: number, y: number): number' expects more arguments than construct signature '(): number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignaturesWithOptionalParameters.ts(27,5): error TS2322: Type 'new (x: number, y: number) => number' is not assignable to type 'new (x?: number) => number'.
+  Construct signature '(x: number, y: number): number' expects more arguments than construct signature '(x?: number): number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignaturesWithOptionalParameters.ts(35,5): error TS2322: Type 'new (x: number, y: number) => number' is not assignable to type 'new (x: number) => number'.
+  Construct signature '(x: number, y: number): number' expects more arguments than construct signature '(x: number): number'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignaturesWithOptionalParameters.ts (5 errors) ====
@@ -24,13 +29,16 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         a = b.a3; // error
         ~
 !!! error TS2322: Type 'new (x: number) => number' is not assignable to type 'new () => number'.
+!!! error TS2322:   Construct signature '(x: number): number' expects more arguments than construct signature '(): number'.
         a = b.a4; // error
         ~
 !!! error TS2322: Type 'new (x: number, y?: number) => number' is not assignable to type 'new () => number'.
+!!! error TS2322:   Construct signature '(x: number, y?: number): number' expects more arguments than construct signature '(): number'.
         a = b.a5; // ok
         a = b.a6; // error
         ~
 !!! error TS2322: Type 'new (x: number, y: number) => number' is not assignable to type 'new () => number'.
+!!! error TS2322:   Construct signature '(x: number, y: number): number' expects more arguments than construct signature '(): number'.
     
     var a2: new (x?: number) => number; 
         a2 = b.a; // ok
@@ -41,6 +49,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         a2 = b.a6; // error
         ~~
 !!! error TS2322: Type 'new (x: number, y: number) => number' is not assignable to type 'new (x?: number) => number'.
+!!! error TS2322:   Construct signature '(x: number, y: number): number' expects more arguments than construct signature '(x?: number): number'.
     
     var a3: new (x: number) => number; 
         a3 = b.a; // ok
@@ -51,6 +60,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         a3 = b.a6; // error
         ~~
 !!! error TS2322: Type 'new (x: number, y: number) => number' is not assignable to type 'new (x: number) => number'.
+!!! error TS2322:   Construct signature '(x: number, y: number): number' expects more arguments than construct signature '(x: number): number'.
     
     var a4: new (x: number, y?: number) => number;
         a4 = b.a; // ok

--- a/tests/baselines/reference/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.errors.txt
@@ -1,5 +1,7 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts(14,13): error TS2322: Type '(x: T) => any' is not assignable to type '() => T'.
+  Call signature '(x: T): any' expects more arguments than call signature '(): T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts(23,13): error TS2322: Type '(x: T, y: T) => any' is not assignable to type '(x: T) => T'.
+  Call signature '(x: T, y: T): any' expects more arguments than call signature '(x: T): T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts(63,9): error TS2322: Type '() => T' is not assignable to type '<T>() => T'.
   Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
     'T' could be instantiated with an arbitrary type which could be unrelated to 'T'.
@@ -7,7 +9,9 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
   Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
     'T' could be instantiated with an arbitrary type which could be unrelated to 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts(65,9): error TS2322: Type '(x: T) => T' is not assignable to type '<T>() => T'.
+  Call signature '(x: T): T' expects more arguments than call signature '<T>(): T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts(66,9): error TS2322: Type '(x: T, y?: T) => T' is not assignable to type '<T>() => T'.
+  Call signature '(x: T, y?: T): T' expects more arguments than call signature '<T>(): T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts(67,9): error TS2322: Type '(x?: T, y?: T) => T' is not assignable to type '<T>() => T'.
   Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
     'T' could be instantiated with an arbitrary type which could be unrelated to 'T'.
@@ -88,7 +92,9 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
       'T' could be instantiated with an arbitrary type which could be unrelated to 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts(107,13): error TS2322: Type '<T>(x: T) => any' is not assignable to type '<T>() => T'.
+  Call signature '<T>(x: T): any' expects more arguments than call signature '<T>(): T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts(116,13): error TS2322: Type '<T>(x: T, y: T) => any' is not assignable to type '<T>(x: T) => T'.
+  Call signature '<T>(x: T, y: T): any' expects more arguments than call signature '<T>(x: T): T'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts (29 errors) ====
@@ -108,6 +114,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
                 this.a = (x: T) => null; // error, too many required params
                 ~~~~~~
 !!! error TS2322: Type '(x: T) => any' is not assignable to type '() => T'.
+!!! error TS2322:   Call signature '(x: T): any' expects more arguments than call signature '(): T'.
     
                 this.a2 = () => null; // ok, same T of required params
                 this.a2 = (x?: T) => null; // ok, same T of required params
@@ -119,6 +126,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
                 this.a3 = (x: T, y: T) => null;  // error, too many required params
                 ~~~~~~~
 !!! error TS2322: Type '(x: T, y: T) => any' is not assignable to type '(x: T) => T'.
+!!! error TS2322:   Call signature '(x: T, y: T): any' expects more arguments than call signature '(x: T): T'.
     
                 this.a4 = () => null; // ok, fewer required params
                 this.a4 = (x?: T, y?: T) => null; // ok, fewer required params
@@ -173,9 +181,11 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
             b.a = t.a3;
             ~~~
 !!! error TS2322: Type '(x: T) => T' is not assignable to type '<T>() => T'.
+!!! error TS2322:   Call signature '(x: T): T' expects more arguments than call signature '<T>(): T'.
             b.a = t.a4;
             ~~~
 !!! error TS2322: Type '(x: T, y?: T) => T' is not assignable to type '<T>() => T'.
+!!! error TS2322:   Call signature '(x: T, y?: T): T' expects more arguments than call signature '<T>(): T'.
             b.a = t.a5;
             ~~~
 !!! error TS2322: Type '(x?: T, y?: T) => T' is not assignable to type '<T>() => T'.
@@ -340,6 +350,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
                 this.a = <T>(x: T) => null; // error, too many required params
                 ~~~~~~
 !!! error TS2322: Type '<T>(x: T) => any' is not assignable to type '<T>() => T'.
+!!! error TS2322:   Call signature '<T>(x: T): any' expects more arguments than call signature '<T>(): T'.
     
                 this.a2 = <T>() => null; // ok, same T of required params
                 this.a2 = <T>(x?: T) => null; // ok, same T of required params
@@ -351,6 +362,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
                 this.a3 = <T>(x: T, y: T) => null;  // error, too many required params
                 ~~~~~~~
 !!! error TS2322: Type '<T>(x: T, y: T) => any' is not assignable to type '<T>(x: T) => T'.
+!!! error TS2322:   Call signature '<T>(x: T, y: T): any' expects more arguments than call signature '<T>(x: T): T'.
     
                 this.a4 = <T>() => null; // ok, fewer required params
                 this.a4 = <T>(x?: T, y?: T) => null; // ok, fewer required params

--- a/tests/baselines/reference/assignmentCompatability44.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability44.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/assignmentCompatability44.ts(5,7): error TS2322: Type 'typeof Foo' is not assignable to type 'new () => Foo'.
   Types of construct signatures are incompatible.
     Type 'new (x: number) => Foo' is not assignable to type 'new () => Foo'.
+      Construct signature '(x: number): Foo' expects more arguments than construct signature '(): Foo'.
 
 
 ==== tests/cases/compiler/assignmentCompatability44.ts (1 errors) ====
@@ -13,4 +14,5 @@ tests/cases/compiler/assignmentCompatability44.ts(5,7): error TS2322: Type 'type
 !!! error TS2322: Type 'typeof Foo' is not assignable to type 'new () => Foo'.
 !!! error TS2322:   Types of construct signatures are incompatible.
 !!! error TS2322:     Type 'new (x: number) => Foo' is not assignable to type 'new () => Foo'.
+!!! error TS2322:       Construct signature '(x: number): Foo' expects more arguments than construct signature '(): Foo'.
     

--- a/tests/baselines/reference/assignmentCompatability45.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability45.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/assignmentCompatability45.ts(7,7): error TS2322: Type 'typeof B' is not assignable to type 'typeof A'.
   Types of construct signatures are incompatible.
     Type 'new (x: number) => B' is not assignable to type 'abstract new () => A'.
+      Construct signature '(x: number): B' expects more arguments than construct signature '(): A'.
 
 
 ==== tests/cases/compiler/assignmentCompatability45.ts (1 errors) ====
@@ -15,4 +16,5 @@ tests/cases/compiler/assignmentCompatability45.ts(7,7): error TS2322: Type 'type
 !!! error TS2322: Type 'typeof B' is not assignable to type 'typeof A'.
 !!! error TS2322:   Types of construct signatures are incompatible.
 !!! error TS2322:     Type 'new (x: number) => B' is not assignable to type 'abstract new () => A'.
+!!! error TS2322:       Construct signature '(x: number): B' expects more arguments than construct signature '(): A'.
     

--- a/tests/baselines/reference/checkJsdocTypeTag6.errors.txt
+++ b/tests/baselines/reference/checkJsdocTypeTag6.errors.txt
@@ -3,8 +3,11 @@ tests/cases/conformance/jsdoc/test.js(7,5): error TS2322: Type '(prop: any) => v
 tests/cases/conformance/jsdoc/test.js(10,12): error TS8030: The type of a function declaration must match the function's signature.
 tests/cases/conformance/jsdoc/test.js(23,12): error TS8030: The type of a function declaration must match the function's signature.
 tests/cases/conformance/jsdoc/test.js(27,7): error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+  Call signature '(more: any): void' expects more arguments than call signature '(): void'.
 tests/cases/conformance/jsdoc/test.js(30,7): error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+  Call signature '(more: any): void' expects more arguments than call signature '(): void'.
 tests/cases/conformance/jsdoc/test.js(34,3): error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+  Call signature '(more: any): void' expects more arguments than call signature '(): void'.
 
 
 ==== tests/cases/conformance/jsdoc/test.js (7 errors) ====
@@ -45,16 +48,19 @@ tests/cases/conformance/jsdoc/test.js(34,3): error TS2322: Type '(more: any) => 
     const variableWithMoreParameters = function (more) {}; // error
           ~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+!!! error TS2322:   Call signature '(more: any): void' expects more arguments than call signature '(): void'.
     
     /** @type {() => void} */
     const arrowWithMoreParameters = (more) => {}; // error
           ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+!!! error TS2322:   Call signature '(more: any): void' expects more arguments than call signature '(): void'.
     
     ({
       /** @type {() => void} */
       methodWithMoreParameters(more) {}, // error
       ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '(more: any) => void' is not assignable to type '() => void'.
+!!! error TS2322:   Call signature '(more: any): void' expects more arguments than call signature '(): void'.
     });
     

--- a/tests/baselines/reference/classCanExtendConstructorFunction.errors.txt
+++ b/tests/baselines/reference/classCanExtendConstructorFunction.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/conformance/salsa/first.js(23,9): error TS2554: Expected 1 arguments, but got 0.
 tests/cases/conformance/salsa/first.js(31,5): error TS2416: Property 'load' in type 'Sql' is not assignable to the same property in base type 'Wagon'.
   Type '(files: string[], format: "csv" | "json" | "xmlolololol") => void' is not assignable to type '(supplies?: any[]) => void'.
+    Call signature '(files: string[], format: "csv" | "json" | "xmlolololol"): void' expects more arguments than call signature '(supplies?: any[]): void'.
 tests/cases/conformance/salsa/first.js(47,24): error TS2507: Type '(numberEaten: number) => void' is not a constructor function type.
 tests/cases/conformance/salsa/generic.js(19,19): error TS2554: Expected 1 arguments, but got 0.
 tests/cases/conformance/salsa/generic.js(20,32): error TS2345: Argument of type 'number' is not assignable to parameter of type '{ claim: "ignorant" | "malicious"; }'.
@@ -52,6 +53,7 @@ tests/cases/conformance/salsa/second.ts(17,15): error TS2345: Argument of type '
         ~~~~
 !!! error TS2416: Property 'load' in type 'Sql' is not assignable to the same property in base type 'Wagon'.
 !!! error TS2416:   Type '(files: string[], format: "csv" | "json" | "xmlolololol") => void' is not assignable to type '(supplies?: any[]) => void'.
+!!! error TS2416:     Call signature '(files: string[], format: "csv" | "json" | "xmlolololol"): void' expects more arguments than call signature '(supplies?: any[]): void'.
             if (format === "xmlolololol") {
                 throw new Error("please do not use XML. It was a joke.");
             }

--- a/tests/baselines/reference/classSideInheritance3.errors.txt
+++ b/tests/baselines/reference/classSideInheritance3.errors.txt
@@ -1,9 +1,11 @@
 tests/cases/compiler/classSideInheritance3.ts(16,5): error TS2322: Type 'typeof B' is not assignable to type 'typeof A'.
   Types of construct signatures are incompatible.
     Type 'new (x: string, data: string) => B' is not assignable to type 'new (x: string) => A'.
+      Construct signature '(x: string, data: string): B' expects more arguments than construct signature '(x: string): A'.
 tests/cases/compiler/classSideInheritance3.ts(17,5): error TS2322: Type 'typeof B' is not assignable to type 'new (x: string) => A'.
   Types of construct signatures are incompatible.
     Type 'new (x: string, data: string) => B' is not assignable to type 'new (x: string) => A'.
+      Construct signature '(x: string, data: string): B' expects more arguments than construct signature '(x: string): A'.
 
 
 ==== tests/cases/compiler/classSideInheritance3.ts (2 errors) ====
@@ -27,9 +29,11 @@ tests/cases/compiler/classSideInheritance3.ts(17,5): error TS2322: Type 'typeof 
 !!! error TS2322: Type 'typeof B' is not assignable to type 'typeof A'.
 !!! error TS2322:   Types of construct signatures are incompatible.
 !!! error TS2322:     Type 'new (x: string, data: string) => B' is not assignable to type 'new (x: string) => A'.
+!!! error TS2322:       Construct signature '(x: string, data: string): B' expects more arguments than construct signature '(x: string): A'.
     var r2: new (x: string) => A = B; // error
         ~~
 !!! error TS2322: Type 'typeof B' is not assignable to type 'new (x: string) => A'.
 !!! error TS2322:   Types of construct signatures are incompatible.
 !!! error TS2322:     Type 'new (x: string, data: string) => B' is not assignable to type 'new (x: string) => A'.
+!!! error TS2322:       Construct signature '(x: string, data: string): B' expects more arguments than construct signature '(x: string): A'.
     var r3: typeof A = C; // ok

--- a/tests/baselines/reference/covariantCallbacks.errors.txt
+++ b/tests/baselines/reference/covariantCallbacks.errors.txt
@@ -16,6 +16,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/covarian
   Types of property 'forEach' are incompatible.
     Type '(cb: (item: A) => void) => void' is not assignable to type '(cb: (item: A, context: any) => void) => void'.
       Types of parameters 'cb' and 'cb' are incompatible.
+        Call signature '(item: A, context: any): void' expects more arguments than call signature '(item: A): void'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/covariantCallbacks.ts(69,5): error TS2322: Type 'AList4' is not assignable to type 'BList4'.
   Types of property 'forEach' are incompatible.
     Type '(cb: (item: A) => A) => void' is not assignable to type '(cb: (item: B) => B) => void'.
@@ -105,6 +106,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/covarian
 !!! error TS2322:   Types of property 'forEach' are incompatible.
 !!! error TS2322:     Type '(cb: (item: A) => void) => void' is not assignable to type '(cb: (item: A, context: any) => void) => void'.
 !!! error TS2322:       Types of parameters 'cb' and 'cb' are incompatible.
+!!! error TS2322:         Call signature '(item: A, context: any): void' expects more arguments than call signature '(item: A): void'.
     }
     
     interface AList4 {

--- a/tests/baselines/reference/derivedInterfaceCallSignature.errors.txt
+++ b/tests/baselines/reference/derivedInterfaceCallSignature.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/derivedInterfaceCallSignature.ts(11,11): error TS2430: Interface 'D3SvgArea' incorrectly extends interface 'D3SvgPath'.
   Types of property 'x' are incompatible.
     Type '(x: (data: any, index?: number) => number) => D3SvgArea' is not assignable to type '() => (data: any, index?: number) => number'.
+      Call signature '(x: (data: any, index?: number) => number): D3SvgArea' expects more arguments than call signature '(): (data: any, index?: number) => number'.
 
 
 ==== tests/cases/compiler/derivedInterfaceCallSignature.ts (1 errors) ====
@@ -19,6 +20,7 @@ tests/cases/compiler/derivedInterfaceCallSignature.ts(11,11): error TS2430: Inte
 !!! error TS2430: Interface 'D3SvgArea' incorrectly extends interface 'D3SvgPath'.
 !!! error TS2430:   Types of property 'x' are incompatible.
 !!! error TS2430:     Type '(x: (data: any, index?: number) => number) => D3SvgArea' is not assignable to type '() => (data: any, index?: number) => number'.
+!!! error TS2430:       Call signature '(x: (data: any, index?: number) => number): D3SvgArea' expects more arguments than call signature '(): (data: any, index?: number) => number'.
         x(x: (data: any, index?: number) => number): D3SvgArea;
         y(y: (data: any, index?: number) => number): D3SvgArea;
         y0(): (data: any, index?: number) => number;

--- a/tests/baselines/reference/functionConstraintSatisfaction2.errors.txt
+++ b/tests/baselines/reference/functionConstraintSatisfaction2.errors.txt
@@ -11,6 +11,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(26,15): error TS2345: Argument of type 'new (x: string) => string' is not assignable to parameter of type '(x: string) => string'.
   Type 'new (x: string) => string' provides no match for the signature '(x: string): string'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(28,16): error TS2345: Argument of type '<U, V>(x: U, y: V) => U' is not assignable to parameter of type '(x: string) => string'.
+  Call signature '<U, V>(x: U, y: V): U' expects more arguments than call signature '(x: string): string'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(29,16): error TS2345: Argument of type 'typeof C2' is not assignable to parameter of type '(x: string) => string'.
   Type 'typeof C2' provides no match for the signature '(x: string): string'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(30,16): error TS2345: Argument of type 'new <T>(x: T) => T' is not assignable to parameter of type '(x: string) => string'.
@@ -74,6 +75,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
     var r11 = foo2(<U, V>(x: U, y: V) => x);
                    ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '<U, V>(x: U, y: V) => U' is not assignable to parameter of type '(x: string) => string'.
+!!! error TS2345:   Call signature '<U, V>(x: U, y: V): U' expects more arguments than call signature '(x: string): string'.
     var r13 = foo2(C2);
                    ~~
 !!! error TS2345: Argument of type 'typeof C2' is not assignable to parameter of type '(x: string) => string'.

--- a/tests/baselines/reference/genericCallWithConstructorTypedArguments5.errors.txt
+++ b/tests/baselines/reference/genericCallWithConstructorTypedArguments5.errors.txt
@@ -1,9 +1,11 @@
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstructorTypedArguments5.ts(11,14): error TS2345: Argument of type '{ cb: new <T>(x: T, y: T) => string; }' is not assignable to parameter of type '{ cb: new (t: unknown) => string; }'.
   Types of property 'cb' are incompatible.
     Type 'new <T>(x: T, y: T) => string' is not assignable to type 'new (t: unknown) => string'.
+      Construct signature '<T>(x: T, y: T): string' expects more arguments than construct signature '(t: unknown): string'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstructorTypedArguments5.ts(13,14): error TS2345: Argument of type '{ cb: new (x: string, y: number) => string; }' is not assignable to parameter of type '{ cb: new (t: string) => string; }'.
   Types of property 'cb' are incompatible.
     Type 'new (x: string, y: number) => string' is not assignable to type 'new (t: string) => string'.
+      Construct signature '(x: string, y: number): string' expects more arguments than construct signature '(t: string): string'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstructorTypedArguments5.ts (2 errors) ====
@@ -22,12 +24,14 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithCon
 !!! error TS2345: Argument of type '{ cb: new <T>(x: T, y: T) => string; }' is not assignable to parameter of type '{ cb: new (t: unknown) => string; }'.
 !!! error TS2345:   Types of property 'cb' are incompatible.
 !!! error TS2345:     Type 'new <T>(x: T, y: T) => string' is not assignable to type 'new (t: unknown) => string'.
+!!! error TS2345:       Construct signature '<T>(x: T, y: T): string' expects more arguments than construct signature '(t: unknown): string'.
     var arg3: { cb: new (x: string, y: number) => string };
     var r3 = foo(arg3); // error
                  ~~~~
 !!! error TS2345: Argument of type '{ cb: new (x: string, y: number) => string; }' is not assignable to parameter of type '{ cb: new (t: string) => string; }'.
 !!! error TS2345:   Types of property 'cb' are incompatible.
 !!! error TS2345:     Type 'new (x: string, y: number) => string' is not assignable to type 'new (t: string) => string'.
+!!! error TS2345:       Construct signature '(x: string, y: number): string' expects more arguments than construct signature '(t: string): string'.
     
     function foo2<T, U>(arg: { cb: new(t: T, t2: T) => U }) {
         return new arg.cb(null, null);

--- a/tests/baselines/reference/genericCallWithFunctionTypedArguments5.errors.txt
+++ b/tests/baselines/reference/genericCallWithFunctionTypedArguments5.errors.txt
@@ -1,5 +1,7 @@
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts(10,16): error TS2322: Type '<T>(x: T, y: T) => string' is not assignable to type '(t: unknown) => string'.
+  Call signature '<T>(x: T, y: T): string' expects more arguments than call signature '(t: unknown): string'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts(11,16): error TS2322: Type '(x: string, y: number) => string' is not assignable to type '(t: string) => string'.
+  Call signature '(x: string, y: number): string' expects more arguments than call signature '(t: string): string'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts (2 errors) ====
@@ -15,10 +17,12 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFun
     var r2 = foo({ cb: <T>(x: T, y: T) => '' }); // error
                    ~~
 !!! error TS2322: Type '<T>(x: T, y: T) => string' is not assignable to type '(t: unknown) => string'.
+!!! error TS2322:   Call signature '<T>(x: T, y: T): string' expects more arguments than call signature '(t: unknown): string'.
 !!! related TS6500 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts:3:27: The expected type comes from property 'cb' which is declared here on type '{ cb: (t: unknown) => string; }'
     var r3 = foo({ cb: (x: string, y: number) => '' }); // error
                    ~~
 !!! error TS2322: Type '(x: string, y: number) => string' is not assignable to type '(t: string) => string'.
+!!! error TS2322:   Call signature '(x: string, y: number): string' expects more arguments than call signature '(t: string): string'.
 !!! related TS6500 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts:3:27: The expected type comes from property 'cb' which is declared here on type '{ cb: (t: string) => string; }'
     
     function foo2<T, U>(arg: { cb: (t: T, t2: T) => U }) {

--- a/tests/baselines/reference/genericCallWithOverloadedConstructorTypedArguments2.errors.txt
+++ b/tests/baselines/reference/genericCallWithOverloadedConstructorTypedArguments2.errors.txt
@@ -1,4 +1,5 @@
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedConstructorTypedArguments2.ts(31,20): error TS2345: Argument of type 'new <T>(x: T, y: T) => string' is not assignable to parameter of type '{ new (x: unknown): string; new (x: unknown, y?: unknown): string; }'.
+  Construct signature '(x: any, y: any): string' expects more arguments than construct signature '(x: unknown): string'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedConstructorTypedArguments2.ts (1 errors) ====
@@ -35,6 +36,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOve
         var r10 = foo6(b); // error
                        ~
 !!! error TS2345: Argument of type 'new <T>(x: T, y: T) => string' is not assignable to parameter of type '{ new (x: unknown): string; new (x: unknown, y?: unknown): string; }'.
+!!! error TS2345:   Construct signature '(x: any, y: any): string' expects more arguments than construct signature '(x: unknown): string'.
     
         function foo7<T>(x:T, cb: { new(x: T): string; new(x: T, y?: T): string }) {
             return cb;

--- a/tests/baselines/reference/genericCallWithOverloadedFunctionTypedArguments2.errors.txt
+++ b/tests/baselines/reference/genericCallWithOverloadedFunctionTypedArguments2.errors.txt
@@ -1,4 +1,5 @@
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments2.ts(28,20): error TS2345: Argument of type '<T>(x: T, y: T) => string' is not assignable to parameter of type '{ (x: unknown): string; (x: unknown, y?: unknown): string; }'.
+  Call signature '(x: any, y: any): string' expects more arguments than call signature '(x: unknown): string'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments2.ts (1 errors) ====
@@ -32,6 +33,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOve
         var r10 = foo6(<T>(x: T, y: T) => ''); // error
                        ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '<T>(x: T, y: T) => string' is not assignable to parameter of type '{ (x: unknown): string; (x: unknown, y?: unknown): string; }'.
+!!! error TS2345:   Call signature '(x: any, y: any): string' expects more arguments than call signature '(x: unknown): string'.
     
         function foo7<T>(x:T, cb: { (x: T): string; (x: T, y?: T): string }) {
             return cb;

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -29,6 +29,7 @@ tests/cases/compiler/incompatibleTypes.ts(66,47): error TS2322: Type '{ e: numbe
   Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
 tests/cases/compiler/incompatibleTypes.ts(72,5): error TS2322: Type 'number' is not assignable to type '() => string'.
 tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) => number' is not assignable to type '() => any'.
+  Call signature '(a: any): number' expects more arguments than call signature '(): any'.
 
 
 ==== tests/cases/compiler/incompatibleTypes.ts (9 errors) ====
@@ -148,4 +149,5 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     var fp1: () =>any = a => 0;
         ~~~
 !!! error TS2322: Type '(a: any) => number' is not assignable to type '() => any'.
+!!! error TS2322:   Call signature '(a: any): number' expects more arguments than call signature '(): any'.
     

--- a/tests/baselines/reference/inferTypes1.errors.txt
+++ b/tests/baselines/reference/inferTypes1.errors.txt
@@ -5,6 +5,7 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(43,25): error TS2344: T
 tests/cases/conformance/types/conditional/inferTypes1.ts(44,25): error TS2344: Type 'Function' does not satisfy the constraint 'abstract new (...args: any) => any'.
   Type 'Function' provides no match for the signature 'new (...args: any): any'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(55,25): error TS2344: Type '(x: string, y: string) => number' does not satisfy the constraint '(x: any) => any'.
+  Call signature '(x: string, y: string): number' expects more arguments than call signature '(x: any): any'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(56,25): error TS2344: Type 'Function' does not satisfy the constraint '(x: any) => any'.
   Type 'Function' provides no match for the signature '(x: any): any'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(82,12): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
@@ -88,6 +89,7 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(153,40): error TS2322: 
     type T24 = ArgumentType<(x: string, y: string) => number>;  // Error
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2344: Type '(x: string, y: string) => number' does not satisfy the constraint '(x: any) => any'.
+!!! error TS2344:   Call signature '(x: string, y: string): number' expects more arguments than call signature '(x: any): any'.
     type T25 = ArgumentType<Function>;  // Error
                             ~~~~~~~~
 !!! error TS2344: Type 'Function' does not satisfy the constraint '(x: any) => any'.

--- a/tests/baselines/reference/inheritance.errors.txt
+++ b/tests/baselines/reference/inheritance.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/inheritance.ts(31,12): error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
 tests/cases/compiler/inheritance.ts(32,12): error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type 'Good'.
   Type '(n: number) => number' is not assignable to type '() => number'.
+    Call signature '(n: number): number' expects more arguments than call signature '(): number'.
 
 
 ==== tests/cases/compiler/inheritance.ts (2 errors) ====
@@ -41,5 +42,6 @@ tests/cases/compiler/inheritance.ts(32,12): error TS2416: Property 'g' in type '
                ~
 !!! error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type 'Good'.
 !!! error TS2416:   Type '(n: number) => number' is not assignable to type '() => number'.
+!!! error TS2416:     Call signature '(n: number): number' expects more arguments than call signature '(): number'.
     }
     

--- a/tests/baselines/reference/lambdaArgCrash.errors.txt
+++ b/tests/baselines/reference/lambdaArgCrash.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/lambdaArgCrash.ts(27,25): error TS2304: Cannot find name 'ItemSet'.
 tests/cases/compiler/lambdaArgCrash.ts(29,14): error TS2345: Argument of type '(items: ItemSet) => void' is not assignable to parameter of type '() => any'.
+  Call signature '(items: ItemSet): void' expects more arguments than call signature '(): any'.
 
 
 ==== tests/cases/compiler/lambdaArgCrash.ts (2 errors) ====
@@ -36,6 +37,7 @@ tests/cases/compiler/lambdaArgCrash.ts(29,14): error TS2345: Argument of type '(
     	 	super.add(listener);
     	 	          ~~~~~~~~
 !!! error TS2345: Argument of type '(items: ItemSet) => void' is not assignable to parameter of type '() => any'.
+!!! error TS2345:   Call signature '(items: ItemSet): void' expects more arguments than call signature '(): any'.
     
     	}
     

--- a/tests/baselines/reference/multipleInheritance.errors.txt
+++ b/tests/baselines/reference/multipleInheritance.errors.txt
@@ -3,6 +3,7 @@ tests/cases/compiler/multipleInheritance.ts(18,21): error TS1174: Classes can on
 tests/cases/compiler/multipleInheritance.ts(35,12): error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
 tests/cases/compiler/multipleInheritance.ts(36,12): error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type 'Good'.
   Type '(n: number) => number' is not assignable to type '() => number'.
+    Call signature '(n: number): number' expects more arguments than call signature '(): number'.
 
 
 ==== tests/cases/compiler/multipleInheritance.ts (4 errors) ====
@@ -51,5 +52,6 @@ tests/cases/compiler/multipleInheritance.ts(36,12): error TS2416: Property 'g' i
                ~
 !!! error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type 'Good'.
 !!! error TS2416:   Type '(n: number) => number' is not assignable to type '() => number'.
+!!! error TS2416:     Call signature '(n: number): number' expects more arguments than call signature '(): number'.
     }
     

--- a/tests/baselines/reference/objectLiteralFunctionArgContextualTyping2.errors.txt
+++ b/tests/baselines/reference/objectLiteralFunctionArgContextualTyping2.errors.txt
@@ -5,8 +5,11 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(9,4): error TS
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(10,17): error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I2'.
   Object literal may only specify known properties, and 'what' does not exist in type 'I2'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(11,6): error TS2322: Type '(s: any) => any' is not assignable to type '() => string'.
+  Call signature '(s: any): any' expects more arguments than call signature '(): string'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(12,6): error TS2322: Type '(s: string) => string' is not assignable to type '() => string'.
+  Call signature '(s: string): string' expects more arguments than call signature '(): string'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(13,17): error TS2322: Type '(s: any) => any' is not assignable to type '() => string'.
+  Call signature '(s: any): any' expects more arguments than call signature '(): string'.
 
 
 ==== tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts (6 errors) ====
@@ -33,9 +36,12 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(13,17): error 
     f2({ toString: (s) => s }) 
          ~~~~~~~~
 !!! error TS2322: Type '(s: any) => any' is not assignable to type '() => string'.
+!!! error TS2322:   Call signature '(s: any): any' expects more arguments than call signature '(): string'.
     f2({ toString: (s: string) => s }) 
          ~~~~~~~~
 !!! error TS2322: Type '(s: string) => string' is not assignable to type '() => string'.
+!!! error TS2322:   Call signature '(s: string): string' expects more arguments than call signature '(): string'.
     f2({ value: '', toString: (s) => s.uhhh }) 
                     ~~~~~~~~
 !!! error TS2322: Type '(s: any) => any' is not assignable to type '() => string'.
+!!! error TS2322:   Call signature '(s: any): any' expects more arguments than call signature '(): string'.

--- a/tests/baselines/reference/parseTypes.errors.txt
+++ b/tests/baselines/reference/parseTypes.errors.txt
@@ -1,5 +1,7 @@
 tests/cases/compiler/parseTypes.ts(8,1): error TS2322: Type '(s: string) => void' is not assignable to type '() => number'.
+  Call signature '(s: string): void' expects more arguments than call signature '(): number'.
 tests/cases/compiler/parseTypes.ts(9,1): error TS2322: Type '(s: string) => void' is not assignable to type '() => number'.
+  Call signature '(s: string): void' expects more arguments than call signature '(): number'.
 tests/cases/compiler/parseTypes.ts(10,1): error TS2322: Type '(s: string) => void' is not assignable to type '{ [x: number]: number; }'.
   Index signature for type 'number' is missing in type '(s: string) => void'.
 tests/cases/compiler/parseTypes.ts(11,1): error TS2322: Type '(s: string) => void' is not assignable to type 'new () => number'.
@@ -17,9 +19,11 @@ tests/cases/compiler/parseTypes.ts(11,1): error TS2322: Type '(s: string) => voi
     y=g;
     ~
 !!! error TS2322: Type '(s: string) => void' is not assignable to type '() => number'.
+!!! error TS2322:   Call signature '(s: string): void' expects more arguments than call signature '(): number'.
     x=g;
     ~
 !!! error TS2322: Type '(s: string) => void' is not assignable to type '() => number'.
+!!! error TS2322:   Call signature '(s: string): void' expects more arguments than call signature '(): number'.
     w=g;
     ~
 !!! error TS2322: Type '(s: string) => void' is not assignable to type '{ [x: number]: number; }'.

--- a/tests/baselines/reference/partiallyAnnotatedFunctionInferenceError.errors.txt
+++ b/tests/baselines/reference/partiallyAnnotatedFunctionInferenceError.errors.txt
@@ -1,6 +1,9 @@
 tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(12,11): error TS2345: Argument of type '(t1: D, t2: any, t3: any) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
+  Call signature '(t1: D, t2: any, t3: any): void' expects more arguments than call signature '(t: any, t1: any): void'.
 tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(13,11): error TS2345: Argument of type '(t1: any, t2: D, t3: any) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
+  Call signature '(t1: any, t2: D, t3: any): void' expects more arguments than call signature '(t: any, t1: any): void'.
 tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(14,11): error TS2345: Argument of type '(t1: any, t2: any, t3: D) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
+  Call signature '(t1: any, t2: any, t3: D): void' expects more arguments than call signature '(t: any, t1: any): void'.
 
 
 ==== tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts (3 errors) ====
@@ -18,10 +21,13 @@ tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partial
     testError((t1: D, t2, t3) => {})
               ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(t1: D, t2: any, t3: any) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
+!!! error TS2345:   Call signature '(t1: D, t2: any, t3: any): void' expects more arguments than call signature '(t: any, t1: any): void'.
     testError((t1, t2: D, t3) => {})
               ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(t1: any, t2: D, t3: any) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
+!!! error TS2345:   Call signature '(t1: any, t2: D, t3: any): void' expects more arguments than call signature '(t: any, t1: any): void'.
     testError((t1, t2, t3: D) => {})
               ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(t1: any, t2: any, t3: D) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
+!!! error TS2345:   Call signature '(t1: any, t2: any, t3: D): void' expects more arguments than call signature '(t: any, t1: any): void'.
     

--- a/tests/baselines/reference/promisePermutations.errors.txt
+++ b/tests/baselines/reference/promisePermutations.errors.txt
@@ -26,27 +26,35 @@ tests/cases/compiler/promisePermutations.ts(84,19): error TS2769: No overload ma
 tests/cases/compiler/promisePermutations.ts(88,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(91,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(92,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+      Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
 tests/cases/compiler/promisePermutations.ts(93,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(97,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(100,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(101,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+      Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
 tests/cases/compiler/promisePermutations.ts(102,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(106,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
@@ -68,18 +76,23 @@ tests/cases/compiler/promisePermutations.ts(111,19): error TS2769: No overload m
 tests/cases/compiler/promisePermutations.ts(117,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations.ts(120,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations.ts(121,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+      Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
 tests/cases/compiler/promisePermutations.ts(122,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations.ts(126,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations.ts(129,33): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => IPromise<number>'.
@@ -88,12 +101,15 @@ tests/cases/compiler/promisePermutations.ts(129,33): error TS2769: No overload m
 tests/cases/compiler/promisePermutations.ts(132,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations.ts(133,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+      Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
 tests/cases/compiler/promisePermutations.ts(134,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations.ts(137,33): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => IPromise<number>'.
@@ -258,6 +274,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2769: No overload m
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:13:5: The last overload is declared here.
     var r5b = r5.then(sIPromise, sIPromise, sIPromise).then(sIPromise, sIPromise, sIPromise); // ok
     var s5: Promise<string>;
@@ -266,18 +283,21 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2769: No overload m
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s5b = s5.then(testFunction5P, testFunction5P, testFunction5P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s5c = s5.then(testFunction5P, testFunction5, testFunction5); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s5d = s5.then(sPromise, sPromise, sPromise).then(sIPromise, sIPromise, sIPromise); // ok
     
@@ -287,6 +307,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2769: No overload m
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:13:5: The last overload is declared here.
     var r6b = r6.then(sIPromise, sIPromise, sIPromise).then(sIPromise, sIPromise, sIPromise); // ok
     var s6: Promise<string>;
@@ -295,18 +316,21 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2769: No overload m
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s6b = s6.then(testFunction6P, testFunction6P, testFunction6P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s6c = s6.then(testFunction6P, testFunction6, testFunction6); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s6d = s6.then(sPromise, sPromise, sPromise).then(sIPromise, sIPromise, sIPromise); // ok
     
@@ -353,6 +377,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2769: No overload m
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:13:5: The last overload is declared here.
     var r8b = r8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     var s8: Promise<number>;
@@ -361,18 +386,21 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2769: No overload m
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s8b = s8.then(testFunction8P, testFunction8P, testFunction8P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s8c = s8.then(testFunction8P, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s8d = s8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     
@@ -382,6 +410,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2769: No overload m
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:13:5: The last overload is declared here.
     var r9b = r9.then(sIPromise, sIPromise, sIPromise); // ok
     var r9c = r9.then(nIPromise, nIPromise, nIPromise); // ok
@@ -400,18 +429,21 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2769: No overload m
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s9b = s9.then(testFunction9P, testFunction9P, testFunction9P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s9c = s9.then(testFunction9P, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s9d = s9.then(sPromise, sPromise, sPromise); // ok
     var s9e = s9.then(nPromise, nPromise, nPromise); // ok

--- a/tests/baselines/reference/promisePermutations2.errors.txt
+++ b/tests/baselines/reference/promisePermutations2.errors.txt
@@ -18,15 +18,23 @@ tests/cases/compiler/promisePermutations2.ts(83,19): error TS2345: Argument of t
 tests/cases/compiler/promisePermutations2.ts(87,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(90,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+  Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(91,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+  Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
 tests/cases/compiler/promisePermutations2.ts(92,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+  Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(96,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(99,19): error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+  Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(100,19): error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+  Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
 tests/cases/compiler/promisePermutations2.ts(101,19): error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+  Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(105,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
@@ -48,20 +56,28 @@ tests/cases/compiler/promisePermutations2.ts(110,19): error TS2769: No overload 
 tests/cases/compiler/promisePermutations2.ts(116,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations2.ts(119,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+  Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations2.ts(120,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+  Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
 tests/cases/compiler/promisePermutations2.ts(121,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+  Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations2.ts(125,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations2.ts(128,33): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => IPromise<number>'.
       Type 'IPromise<string>' is not assignable to type 'IPromise<number>'.
         Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations2.ts(131,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+  Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations2.ts(132,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+  Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
 tests/cases/compiler/promisePermutations2.ts(133,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+  Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations2.ts(136,33): error TS2345: Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => IPromise<number>'.
   Type 'IPromise<string>' is not assignable to type 'IPromise<number>'.
 tests/cases/compiler/promisePermutations2.ts(143,35): error TS2769: No overload matches this call.
@@ -203,18 +219,22 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations2.ts:12:5: The last overload is declared here.
     var r5b = r5.then(sIPromise, sIPromise, sIPromise).then(sIPromise, sIPromise, sIPromise); // ok
     var s5: Promise<string>;
     var s5a = s5.then(testFunction5, testFunction5, testFunction5); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2345:   Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
     var s5b = s5.then(testFunction5P, testFunction5P, testFunction5P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+!!! error TS2345:   Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
     var s5c = s5.then(testFunction5P, testFunction5, testFunction5); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2345:   Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
     var s5d = s5.then(sPromise, sPromise, sPromise).then(sIPromise, sIPromise, sIPromise); // ok
     
     var r6: IPromise<string>;
@@ -223,18 +243,22 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations2.ts:12:5: The last overload is declared here.
     var r6b = r6.then(sIPromise, sIPromise, sIPromise).then(sIPromise, sIPromise, sIPromise); // ok
     var s6: Promise<string>;
     var s6a = s6.then(testFunction6, testFunction6, testFunction6); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2345:   Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
     var s6b = s6.then(testFunction6P, testFunction6P, testFunction6P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+!!! error TS2345:   Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
     var s6c = s6.then(testFunction6P, testFunction6, testFunction6); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2345:   Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
     var s6d = s6.then(sPromise, sPromise, sPromise).then(sIPromise, sIPromise, sIPromise); // ok
     
     var r7: IPromise<string>;
@@ -280,18 +304,22 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations2.ts:12:5: The last overload is declared here.
     var r8b = r8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     var s8: Promise<number>;
     var s8a = s8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345:   Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
     var s8b = s8.then(testFunction8P, testFunction8P, testFunction8P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345:   Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
     var s8c = s8.then(testFunction8P, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345:   Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
     var s8d = s8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     
     var r9: IPromise<number>;
@@ -300,6 +328,7 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations2.ts:12:5: The last overload is declared here.
     var r9b = r9.then(sIPromise, sIPromise, sIPromise); // ok
     var r9c = r9.then(nIPromise, nIPromise, nIPromise); // ok
@@ -316,12 +345,15 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
     var s9a = s9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345:   Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
     var s9b = s9.then(testFunction9P, testFunction9P, testFunction9P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345:   Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
     var s9c = s9.then(testFunction9P, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345:   Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
     var s9d = s9.then(sPromise, sPromise, sPromise); // ok
     var s9e = s9.then(nPromise, nPromise, nPromise); // ok
     var s9f = s9.then(testFunction, sIPromise, nIPromise); // error

--- a/tests/baselines/reference/promisePermutations3.errors.txt
+++ b/tests/baselines/reference/promisePermutations3.errors.txt
@@ -25,25 +25,33 @@ tests/cases/compiler/promisePermutations3.ts(83,19): error TS2769: No overload m
       Types of parameters 'x' and 'value' are incompatible.
         Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations3.ts(87,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+  Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(90,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(91,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+      Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
 tests/cases/compiler/promisePermutations3.ts(92,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(96,19): error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+  Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(99,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(100,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+      Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
 tests/cases/compiler/promisePermutations3.ts(101,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+      Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(105,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
@@ -55,28 +63,36 @@ tests/cases/compiler/promisePermutations3.ts(110,19): error TS2345: Argument of 
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations3.ts(116,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+  Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations3.ts(119,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations3.ts(120,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+      Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
 tests/cases/compiler/promisePermutations3.ts(121,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations3.ts(125,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+  Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations3.ts(128,33): error TS2345: Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => IPromise<number>'.
   Type 'IPromise<string>' is not assignable to type 'IPromise<number>'.
     Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations3.ts(131,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations3.ts(132,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+      Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
 tests/cases/compiler/promisePermutations3.ts(133,19): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+      Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 tests/cases/compiler/promisePermutations3.ts(136,33): error TS2769: No overload matches this call.
   The last overload gave the following error.
     Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => IPromise<number>'.
@@ -237,6 +253,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
     var r5a = r5.then(testFunction5, testFunction5, testFunction5); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2345:   Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
     var r5b = r5.then(sIPromise, sIPromise, sIPromise).then(sIPromise, sIPromise, sIPromise); // ok
     var s5: Promise<string>;
     var s5a = s5.then(testFunction5, testFunction5, testFunction5); // error
@@ -244,18 +261,21 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: (a: string) => string): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s5b = s5.then(testFunction5P, testFunction5P, testFunction5P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s5c = s5.then(testFunction5P, testFunction5, testFunction5); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: (a: string) => string): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s5d = s5.then(sPromise, sPromise, sPromise).then(sIPromise, sIPromise, sIPromise); // ok
     
@@ -263,6 +283,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
     var r6a = r6.then(testFunction6, testFunction6, testFunction6); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2345:   Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
     var r6b = r6.then(sIPromise, sIPromise, sIPromise).then(sIPromise, sIPromise, sIPromise); // ok
     var s6: Promise<string>;
     var s6a = s6.then(testFunction6, testFunction6, testFunction6); // error
@@ -270,18 +291,21 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: <T>(a: T) => T): IPromise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s6b = s6.then(testFunction6P, testFunction6P, testFunction6P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): Promise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s6c = s6.then(testFunction6P, testFunction6, testFunction6); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
+!!! error TS2769:       Call signature '(x: number, cb: <T>(a: T) => T): Promise<string>' expects more arguments than call signature '(value: string): IPromise<string>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s6d = s6.then(sPromise, sPromise, sPromise).then(sIPromise, sIPromise, sIPromise); // ok
     
@@ -314,6 +338,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
     var r8a = r8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345:   Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
     var r8b = r8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     var s8: Promise<number>;
     var s8a = s8.then(testFunction8, testFunction8, testFunction8); // error
@@ -321,18 +346,21 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: (a: T) => T): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s8b = s8.then(testFunction8P, testFunction8P, testFunction8P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s8c = s8.then(testFunction8P, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: (a: T) => T): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s8d = s8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     
@@ -340,6 +368,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
     var r9a = r9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345:   Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
     var r9b = r9.then(sIPromise, sIPromise, sIPromise); // ok
     var r9c = r9.then(nIPromise, nIPromise, nIPromise); // ok
     var r9d = r9.then(testFunction, sIPromise, nIPromise); // error
@@ -354,18 +383,21 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: <U>(a: U) => U): IPromise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s9b = s9.then(testFunction9P, testFunction9P, testFunction9P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): Promise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s9c = s9.then(testFunction9P, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2769:       Call signature '<T>(x: T, cb: <U>(a: U) => U): Promise<T>' expects more arguments than call signature '(value: number): IPromise<any>'.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s9d = s9.then(sPromise, sPromise, sPromise); // ok
     var s9e = s9.then(nPromise, nPromise, nPromise); // ok

--- a/tests/baselines/reference/requiredInitializedParameter2.errors.txt
+++ b/tests/baselines/reference/requiredInitializedParameter2.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/requiredInitializedParameter2.ts(6,5): error TS2416: Property 'method' in type 'C1' is not assignable to the same property in base type 'I1'.
   Type '(a: number, b: any) => void' is not assignable to type '() => any'.
+    Call signature '(a: number, b: any): void' expects more arguments than call signature '(): any'.
 
 
 ==== tests/cases/compiler/requiredInitializedParameter2.ts (1 errors) ====
@@ -12,4 +13,5 @@ tests/cases/compiler/requiredInitializedParameter2.ts(6,5): error TS2416: Proper
         ~~~~~~
 !!! error TS2416: Property 'method' in type 'C1' is not assignable to the same property in base type 'I1'.
 !!! error TS2416:   Type '(a: number, b: any) => void' is not assignable to type '() => any'.
+!!! error TS2416:     Call signature '(a: number, b: any): void' expects more arguments than call signature '(): any'.
     }

--- a/tests/baselines/reference/reverseMappedTypeContextualTypeNotCircular.errors.txt
+++ b/tests/baselines/reference/reverseMappedTypeContextualTypeNotCircular.errors.txt
@@ -1,4 +1,5 @@
 tests/cases/compiler/reverseMappedTypeContextualTypeNotCircular.ts(10,3): error TS2322: Type '(state: any, props: any) => {}' is not assignable to type 'Selector<unknown, {}>'.
+  Call signature '(state: any, props: any): {}' expects more arguments than call signature '(state: unknown): {}'.
 
 
 ==== tests/cases/compiler/reverseMappedTypeContextualTypeNotCircular.ts (1 errors) ====
@@ -14,5 +15,6 @@ tests/cases/compiler/reverseMappedTypeContextualTypeNotCircular.ts(10,3): error 
       editable: (state: any, props: any) => editable(), // expect "Type '(state: any, props: any) => {}' is not assignable to type 'Selector<unknown, {}>'", _not_ a circularity error
       ~~~~~~~~
 !!! error TS2322: Type '(state: any, props: any) => {}' is not assignable to type 'Selector<unknown, {}>'.
+!!! error TS2322:   Call signature '(state: any, props: any): {}' expects more arguments than call signature '(state: unknown): {}'.
 !!! related TS6500 tests/cases/compiler/reverseMappedTypeContextualTypeNotCircular.ts:10:3: The expected type comes from property 'editable' which is declared here on type '{ editable: Selector<unknown, {}>; }'
     });

--- a/tests/baselines/reference/signatureLengthMismatchCall.errors.txt
+++ b/tests/baselines/reference/signatureLengthMismatchCall.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/signatureLengthMismatchCall.ts(5,15): error TS2345: Argument of type '(a: number, b: number) => void' is not assignable to parameter of type '(a: number) => void'.
+  Call signature '(a: number, b: number): void' expects more arguments than call signature '(a: number): void'.
+
+
+==== tests/cases/compiler/signatureLengthMismatchCall.ts (1 errors) ====
+    function takesCallback(fn: (a: number) => void) {
+      // ...
+    }
+    
+    takesCallback((a: number, b: number) => {});
+                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '(a: number, b: number) => void' is not assignable to parameter of type '(a: number) => void'.
+!!! error TS2345:   Call signature '(a: number, b: number): void' expects more arguments than call signature '(a: number): void'.
+    

--- a/tests/baselines/reference/signatureLengthMismatchCall.js
+++ b/tests/baselines/reference/signatureLengthMismatchCall.js
@@ -1,0 +1,13 @@
+//// [signatureLengthMismatchCall.ts]
+function takesCallback(fn: (a: number) => void) {
+  // ...
+}
+
+takesCallback((a: number, b: number) => {});
+
+
+//// [signatureLengthMismatchCall.js]
+function takesCallback(fn) {
+    // ...
+}
+takesCallback(function (a, b) { });

--- a/tests/baselines/reference/signatureLengthMismatchCall.symbols
+++ b/tests/baselines/reference/signatureLengthMismatchCall.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/signatureLengthMismatchCall.ts ===
+function takesCallback(fn: (a: number) => void) {
+>takesCallback : Symbol(takesCallback, Decl(signatureLengthMismatchCall.ts, 0, 0))
+>fn : Symbol(fn, Decl(signatureLengthMismatchCall.ts, 0, 23))
+>a : Symbol(a, Decl(signatureLengthMismatchCall.ts, 0, 28))
+
+  // ...
+}
+
+takesCallback((a: number, b: number) => {});
+>takesCallback : Symbol(takesCallback, Decl(signatureLengthMismatchCall.ts, 0, 0))
+>a : Symbol(a, Decl(signatureLengthMismatchCall.ts, 4, 15))
+>b : Symbol(b, Decl(signatureLengthMismatchCall.ts, 4, 25))
+

--- a/tests/baselines/reference/signatureLengthMismatchCall.types
+++ b/tests/baselines/reference/signatureLengthMismatchCall.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/signatureLengthMismatchCall.ts ===
+function takesCallback(fn: (a: number) => void) {
+>takesCallback : (fn: (a: number) => void) => void
+>fn : (a: number) => void
+>a : number
+
+  // ...
+}
+
+takesCallback((a: number, b: number) => {});
+>takesCallback((a: number, b: number) => {}) : void
+>takesCallback : (fn: (a: number) => void) => void
+>(a: number, b: number) => {} : (a: number, b: number) => void
+>a : number
+>b : number
+

--- a/tests/baselines/reference/signatureLengthMismatchConstruct.errors.txt
+++ b/tests/baselines/reference/signatureLengthMismatchConstruct.errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/signatureLengthMismatchConstruct.ts(9,15): error TS2345: Argument of type 'typeof OverlongCtor' is not assignable to parameter of type 'new (a: number) => void'.
+  Types of construct signatures are incompatible.
+    Type 'new (a: number, b: number) => OverlongCtor' is not assignable to type 'new (a: number) => void'.
+      Construct signature '(a: number, b: number): OverlongCtor' expects more arguments than construct signature '(a: number): void'.
+
+
+==== tests/cases/compiler/signatureLengthMismatchConstruct.ts (1 errors) ====
+    function takesCallback(fn: new (a: number) => void) {
+      // ...
+    }
+    
+    class OverlongCtor {
+      constructor(a: number, b: number) {}
+    }
+    
+    takesCallback(OverlongCtor);
+                  ~~~~~~~~~~~~
+!!! error TS2345: Argument of type 'typeof OverlongCtor' is not assignable to parameter of type 'new (a: number) => void'.
+!!! error TS2345:   Types of construct signatures are incompatible.
+!!! error TS2345:     Type 'new (a: number, b: number) => OverlongCtor' is not assignable to type 'new (a: number) => void'.
+!!! error TS2345:       Construct signature '(a: number, b: number): OverlongCtor' expects more arguments than construct signature '(a: number): void'.
+    

--- a/tests/baselines/reference/signatureLengthMismatchConstruct.js
+++ b/tests/baselines/reference/signatureLengthMismatchConstruct.js
@@ -1,0 +1,22 @@
+//// [signatureLengthMismatchConstruct.ts]
+function takesCallback(fn: new (a: number) => void) {
+  // ...
+}
+
+class OverlongCtor {
+  constructor(a: number, b: number) {}
+}
+
+takesCallback(OverlongCtor);
+
+
+//// [signatureLengthMismatchConstruct.js]
+function takesCallback(fn) {
+    // ...
+}
+var OverlongCtor = /** @class */ (function () {
+    function OverlongCtor(a, b) {
+    }
+    return OverlongCtor;
+}());
+takesCallback(OverlongCtor);

--- a/tests/baselines/reference/signatureLengthMismatchConstruct.symbols
+++ b/tests/baselines/reference/signatureLengthMismatchConstruct.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/signatureLengthMismatchConstruct.ts ===
+function takesCallback(fn: new (a: number) => void) {
+>takesCallback : Symbol(takesCallback, Decl(signatureLengthMismatchConstruct.ts, 0, 0))
+>fn : Symbol(fn, Decl(signatureLengthMismatchConstruct.ts, 0, 23))
+>a : Symbol(a, Decl(signatureLengthMismatchConstruct.ts, 0, 32))
+
+  // ...
+}
+
+class OverlongCtor {
+>OverlongCtor : Symbol(OverlongCtor, Decl(signatureLengthMismatchConstruct.ts, 2, 1))
+
+  constructor(a: number, b: number) {}
+>a : Symbol(a, Decl(signatureLengthMismatchConstruct.ts, 5, 14))
+>b : Symbol(b, Decl(signatureLengthMismatchConstruct.ts, 5, 24))
+}
+
+takesCallback(OverlongCtor);
+>takesCallback : Symbol(takesCallback, Decl(signatureLengthMismatchConstruct.ts, 0, 0))
+>OverlongCtor : Symbol(OverlongCtor, Decl(signatureLengthMismatchConstruct.ts, 2, 1))
+

--- a/tests/baselines/reference/signatureLengthMismatchConstruct.types
+++ b/tests/baselines/reference/signatureLengthMismatchConstruct.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/signatureLengthMismatchConstruct.ts ===
+function takesCallback(fn: new (a: number) => void) {
+>takesCallback : (fn: new (a: number) => void) => void
+>fn : new (a: number) => void
+>a : number
+
+  // ...
+}
+
+class OverlongCtor {
+>OverlongCtor : OverlongCtor
+
+  constructor(a: number, b: number) {}
+>a : number
+>b : number
+}
+
+takesCallback(OverlongCtor);
+>takesCallback(OverlongCtor) : void
+>takesCallback : (fn: new (a: number) => void) => void
+>OverlongCtor : typeof OverlongCtor
+

--- a/tests/baselines/reference/subtypingWithCallSignaturesWithOptionalParameters.errors.txt
+++ b/tests/baselines/reference/subtypingWithCallSignaturesWithOptionalParameters.errors.txt
@@ -1,9 +1,11 @@
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithOptionalParameters.ts(19,11): error TS2430: Interface 'I3' incorrectly extends interface 'Base'.
   Types of property 'a' are incompatible.
     Type '(x: number) => number' is not assignable to type '() => number'.
+      Call signature '(x: number): number' expects more arguments than call signature '(): number'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithOptionalParameters.ts(49,11): error TS2430: Interface 'I10' incorrectly extends interface 'Base'.
   Types of property 'a3' are incompatible.
     Type '(x: number, y: number) => number' is not assignable to type '(x: number) => number'.
+      Call signature '(x: number, y: number): number' expects more arguments than call signature '(x: number): number'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithOptionalParameters.ts (2 errors) ====
@@ -30,6 +32,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I3' incorrectly extends interface 'Base'.
 !!! error TS2430:   Types of property 'a' are incompatible.
 !!! error TS2430:     Type '(x: number) => number' is not assignable to type '() => number'.
+!!! error TS2430:       Call signature '(x: number): number' expects more arguments than call signature '(): number'.
         a: (x: number) => number; // error, too many required params
     }
     
@@ -64,6 +67,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I10' incorrectly extends interface 'Base'.
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type '(x: number, y: number) => number' is not assignable to type '(x: number) => number'.
+!!! error TS2430:       Call signature '(x: number, y: number): number' expects more arguments than call signature '(x: number): number'.
         a3: (x: number, y: number) => number;  // error, too many required params
     }
     

--- a/tests/baselines/reference/subtypingWithConstructSignaturesWithOptionalParameters.errors.txt
+++ b/tests/baselines/reference/subtypingWithConstructSignaturesWithOptionalParameters.errors.txt
@@ -1,9 +1,11 @@
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignaturesWithOptionalParameters.ts(19,11): error TS2430: Interface 'I3' incorrectly extends interface 'Base'.
   Types of property 'a' are incompatible.
     Type 'new (x: number) => number' is not assignable to type 'new () => number'.
+      Construct signature '(x: number): number' expects more arguments than construct signature '(): number'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignaturesWithOptionalParameters.ts(49,11): error TS2430: Interface 'I10' incorrectly extends interface 'Base'.
   Types of property 'a3' are incompatible.
     Type 'new (x: number, y: number) => number' is not assignable to type 'new (x: number) => number'.
+      Construct signature '(x: number, y: number): number' expects more arguments than construct signature '(x: number): number'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignaturesWithOptionalParameters.ts (2 errors) ====
@@ -30,6 +32,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I3' incorrectly extends interface 'Base'.
 !!! error TS2430:   Types of property 'a' are incompatible.
 !!! error TS2430:     Type 'new (x: number) => number' is not assignable to type 'new () => number'.
+!!! error TS2430:       Construct signature '(x: number): number' expects more arguments than construct signature '(): number'.
         a: new (x: number) => number; // error, too many required params
     }
     
@@ -64,6 +67,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I10' incorrectly extends interface 'Base'.
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type 'new (x: number, y: number) => number' is not assignable to type 'new (x: number) => number'.
+!!! error TS2430:       Construct signature '(x: number, y: number): number' expects more arguments than construct signature '(x: number): number'.
         a3: new (x: number, y: number) => number;  // error, too many required params
     }
     

--- a/tests/baselines/reference/subtypingWithGenericCallSignaturesWithOptionalParameters.errors.txt
+++ b/tests/baselines/reference/subtypingWithGenericCallSignaturesWithOptionalParameters.errors.txt
@@ -1,9 +1,11 @@
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts(20,15): error TS2430: Interface 'I3<T>' incorrectly extends interface 'Base<T>'.
   Types of property 'a' are incompatible.
     Type '(x: T) => T' is not assignable to type '() => T'.
+      Call signature '(x: T): T' expects more arguments than call signature '(): T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts(50,15): error TS2430: Interface 'I10<T>' incorrectly extends interface 'Base<T>'.
   Types of property 'a3' are incompatible.
     Type '(x: T, y: T) => T' is not assignable to type '(x: T) => T'.
+      Call signature '(x: T, y: T): T' expects more arguments than call signature '(x: T): T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts(100,15): error TS2430: Interface 'I1<T>' incorrectly extends interface 'Base2'.
   The types returned by 'a()' are incompatible between these types.
     Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
@@ -15,6 +17,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts(108,15): error TS2430: Interface 'I3<T>' incorrectly extends interface 'Base2'.
   Types of property 'a' are incompatible.
     Type '(x: T) => T' is not assignable to type '<T>() => T'.
+      Call signature '(x: T): T' expects more arguments than call signature '<T>(): T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts(113,15): error TS2430: Interface 'I4<T>' incorrectly extends interface 'Base2'.
   The types returned by 'a2(...)' are incompatible between these types.
     Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
@@ -50,6 +53,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts(138,15): error TS2430: Interface 'I10<T>' incorrectly extends interface 'Base2'.
   Types of property 'a3' are incompatible.
     Type '(x: T, y: T) => T' is not assignable to type '<T>(x: T) => T'.
+      Call signature '(x: T, y: T): T' expects more arguments than call signature '<T>(x: T): T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts(143,15): error TS2430: Interface 'I11<T>' incorrectly extends interface 'Base2'.
   The types returned by 'a4(...)' are incompatible between these types.
     Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
@@ -97,9 +101,11 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts(196,15): error TS2430: Interface 'I3' incorrectly extends interface 'Base2'.
   Types of property 'a' are incompatible.
     Type '<T>(x: T) => T' is not assignable to type '<T>() => T'.
+      Call signature '<T>(x: T): T' expects more arguments than call signature '<T>(): T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts(226,15): error TS2430: Interface 'I10' incorrectly extends interface 'Base2'.
   Types of property 'a3' are incompatible.
     Type '<T>(x: T, y: T) => T' is not assignable to type '<T>(x: T) => T'.
+      Call signature '<T>(x: T, y: T): T' expects more arguments than call signature '<T>(x: T): T'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericCallSignaturesWithOptionalParameters.ts (22 errors) ====
@@ -127,6 +133,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I3<T>' incorrectly extends interface 'Base<T>'.
 !!! error TS2430:   Types of property 'a' are incompatible.
 !!! error TS2430:     Type '(x: T) => T' is not assignable to type '() => T'.
+!!! error TS2430:       Call signature '(x: T): T' expects more arguments than call signature '(): T'.
             a: (x: T) => T; // error, too many required params
         }
     
@@ -161,6 +168,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I10<T>' incorrectly extends interface 'Base<T>'.
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type '(x: T, y: T) => T' is not assignable to type '(x: T) => T'.
+!!! error TS2430:       Call signature '(x: T, y: T): T' expects more arguments than call signature '(x: T): T'.
             a3: (x: T, y: T) => T;  // error, too many required params
         }
     
@@ -235,6 +243,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I3<T>' incorrectly extends interface 'Base2'.
 !!! error TS2430:   Types of property 'a' are incompatible.
 !!! error TS2430:     Type '(x: T) => T' is not assignable to type '<T>() => T'.
+!!! error TS2430:       Call signature '(x: T): T' expects more arguments than call signature '<T>(): T'.
             a: (x: T) => T; 
         }
     
@@ -313,6 +322,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I10<T>' incorrectly extends interface 'Base2'.
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type '(x: T, y: T) => T' is not assignable to type '<T>(x: T) => T'.
+!!! error TS2430:       Call signature '(x: T, y: T): T' expects more arguments than call signature '<T>(x: T): T'.
             a3: (x: T, y: T) => T;  
         }
     
@@ -435,6 +445,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I3' incorrectly extends interface 'Base2'.
 !!! error TS2430:   Types of property 'a' are incompatible.
 !!! error TS2430:     Type '<T>(x: T) => T' is not assignable to type '<T>() => T'.
+!!! error TS2430:       Call signature '<T>(x: T): T' expects more arguments than call signature '<T>(): T'.
             a: <T>(x: T) => T; // error, not identical and contextual signature instatiation can't make inference from T to T
         }
     
@@ -469,6 +480,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I10' incorrectly extends interface 'Base2'.
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type '<T>(x: T, y: T) => T' is not assignable to type '<T>(x: T) => T'.
+!!! error TS2430:       Call signature '<T>(x: T, y: T): T' expects more arguments than call signature '<T>(x: T): T'.
             a3: <T>(x: T, y: T) => T;  // error, too many required params
         }
     

--- a/tests/baselines/reference/subtypingWithGenericConstructSignaturesWithOptionalParameters.errors.txt
+++ b/tests/baselines/reference/subtypingWithGenericConstructSignaturesWithOptionalParameters.errors.txt
@@ -1,9 +1,11 @@
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts(20,15): error TS2430: Interface 'I3<T>' incorrectly extends interface 'Base<T>'.
   Types of property 'a' are incompatible.
     Type 'new (x: T) => T' is not assignable to type 'new () => T'.
+      Construct signature '(x: T): T' expects more arguments than construct signature '(): T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts(50,15): error TS2430: Interface 'I10<T>' incorrectly extends interface 'Base<T>'.
   Types of property 'a3' are incompatible.
     Type 'new (x: T, y: T) => T' is not assignable to type 'new (x: T) => T'.
+      Construct signature '(x: T, y: T): T' expects more arguments than construct signature '(x: T): T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts(100,15): error TS2430: Interface 'I1<T>' incorrectly extends interface 'Base2'.
   The types returned by 'new a()' are incompatible between these types.
     Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
@@ -15,6 +17,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts(108,15): error TS2430: Interface 'I3<T>' incorrectly extends interface 'Base2'.
   Types of property 'a' are incompatible.
     Type 'new (x: T) => T' is not assignable to type 'new <T>() => T'.
+      Construct signature '(x: T): T' expects more arguments than construct signature '<T>(): T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts(113,15): error TS2430: Interface 'I4<T>' incorrectly extends interface 'Base2'.
   The types returned by 'new a2(...)' are incompatible between these types.
     Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
@@ -50,6 +53,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts(138,15): error TS2430: Interface 'I10<T>' incorrectly extends interface 'Base2'.
   Types of property 'a3' are incompatible.
     Type 'new (x: T, y: T) => T' is not assignable to type 'new <T>(x: T) => T'.
+      Construct signature '(x: T, y: T): T' expects more arguments than construct signature '<T>(x: T): T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts(143,15): error TS2430: Interface 'I11<T>' incorrectly extends interface 'Base2'.
   The types returned by 'new a4(...)' are incompatible between these types.
     Type 'T' is not assignable to type 'T'. Two different types with this name exist, but they are unrelated.
@@ -97,9 +101,11 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts(196,15): error TS2430: Interface 'I3' incorrectly extends interface 'Base2'.
   Types of property 'a' are incompatible.
     Type 'new <T>(x: T) => T' is not assignable to type 'new <T>() => T'.
+      Construct signature '<T>(x: T): T' expects more arguments than construct signature '<T>(): T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts(226,15): error TS2430: Interface 'I10' incorrectly extends interface 'Base2'.
   Types of property 'a3' are incompatible.
     Type 'new <T>(x: T, y: T) => T' is not assignable to type 'new <T>(x: T) => T'.
+      Construct signature '<T>(x: T, y: T): T' expects more arguments than construct signature '<T>(x: T): T'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithGenericConstructSignaturesWithOptionalParameters.ts (22 errors) ====
@@ -127,6 +133,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I3<T>' incorrectly extends interface 'Base<T>'.
 !!! error TS2430:   Types of property 'a' are incompatible.
 !!! error TS2430:     Type 'new (x: T) => T' is not assignable to type 'new () => T'.
+!!! error TS2430:       Construct signature '(x: T): T' expects more arguments than construct signature '(): T'.
             a: new (x: T) => T; // error, too many required params
         }
     
@@ -161,6 +168,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I10<T>' incorrectly extends interface 'Base<T>'.
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type 'new (x: T, y: T) => T' is not assignable to type 'new (x: T) => T'.
+!!! error TS2430:       Construct signature '(x: T, y: T): T' expects more arguments than construct signature '(x: T): T'.
             a3: new (x: T, y: T) => T;  // error, too many required params
         }
     
@@ -235,6 +243,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I3<T>' incorrectly extends interface 'Base2'.
 !!! error TS2430:   Types of property 'a' are incompatible.
 !!! error TS2430:     Type 'new (x: T) => T' is not assignable to type 'new <T>() => T'.
+!!! error TS2430:       Construct signature '(x: T): T' expects more arguments than construct signature '<T>(): T'.
             a: new (x: T) => T; 
         }
     
@@ -313,6 +322,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I10<T>' incorrectly extends interface 'Base2'.
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type 'new (x: T, y: T) => T' is not assignable to type 'new <T>(x: T) => T'.
+!!! error TS2430:       Construct signature '(x: T, y: T): T' expects more arguments than construct signature '<T>(x: T): T'.
             a3: new (x: T, y: T) => T;  
         }
     
@@ -435,6 +445,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I3' incorrectly extends interface 'Base2'.
 !!! error TS2430:   Types of property 'a' are incompatible.
 !!! error TS2430:     Type 'new <T>(x: T) => T' is not assignable to type 'new <T>() => T'.
+!!! error TS2430:       Construct signature '<T>(x: T): T' expects more arguments than construct signature '<T>(): T'.
             a: new <T>(x: T) => T; // error, not identical and contextual signature instatiation can't make inference from T to T
         }
     
@@ -469,6 +480,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430: Interface 'I10' incorrectly extends interface 'Base2'.
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type 'new <T>(x: T, y: T) => T' is not assignable to type 'new <T>(x: T) => T'.
+!!! error TS2430:       Construct signature '<T>(x: T, y: T): T' expects more arguments than construct signature '<T>(x: T): T'.
             a3: new <T>(x: T, y: T) => T;  // error, too many required params
         }
     

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments2.errors.txt
@@ -5,6 +5,7 @@ tests/cases/conformance/jsx/file.tsx(8,15): error TS2322: Type 'T & { "ignore-pr
 tests/cases/conformance/jsx/file.tsx(13,15): error TS2322: Type 'T' is not assignable to type 'IntrinsicAttributes & { prop: unknown; "ignore-prop": string; }'.
   Type 'T' is not assignable to type '{ prop: unknown; "ignore-prop": string; }'.
 tests/cases/conformance/jsx/file.tsx(20,19): error TS2322: Type '(a: number, b: string) => void' is not assignable to type '(arg: number) => void'.
+  Call signature '(a: number, b: string): void' expects more arguments than call signature '(arg: number): void'.
 tests/cases/conformance/jsx/file.tsx(31,52): error TS2322: Type '(val: string) => void' is not assignable to type '(selectedVal: number) => void'.
   Types of parameters 'val' and 'selectedVal' are incompatible.
     Type 'number' is not assignable to type 'string'.
@@ -43,6 +44,7 @@ tests/cases/conformance/jsx/file.tsx(31,52): error TS2322: Type '(val: string) =
         let o = <Link func={func} />
                       ~~~~
 !!! error TS2322: Type '(a: number, b: string) => void' is not assignable to type '(arg: number) => void'.
+!!! error TS2322:   Call signature '(a: number, b: string): void' expects more arguments than call signature '(arg: number): void'.
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:16:30: The expected type comes from property 'func' which is declared here on type 'IntrinsicAttributes & { func: (arg: number) => void; }'
     }
     

--- a/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
+++ b/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
@@ -27,6 +27,7 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(84,1):
   Type predicate 'p2 is A' is not assignable to 'p1 is A'.
     Parameter 'p2' is not in the same position as parameter 'p1'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(90,1): error TS2322: Type '(p1: any, p2: any, p3: any) => p1 is A' is not assignable to type '(p1: any, p2: any) => p1 is A'.
+  Call signature '(p1: any, p2: any, p3: any): p1 is A' expects more arguments than call signature '(p1: any, p2: any): p1 is A'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(95,9): error TS2749: 'b' refers to a value, but is being used as a type here. Did you mean 'typeof b'?
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(95,11): error TS1005: ',' expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(95,14): error TS1005: ',' expected.
@@ -211,6 +212,7 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(166,54
     assign3 = function(p1, p2, p3): p1 is A {
     ~~~~~~~
 !!! error TS2322: Type '(p1: any, p2: any, p3: any) => p1 is A' is not assignable to type '(p1: any, p2: any) => p1 is A'.
+!!! error TS2322:   Call signature '(p1: any, p2: any, p3: any): p1 is A' expects more arguments than call signature '(p1: any, p2: any): p1 is A'.
         return true;
     };
     

--- a/tests/cases/compiler/signatureLengthMismatchCall.ts
+++ b/tests/cases/compiler/signatureLengthMismatchCall.ts
@@ -1,0 +1,5 @@
+function takesCallback(fn: (a: number) => void) {
+  // ...
+}
+
+takesCallback((a: number, b: number) => {});

--- a/tests/cases/compiler/signatureLengthMismatchConstruct.ts
+++ b/tests/cases/compiler/signatureLengthMismatchConstruct.ts
@@ -1,0 +1,9 @@
+function takesCallback(fn: new (a: number) => void) {
+  // ...
+}
+
+class OverlongCtor {
+  constructor(a: number, b: number) {}
+}
+
+takesCallback(OverlongCtor);


### PR DESCRIPTION
Fixes #51429.

The first commit is straightforward.

The second is less straightforward. All it's doing differentiating between "call signature" and "construct signature", which I'm only doing because other diagnostics look like they make that distinction. Differentiating requires threading through knowledge of which kind of signature is being analyzed, which is why it's a larger change. The factoring is kind of weird, but if you don't care feel free to ignore the remainder of this PR message. Or if a bare "signature" is fine instead of differentiate "call signature" from "construct signature", I can back out the second commit and use that wording instead.

---

The signature kind is also used to derive the earlier `incompatibleErrorReporter` parameter of `compareSignaturesRelated` [^1]. This factoring is thus a bit weird, because `kind` is used both to derive a parameter and as a parameter itself. It might make more sense to derive `incompatibleReporter` inside of `signaturesRelatedTo`, though that would require moving more code around, and keeps the same number of parameters since the `reportIncompatibleConstructSignatureReturn` functions close over a value (namely `reportIncompatibleError`) which would need to get passed in.

[^1]: as in
    ```ts
    const incompatibleReporter = kind === SignatureKind.Construct
      ? reportIncompatibleConstructSignatureReturn
      : reportIncompatibleCallSignatureReturn;
    // ...
    compareSignaturesRelated(source, target, /*...*/, incompatibleReporter(source, target), kind)
    ```

I'm happy with any of
- leave it as is in this PR; it's good enough
- reword the error messages so that call and construct signatures do not need to be differentiated
- refactor `compareSignaturesRelated` so that the logic deriving `incompatibleReporter` is inside of `compareSignaturesRelated`
- some other option

Just let me know which you'd prefer