### PR TITLE
Try disabling object-rest-spread

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -216,6 +216,9 @@ function createBundler(entrypoint, outfile, taskOptions = {}) {
             ],
             logLevel: "warning",
             // legalComments: "none", // If we add copyright headers to the source files, uncomment.
+            supported: {
+                "object-rest-spread": false,
+            },
             plugins: [
                 {
                     name: "no-node-modules",


### PR DESCRIPTION
See: https://github.com/evanw/esbuild/blob/master/CHANGELOG.md#01446

In the module conversion, I opted to not disable this as my local perf testing between node versions seemed to imply it was no longer an issue.

But, I'd like to see what our perf infra says.