### PR TITLE
fix(51920): "Add missing members" quick fixes incorrectly add TypeScript types in JavaScript files

### DIFF
--- a/tests/cases/fourslash/codeFixAddMissingProperties25.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties25.ts
@@ -1,0 +1,20 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+// @filename: /a.js
+/////**
+//// * @type {{ f: (x: string) => number }}
+//// */
+////[|export const foo = {}|]
+
+verify.codeFix({
+    index: 0,
+    description: ts.Diagnostics.Add_missing_properties.message,
+    newRangeContent:
+`export const foo = {
+    f: function(x) {
+        throw new Error("Function not implemented.");
+    }
+}`,
+});


### PR DESCRIPTION
Fixes #51920