### PR TITLE
feat: dependent contextual inference

### DIFF
--- a/tests/baselines/reference/dependentContextualInference1.js
+++ b/tests/baselines/reference/dependentContextualInference1.js
@@ -1,0 +1,20 @@
+//// [dependentContextualInference1.ts]
+declare const f:
+  <T extends F<T>>(t: T) => T
+
+type F<T> =
+  { a: unknown
+  , b: (a: T["a" & keyof T]) => unknown
+  }
+
+f({
+  a: "hello",
+  b: x => x.toUpperCase()
+})
+
+
+//// [dependentContextualInference1.js]
+f({
+    a: "hello",
+    b: function (x) { return x.toUpperCase(); }
+});

--- a/tests/baselines/reference/dependentContextualInference1.symbols
+++ b/tests/baselines/reference/dependentContextualInference1.symbols
@@ -1,0 +1,41 @@
+=== tests/cases/compiler/dependentContextualInference1.ts ===
+declare const f:
+>f : Symbol(f, Decl(dependentContextualInference1.ts, 0, 13))
+
+  <T extends F<T>>(t: T) => T
+>T : Symbol(T, Decl(dependentContextualInference1.ts, 1, 3))
+>F : Symbol(F, Decl(dependentContextualInference1.ts, 1, 29))
+>T : Symbol(T, Decl(dependentContextualInference1.ts, 1, 3))
+>t : Symbol(t, Decl(dependentContextualInference1.ts, 1, 19))
+>T : Symbol(T, Decl(dependentContextualInference1.ts, 1, 3))
+>T : Symbol(T, Decl(dependentContextualInference1.ts, 1, 3))
+
+type F<T> =
+>F : Symbol(F, Decl(dependentContextualInference1.ts, 1, 29))
+>T : Symbol(T, Decl(dependentContextualInference1.ts, 3, 7))
+
+  { a: unknown
+>a : Symbol(a, Decl(dependentContextualInference1.ts, 4, 3))
+
+  , b: (a: T["a" & keyof T]) => unknown
+>b : Symbol(b, Decl(dependentContextualInference1.ts, 5, 3))
+>a : Symbol(a, Decl(dependentContextualInference1.ts, 5, 8))
+>T : Symbol(T, Decl(dependentContextualInference1.ts, 3, 7))
+>T : Symbol(T, Decl(dependentContextualInference1.ts, 3, 7))
+  }
+
+f({
+>f : Symbol(f, Decl(dependentContextualInference1.ts, 0, 13))
+
+  a: "hello",
+>a : Symbol(a, Decl(dependentContextualInference1.ts, 8, 3))
+
+  b: x => x.toUpperCase()
+>b : Symbol(b, Decl(dependentContextualInference1.ts, 9, 13))
+>x : Symbol(x, Decl(dependentContextualInference1.ts, 10, 4))
+>x.toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(dependentContextualInference1.ts, 10, 4))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+
+})
+

--- a/tests/baselines/reference/dependentContextualInference1.types
+++ b/tests/baselines/reference/dependentContextualInference1.types
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/dependentContextualInference1.ts ===
+declare const f:
+>f : <T extends F<T>>(t: T) => T
+
+  <T extends F<T>>(t: T) => T
+>t : T
+
+type F<T> =
+>F : F<T>
+
+  { a: unknown
+>a : unknown
+
+  , b: (a: T["a" & keyof T]) => unknown
+>b : (a: T["a" & keyof T]) => unknown
+>a : T["a" & keyof T]
+  }
+
+f({
+>f({  a: "hello",  b: x => x.toUpperCase()}) : { a: string; b: (x: string) => string; }
+>f : <T extends F<T>>(t: T) => T
+>{  a: "hello",  b: x => x.toUpperCase()} : { a: string; b: (x: string) => string; }
+
+  a: "hello",
+>a : string
+>"hello" : "hello"
+
+  b: x => x.toUpperCase()
+>b : (x: string) => string
+>x => x.toUpperCase() : (x: string) => string
+>x : string
+>x.toUpperCase() : string
+>x.toUpperCase : () => string
+>x : string
+>toUpperCase : () => string
+
+})
+

--- a/tests/baselines/reference/dependentContextualInference2.js
+++ b/tests/baselines/reference/dependentContextualInference2.js
@@ -1,0 +1,25 @@
+//// [dependentContextualInference2.ts]
+declare const m: <T extends M<T>>(m: T) => T
+type M<Self> =
+  { a?: number
+  , b?: number
+  , c?: number
+  , d?: number
+  , k?: Exclude<keyof Self, "k" | "t">
+  , t?: (k: Exclude<keyof Self, "k" | "t">) => void
+  }
+
+m({
+  a: 1,
+  b: 2,
+  k: "a", 
+  t: k => {}
+})
+
+//// [dependentContextualInference2.js]
+m({
+    a: 1,
+    b: 2,
+    k: "a",
+    t: function (k) { }
+});

--- a/tests/baselines/reference/dependentContextualInference2.symbols
+++ b/tests/baselines/reference/dependentContextualInference2.symbols
@@ -1,0 +1,55 @@
+=== tests/cases/compiler/dependentContextualInference2.ts ===
+declare const m: <T extends M<T>>(m: T) => T
+>m : Symbol(m, Decl(dependentContextualInference2.ts, 0, 13))
+>T : Symbol(T, Decl(dependentContextualInference2.ts, 0, 18))
+>M : Symbol(M, Decl(dependentContextualInference2.ts, 0, 44))
+>T : Symbol(T, Decl(dependentContextualInference2.ts, 0, 18))
+>m : Symbol(m, Decl(dependentContextualInference2.ts, 0, 34))
+>T : Symbol(T, Decl(dependentContextualInference2.ts, 0, 18))
+>T : Symbol(T, Decl(dependentContextualInference2.ts, 0, 18))
+
+type M<Self> =
+>M : Symbol(M, Decl(dependentContextualInference2.ts, 0, 44))
+>Self : Symbol(Self, Decl(dependentContextualInference2.ts, 1, 7))
+
+  { a?: number
+>a : Symbol(a, Decl(dependentContextualInference2.ts, 2, 3))
+
+  , b?: number
+>b : Symbol(b, Decl(dependentContextualInference2.ts, 3, 3))
+
+  , c?: number
+>c : Symbol(c, Decl(dependentContextualInference2.ts, 4, 3))
+
+  , d?: number
+>d : Symbol(d, Decl(dependentContextualInference2.ts, 5, 3))
+
+  , k?: Exclude<keyof Self, "k" | "t">
+>k : Symbol(k, Decl(dependentContextualInference2.ts, 6, 3))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+>Self : Symbol(Self, Decl(dependentContextualInference2.ts, 1, 7))
+
+  , t?: (k: Exclude<keyof Self, "k" | "t">) => void
+>t : Symbol(t, Decl(dependentContextualInference2.ts, 7, 3))
+>k : Symbol(k, Decl(dependentContextualInference2.ts, 7, 9))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+>Self : Symbol(Self, Decl(dependentContextualInference2.ts, 1, 7))
+  }
+
+m({
+>m : Symbol(m, Decl(dependentContextualInference2.ts, 0, 13))
+
+  a: 1,
+>a : Symbol(a, Decl(dependentContextualInference2.ts, 10, 3))
+
+  b: 2,
+>b : Symbol(b, Decl(dependentContextualInference2.ts, 11, 7))
+
+  k: "a", 
+>k : Symbol(k, Decl(dependentContextualInference2.ts, 12, 7))
+
+  t: k => {}
+>t : Symbol(t, Decl(dependentContextualInference2.ts, 13, 9))
+>k : Symbol(k, Decl(dependentContextualInference2.ts, 14, 4))
+
+})

--- a/tests/baselines/reference/dependentContextualInference2.types
+++ b/tests/baselines/reference/dependentContextualInference2.types
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/dependentContextualInference2.ts ===
+declare const m: <T extends M<T>>(m: T) => T
+>m : <T extends M<T>>(m: T) => T
+>m : T
+
+type M<Self> =
+>M : M<Self>
+
+  { a?: number
+>a : number
+
+  , b?: number
+>b : number
+
+  , c?: number
+>c : number
+
+  , d?: number
+>d : number
+
+  , k?: Exclude<keyof Self, "k" | "t">
+>k : Exclude<keyof Self, "k" | "t">
+
+  , t?: (k: Exclude<keyof Self, "k" | "t">) => void
+>t : (k: Exclude<keyof Self, "k" | "t">) => void
+>k : Exclude<keyof Self, "k" | "t">
+  }
+
+m({
+>m({  a: 1,  b: 2,  k: "a",   t: k => {}}) : { a: number; b: number; k: "a"; t: (k: "a" | "b") => void; }
+>m : <T extends M<T>>(m: T) => T
+>{  a: 1,  b: 2,  k: "a",   t: k => {}} : { a: number; b: number; k: "a"; t: (k: "a" | "b") => void; }
+
+  a: 1,
+>a : number
+>1 : 1
+
+  b: 2,
+>b : number
+>2 : 2
+
+  k: "a", 
+>k : "a"
+>"a" : "a"
+
+  t: k => {}
+>t : (k: "a" | "b") => void
+>k => {} : (k: "a" | "b") => void
+>k : "a" | "b"
+
+})

--- a/tests/cases/compiler/dependentContextualInference1.ts
+++ b/tests/cases/compiler/dependentContextualInference1.ts
@@ -1,0 +1,12 @@
+declare const f:
+  <T extends F<T>>(t: T) => T
+
+type F<T> =
+  { a: unknown
+  , b: (a: T["a" & keyof T]) => unknown
+  }
+
+f({
+  a: "hello",
+  b: x => x.toUpperCase()
+})

--- a/tests/cases/compiler/dependentContextualInference2.ts
+++ b/tests/cases/compiler/dependentContextualInference2.ts
@@ -1,0 +1,16 @@
+declare const m: <T extends M<T>>(m: T) => T
+type M<Self> =
+  { a?: number
+  , b?: number
+  , c?: number
+  , d?: number
+  , k?: Exclude<keyof Self, "k" | "t">
+  , t?: (k: Exclude<keyof Self, "k" | "t">) => void
+  }
+
+m({
+  a: 1,
+  b: 2,
+  k: "a", 
+  t: k => {}
+})


### PR DESCRIPTION
Fixes #51377, #40439

This PR adds support for what I'm calling "dependent contextual inference"... Sometimes the type for a value depends on the value itself (see linked issues), in those cases the contextual type of the value becomes something like `T extends F<T>`. Here what you'd want to do is first check the value against the contextual type `T extends F<T>` (which is what already happens), let's say the type of the value was inferrred to X, and then (this is the new part) do a second check against the contextual type `T extends F<X>` and that would be the final contextually inferred type of the value

Consider this PR a shabby experiment, I want to first get a green light if we want to do something like this, if yes then I can work on it further.

If ya'll prefer me opening an issue proposing this change and discussing it there first then let me know. Types like `T extends F<T>` pop up when you're typing DSLs and it'd be really great if we could support them better.

Also note that most of this is a sophisticated guesswork, I know what I wanted to do but I don't know shit about the codebase or compilers xD, so there would probably be better ways to write it (I'll leave some review comments).

Also leaving some todos:
- [ ] support all values and not just object literals
- [ ] support all kinds of circular type parameters, ie `T extends <any-type-that-has-T>`, not just `T extends F<T>`
- [ ] multiple passes? I think in some cases two passes won't suffice, in theory you'd probably keep doing checks till you get the same type back
