### PR TITLE
Simplistic watch mode for runtests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "azure-devops-node-api": "^11.2.0",
                 "chai": "latest",
                 "chalk": "^4.1.2",
+                "chokidar": "^3.5.3",
                 "del": "^6.1.1",
                 "diff": "^5.1.0",
                 "esbuild": "^0.15.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "tsserver": "bin/tsserver"
             },
             "devDependencies": {
+                "@esfx/canceltoken": "^1.0.0",
                 "@octokit/rest": "latest",
                 "@types/chai": "latest",
                 "@types/fs-extra": "^9.0.13",
@@ -88,6 +89,38 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/@esfx/cancelable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0.tgz",
+            "integrity": "sha512-2dry/TuOT9ydpw86f396v09cyi/gLeGPIZSH4Gx+V/qKQaS/OXCRurCY+Cn8zkBfTAgFsjk9NE15d+LPo2kt9A==",
+            "dev": true,
+            "dependencies": {
+                "@esfx/disposable": "^1.0.0"
+            }
+        },
+        "node_modules/@esfx/canceltoken": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@esfx/canceltoken/-/canceltoken-1.0.0.tgz",
+            "integrity": "sha512-/TgdzC5O89w5v0TgwE2wcdtampWNAFOxzurCtb4RxYVr3m72yk3Bg82vMdznx+H9nnf28zVDR0PtpZO9FxmOkw==",
+            "dev": true,
+            "dependencies": {
+                "@esfx/cancelable": "^1.0.0",
+                "@esfx/disposable": "^1.0.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@esfx/canceltoken/node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
+        },
+        "node_modules/@esfx/disposable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0.tgz",
+            "integrity": "sha512-hu7EI+YxlEWEKrb2himbS13HNaq5mlUePASf99KeQqkiNeqiAZbKqG4w59uDcLZs8JrV3qJqS/NYib5ZMhbfTQ==",
+            "dev": true
         },
         "node_modules/@eslint/eslintrc": {
             "version": "1.3.3",
@@ -4472,6 +4505,40 @@
             "integrity": "sha512-+BoyIm4I8uJmH/QDIH0fu7MG0AEx9OXEDXnqptXCwKOlOqZiS4iraH1Nr7/ObLMokW3sOCeBNyD68ATcV9b9Ag==",
             "dev": true,
             "optional": true
+        },
+        "@esfx/cancelable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0.tgz",
+            "integrity": "sha512-2dry/TuOT9ydpw86f396v09cyi/gLeGPIZSH4Gx+V/qKQaS/OXCRurCY+Cn8zkBfTAgFsjk9NE15d+LPo2kt9A==",
+            "dev": true,
+            "requires": {
+                "@esfx/disposable": "^1.0.0"
+            }
+        },
+        "@esfx/canceltoken": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@esfx/canceltoken/-/canceltoken-1.0.0.tgz",
+            "integrity": "sha512-/TgdzC5O89w5v0TgwE2wcdtampWNAFOxzurCtb4RxYVr3m72yk3Bg82vMdznx+H9nnf28zVDR0PtpZO9FxmOkw==",
+            "dev": true,
+            "requires": {
+                "@esfx/cancelable": "^1.0.0",
+                "@esfx/disposable": "^1.0.0",
+                "tslib": "^2.4.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+                    "dev": true
+                }
+            }
+        },
+        "@esfx/disposable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0.tgz",
+            "integrity": "sha512-hu7EI+YxlEWEKrb2himbS13HNaq5mlUePASf99KeQqkiNeqiAZbKqG4w59uDcLZs8JrV3qJqS/NYib5ZMhbfTQ==",
+            "dev": true
         },
         "@eslint/eslintrc": {
             "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "!**/.gitattributes"
     ],
     "devDependencies": {
+        "@esfx/canceltoken": "^1.0.0",
         "@octokit/rest": "latest",
         "@types/chai": "latest",
         "@types/fs-extra": "^9.0.13",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "azure-devops-node-api": "^11.2.0",
         "chai": "latest",
         "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
         "del": "^6.1.1",
         "diff": "^5.1.0",
         "esbuild": "^0.15.13",

--- a/scripts/build/tests.mjs
+++ b/scripts/build/tests.mjs
@@ -17,8 +17,9 @@ export const localTest262Baseline = "internal/baselines/test262/local";
  * @param {string} runJs
  * @param {string} defaultReporter
  * @param {boolean} runInParallel
+ * @param {AbortSignal} [signal]
  */
-export async function runConsoleTests(runJs, defaultReporter, runInParallel) {
+export async function runConsoleTests(runJs, defaultReporter, runInParallel, signal) {
     let testTimeout = cmdLineOptions.timeout;
     const tests = cmdLineOptions.tests;
     const inspect = cmdLineOptions.break || cmdLineOptions.inspect;
@@ -114,7 +115,7 @@ export async function runConsoleTests(runJs, defaultReporter, runInParallel) {
 
     try {
         setNodeEnvToDevelopment();
-        const { exitCode } = await exec(process.execPath, args);
+        const { exitCode } = await exec(process.execPath, args, { signal });
         if (exitCode !== 0) {
             errorStatus = exitCode;
             error = new Error(`Process exited with status code ${errorStatus}.`);

--- a/scripts/build/utils.mjs
+++ b/scripts/build/utils.mjs
@@ -173,7 +173,7 @@ export class Deferred {
 export class Debouncer {
     /**
      * @param {number} timeout
-     * @param {() => Promise<any>} action
+     * @param {() => Promise<any> | void} action
      */
     constructor(timeout, action) {
         this._timeout = timeout;

--- a/scripts/build/utils.mjs
+++ b/scripts/build/utils.mjs
@@ -7,6 +7,7 @@ import which from "which";
 import { spawn } from "child_process";
 import assert from "assert";
 import JSONC from "jsonc-parser";
+import { CancelError } from "@esfx/canceltoken";
 
 /**
  * Executes the provided command once with the supplied arguments.
@@ -18,7 +19,7 @@ import JSONC from "jsonc-parser";
  * @property {boolean} [ignoreExitCode]
  * @property {boolean} [hidePrompt]
  * @property {boolean} [waitForExit=true]
- * @property {AbortSignal} [signal]
+ * @property {import("@esfx/canceltoken").CancelToken} [token]
  */
 export async function exec(cmd, args, options = {}) {
     return /**@type {Promise<{exitCode?: number}>}*/(new Promise((resolve, reject) => {
@@ -27,22 +28,24 @@ export async function exec(cmd, args, options = {}) {
         if (!options.hidePrompt) console.log(`> ${chalk.green(cmd)} ${args.join(" ")}`);
         const proc = spawn(which.sync(cmd), args, { stdio: waitForExit ? "inherit" : "ignore" });
         if (waitForExit) {
-            const onAbort = () => {
+            const onCanceled = () => {
                 proc.kill();
             };
-            options.signal?.addEventListener("abort", onAbort, { once: true });
+            const subscription = options.token?.subscribe(onCanceled);
             proc.on("exit", exitCode => {
                 if (exitCode === 0 || ignoreExitCode) {
                     resolve({ exitCode: exitCode ?? undefined });
                 }
                 else {
-                    reject(new Error(`Process exited with code: ${exitCode}`));
+                    const reason = options.token?.signaled ? options.token.reason ?? new CancelError() :
+                        new Error(`Process exited with code: ${exitCode}`);
+                    reject(reason);
                 }
-                options?.signal?.removeEventListener("abort", onAbort);
+                subscription?.unsubscribe();
             });
             proc.on("error", error => {
                 reject(error);
-                options?.signal?.removeEventListener("abort", onAbort);
+                subscription?.unsubscribe();
             });
         }
         else {


### PR DESCRIPTION
This adds a rudimentary watch mode for use with `runtests`, with the following caveats:

- Does not work with `runtests-parallel`
- Not designed to run all tests (it would do so very slowly). Requires either `--tests <pattern>` (`-t <pattern>`) or `--failed`.
- Uses `watch-tests` task to update `run.js`, looks for changes to `run.js` and various paths under `tests/*`.
- Debounces multiple file changes in close succession.
- Aborts in-progress test runs when changes are detected.
- Existing watch mode may not be 100% reliable.

Usage:

```sh
# using hereby
$ hereby runtests-watch -t <pattern>

# using gulp
$ gulp runtests-watch -t <pattern>
```