### PR TITLE
Don't offer exhaustive case completion after dot

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -866,6 +866,7 @@ function completionInfoFromData(
         isTypeOnlyLocation,
         isJsxIdentifierExpected,
         isRightOfOpenTag,
+        isRightOfDotOrQuestionDot,
         importStatementCompletion,
         insideJsDocTagTypeExpression,
         symbolToSortTextMap: symbolToSortTextMap,
@@ -941,6 +942,8 @@ function completionInfoFromData(
     let caseBlock: CaseBlock | undefined;
     if (preferences.includeCompletionsWithInsertText
         && contextToken
+        && !isRightOfOpenTag
+        && !isRightOfDotOrQuestionDot
         && (caseBlock = findAncestor(contextToken, isCaseBlock))) {
         const cases = getExhaustiveCaseSnippets(caseBlock, sourceFile, preferences, compilerOptions, host, program, formatContext);
         if (cases) {
@@ -2524,6 +2527,7 @@ interface CompletionData {
     /** In JSX tag name and attribute names, identifiers like "my-tag" or "aria-name" is valid identifier. */
     readonly isJsxIdentifierExpected: boolean;
     readonly isRightOfOpenTag: boolean;
+    readonly isRightOfDotOrQuestionDot: boolean;
     readonly importStatementCompletion?: ImportStatementCompletionInfo;
     readonly hasUnresolvedAutoImports?: boolean;
     readonly flags: CompletionInfoFlags;
@@ -2940,6 +2944,7 @@ function getCompletionData(
         isTypeOnlyLocation,
         isJsxIdentifierExpected,
         isRightOfOpenTag,
+        isRightOfDotOrQuestionDot: isRightOfDot || isRightOfQuestionDot,
         importStatementCompletion,
         hasUnresolvedAutoImports,
         flags,

--- a/tests/cases/fourslash/exhaustiveCaseCompletions3.ts
+++ b/tests/cases/fourslash/exhaustiveCaseCompletions3.ts
@@ -30,6 +30,9 @@
 //// switch (u) {
 ////     /*7*/
 ////
+//// switch (u) {
+////     case E./*8*/
+//// }
 
 const exhaustiveCaseCompletion = {
     name: "case E.A: ...",
@@ -104,6 +107,17 @@ verify.completions(
         marker: "7",
         includes: [
             exhaustiveCaseCompletion,
+        ],
+        preferences: {
+            includeCompletionsWithInsertText: true,
+        }
+    },
+    {
+        marker: "8",
+        exact: [
+            "A",
+            "B",
+            "C"
         ],
         preferences: {
             includeCompletionsWithInsertText: true,


### PR DESCRIPTION
I didn't open an issue, but I noticed the new exhaustive case completion was showing up on completions triggered by a dot:

![image](https://user-images.githubusercontent.com/19519347/206042281-a6b1a927-e85d-4704-8371-1a70fba311bc.png)

This PR fixes this and makes sure the exhaustive case completion doesn't show up after dot or question dot, or after JSX opening tags.
