### PR TITLE
Make Collection and ReadonlyCollection internal

### DIFF
--- a/src/compiler/corePublic.ts
+++ b/src/compiler/corePublic.ts
@@ -23,18 +23,27 @@ export interface SortedArray<T> extends Array<T> {
     " __sortedArrayBrand": any;
 }
 
-/** Common read methods for ES6 Map/Set. */
+/**
+ * Common read methods for ES6 Map/Set.
+ *
+ * @internal
+ */
 export interface ReadonlyCollection<K> {
     readonly size: number;
     has(key: K): boolean;
     keys(): Iterator<K>;
 }
 
-/** Common write methods for ES6 Map/Set. */
+/**
+ * Common write methods for ES6 Map/Set.
+ *
+ * @internal
+ */
 export interface Collection<K> extends ReadonlyCollection<K> {
     delete(key: K): boolean;
     clear(): void;
 }
+
 /** Array that is only intended to be pushed to, never read. */
 export interface Push<T> {
     push(...values: T[]): void;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3966,17 +3966,6 @@ declare namespace ts {
     interface SortedArray<T> extends Array<T> {
         " __sortedArrayBrand": any;
     }
-    /** Common read methods for ES6 Map/Set. */
-    interface ReadonlyCollection<K> {
-        readonly size: number;
-        has(key: K): boolean;
-        keys(): Iterator<K>;
-    }
-    /** Common write methods for ES6 Map/Set. */
-    interface Collection<K> extends ReadonlyCollection<K> {
-        delete(key: K): boolean;
-        clear(): void;
-    }
     /** Array that is only intended to be pushed to, never read. */
     interface Push<T> {
         push(...values: T[]): void;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -31,17 +31,6 @@ declare namespace ts {
     interface SortedArray<T> extends Array<T> {
         " __sortedArrayBrand": any;
     }
-    /** Common read methods for ES6 Map/Set. */
-    interface ReadonlyCollection<K> {
-        readonly size: number;
-        has(key: K): boolean;
-        keys(): Iterator<K>;
-    }
-    /** Common write methods for ES6 Map/Set. */
-    interface Collection<K> extends ReadonlyCollection<K> {
-        delete(key: K): boolean;
-        clear(): void;
-    }
     /** Array that is only intended to be pushed to, never read. */
     interface Push<T> {
         push(...values: T[]): void;


### PR DESCRIPTION
This is a follow-up to #51439; these types were declared next to our `Map` and `Set` types, but these types are not actually used in our public API, only in a very small number of internal ones.

I don't think there's a major reason to have these in our public API, and given we've removed Map/Set (which were a part of other public APIs), now seems like a good time to drop these.

I did try removing them entirely, but doing that turned out to be tricky in a couple of places. It's probably worth reevaluating if/when we start using native iterator helpers.