### PR TITLE
[experiment] Try using consistent shapes for FlowNodes

### DIFF
--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -519,7 +519,7 @@ export namespace Debug {
                     }
                 },
                 __debugFlowFlags: { get(this: FlowNodeBase) { return formatEnum(this.flags, (ts as any).FlowFlags, /*isFlags*/ true); } },
-                __debugToString: { value(this: FlowNodeBase) { return formatControlFlowGraph(this); } }
+                __debugToString: { value(this: FlowNodeBase) { return formatControlFlowGraph(this as FlowNode); } }
             });
         }
     }
@@ -912,7 +912,7 @@ m2: ${(this.mapper2 as unknown as DebugTypeMapper).__debugToString().split("\n")
             return !!(f.flags & hasAntecedentFlags);
         }
 
-        function hasNode(f: FlowNode): f is Extract<FlowNode, { node?: Node }> {
+        function hasNode(f: FlowNode): f is Extract<FlowNode, { node: Node | undefined }> {
             return !!(f.flags & hasNodeFlags);
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3889,6 +3889,15 @@ export type FlowNode =
 export interface FlowNodeBase {
     flags: FlowFlags;
     id?: number;     // Node id used by flow type cache in checker
+
+    // Declared here so we can construct flow nodes with properties in a consistent order.
+    /** @internal */ node?: Node;
+    /** @internal */ antecedent?: FlowNode;
+    /** @internal */ antecedents?: FlowNode[];
+    /** @internal */ target?: FlowLabel;
+    /** @internal */ switchStatement?: SwitchStatement;
+    /** @internal */ clauseStart?: number;
+    /** @internal */ clauseEnd?: number;
 }
 
 // FlowStart represents the start of a control flow. For a function expression or arrow


### PR DESCRIPTION
This is in the spirit of #51380 but I didn't use any tooling to tell me if this was good or not. I noticed this while trying to see about another binder change, not because I used the deopt explorer or anything (the right thing to do).

Testing on my perf machine says it does help at the cost of memory, but I want to see if the perf runner says the same thing.
