### PR TITLE
Cherry-pick fix around `visitEachChild` to release-4.9.

### DIFF
--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -1304,9 +1304,9 @@ namespace ts {
         },
 
         // Top-level nodes
-        [SyntaxKind.SourceFile]: function visitEachChildOfSourceFile(node, visitor, context, nodesVisitor, _nodeVisitor, _tokenVisitor) {
+        [SyntaxKind.SourceFile]: function visitEachChildOfSourceFile(node, visitor, context, _nodesVisitor, _nodeVisitor, _tokenVisitor) {
             return context.factory.updateSourceFile(node,
-                visitLexicalEnvironment(node.statements, visitor, context, /*start*/ undefined, /*ensureUseStrict*/ undefined, nodesVisitor));
+                visitLexicalEnvironment(node.statements, visitor, context));
         },
 
         // Transformation nodes


### PR DESCRIPTION
Manually brings in #51543 to `release-4.9`.