### PR TITLE
Basic JSX attribute snippet fixes

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2844,8 +2844,10 @@ function getCompletionData(
 
                 case SyntaxKind.JsxExpression:
                 case SyntaxKind.JsxSpreadAttribute:
-                    // For `<div foo={true} [||] ></div>`, `parent` will be `{true}` and `previousToken` will be `}`
-                    if (previousToken.kind === SyntaxKind.CloseBraceToken && currentToken.kind === SyntaxKind.GreaterThanToken) {
+                    // First case is for `<div foo={true} [||] />` or `<div foo={true} [||] ></div>`,
+                    // `parent` will be `{true}` and `compareToken` will be `}`
+                    // Second case is for `<div foo={true} t[||] ></div>`
+                    if (previousToken.kind === SyntaxKind.CloseBraceToken || (previousToken.kind === SyntaxKind.Identifier || previousToken.parent.kind === SyntaxKind.JsxAttribute)) {
                         isJsxIdentifierExpected = true;
                     }
                     break;
@@ -5173,4 +5175,3 @@ function toUpperCharCode(charCode: number) {
     }
     return charCode;
 }
-

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2845,7 +2845,7 @@ function getCompletionData(
                 case SyntaxKind.JsxExpression:
                 case SyntaxKind.JsxSpreadAttribute:
                     // First case is for `<div foo={true} [||] />` or `<div foo={true} [||] ></div>`,
-                    // `parent` will be `{true}` and `compareToken` will be `}`
+                    // `parent` will be `{true}` and `previousToken` will be `}`
                     // Second case is for `<div foo={true} t[||] ></div>`
                     if (previousToken.kind === SyntaxKind.CloseBraceToken || (previousToken.kind === SyntaxKind.Identifier || previousToken.parent.kind === SyntaxKind.JsxAttribute)) {
                         isJsxIdentifierExpected = true;

--- a/tests/cases/fourslash/jsxAttributeSnippetCompletionClosed.ts
+++ b/tests/cases/fourslash/jsxAttributeSnippetCompletionClosed.ts
@@ -52,12 +52,21 @@
 ////function fn11() {
 ////    return <Foo something cla/*11*/ />
 ////}
+////function fn12() {
+////    return <Foo something='foo' cla/*12*/ />
+////}
+////function fn13() {
+////    return <Foo something={false} cla/*13*/ />
+////}
+////function fn14() {
+////    return <Foo something={false} cla/*14*/ foo />
+////}
 
 var preferences: FourSlashInterface.UserPreferences = {
     jsxAttributeCompletionStyle: "braces",
     includeCompletionsWithSnippetText: true,
     includeCompletionsWithInsertText: true,
-}; 
+};
 
 verify.completions(
     { marker: "1", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
@@ -71,4 +80,7 @@ verify.completions(
     { marker: "9", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
     { marker: "10", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
     { marker: "11", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "12", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "13", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "14", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
 )

--- a/tests/cases/fourslash/jsxAttributeSnippetCompletionClosed.ts
+++ b/tests/cases/fourslash/jsxAttributeSnippetCompletionClosed.ts
@@ -53,10 +53,10 @@
 ////    return <Foo something cla/*11*/ />
 ////}
 ////function fn12() {
-////    return <Foo something='foo' cla/*12*/ />
+////    return <Foo something={false} cla/*12*/ />
 ////}
 ////function fn13() {
-////    return <Foo something={false} cla/*13*/ />
+////    return <Foo something={false} /*13*/ foo />
 ////}
 ////function fn14() {
 ////    return <Foo something={false} cla/*14*/ foo />

--- a/tests/cases/fourslash/jsxAttributeSnippetCompletionClosed.ts
+++ b/tests/cases/fourslash/jsxAttributeSnippetCompletionClosed.ts
@@ -2,7 +2,7 @@
 //@Filename: file.tsx
 ////interface NestedInterface {
 ////    Foo: NestedInterface;
-////    (props: {className?: string}): any;
+////    (props: {className?: string, onClick?: () => void}): any;
 ////}
 ////
 ////declare const Foo: NestedInterface;
@@ -61,6 +61,12 @@
 ////function fn14() {
 ////    return <Foo something={false} cla/*14*/ foo />
 ////}
+////function fn15() {
+////    return <Foo onC/*15*/="" />
+////}
+////function fn16() {
+////    return <Foo something={false} onC/*16*/="" foo />
+////}
 
 var preferences: FourSlashInterface.UserPreferences = {
     jsxAttributeCompletionStyle: "braces",
@@ -83,4 +89,6 @@ verify.completions(
     { marker: "12", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
     { marker: "13", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
     { marker: "14", preferences, includes: { name: "className", insertText: "className={$1}", text: "(property) className?: string", isSnippet: true, sortText: completion.SortText.OptionalMember } },
+    { marker: "15", preferences, includes: { name: "onClick", insertText: undefined, text: "(property) onClick?: () => void", isSnippet: undefined, sortText: completion.SortText.OptionalMember } },
+    { marker: "16", preferences, includes: { name: "onClick", insertText: undefined, text: "(property) onClick?: () => void", isSnippet: undefined, sortText: completion.SortText.OptionalMember } },
 )


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/51845
Fixes #47302

It wasn't working in the following cases:

```tsx
;<SomeElem foo={''} [||] />
;<SomeElem foo={''} [||] x />
;<SomeElem foo={''} x[||] />
;<SomeElem foo={''} x[||] f />
```

(see linked issue with playground link)

On that line:

https://github.com/microsoft/TypeScript/blob/1f32fef5a2e9cfdcd95a2628816c26fed7e633e4/src/services/completions.ts#L2848

```tsx
;<div foo={''} [||] /> // currentToken.kind = Slash
;<div foo={''} [||] test /> // currentToken.kind = Identifier
```

I couldn't figure out why `currentToken.kind === SyntaxKind.GreaterThanToken` is being used here, documentation comment doesn't state why this restriction is required. Also I saw all tests are passing locally.
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->



