### PR TITLE
Remove isJSDocOptionalParameter and isOptionalDeclaration from public API

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -9458,6 +9458,7 @@ export function hasTabstop(node: Node): boolean {
     return getSnippetElement(node)?.kind === SnippetKind.TabStop;
 }
 
+/** @internal */
 export function isJSDocOptionalParameter(node: ParameterDeclaration) {
     return isInJSFile(node) && (
         // node.type should only be a JSDocOptionalType when node is a parameter of a JSDocFunctionType
@@ -9466,6 +9467,7 @@ export function isJSDocOptionalParameter(node: ParameterDeclaration) {
             isBracketed || !!typeExpression && typeExpression.type.kind === SyntaxKind.JSDocOptionalType));
 }
 
+/** @internal */
 export function isOptionalDeclaration(declaration: Declaration): boolean {
     switch (declaration.kind) {
         case SyntaxKind.PropertyDeclaration:

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8795,8 +8795,6 @@ declare namespace ts {
         name: Identifier;
     };
     function emitModuleKindIsNonNodeESM(moduleKind: ModuleKind): boolean;
-    function isJSDocOptionalParameter(node: ParameterDeclaration): boolean;
-    function isOptionalDeclaration(declaration: Declaration): boolean;
     function createUnparsedSourceFile(text: string): UnparsedSource;
     function createUnparsedSourceFile(inputFile: InputFiles, type: "js" | "dts", stripInternal?: boolean): UnparsedSource;
     function createUnparsedSourceFile(text: string, mapPath: string | undefined, map: string | undefined): UnparsedSource;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4860,8 +4860,6 @@ declare namespace ts {
         name: Identifier;
     };
     function emitModuleKindIsNonNodeESM(moduleKind: ModuleKind): boolean;
-    function isJSDocOptionalParameter(node: ParameterDeclaration): boolean;
-    function isOptionalDeclaration(declaration: Declaration): boolean;
     function createUnparsedSourceFile(text: string): UnparsedSource;
     function createUnparsedSourceFile(inputFile: InputFiles, type: "js" | "dts", stripInternal?: boolean): UnparsedSource;
     function createUnparsedSourceFile(text: string, mapPath: string | undefined, map: string | undefined): UnparsedSource;


### PR DESCRIPTION
I added these two helpers in this PR https://github.com/microsoft/TypeScript/pull/49910., I think both should not be public. What do you think @sandersn @jakebailey?