### PR TITLE
Consistently respect --no-typecheck flag in build

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,7 @@
             // https://github.com/microsoft/vscode/issues/93001
             "label": "gulp: tests",
             "type": "npm",
-            "script": "build:tests",
+            "script": "build:tests -- --no-typecheck",
             "group": "build",
             "hide": true,
             "problemMatcher": [
@@ -44,7 +44,7 @@
         {
             "label": "npm: build:tests",
             "type": "npm",
-            "script": "build:tests",
+            "script": "build:tests -- --no-typecheck",
             "group": "build",
             "problemMatcher": [
                 "$tsc"

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -611,7 +611,7 @@ export const watchLocal = task({
     dependencies: [localize, watchTsc, watchTsserver, watchServices, watchLssl, watchOtherOutputs, dts, watchSrc],
 });
 
-const runtestsDeps = [tests, generateLibs];
+const runtestsDeps = [tests, generateLibs, dts];
 
 export const runTests = task({
     name: "runtests",

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -328,10 +328,21 @@ function entrypointBuildTask(options) {
         },
     });
 
+    const mainDeps = options.mainDeps?.slice(0) ?? [];
+    if (cmdLineOptions.bundle) {
+        mainDeps.push(bundle);
+        if (cmdLineOptions.typecheck) {
+            mainDeps.push(build);
+        }
+    }
+    else {
+        mainDeps.push(build, shim);
+    }
+
     const main = task({
         name: options.name,
         description: options.description,
-        dependencies: (options.mainDeps ?? []).concat(cmdLineOptions.bundle ? [bundle] : [build, shim]),
+        dependencies: mainDeps,
     });
 
     const watch = task({
@@ -358,7 +369,7 @@ function entrypointBuildTask(options) {
 }
 
 
-const { main: tsc, build: buildTsc, watch: watchTsc } = entrypointBuildTask({
+const { main: tsc, watch: watchTsc } = entrypointBuildTask({
     name: "tsc",
     description: "Builds the command-line compiler",
     buildDeps: [generateDiagnostics],
@@ -396,7 +407,7 @@ export const dtsServices = task({
 });
 
 
-const { main: tsserver, build: buildTsserver, watch: watchTsserver } = entrypointBuildTask({
+const { main: tsserver, watch: watchTsserver } = entrypointBuildTask({
     name: "tsserver",
     description: "Builds the language server",
     buildDeps: [generateDiagnostics],
@@ -414,15 +425,10 @@ const { main: tsserver, build: buildTsserver, watch: watchTsserver } = entrypoin
 export { tsserver, watchTsserver };
 
 
-const buildMin = task({
-    name: "build-min",
-    dependencies: [buildTsc, buildTsserver],
-});
-
 export const min = task({
     name: "min",
     description: "Builds only tsc and tsserver",
-    dependencies: [tsc, tsserver].concat(cmdLineOptions.typecheck ? [buildMin] : []),
+    dependencies: [tsc, tsserver],
 });
 
 export const watchMin = task({
@@ -591,15 +597,10 @@ export const watchOtherOutputs = task({
     dependencies: [watchCancellationToken, watchTypingsInstaller, watchWatchGuard, generateTypesMap, copyBuiltLocalDiagnosticMessages],
 });
 
-const buildLocal = task({
-    name: "build-local",
-    dependencies: [buildTsc, buildTsserver, buildServices, buildLssl]
-});
-
 export const local = task({
     name: "local",
     description: "Builds the full compiler and services",
-    dependencies: [localize, tsc, tsserver, services, lssl, otherOutputs, dts].concat(cmdLineOptions.typecheck ? [buildLocal] : []),
+    dependencies: [localize, tsc, tsserver, services, lssl, otherOutputs, dts],
 });
 export default local;
 
@@ -610,7 +611,7 @@ export const watchLocal = task({
     dependencies: [localize, watchTsc, watchTsserver, watchServices, watchLssl, watchOtherOutputs, dts, watchSrc],
 });
 
-const runtestsDeps = [tests, generateLibs].concat(cmdLineOptions.typecheck ? [dts, buildSrc] : []);
+const runtestsDeps = [tests, generateLibs];
 
 export const runTests = task({
     name: "runtests",

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -611,7 +611,7 @@ export const watchLocal = task({
     dependencies: [localize, watchTsc, watchTsserver, watchServices, watchLssl, watchOtherOutputs, dts, watchSrc],
 });
 
-const runtestsDeps = [tests, generateLibs, dts];
+const runtestsDeps = [tests, generateLibs].concat(cmdLineOptions.typecheck ? [dts] : []);
 
 export const runTests = task({
     name: "runtests",

--- a/scripts/build/options.mjs
+++ b/scripts/build/options.mjs
@@ -51,6 +51,10 @@ if (options.built) {
     options.lkg = false;
 }
 
+if (!options.bundle && !options.typecheck) {
+    throw new Error("--no-typecheck cannot be passed when bundling is disabled");
+}
+
 export default options;
 
 


### PR DESCRIPTION
In previous PRs, we've been tweaking when typechecking happens in the new build system. It's currently the case that you get typechecking when you run `local`, `min`, or one of the `runtests`, but not when you run `tsc`, `tsserver`, `lssl`, etc.

Now that we have the `--no-typecheck` build flag, it seems like it makes more sense to have the default behavior be consistent across all of our tasks, opting for the safer choice of `--typecheck`.

I have changed our launch task to continue to not typecheck, as I think that's likely the most valuable place to pass this flag.