### PR TITLE
Fix missing awaits in Herebyfile

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -141,7 +141,7 @@ const localize = task({
     dependencies: [generateDiagnostics],
     run: async () => {
         if (needsUpdate(diagnosticMessagesGeneratedJson, generatedLCGFile)) {
-            return exec(process.execPath, ["scripts/generateLocalizedDiagnosticMessages.mjs", "src/loc/lcl", "built/local", diagnosticMessagesGeneratedJson], { ignoreExitCode: true });
+            await exec(process.execPath, ["scripts/generateLocalizedDiagnosticMessages.mjs", "src/loc/lcl", "built/local", diagnosticMessagesGeneratedJson], { ignoreExitCode: true });
         }
     }
 });
@@ -386,7 +386,7 @@ export const dtsServices = task({
     dependencies: [buildServices],
     run: async () => {
         if (needsUpdate("./built/local/typescript/tsconfig.tsbuildinfo", ["./built/local/typescript.d.ts", "./built/local/typescript.internal.d.ts"])) {
-            runDtsBundler("./built/local/typescript/typescript.d.ts", "./built/local/typescript.d.ts");
+            await runDtsBundler("./built/local/typescript/typescript.d.ts", "./built/local/typescript.d.ts");
         }
     },
 });


### PR DESCRIPTION
I screwed this up during a rebase. These need to be awaited; if it's working now, it's because it raced just right.

Noticed because https://github.com/microsoft/TypeScript/actions/runs/3425632138/jobs/5706608686 failed in a way that shouldn't have been possible.