### PR TITLE
Use IIFE to capture variable for transformed dynamic import

### DIFF
--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -5763,9 +5763,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         );
     }
 
-    function createImmediatelyInvokedArrowFunction(statements: readonly Statement[]): CallExpression;
-    function createImmediatelyInvokedArrowFunction(statements: readonly Statement[], param: ParameterDeclaration, paramValue: Expression): CallExpression;
-    function createImmediatelyInvokedArrowFunction(statements: readonly Statement[], param?: ParameterDeclaration, paramValue?: Expression) {
+    function createImmediatelyInvokedArrowFunction(statements: readonly Statement[] | ConciseBody): CallExpression;
+    function createImmediatelyInvokedArrowFunction(statements: readonly Statement[] | ConciseBody, param: ParameterDeclaration, paramValue: Expression): CallExpression;
+    function createImmediatelyInvokedArrowFunction(statements: readonly Statement[] | ConciseBody, param?: ParameterDeclaration, paramValue?: Expression) {
         return createCallExpression(
             createArrowFunction(
                 /*modifiers*/ undefined,
@@ -5773,7 +5773,7 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
                 /*parameters*/ param ? [param] : [],
                 /*type*/ undefined,
                 /*equalsGreaterThanToken*/ undefined,
-                createBlock(statements, /*multiLine*/ true)
+                isArray(statements) ? createBlock(statements, /*multiLine*/ true) : statements
             ),
             /*typeArguments*/ undefined,
             /*argumentsArray*/ paramValue ? [paramValue] : []

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8366,8 +8366,8 @@ export interface NodeFactory {
 
     createImmediatelyInvokedFunctionExpression(statements: readonly Statement[]): CallExpression;
     createImmediatelyInvokedFunctionExpression(statements: readonly Statement[], param: ParameterDeclaration, paramValue: Expression): CallExpression;
-    createImmediatelyInvokedArrowFunction(statements: readonly Statement[]): CallExpression;
-    createImmediatelyInvokedArrowFunction(statements: readonly Statement[], param: ParameterDeclaration, paramValue: Expression): CallExpression;
+    createImmediatelyInvokedArrowFunction(statements: readonly Statement[] | ConciseBody): CallExpression;
+    createImmediatelyInvokedArrowFunction(statements: readonly Statement[] | ConciseBody, param: ParameterDeclaration, paramValue: Expression): CallExpression;
 
 
     createVoidZero(): VoidExpression;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7888,8 +7888,8 @@ declare namespace ts {
         createPostfixDecrement(operand: Expression): PostfixUnaryExpression;
         createImmediatelyInvokedFunctionExpression(statements: readonly Statement[]): CallExpression;
         createImmediatelyInvokedFunctionExpression(statements: readonly Statement[], param: ParameterDeclaration, paramValue: Expression): CallExpression;
-        createImmediatelyInvokedArrowFunction(statements: readonly Statement[]): CallExpression;
-        createImmediatelyInvokedArrowFunction(statements: readonly Statement[], param: ParameterDeclaration, paramValue: Expression): CallExpression;
+        createImmediatelyInvokedArrowFunction(statements: readonly Statement[] | ConciseBody): CallExpression;
+        createImmediatelyInvokedArrowFunction(statements: readonly Statement[] | ConciseBody, param: ParameterDeclaration, paramValue: Expression): CallExpression;
         createVoidZero(): VoidExpression;
         createExportDefault(expression: Expression): ExportAssignment;
         createExternalModuleExport(exportName: Identifier): ExportDeclaration;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3952,8 +3952,8 @@ declare namespace ts {
         createPostfixDecrement(operand: Expression): PostfixUnaryExpression;
         createImmediatelyInvokedFunctionExpression(statements: readonly Statement[]): CallExpression;
         createImmediatelyInvokedFunctionExpression(statements: readonly Statement[], param: ParameterDeclaration, paramValue: Expression): CallExpression;
-        createImmediatelyInvokedArrowFunction(statements: readonly Statement[]): CallExpression;
-        createImmediatelyInvokedArrowFunction(statements: readonly Statement[], param: ParameterDeclaration, paramValue: Expression): CallExpression;
+        createImmediatelyInvokedArrowFunction(statements: readonly Statement[] | ConciseBody): CallExpression;
+        createImmediatelyInvokedArrowFunction(statements: readonly Statement[] | ConciseBody, param: ParameterDeclaration, paramValue: Expression): CallExpression;
         createVoidZero(): VoidExpression;
         createExportDefault(expression: Expression): ExportAssignment;
         createExternalModuleExport(exportName: Identifier): ExportDeclaration;

--- a/tests/baselines/reference/asyncImportNestedYield.js
+++ b/tests/baselines/reference/asyncImportNestedYield.js
@@ -46,13 +46,16 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 function foo() {
     return __asyncGenerator(this, arguments, function foo_1() {
         return __generator(this, function (_a) {
-            var _b, _c;
             switch (_a.label) {
                 case 0: return [4 /*yield*/, __await("foo")];
                 case 1: return [4 /*yield*/, _a.sent()];
-                case 2: return [4 /*yield*/, __await.apply(void 0, [(_b = _a.sent(), Promise.resolve().then(function () { return require(_b); }))])];
+                case 2: return [4 /*yield*/, __await.apply(void 0, [function (_a) {
+                            return Promise.resolve().then(function () { return require(_a); });
+                        }(_a.sent())])];
                 case 3:
-                    _c = (_a.sent())["default"], Promise.resolve().then(function () { return require(_c); });
+                    (function (_a) {
+                        return Promise.resolve().then(function () { return require(_a); });
+                    })((_a.sent())["default"]);
                     return [2 /*return*/];
             }
         });

--- a/tests/baselines/reference/dynamicImportEvaluateSpecifier.js
+++ b/tests/baselines/reference/dynamicImportEvaluateSpecifier.js
@@ -16,16 +16,14 @@ const someFunction = async () => {
 
 
 //// [dynamicImportEvaluateSpecifier.js]
-var _a, _b;
 // https://github.com/microsoft/TypeScript/issues/48285
 let i = 0;
-_a = String(i++), Promise.resolve().then(() => require(_a));
-_b = String(i++), Promise.resolve().then(() => require(_b));
+(_a => Promise.resolve().then(() => require(_a)))(String(i++));
+(_b => Promise.resolve().then(() => require(_b)))(String(i++));
 const getPath = async () => {
     /* in reality this would do some async FS operation, or a web request */
     return "/root/my/cool/path";
 };
 const someFunction = async () => {
-    var _a;
-    const result = await (_a = await getPath(), Promise.resolve().then(() => require(_a)));
+    const result = await (_a => Promise.resolve().then(() => require(_a)))(await getPath());
 };

--- a/tests/baselines/reference/dynamicImportTrailingComma.js
+++ b/tests/baselines/reference/dynamicImportTrailingComma.js
@@ -3,6 +3,7 @@ const path = './foo';
 import(path,);
 
 //// [dynamicImportTrailingComma.js]
-var _a;
 var path = './foo';
-_a = path, Promise.resolve().then(function () { return require(_a); });
+(function (_a) {
+    return Promise.resolve().then(function () { return require(_a); });
+})(path);

--- a/tests/baselines/reference/importCallExpressionDeclarationEmit1.js
+++ b/tests/baselines/reference/importCallExpressionDeclarationEmit1.js
@@ -15,14 +15,12 @@ function returnDynamicLoad(path: string) {
 }
 
 //// [importCallExpressionDeclarationEmit1.js]
-var _a, _b, _c, _d;
-_a = getSpecifier(), Promise.resolve().then(() => require(_a));
-var p0 = (_b = `${directory}\\${moduleFile}`, Promise.resolve().then(() => require(_b)));
-var p1 = (_c = getSpecifier(), Promise.resolve().then(() => require(_c)));
-const p2 = (_d = whatToLoad ? getSpecifier() : "defaulPath", Promise.resolve().then(() => require(_d)));
+(_a => Promise.resolve().then(() => require(_a)))(getSpecifier());
+var p0 = (_b => Promise.resolve().then(() => require(_b)))(`${directory}\\${moduleFile}`);
+var p1 = (_c => Promise.resolve().then(() => require(_c)))(getSpecifier());
+const p2 = (_d => Promise.resolve().then(() => require(_d)))(whatToLoad ? getSpecifier() : "defaulPath");
 function returnDynamicLoad(path) {
-    var _a;
-    return _a = path, Promise.resolve().then(() => require(_a));
+    return (_a => Promise.resolve().then(() => require(_a)))(path);
 }
 
 

--- a/tests/baselines/reference/importCallExpressionGrammarError.js
+++ b/tests/baselines/reference/importCallExpressionGrammarError.js
@@ -10,9 +10,8 @@ const p2 = import();
 const p4 = import("pathToModule", "secondModule");
 
 //// [importCallExpressionGrammarError.js]
-var _a, _b;
 var a = ["./0"];
-_a = (...["PathModule"]), Promise.resolve().then(() => require(_a));
-var p1 = (_b = (...a), Promise.resolve().then(() => require(_b)));
+(_a => Promise.resolve().then(() => require(_a)))(...["PathModule"]);
+var p1 = (_b => Promise.resolve().then(() => require(_b)))(...a);
 const p2 = Promise.resolve().then(() => require());
 const p4 = Promise.resolve().then(() => require("pathToModule"));

--- a/tests/baselines/reference/importCallExpressionNestedCJS.js
+++ b/tests/baselines/reference/importCallExpressionNestedCJS.js
@@ -24,7 +24,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 function foo() {
     return __awaiter(this, void 0, void 0, function* () {
-        var _a;
-        return yield (_a = (yield Promise.resolve().then(() => require("./foo"))).default, Promise.resolve().then(() => require(_a)));
+        return yield (_a => Promise.resolve().then(() => require(_a)))((yield Promise.resolve().then(() => require("./foo"))).default);
     });
 }

--- a/tests/baselines/reference/importCallExpressionNestedCJS2.js
+++ b/tests/baselines/reference/importCallExpressionNestedCJS2.js
@@ -52,10 +52,11 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 function foo() {
     return __awaiter(this, void 0, void 0, function () {
         return __generator(this, function (_a) {
-            var _b;
             switch (_a.label) {
                 case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require("./foo"); })];
-                case 1: return [4 /*yield*/, (_b = (_a.sent()).default, Promise.resolve().then(function () { return require(_b); }))];
+                case 1: return [4 /*yield*/, function (_a) {
+                        return Promise.resolve().then(function () { return require(_a); });
+                    }((_a.sent()).default)];
                 case 2: return [2 /*return*/, _a.sent()];
             }
         });

--- a/tests/baselines/reference/importCallExpressionReturnPromiseOfAny.js
+++ b/tests/baselines/reference/importCallExpressionReturnPromiseOfAny.js
@@ -42,23 +42,21 @@ class C {
 exports.C = C;
 //// [1.js]
 "use strict";
-var _a, _b, _c, _d, _e, _f, _g;
 Object.defineProperty(exports, "__esModule", { value: true });
-_a = `${directory}\\${moduleFile}`, Promise.resolve().then(() => require(_a));
-_b = getSpecifier(), Promise.resolve().then(() => require(_b));
-var p1 = (_c = ValidSomeCondition() ? "./0" : "externalModule", Promise.resolve().then(() => require(_c)));
-var p1 = (_d = getSpecifier(), Promise.resolve().then(() => require(_d)));
-var p11 = (_e = getSpecifier(), Promise.resolve().then(() => require(_e)));
-const p2 = (_f = whatToLoad ? getSpecifier() : "defaulPath", Promise.resolve().then(() => require(_f)));
+(_a => Promise.resolve().then(() => require(_a)))(`${directory}\\${moduleFile}`);
+(_b => Promise.resolve().then(() => require(_b)))(getSpecifier());
+var p1 = (_c => Promise.resolve().then(() => require(_c)))(ValidSomeCondition() ? "./0" : "externalModule");
+var p1 = (_d => Promise.resolve().then(() => require(_d)))(getSpecifier());
+var p11 = (_e => Promise.resolve().then(() => require(_e)))(getSpecifier());
+const p2 = (_f => Promise.resolve().then(() => require(_f)))(whatToLoad ? getSpecifier() : "defaulPath");
 p1.then(zero => {
     return zero.foo(); // ok, zero is any
 });
 let j;
-var p3 = (_g = j = getSpecifier(), Promise.resolve().then(() => require(_g)));
+var p3 = (_g => Promise.resolve().then(() => require(_g)))(j = getSpecifier());
 function* loadModule(directories) {
-    var _a;
     for (const directory of directories) {
         const path = `${directory}\\moduleFile`;
-        _a = yield path, Promise.resolve().then(() => require(_a));
+        (_a => Promise.resolve().then(() => require(_a)))(yield path);
     }
 }

--- a/tests/baselines/reference/importCallExpressionSpecifierNotStringTypeError.js
+++ b/tests/baselines/reference/importCallExpressionSpecifierNotStringTypeError.js
@@ -14,13 +14,12 @@ var p3 = import(["path1", "path2"]);
 var p4 = import(()=>"PathToModule");
 
 //// [importCallExpressionSpecifierNotStringTypeError.js]
-var _a, _b, _c, _d, _e;
 // Error specifier is not assignable to string
-_a = getSpecifier(), Promise.resolve().then(() => require(_a));
-var p1 = (_b = getSpecifier(), Promise.resolve().then(() => require(_b)));
-const p2 = (_c = whatToLoad ? getSpecifier() : "defaulPath", Promise.resolve().then(() => require(_c)));
+(_a => Promise.resolve().then(() => require(_a)))(getSpecifier());
+var p1 = (_b => Promise.resolve().then(() => require(_b)))(getSpecifier());
+const p2 = (_c => Promise.resolve().then(() => require(_c)))(whatToLoad ? getSpecifier() : "defaulPath");
 p1.then(zero => {
     return zero.foo(); // ok, zero is any
 });
-var p3 = (_d = ["path1", "path2"], Promise.resolve().then(() => require(_d)));
-var p4 = (_e = () => "PathToModule", Promise.resolve().then(() => require(_e)));
+var p3 = (_d => Promise.resolve().then(() => require(_d)))(["path1", "path2"]);
+var p4 = (_e => Promise.resolve().then(() => require(_e)))(() => "PathToModule");

--- a/tests/baselines/reference/jsdocInTypeScript.js
+++ b/tests/baselines/reference/jsdocInTypeScript.js
@@ -58,7 +58,6 @@ var v = import(String());
 
 
 //// [jsdocInTypeScript.js]
-var _a;
 var T = /** @class */ (function () {
     function T() {
     }
@@ -93,4 +92,6 @@ var E = {};
 E[""];
 // make sure import types in JSDoc are not resolved
 /** @type {import("should-not-be-resolved").Type} */
-var v = (_a = String(), Promise.resolve().then(function () { return require(_a); }));
+var v = function (_a) {
+    return Promise.resolve().then(function () { return require(_a); });
+}(String());


### PR DESCRIPTION
In #49663 we fixed one issue related to closures and dynamic import, but introduced another. This changes the emit to use an IIFE to ensure the value of the variable is captured properly. We could potentially drop back to the `_a = x, Promise.resolve().then(...)` emit if we're not in any loop, but that would require tracking iteration statements as we descend, and dynamic import isn't likely to be used in a fast path that cares about the overhead of an IIFE.

Fixes #51554.
