### PR TITLE
Filter signatures by matching constraints when instantiating them for instantiation signatures

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33694,8 +33694,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         function getInstantiatedSignatures(signatures: readonly Signature[]) {
-            const applicableSignatures = filter(signatures, sig => !!sig.typeParameters && hasCorrectTypeArgumentArity(sig, typeArguments));
-            return sameMap(applicableSignatures, sig => {
+            const sameTypeAritySignatures = filter(signatures, sig => !!sig.typeParameters && hasCorrectTypeArgumentArity(sig, typeArguments));
+            if (!sameTypeAritySignatures.length) {
+                return sameTypeAritySignatures;
+            }
+            const applicableSignatures = mapDefined(sameTypeAritySignatures, sig => {
+                const typeArgumentTypes = checkTypeArguments(sig, typeArguments!, /*reportErrors*/ false);
+                return typeArgumentTypes && getSignatureInstantiation(sig, typeArgumentTypes, isInJSFile(sig.declaration));
+            });
+            if (applicableSignatures.length) {
+                return applicableSignatures;
+            }
+            return sameMap(sameTypeAritySignatures, sig => {
                 const typeArgumentTypes = checkTypeArguments(sig, typeArguments!, /*reportErrors*/ true);
                 return typeArgumentTypes ? getSignatureInstantiation(sig, typeArgumentTypes, isInJSFile(sig.declaration)) : sig;
             });

--- a/tests/baselines/reference/instantiationExpressions.errors.txt
+++ b/tests/baselines/reference/instantiationExpressions.errors.txt
@@ -226,3 +226,13 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpr
     type T50<U extends string> = typeof g3<U>;  // (a: U) => U
     type T51<U extends number> = typeof g3<U, any>;  // (b: U) => U
     
+    // repro #47607#issuecomment-1331744280
+    
+    type DivElement = { type: 'div' }
+    interface ElementMap { div: DivElement }
+    
+    declare function foo<T extends keyof ElementMap>(arg: T): ElementMap[T];
+    declare function foo<T extends DivElement>(arg: T): T;
+    
+    type DivFromMap = typeof foo<"div">;
+    

--- a/tests/baselines/reference/instantiationExpressions.js
+++ b/tests/baselines/reference/instantiationExpressions.js
@@ -172,6 +172,16 @@ declare const g3: {
 type T50<U extends string> = typeof g3<U>;  // (a: U) => U
 type T51<U extends number> = typeof g3<U, any>;  // (b: U) => U
 
+// repro #47607#issuecomment-1331744280
+
+type DivElement = { type: 'div' }
+interface ElementMap { div: DivElement }
+
+declare function foo<T extends keyof ElementMap>(arg: T): ElementMap[T];
+declare function foo<T extends DivElement>(arg: T): T;
+
+type DivFromMap = typeof foo<"div">;
+
 
 //// [instantiationExpressions.js]
 "use strict";
@@ -380,3 +390,12 @@ declare const g3: {
 };
 type T50<U extends string> = typeof g3<U>;
 type T51<U extends number> = typeof g3<U, any>;
+type DivElement = {
+    type: 'div';
+};
+interface ElementMap {
+    div: DivElement;
+}
+declare function foo<T extends keyof ElementMap>(arg: T): ElementMap[T];
+declare function foo<T extends DivElement>(arg: T): T;
+type DivFromMap = typeof foo<"div">;

--- a/tests/baselines/reference/instantiationExpressions.symbols
+++ b/tests/baselines/reference/instantiationExpressions.symbols
@@ -648,3 +648,35 @@ type T51<U extends number> = typeof g3<U, any>;  // (b: U) => U
 >g3 : Symbol(g3, Decl(instantiationExpressions.ts, 165, 13))
 >U : Symbol(U, Decl(instantiationExpressions.ts, 171, 9))
 
+// repro #47607#issuecomment-1331744280
+
+type DivElement = { type: 'div' }
+>DivElement : Symbol(DivElement, Decl(instantiationExpressions.ts, 171, 47))
+>type : Symbol(type, Decl(instantiationExpressions.ts, 175, 19))
+
+interface ElementMap { div: DivElement }
+>ElementMap : Symbol(ElementMap, Decl(instantiationExpressions.ts, 175, 33))
+>div : Symbol(ElementMap.div, Decl(instantiationExpressions.ts, 176, 22))
+>DivElement : Symbol(DivElement, Decl(instantiationExpressions.ts, 171, 47))
+
+declare function foo<T extends keyof ElementMap>(arg: T): ElementMap[T];
+>foo : Symbol(foo, Decl(instantiationExpressions.ts, 176, 40), Decl(instantiationExpressions.ts, 178, 72))
+>T : Symbol(T, Decl(instantiationExpressions.ts, 178, 21))
+>ElementMap : Symbol(ElementMap, Decl(instantiationExpressions.ts, 175, 33))
+>arg : Symbol(arg, Decl(instantiationExpressions.ts, 178, 49))
+>T : Symbol(T, Decl(instantiationExpressions.ts, 178, 21))
+>ElementMap : Symbol(ElementMap, Decl(instantiationExpressions.ts, 175, 33))
+>T : Symbol(T, Decl(instantiationExpressions.ts, 178, 21))
+
+declare function foo<T extends DivElement>(arg: T): T;
+>foo : Symbol(foo, Decl(instantiationExpressions.ts, 176, 40), Decl(instantiationExpressions.ts, 178, 72))
+>T : Symbol(T, Decl(instantiationExpressions.ts, 179, 21))
+>DivElement : Symbol(DivElement, Decl(instantiationExpressions.ts, 171, 47))
+>arg : Symbol(arg, Decl(instantiationExpressions.ts, 179, 43))
+>T : Symbol(T, Decl(instantiationExpressions.ts, 179, 21))
+>T : Symbol(T, Decl(instantiationExpressions.ts, 179, 21))
+
+type DivFromMap = typeof foo<"div">;
+>DivFromMap : Symbol(DivFromMap, Decl(instantiationExpressions.ts, 179, 54))
+>foo : Symbol(foo, Decl(instantiationExpressions.ts, 176, 40), Decl(instantiationExpressions.ts, 178, 72))
+

--- a/tests/baselines/reference/instantiationExpressions.types
+++ b/tests/baselines/reference/instantiationExpressions.types
@@ -514,3 +514,24 @@ type T51<U extends number> = typeof g3<U, any>;  // (b: U) => U
 >T51 : new (b: U) => U
 >g3 : { <T extends string>(a: T): T; new <T extends number, Q>(b: T): T; }
 
+// repro #47607#issuecomment-1331744280
+
+type DivElement = { type: 'div' }
+>DivElement : { type: 'div'; }
+>type : "div"
+
+interface ElementMap { div: DivElement }
+>div : DivElement
+
+declare function foo<T extends keyof ElementMap>(arg: T): ElementMap[T];
+>foo : { <T extends "div">(arg: T): ElementMap[T]; <T extends DivElement>(arg: T): T; }
+>arg : T
+
+declare function foo<T extends DivElement>(arg: T): T;
+>foo : { <T extends "div">(arg: T): ElementMap[T]; <T extends DivElement>(arg: T): T; }
+>arg : T
+
+type DivFromMap = typeof foo<"div">;
+>DivFromMap : (arg: "div") => DivElement
+>foo : { <T extends "div">(arg: T): ElementMap[T]; <T extends DivElement>(arg: T): T; }
+

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressions.ts
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressions.ts
@@ -173,3 +173,13 @@ declare const g3: {
 
 type T50<U extends string> = typeof g3<U>;  // (a: U) => U
 type T51<U extends number> = typeof g3<U, any>;  // (b: U) => U
+
+// repro #47607#issuecomment-1331744280
+
+type DivElement = { type: 'div' }
+interface ElementMap { div: DivElement }
+
+declare function foo<T extends keyof ElementMap>(arg: T): ElementMap[T];
+declare function foo<T extends DivElement>(arg: T): T;
+
+type DivFromMap = typeof foo<"div">;


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/51694

There are some open questions related to the design of instantiations expressions and how they relate to overloads etc. But since I was looking into the implementation to see why the reported issue doesn't type-check OK, I've figured out I can create a draft that would address that as the change was fairly easy to introduce.