### PR TITLE
Potentially enhanced typings for `ProxyHandler` traps

### DIFF
--- a/src/lib/es2015.proxy.d.ts
+++ b/src/lib/es2015.proxy.d.ts
@@ -1,27 +1,25 @@
-type ProxyParameters<T> = T extends (...args: infer P) => any ? P : never;
-type ProxyConstructorParameters<T> = T extends abstract new (...args: infer P) => any ? P : never;
-type ProxyConstructorFunction<T> = T extends { constructor: infer C } ? C : never;
+type ApplyTrap<T> = T extends (...args: infer P) => any ? (target: T, thisArg: any, argArray: P) => any : never;
 
 interface ProxyHandler<T extends object> {
     /**
      * A trap method for a function call.
      * @param target The original callable object which is being proxied.
      */
-    apply?(target: T, thisArg: any, argArray: ProxyParameters<T>): any;
+    apply?: ApplyTrap<T>;
 
     /**
      * A trap for the `new` operator.
      * @param target The original object which is being proxied.
      * @param newTarget The constructor that was originally called.
      */
-    construct?(target: T, argArray: ProxyConstructorParameters<T>, newTarget: ProxyConstructorFunction<T>): object;
+    construct?(target: T, argArray: any[], newTarget: Function): object;
 
     /**
      * A trap for `Object.defineProperty()`.
      * @param target The original object which is being proxied.
      * @returns A `Boolean` indicating whether or not the property has been defined.
      */
-    defineProperty?(target: T, property: keyof T, attributes: PropertyDescriptor): boolean;
+    defineProperty?(target: T, property: string | symbol, attributes: PropertyDescriptor): boolean;
 
     /**
      * A trap for the `delete` operator.
@@ -69,7 +67,7 @@ interface ProxyHandler<T extends object> {
      * A trap for `Reflect.ownKeys()`.
      * @param target The original object which is being proxied.
      */
-    ownKeys?(target: T): ArrayLike<keyof T>;
+    ownKeys?(target: T): ArrayLike<string | symbol>;
 
     /**
      * A trap for `Object.preventExtensions()`.

--- a/src/lib/es2015.proxy.d.ts
+++ b/src/lib/es2015.proxy.d.ts
@@ -1,23 +1,27 @@
+type ProxyParameters<T> = T extends (...args: infer P) => any ? P : never;
+type ProxyConstructorParameters<T> = T extends abstract new (...args: infer P) => any ? P : never;
+type ProxyConstructorFunction<T> = T extends { constructor: infer C } ? C : never;
+
 interface ProxyHandler<T extends object> {
     /**
      * A trap method for a function call.
      * @param target The original callable object which is being proxied.
      */
-    apply?(target: T, thisArg: any, argArray: any[]): any;
+    apply?(target: T, thisArg: any, argArray: ProxyParameters<T>): any;
 
     /**
      * A trap for the `new` operator.
      * @param target The original object which is being proxied.
      * @param newTarget The constructor that was originally called.
      */
-    construct?(target: T, argArray: any[], newTarget: Function): object;
+    construct?(target: T, argArray: ProxyConstructorParameters<T>, newTarget: ProxyConstructorFunction<T>): object;
 
     /**
      * A trap for `Object.defineProperty()`.
      * @param target The original object which is being proxied.
      * @returns A `Boolean` indicating whether or not the property has been defined.
      */
-    defineProperty?(target: T, property: string | symbol, attributes: PropertyDescriptor): boolean;
+    defineProperty?(target: T, property: keyof T, attributes: PropertyDescriptor): boolean;
 
     /**
      * A trap for the `delete` operator.
@@ -25,7 +29,7 @@ interface ProxyHandler<T extends object> {
      * @param p The name or `Symbol` of the property to delete.
      * @returns A `Boolean` indicating whether or not the property was deleted.
      */
-    deleteProperty?(target: T, p: string | symbol): boolean;
+    deleteProperty?(target: T, p: keyof T): boolean;
 
     /**
      * A trap for getting a property value.
@@ -33,14 +37,14 @@ interface ProxyHandler<T extends object> {
      * @param p The name or `Symbol` of the property to get.
      * @param receiver The proxy or an object that inherits from the proxy.
      */
-    get?(target: T, p: string | symbol, receiver: any): any;
+    get?(target: T, p: keyof T, receiver: any): any;
 
     /**
      * A trap for `Object.getOwnPropertyDescriptor()`.
      * @param target The original object which is being proxied.
      * @param p The name of the property whose description should be retrieved.
      */
-    getOwnPropertyDescriptor?(target: T, p: string | symbol): PropertyDescriptor | undefined;
+    getOwnPropertyDescriptor?(target: T, p: keyof T): PropertyDescriptor | undefined;
 
     /**
      * A trap for the `[[GetPrototypeOf]]` internal method.
@@ -53,7 +57,7 @@ interface ProxyHandler<T extends object> {
      * @param target The original object which is being proxied.
      * @param p The name or `Symbol` of the property to check for existence.
      */
-    has?(target: T, p: string | symbol): boolean;
+    has?(target: T, p: keyof T): boolean;
 
     /**
      * A trap for `Object.isExtensible()`.
@@ -65,7 +69,7 @@ interface ProxyHandler<T extends object> {
      * A trap for `Reflect.ownKeys()`.
      * @param target The original object which is being proxied.
      */
-    ownKeys?(target: T): ArrayLike<string | symbol>;
+    ownKeys?(target: T): ArrayLike<keyof T>;
 
     /**
      * A trap for `Object.preventExtensions()`.
@@ -80,7 +84,7 @@ interface ProxyHandler<T extends object> {
      * @param receiver The object to which the assignment was originally directed.
      * @returns A `Boolean` indicating whether or not the property was set.
      */
-    set?(target: T, p: string | symbol, newValue: any, receiver: any): boolean;
+    set?(target: T, p: keyof T, newValue: any, receiver: any): boolean;
 
     /**
      * A trap for `Object.setPrototypeOf()`.


### PR DESCRIPTION
# Linked issue: https://github.com/microsoft/TypeScript/issues/51514

<!--
Thank you for submitting a pull request!

Please verify that:
* [ x ] There is an associated issue in the `Backlog` milestone (**required**)
* [ x ] Code is up-to-date with the `main` branch
* [ x ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

# Proposes a better `apply` trap handler & narrower types on trap `property` access.

### Change 1: `apply`
If I'm understanding the `Proxy` spec correctly [here](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist), we _should_ be able to infer that `argArray` is of type `Parameters<T>`, since the target object needs an `apply` method in the first place, therefore should be `Function`-like. 

I don't think we can't use the `Parameters` type built-in easily here, since we haven't sufficiently narrowed `T`, so we have our own variant. Open to suggestions here if there's a better way.

### Change 2: Type narrowing of `property` access in following traps:`deleteProperty`, `get`, `getOwnPropertyDescriptor`, `has` 
It seems that we should be able to narrow the type on traps which access symbols on the target object from `string | symbol` to `keyof T`. Since a consumer of a proxy object would be interfacing with type `T`, when we trap these calls, we should be able to infer that callers accessed properties on `T`. 

Follow-ups:
- I think there's probably some low-lift enhancement of the `construct` trap to, seems that `argArray` and `newTarget` should be similarly inferable to `apply`
- Happy to write tests if this ends up being a desirable change. 
