### PR TITLE
Load js config file

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2047,7 +2047,19 @@ export function readJsonConfigFile(fileName: string, readFile: (path: string) =>
 export function tryReadFile(fileName: string, readFile: (path: string) => string | undefined): string | Diagnostic {
     let text: string | undefined;
     try {
-        text = readFile(fileName);
+        if (fileName.slice(-3) === '.js') {
+            try {
+                text = JSON.stringify( require( process.cwd() + '/' + fileName ) );
+            }
+            catch (err) {
+                return createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, err);
+            }
+
+        } else if (fileName.slice(-5) === '.json') {
+            text = readFile(fileName);
+        } else {
+            return createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, "Config file extension is neither .js nor .json");
+        }
     }
     catch (e) {
         return createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, e.message);

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2047,16 +2047,18 @@ export function readJsonConfigFile(fileName: string, readFile: (path: string) =>
 export function tryReadFile(fileName: string, readFile: (path: string) => string | undefined): string | Diagnostic {
     let text: string | undefined;
     try {
-        if (fileName.slice(-3) === '.js') {
+        if (fileName.slice(-3) === ".js") {
             try {
-                text = JSON.stringify( require( combinePaths(process.cwd(), fileName) ) );
+                text = JSON.stringify(require(combinePaths(process.cwd(), fileName)));
             }
             catch (err) {
                 return createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, err);
             }
-        } else if (fileName.slice(-5) === '.json') {
+        }
+        else if (fileName.slice(-5) === ".json") {
             text = readFile(fileName);
-        } else {
+        }
+        else {
             return createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, "Config file extension is neither .js nor .json");
         }
     }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2049,12 +2049,11 @@ export function tryReadFile(fileName: string, readFile: (path: string) => string
     try {
         if (fileName.slice(-3) === '.js') {
             try {
-                text = JSON.stringify( require( process.cwd() + '/' + fileName ) );
+                text = JSON.stringify( require( combinePaths(process.cwd(), fileName) ) );
             }
             catch (err) {
                 return createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, err);
             }
-
         } else if (fileName.slice(-5) === '.json') {
             text = readFile(fileName);
         } else {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #30400 , #39441 and potentially #37884

I was coding a helper for [Prebuilder](https://github.com/prebuilderjs/prebuilder) like [this one for Rollup](https://github.com/prebuilderjs/rollup),
It needs a javascript config file, in order to let Prebuilder control the compilation process with dynamic paths.
I was surprised to see that it's still not possible in typescript, so i dug in this repo this weekend, and came up with this solution, that apparently satisfies some of the points expressed in #30400:
- it's fairly secure, the js config is obtained by converting the tsconfig.js' default import to a json string, and then treated the same as a tsconfig.json
  - So no function will be used by the compiler, just raw json-like data
  - Any config error handling already in place for a .json config works for the .js one too (i tested, putting an inexistant compiler option)
- it's not complicated, as it only adds one step to the process
- in order to use a js config file, tsc will need it to be specified using the -p parameter, so the default behavior is preserved


## Testing
I tried writing a test, but it has not been easy, i spent more time trying to do this, than the actual implementation...
I would leave this task to any willing person, as i couldn't figure where to put the .js config file

I have tested manually like this:
- built with `npm run build`
- tested with `npm run test` (✔)
- prepared with `npx hereby LKG`
- published the package to my local registry
- created a test project with two .ts scripts and the tsconfig.js (below) and without a tsconfig.json file in the project
- ensured that the test project ran tsc using the local typescript package i published

And it worked perfectly, transpiling to the 'dist' folder.✔
Config extensibility (`extends: "./tsconfig.js",`) works with js config files too ✔

## Usage

```sh
tsc -p tsconfig.js
```
tsconfig.js :
```js
module.exports = {
    compilerOptions: {
      declaration: true,
      target: "es5",
      module: "commonjs",
      strict: true,
      noUnusedLocals: true,
      noUnusedParameters: true,
      noImplicitReturns: true,
      noFallthroughCasesInSwitch: true,
      composite: true,
  
      outDir: "dist/prod",
    },
    include: [ "./src/" ]
}
```

Also:
Dynamically adding a path ✔
And extending with a .js config ✔
```sh
SET NODE_ENV=dev&& tsc -p tsconfig-extended.js
```
```js
const path = require('path');

module.exports = {
    extends: "./tsconfig.js",
    compilerOptions: {
        // transpiles to the 'dist/dev' folder
        outDir: path.join("dist", process.env.NODE_ENV),
    }
}
```
