### PR TITLE
Remove emitDeclarationOnly hack now that build mode supports it as a flag

### DIFF
--- a/scripts/build/projects.mjs
+++ b/scripts/build/projects.mjs
@@ -35,7 +35,7 @@ const execTsc = (/** @type {string[]} */ ...args) =>
           "-b", ...args],
          { hidePrompt: true });
 
-const projectBuilder = new ProjectQueue((projects) => execTsc(...projects));
+const projectBuilder = new ProjectQueue((projects) => execTsc(...(cmdLineOptions.bundle ? [] : ["--emitDeclarationOnly", "false"]), ...projects));
 
 /**
  * @param {string} project


### PR DESCRIPTION
Now that our LKG is new enough, we no longer need to have this hack around to screw with the config. We can now pass `--emitDeclarationOnly false` as an arg.