### PR TITLE
Unconditionally call `checkExpression` from `checkSatisfiesExpression`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33704,13 +33704,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function checkSatisfiesExpression(node: SatisfiesExpression) {
         checkSourceElement(node.type);
+        const exprType = checkExpression(node.expression);
 
         const targetType = getTypeFromTypeNode(node.type);
         if (isErrorType(targetType)) {
             return targetType;
         }
 
-        const exprType = checkExpression(node.expression);
         checkTypeAssignableToAndOptionallyElaborate(exprType, targetType, node.type, node.expression, Diagnostics.Type_0_does_not_satisfy_the_expected_type_1);
 
         return exprType;

--- a/tests/baselines/reference/satisfiesEmit.errors.txt
+++ b/tests/baselines/reference/satisfiesEmit.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/satisfiesEmit.ts(2,20): error TS2307: Cannot find module 'foo' or its corresponding type declarations.
+tests/cases/compiler/satisfiesEmit.ts(3,23): error TS2304: Cannot find name 'bleh'.
+
+
+==== tests/cases/compiler/satisfiesEmit.ts (2 errors) ====
+    // This import should not be elided in the emitted JS
+    import a = require("foo");
+                       ~~~~~
+!!! error TS2307: Cannot find module 'foo' or its corresponding type declarations.
+    const p = a satisfies bleh;
+                          ~~~~
+!!! error TS2304: Cannot find name 'bleh'.
+    

--- a/tests/baselines/reference/satisfiesEmit.js
+++ b/tests/baselines/reference/satisfiesEmit.js
@@ -1,0 +1,12 @@
+//// [satisfiesEmit.ts]
+// This import should not be elided in the emitted JS
+import a = require("foo");
+const p = a satisfies bleh;
+
+
+//// [satisfiesEmit.js]
+"use strict";
+exports.__esModule = true;
+// This import should not be elided in the emitted JS
+var a = require("foo");
+var p = a;

--- a/tests/baselines/reference/satisfiesEmit.symbols
+++ b/tests/baselines/reference/satisfiesEmit.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/satisfiesEmit.ts ===
+// This import should not be elided in the emitted JS
+import a = require("foo");
+>a : Symbol(a, Decl(satisfiesEmit.ts, 0, 0))
+
+const p = a satisfies bleh;
+>p : Symbol(p, Decl(satisfiesEmit.ts, 2, 5))
+>a : Symbol(a, Decl(satisfiesEmit.ts, 0, 0))
+>bleh : Symbol(bleh)
+

--- a/tests/baselines/reference/satisfiesEmit.types
+++ b/tests/baselines/reference/satisfiesEmit.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/satisfiesEmit.ts ===
+// This import should not be elided in the emitted JS
+import a = require("foo");
+>a : any
+
+const p = a satisfies bleh;
+>p : bleh
+>a satisfies bleh : bleh
+>a : any
+

--- a/tests/cases/compiler/satisfiesEmit.ts
+++ b/tests/cases/compiler/satisfiesEmit.ts
@@ -1,0 +1,3 @@
+// This import should not be elided in the emitted JS
+import a = require("foo");
+const p = a satisfies bleh;


### PR DESCRIPTION
An unenforced invariant of our checker is that all subcalls of `checkExpression` must unconditionally call `checkExpression` on their children in order for emit to work. `checkSatisfiesExpression` broke this by bailing early when the asserted type was invalid, thus breaking the example shown in the OP and testcase

[Playground link showing the problem](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAQzgXjlApgRwK7AwCgCIAzCCQgSgG4AoAYwgDsBneMFROZhGYZ44OmZwARgBt0AC1pA)

Fixes #51642. Propose to port to 4.9.
