### PR TITLE
Add --no-typecheck option for runtests/runtests-parallel/min/local

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -591,11 +591,12 @@ export const watchLocal = task({
     dependencies: [localize, watchTsc, watchTsserver, watchServices, watchLssl, watchOtherOutputs, dts, watchSrc],
 });
 
+const runtestsDeps = [tests, generateLibs].concat(cmdLineOptions.typecheck ? [dts, buildSrc] : []);
 
 export const runTests = task({
     name: "runtests",
     description: "Runs the tests using the built run.js file.",
-    dependencies: [tests, generateLibs, dts, buildSrc],
+    dependencies: runtestsDeps,
     run: () => runConsoleTests(testRunner, "mocha-fivemat-progress-reporter", /*runInParallel*/ false),
 });
 // task("runtests").flags = {
@@ -617,7 +618,7 @@ export const runTests = task({
 export const runTestsParallel = task({
     name: "runtests-parallel",
     description: "Runs all the tests in parallel using the built run.js file.",
-    dependencies: [tests, generateLibs, dts, buildSrc],
+    dependencies: runtestsDeps,
     run: () => runConsoleTests(testRunner, "min", /*runInParallel*/ cmdLineOptions.workers > 1),
 });
 // task("runtests-parallel").flags = {

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -354,7 +354,7 @@ function entrypointBuildTask(options) {
 }
 
 
-const { main: tsc, watch: watchTsc } = entrypointBuildTask({
+const { main: tsc, build: buildTsc, watch: watchTsc } = entrypointBuildTask({
     name: "tsc",
     description: "Builds the command-line compiler",
     buildDeps: [generateDiagnostics],
@@ -392,7 +392,7 @@ export const dtsServices = task({
 });
 
 
-const { main: tsserver, watch: watchTsserver } = entrypointBuildTask({
+const { main: tsserver, build: buildTsserver, watch: watchTsserver } = entrypointBuildTask({
     name: "tsserver",
     description: "Builds the language server",
     buildDeps: [generateDiagnostics],
@@ -410,10 +410,15 @@ const { main: tsserver, watch: watchTsserver } = entrypointBuildTask({
 export { tsserver, watchTsserver };
 
 
+const buildMin = task({
+    name: "build-min",
+    dependencies: [buildTsc, buildTsserver],
+});
+
 export const min = task({
     name: "min",
     description: "Builds only tsc and tsserver",
-    dependencies: [tsc, tsserver],
+    dependencies: [tsc, tsserver].concat(cmdLineOptions.typecheck ? [buildMin] : []),
 });
 
 export const watchMin = task({
@@ -577,10 +582,15 @@ export const watchOtherOutputs = task({
     dependencies: [watchCancellationToken, watchTypingsInstaller, watchWatchGuard, generateTypesMap, copyBuiltLocalDiagnosticMessages],
 });
 
+const buildLocal = task({
+    name: "build-local",
+    dependencies: [buildTsc, buildTsserver, buildServices, buildLssl]
+});
+
 export const local = task({
     name: "local",
     description: "Builds the full compiler and services",
-    dependencies: [localize, tsc, tsserver, services, lssl, otherOutputs, dts, buildSrc],
+    dependencies: [localize, tsc, tsserver, services, lssl, otherOutputs, dts].concat(cmdLineOptions.typecheck ? [buildLocal] : []),
 });
 export default local;
 

--- a/scripts/build/options.mjs
+++ b/scripts/build/options.mjs
@@ -4,7 +4,7 @@ import os from "os";
 const ci = ["1", "true"].includes(process.env.CI ?? "");
 
 const parsed = minimist(process.argv.slice(2), {
-    boolean: ["dirty", "light", "colors", "lkg", "soft", "fix", "failed", "keepFailed", "force", "built", "ci", "bundle"],
+    boolean: ["dirty", "light", "colors", "lkg", "soft", "fix", "failed", "keepFailed", "force", "built", "ci", "bundle", "typecheck"],
     string: ["browser", "tests", "break", "host", "reporter", "stackTraceLimit", "timeout", "shards", "shardId"],
     alias: {
         /* eslint-disable quote-props */
@@ -39,7 +39,8 @@ const parsed = minimist(process.argv.slice(2), {
         dirty: false,
         built: false,
         ci,
-        bundle: true
+        bundle: true,
+        typecheck: true,
     }
 });
 
@@ -80,5 +81,6 @@ export default options;
  * @property {string} shardId
  * @property {string} break
  * @property {boolean} bundle
+ * @property {boolean} typecheck
  */
 void 0;


### PR DESCRIPTION
With this, you can run:

```
hereby runtests-parallel --no-typecheck
```

And it will start the tests immediately after bundling.

Maybe better would be to run typechecking in parallel off to the side and exit if that fails, but this is fine for a first attempt.

(`--typecheck=false` also works.)