### PR TITLE
Improve string literal completions for property values when a partially-typed string fixes inference to a type parameter

### DIFF
--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -417,7 +417,7 @@ function getStringLiteralCompletionEntries(sourceFile: SourceFile, node: StringL
     function fromContextualType(): StringLiteralCompletion {
         // Get completion for string literal from string literal type
         // i.e. var x: "hi" | "hello" = "/*completion position*/"
-        return { kind: StringLiteralCompletionKind.Types, types: getStringLiteralTypes(getContextualTypeFromParent(node, typeChecker)), isNewIdentifier: false };
+        return { kind: StringLiteralCompletionKind.Types, types: getStringLiteralTypes(getContextualTypeFromParent(node, typeChecker, ContextFlags.Completions)), isNewIdentifier: false };
     }
 }
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -29,6 +29,7 @@ import {
     CompilerOptions,
     ConditionalExpression,
     contains,
+    ContextFlags,
     createPrinter,
     createRange,
     createScanner,
@@ -3277,21 +3278,21 @@ export function needsParentheses(expression: Expression): boolean {
 }
 
 /** @internal */
-export function getContextualTypeFromParent(node: Expression, checker: TypeChecker): Type | undefined {
+export function getContextualTypeFromParent(node: Expression, checker: TypeChecker, contextFlags?: ContextFlags): Type | undefined {
     const { parent } = node;
     switch (parent.kind) {
         case SyntaxKind.NewExpression:
-            return checker.getContextualType(parent as NewExpression);
+            return checker.getContextualType(parent as NewExpression, contextFlags);
         case SyntaxKind.BinaryExpression: {
             const { left, operatorToken, right } = parent as BinaryExpression;
             return isEqualityOperatorKind(operatorToken.kind)
                 ? checker.getTypeAtLocation(node === right ? left : right)
-                : checker.getContextualType(node);
+                : checker.getContextualType(node, contextFlags);
         }
         case SyntaxKind.CaseClause:
             return (parent as CaseClause).expression === node ? getSwitchedType(parent as CaseClause, checker) : undefined;
         default:
-            return checker.getContextualType(node);
+            return checker.getContextualType(node, contextFlags);
     }
 }
 

--- a/tests/cases/fourslash/completionsLiteralOnPropertyValueMatchingGeneric.ts
+++ b/tests/cases/fourslash/completionsLiteralOnPropertyValueMatchingGeneric.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.tsx
+//// declare function bar1<P extends "" | "bar" | "baz">(p: { type: P }): void;
+////
+//// bar1({ type: "/*ts*/" })
+////
+
+verify.completions({ marker: ["ts"], exact: ["", "bar", "baz"] });


### PR DESCRIPTION
Makes further improvements to what was implemented here: https://github.com/microsoft/TypeScript/pull/48410

cc @andrewbranch 