### PR TITLE
Create special --no-typecheck script

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,7 @@
             // https://github.com/microsoft/vscode/issues/93001
             "label": "gulp: tests",
             "type": "npm",
-            "script": "build:tests -- --no-typecheck",
+            "script": "build:tests:notypecheck",
             "group": "build",
             "hide": true,
             "problemMatcher": [
@@ -44,7 +44,7 @@
         {
             "label": "npm: build:tests",
             "type": "npm",
-            "script": "build:tests -- --no-typecheck",
+            "script": "build:tests:notypecheck",
             "group": "build",
             "problemMatcher": [
                 "$tsc"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "build": "npm run build:compiler && npm run build:tests",
         "build:compiler": "hereby local",
         "build:tests": "hereby tests",
+        "build:tests:notypecheck": "hereby tests --no-typecheck",
         "start": "node lib/tsc",
         "clean": "hereby clean",
         "gulp": "hereby",


### PR DESCRIPTION
It seems that if you have a task set up on vscode (on `tasks.json`) whose script string has spaces in it, e.g. `"script": "build:tests -- --no-typecheck"`, then on WSL vscode adds quotes around the script string when it runs the task, meaning that for our `npm: build:tests` task, vscode ran the command `npm run "build:tests -- --no-typecheck"`, which the `npm run` command doesn't recognize. This was getting in the way of using our preconfigured test debug setting on vscode on WSL, so I created a separate npm build tests script that adds the `--no-typecheck` flag to its invocation directly.