### PR TITLE
Fix: applied comment directive error suppressions to program diagnostics

### DIFF
--- a/tests/baselines/reference/project/ignoredProgramDiagnostic/amd/ignoredProgramDiagnostic.errors.txt
+++ b/tests/baselines/reference/project/ignoredProgramDiagnostic/amd/ignoredProgramDiagnostic.errors.txt
@@ -1,0 +1,5 @@
+==== outside.ts (0 errors) ====
+    export const a = 1;
+    
+==== nested/consume.ts (0 errors) ====
+    import "../outside";

--- a/tests/baselines/reference/project/ignoredProgramDiagnostic/amd/ignoredProgramDiagnostic.json
+++ b/tests/baselines/reference/project/ignoredProgramDiagnostic/amd/ignoredProgramDiagnostic.json
@@ -1,0 +1,21 @@
+{
+    "scenario": "out-of-root project diagnostic, ignored with // @ts-expect-error",
+    "projectRoot": "tests/cases/projects/IgnoredProgramDiagnostic",
+    "rootDir": "nested",
+    "ignoredFiles": [
+        "outside.ts"
+    ],
+    "inputFiles": [
+        "nested/consume.ts"
+    ],
+    "runTest": true,
+    "resolvedInputFiles": [
+        "lib.es5.d.ts",
+        "outside.ts",
+        "nested/consume.ts"
+    ],
+    "emittedFiles": [
+        "outside.js",
+        "nested/consume.js"
+    ]
+}

--- a/tests/baselines/reference/project/ignoredProgramDiagnostic/node/ignoredProgramDiagnostic.errors.txt
+++ b/tests/baselines/reference/project/ignoredProgramDiagnostic/node/ignoredProgramDiagnostic.errors.txt
@@ -1,0 +1,5 @@
+==== outside.ts (0 errors) ====
+    export const a = 1;
+    
+==== nested/consume.ts (0 errors) ====
+    import "../outside";

--- a/tests/baselines/reference/project/ignoredProgramDiagnostic/node/ignoredProgramDiagnostic.json
+++ b/tests/baselines/reference/project/ignoredProgramDiagnostic/node/ignoredProgramDiagnostic.json
@@ -1,0 +1,21 @@
+{
+    "scenario": "out-of-root project diagnostic, ignored with // @ts-expect-error",
+    "projectRoot": "tests/cases/projects/IgnoredProgramDiagnostic",
+    "rootDir": "nested",
+    "ignoredFiles": [
+        "outside.ts"
+    ],
+    "inputFiles": [
+        "nested/consume.ts"
+    ],
+    "runTest": true,
+    "resolvedInputFiles": [
+        "lib.es5.d.ts",
+        "outside.ts",
+        "nested/consume.ts"
+    ],
+    "emittedFiles": [
+        "outside.js",
+        "nested/consume.js"
+    ]
+}

--- a/tests/cases/project/ignoredProgramDiagnostic.json
+++ b/tests/cases/project/ignoredProgramDiagnostic.json
@@ -1,0 +1,12 @@
+{
+    "scenario": "out-of-root project diagnostic, ignored with // @ts-expect-error",
+    "projectRoot": "tests/cases/projects/IgnoredProgramDiagnostic",
+    "rootDir": "nested",
+    "ignoredFiles": [
+        "outside.ts"
+    ],
+    "inputFiles": [
+        "nested/consume.ts"
+    ],
+    "runTest": true
+}

--- a/tests/cases/projects/IgnoredProgramDiagnostic/nested/consume.ts
+++ b/tests/cases/projects/IgnoredProgramDiagnostic/nested/consume.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error
+import "../outside";

--- a/tests/cases/projects/IgnoredProgramDiagnostic/outside.ts
+++ b/tests/cases/projects/IgnoredProgramDiagnostic/outside.ts
@@ -1,0 +1,1 @@
+export const a = 1;


### PR DESCRIPTION
Fixes #48850

I'm not 100% happy with with this solution. `programDiagnostics.getDiagnostics(sourceFile.fileName)` is now getting called twice under `getSemanticDiagnosticsForFile`:

1. `getBindAndCheckDiagnosticsForFile` > `getBindAndCheckDiagnosticsForFileNoCache` > `getMergedBindAndCheckDiagnostics`
2. `getProgramDiagnostics`

...however, I'm under the impression files mostly never have more than a few program diagnostics, so the cost of computing that map should be small? If that's the case then this feels like a pretty clean solution, optimizing for the least amount of added code?