### PR TITLE
Fix smoke test substitution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,10 @@ jobs:
             success = !!fn();
           }
           catch {}
-          if (success !== shouldSucceed) {
+          if (success === shouldSucceed) {
+            console.log(`${fn.toString()} behaved as expected.`);
+          }
+          else {
             if (success) {
               console.error(`${fn.toString()} unexpectedly succeeded.`);
             }
@@ -142,6 +145,7 @@ jobs:
             process.exitCode = 1;
           }
         }
+        console.log("ok");
         EOF
 
         node ./smoke.js typescript

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,14 @@ jobs:
         npm init --yes
         npm install $PACKAGE tslib
 
+        echo "Testing tsc..."
         npx tsc --version
+
+        echo "Testing tsserver..."
         echo '{"seq": 1, "command": "status"}' | npx tsserver
 
         cat > smoke.js << 'EOF'
+        console.log(`Testing ${process.argv[2]}...`);
         const { __importDefault, __importStar } = require("tslib");
         const ts = require(process.argv[2]);
 
@@ -132,16 +136,12 @@ jobs:
             success = !!fn();
           }
           catch {}
+          const status = success ? "succeeded" : "failed";
           if (success === shouldSucceed) {
-            console.log(`${fn.toString()} behaved as expected.`);
+            console.log(`${fn.toString()} ${status} as expected.`);
           }
           else {
-            if (success) {
-              console.error(`${fn.toString()} unexpectedly succeeded.`);
-            }
-            else {
-              console.error(`${fn.toString()} did not succeed.`);
-            }
+            console.log(`${fn.toString()} unexpectedly ${status}.`);
             process.exitCode = 1;
           }
         }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         npx tsc --version
         echo '{"seq": 1, "command": "status"}' | npx tsserver
 
-        cat > smoke.js << EOF
+        cat > smoke.js << 'EOF'
         const { __importDefault, __importStar } = require("tslib");
         const ts = require(process.argv[2]);
 


### PR DESCRIPTION
I just merged the smoke test from #51464, but while it passed, I reread the logs on main and saw that it didn't actually work as expected; the heredoc wasn't in the right format and so was interpolating some of the code when I just wanted it raw.

Maybe I should just make it a script in the repo :\