### PR TITLE
fix(51223): Go-to-definition for yield and await keyword; jump to respective function definition

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -131,6 +131,18 @@ export function getDefinitionAtPosition(program: Program, sourceFile: SourceFile
         return functionDeclaration ? [createDefinitionFromSignatureDeclaration(typeChecker, functionDeclaration)] : undefined;
     }
 
+    if (node.kind === SyntaxKind.AwaitKeyword) {
+        const functionDeclaration = findAncestor(node, n => isFunctionLikeDeclaration(n)) as FunctionLikeDeclaration | undefined;
+        const isAsyncFunction = functionDeclaration && some(functionDeclaration.modifiers, (node) => node.kind === SyntaxKind.AsyncKeyword);
+        return isAsyncFunction ? [createDefinitionFromSignatureDeclaration(typeChecker, functionDeclaration)] : undefined;
+    }
+
+    if (node.kind === SyntaxKind.YieldKeyword) {
+        const functionDeclaration = findAncestor(node, n => isFunctionLikeDeclaration(n)) as FunctionLikeDeclaration | undefined;
+        const isGeneratorFunction = functionDeclaration && functionDeclaration.asteriskToken;
+        return isGeneratorFunction ? [createDefinitionFromSignatureDeclaration(typeChecker, functionDeclaration)] : undefined;
+    }
+
     if (isStaticModifier(node) && isClassStaticBlockDeclaration(node.parent)) {
         const classDecl = node.parent.parent;
         const { symbol, failedAliasResolution } = getSymbol(classDecl, typeChecker, stopAtAlias);

--- a/tests/cases/fourslash/goToDefinitionAwait1.ts
+++ b/tests/cases/fourslash/goToDefinitionAwait1.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+//// async function /*end1*/foo() {
+////     [|/*start1*/await|] Promise.resolve(0);
+//// }
+
+//// function notAsync() {
+////     [|/*start2*/await|] Promise.resolve(0);
+//// }
+
+verify.goToDefinition("start1", "end1");
+verify.goToDefinition("start2", []);

--- a/tests/cases/fourslash/goToDefinitionAwait2.ts
+++ b/tests/cases/fourslash/goToDefinitionAwait2.ts
@@ -1,0 +1,5 @@
+/// <reference path="fourslash.ts" />
+
+//// [|/*start*/await|] Promise.resolve(0);
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionAwait3.ts
+++ b/tests/cases/fourslash/goToDefinitionAwait3.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+//// class C {
+////     notAsync() {
+////       [|/*start1*/await|] Promise.resolve(0);
+////     }
+////
+////     async /*end2*/foo() {
+////       [|/*start2*/await|] Promise.resolve(0);
+////     }
+//// }
+
+verify.goToDefinition("start1", []);
+verify.goToDefinition("start2", "end2");

--- a/tests/cases/fourslash/goToDefinitionAwait4.ts
+++ b/tests/cases/fourslash/goToDefinitionAwait4.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+//// async function outerAsyncFun() {
+////     let /*end*/af = async () => {
+////       [|/*start*/await|] Promise.resolve(0);
+////     }
+//// }
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionYield1.ts
+++ b/tests/cases/fourslash/goToDefinitionYield1.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+//// function* /*end1*/gen() {
+////     [|/*start1*/yield|] 0;
+//// }
+////
+//// const /*end2*/genFunction = function*() {
+////     [|/*start2*/yield|] 0;
+//// }
+
+verify.goToDefinition("start1", "end1");
+verify.goToDefinition("start2", "end2");

--- a/tests/cases/fourslash/goToDefinitionYield2.ts
+++ b/tests/cases/fourslash/goToDefinitionYield2.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+//// function* outerGen() {
+////     function* /*end*/gen() {
+////         [|/*start*/yield|] 0;
+////     }
+////     return gen
+//// }
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionYield3.ts
+++ b/tests/cases/fourslash/goToDefinitionYield3.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+//// class C {
+////     notAGenerator() {
+////       [|/*start1*/yield|] 0;
+////     }
+////
+////     foo*/*end2*/() {
+////       [|/*start2*/yield|] 0;
+////     }
+//// }
+
+verify.goToDefinition("start1", []);
+verify.goToDefinition("start2", "end2");

--- a/tests/cases/fourslash/goToDefinitionYield4.ts
+++ b/tests/cases/fourslash/goToDefinitionYield4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+//// function* gen() {
+////     class C { [/*start*/yield 10]() {} }
+//// }
+
+verify.goToDefinition("start", []);


### PR DESCRIPTION
Fixes #51223

My first PR on this project, apologies in advance in case I missed anything in the guidelines. 

Please note that there was some discussion in the issue for `await`, whether it should jump to the function definition or the respective `async`. This PR does the former - in the very most cases, they should be right next to each other either way, and the latter seems slightly more involved to implement (which I'm absolutely willing to tackle though if preferred). 

Furthermore, in the case of an error (e.g. surrounding function is not async/generator), this implementation should not provide any goToDefinition. 
