### PR TITLE
Call `getTypeOfSymbol` in `getNarrowedTypeOfSymbol` to avoid running into circularities when computing types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27028,6 +27028,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getNarrowedTypeOfSymbol(symbol: Symbol, location: Identifier) {
+        const type = getTypeOfSymbol(symbol);
         const declaration = symbol.valueDeclaration;
         if (declaration) {
             // If we have a non-rest binding element with no initializer declared as a const variable or a const-like
@@ -27108,7 +27109,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
         }
-        return getTypeOfSymbol(symbol);
+        return type;
     }
 
     function checkIdentifier(node: Identifier, checkMode: CheckMode | undefined): Type {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1140,6 +1140,17 @@ export class TestState {
         }
     }
 
+    public verifyTypeAtLocation(range: Range, expected: string): void {
+        const node = this.goToAndGetNode(range);
+        const checker = this.getChecker();
+        const type = checker.getTypeAtLocation(node);
+
+        const actual = checker.typeToString(type);
+        if (actual !== expected) {
+            this.raiseError(displayExpectedAndActualString(expected, actual));
+        }
+    }
+
     public verifyBaselineFindAllReferences(...markerNames: string[]) {
         ts.Debug.assert(markerNames.length > 0, "Must pass at least one marker name to `verifyBaselineFindAllReferences()`");
         this.verifyBaselineFindAllReferencesWorker("", markerNames);

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -354,6 +354,10 @@ export class Verify extends VerifyNegatable {
         this.state.verifyTypeOfSymbolAtLocation(range, symbol, expected);
     }
 
+    public typeAtLocation(range: FourSlash.Range, expected: string) {
+        this.state.verifyTypeAtLocation(range, expected);
+    }
+
     public baselineFindAllReferences(...markerNames: string[]) {
         this.state.verifyBaselineFindAllReferences(...markerNames);
     }

--- a/tests/cases/fourslash/circularGetTypeAtLocation.ts
+++ b/tests/cases/fourslash/circularGetTypeAtLocation.ts
@@ -1,5 +1,7 @@
 /// <reference path='fourslash.ts' />
 
+// Issue #48313
+
 // @strict: true
 // @target: esnext
 // @Filename: /file.tsx

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -335,6 +335,7 @@ declare namespace FourSlashInterface {
         baselineGetFileReferences(fileName: string): void;
         symbolAtLocation(startRange: Range, ...declarationRanges: Range[]): void;
         typeOfSymbolAtLocation(range: Range, symbol: any, expected: string): void;
+        typeAtLocation(range: Range, expected: string): void;
         /** @deprecated Use baselineFindAllReferences instead */
         singleReferenceGroup(definition: ReferencesDefinition, ranges?: Range[] | string): void;
         rangesAreOccurrences(isWriteAccess?: boolean, ranges?: Range[]): void;

--- a/tests/cases/fourslash/getTypeAtLocation.ts
+++ b/tests/cases/fourslash/getTypeAtLocation.ts
@@ -1,0 +1,28 @@
+/// <reference path='fourslash.ts' />
+
+// @strict: true
+// @target: esnext
+// @Filename: /file.tsx
+//// export function working(baseVersion?: string): number[] {
+////     const toRelease: number[] = [];
+////     const baseRelease: number[] = [];
+////     return baseRelease.map((_, index) => {
+////         const toPart = toRelease[index] ?? 0;
+////         [|toPart|]; // this is the "working" log
+////         return 0;
+////     });
+//// }
+//// 
+//// export function broken(baseVersion?: string): number[] {
+////     const toRelease: number[] = [];
+////     const baseRelease: number[] = [];
+////     return baseRelease.map((_, index) => {
+////         const toPart = toRelease[index] ?? 0;
+////         [|toPart|]; // this is the "broken" log
+////         return toPart + (baseVersion === undefined ? 0 : 1);
+////     });
+//// }
+
+const [r_ok, r_bad] = test.ranges();
+verify.typeAtLocation(r_ok, "number");
+verify.typeAtLocation(r_bad, "number");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #48313.
