### PR TITLE
Remove excluded CodeQL rules, fix reference to Gulpfile

### DIFF
--- a/.github/codeql/codeql-configuration.yml
+++ b/.github/codeql/codeql-configuration.yml
@@ -3,32 +3,6 @@ name : CodeQL Configuration
 paths:
   - src
   - scripts
-  - Gulpfile.mjs
+  - Herebyfile.mjs
 paths-ignore:
   - src/lib
-
-# These queries appear to time out after the module conversion.
-# https://github.com/github/codeql/issues/10937
-query-filters:
-  - exclude:
-      id: js/path-injection # TaintedPath.ql
-  - exclude:
-      id: js/command-line-injection # CommandInjection.ql
-  - exclude:
-      id: js/code-injection # CodeInjection.ql
-  - exclude:
-      id: js/bad-code-sanitization # ImproperCodeSanitization.ql
-  - exclude:
-      id: js/unsafe-dynamic-method-access # UnsafeDynamicMethodAccess.ql
-  - exclude:
-      id: js/clear-text-logging # CleartextLogging.ql
-  - exclude:
-      id: js/regex-injection # RegExpInjection.ql
-  - exclude:
-      id: js/unvalidated-dynamic-method-call # UnvalidatedDynamicMethodCall.ql
-  - exclude:
-      id: js/insecure-download # InsecureDownload.ql
-  - exclude:
-      id: js/prototype-polluting-assignment # PrototypePollutingAssignment.ql
-  - exclude:
-      id: js/request-forgery # RequestForgery.ql


### PR DESCRIPTION
Fixes #51401

The new CodeQL bundle was released yesterday; remove these exclusions and see if we pass.

Also, the new Herebyfile wasn't getting checked; I forgot to change this in the module conversion.
