### PR TITLE
Add missing type argument constraints check

### DIFF
--- a/tests/baselines/reference/unmetTypeConstraintInImportCall.errors.txt
+++ b/tests/baselines/reference/unmetTypeConstraintInImportCall.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/file2.ts(1,37): error TS2344: Type 'T' does not satisfy the constraint 'string'.
+
+
+==== tests/cases/compiler/file1.ts (0 errors) ====
+    export type Foo<T extends string> = { foo: T }
+    
+==== tests/cases/compiler/file2.ts (1 errors) ====
+    type Bar<T> = import('./file1').Foo<T>;
+                                        ~
+!!! error TS2344: Type 'T' does not satisfy the constraint 'string'.
+!!! related TS2208 tests/cases/compiler/file2.ts:1:10: This type parameter might need an `extends string` constraint.
+    

--- a/tests/baselines/reference/unmetTypeConstraintInImportCall.symbols
+++ b/tests/baselines/reference/unmetTypeConstraintInImportCall.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/file1.ts ===
+export type Foo<T extends string> = { foo: T }
+>Foo : Symbol(Foo, Decl(file1.ts, 0, 0))
+>T : Symbol(T, Decl(file1.ts, 0, 16))
+>foo : Symbol(foo, Decl(file1.ts, 0, 37))
+>T : Symbol(T, Decl(file1.ts, 0, 16))
+
+=== tests/cases/compiler/file2.ts ===
+type Bar<T> = import('./file1').Foo<T>;
+>Bar : Symbol(Bar, Decl(file2.ts, 0, 0))
+>T : Symbol(T, Decl(file2.ts, 0, 9))
+>Foo : Symbol(Foo, Decl(file1.ts, 0, 0))
+>T : Symbol(T, Decl(file2.ts, 0, 9))
+

--- a/tests/baselines/reference/unmetTypeConstraintInImportCall.types
+++ b/tests/baselines/reference/unmetTypeConstraintInImportCall.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/file1.ts ===
+export type Foo<T extends string> = { foo: T }
+>Foo : Foo<T>
+>foo : T
+
+=== tests/cases/compiler/file2.ts ===
+type Bar<T> = import('./file1').Foo<T>;
+>Bar : Bar<T>
+

--- a/tests/baselines/reference/unmetTypeConstraintInJSDocImportCall.errors.txt
+++ b/tests/baselines/reference/unmetTypeConstraintInJSDocImportCall.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/compiler/file2.js(3,36): error TS2344: Type 'T' does not satisfy the constraint 'string'.
+
+
+==== tests/cases/compiler/file1.js (0 errors) ====
+    /**
+     * @template {string} T
+     * @typedef {{ foo: T }} Foo
+     */
+    
+    export default {};
+    
+==== tests/cases/compiler/file2.js (1 errors) ====
+    /**
+     * @template T
+     * @typedef {import('./file1').Foo<T>} Bar
+                                       ~
+!!! error TS2344: Type 'T' does not satisfy the constraint 'string'.
+!!! related TS2208 tests/cases/compiler/file2.js:2:14: This type parameter might need an `extends string` constraint.
+     */
+    

--- a/tests/baselines/reference/unmetTypeConstraintInJSDocImportCall.symbols
+++ b/tests/baselines/reference/unmetTypeConstraintInJSDocImportCall.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/file1.js ===
+
+/**
+ * @template {string} T
+ * @typedef {{ foo: T }} Foo
+ */
+
+export default {};
+
+=== tests/cases/compiler/file2.js ===
+
+/**
+ * @template T
+ * @typedef {import('./file1').Foo<T>} Bar
+ */
+

--- a/tests/baselines/reference/unmetTypeConstraintInJSDocImportCall.types
+++ b/tests/baselines/reference/unmetTypeConstraintInJSDocImportCall.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/file1.js ===
+/**
+ * @template {string} T
+ * @typedef {{ foo: T }} Foo
+ */
+
+export default {};
+>{} : {}
+
+=== tests/cases/compiler/file2.js ===
+
+/**
+ * @template T
+ * @typedef {import('./file1').Foo<T>} Bar
+ */
+

--- a/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
+++ b/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
@@ -1,0 +1,7 @@
+// @noEmit: true
+// @filename: file1.ts
+export type Foo<T extends string> = { foo: T }
+
+// @noEmit: true
+// @filename: file2.ts
+type Bar<T> = import('./file1').Foo<T>;

--- a/tests/cases/compiler/unmetTypeConstraintInJSDocImportCall.ts
+++ b/tests/cases/compiler/unmetTypeConstraintInJSDocImportCall.ts
@@ -1,0 +1,19 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @filename: file1.js
+/**
+ * @template {string} T
+ * @typedef {{ foo: T }} Foo
+ */
+
+export default {};
+
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @filename: file2.js
+/**
+ * @template T
+ * @typedef {import('./file1').Foo<T>} Bar
+ */


### PR DESCRIPTION
Fixes #29530

Normally the argument constraints check would be executed via `checkTypeReferenceNode()` but since an expression of the form `import(...).Type<A, B, C>` yields `SyntaxKind.ImportType` rather than `SyntaxKind.TypeReference`, this is not happening. I was trying to find a place in the code where this validation could be added, which would be as close to `checkImportType()` as possible and it would not require any major refactoring. This is how I landed at `resolveImportSymbolType()`, but I am not sure if it's the best possible choice.

My guts feeling is that I should be able to perform a similar check using the type evaluated with `getTypeReferenceType()`, and so the constraints validation could potentially be encapsulated within `checkImportType()`, which I think would be more appropriate. I'd appreciate any piece of advise on this matter.