### PR TITLE
Go back to using explicit node verisons in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
 
     strategy:
       matrix:
-        # Test the latest version of Node.js plus the last two LTS versions.
         node-version:
-          - "*"
-          - lts/*
-          - lts/-1
+          - "19"
+          - "18"
+          - "16"
+          - "14"
         bundle:
           - "true"
         include:

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -172,7 +172,13 @@ function getPlainDiagnosticFollowingNewLines(diagnostic: Diagnostic, newLine: st
 export function getLocaleTimeString(system: System) {
     return !system.now ?
         new Date().toLocaleTimeString() :
-        system.now().toLocaleTimeString("en-US", { timeZone: "UTC" });
+        // In Node 19+, there's a non-breaking space between the time and AM/PM.
+        // This branch is solely for testing, so just switch it to a normal space for
+        // baseline stability.
+        // See:
+        //     - https://github.com/nodejs/node/issues/45171
+        //     - https://github.com/nodejs/node/issues/45753
+        system.now().toLocaleTimeString("en-US", { timeZone: "UTC" }).replace("\u202f", " ");
 }
 
 /**

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -172,9 +172,8 @@ function getPlainDiagnosticFollowingNewLines(diagnostic: Diagnostic, newLine: st
 export function getLocaleTimeString(system: System) {
     return !system.now ?
         new Date().toLocaleTimeString() :
-        // In Node 19+, there's a non-breaking space between the time and AM/PM.
-        // This branch is solely for testing, so just switch it to a normal space for
-        // baseline stability.
+        // On some systems / builds of Node, there's a non-breaking space between the time and AM/PM.
+        // This branch is solely for testing, so just switch it to a normal space for baseline stability.
         // See:
         //     - https://github.com/nodejs/node/issues/45171
         //     - https://github.com/nodejs/node/issues/45753


### PR DESCRIPTION
Fixes #51943

We were using "\*" and "lts" assuming that one would be the most recent node release, and the other be LTS. This turns out to be wrong because "\*" means "whatever is newest in GHA's cache", not the actual latest.

We could switch to say "current" or "latest", which would ensure we always get the actual current Node version. However, the current setup has another problem; it assumes that there are only two LTS versions out at one time. This isn't accurate; right now, Node 14, 16, and 18 are all LTS, and we are now suddenly not testing Node 14, which is scary.

I don't see a way to solve this, because at some points of the year, there will be two LTS releases, and sometimes, there will be three.

Just go back to explicitly listing the versions we test with. This will make us definitely run on all of our intended targets, but also mean old release branches won't suddenly test on the wrong versions, which is good.

We'll have to remember to update these, but I am personally confident that is fine. I also imagine that we don't want to drop Node 14 anytime soon, because it's the last version with stack restarting in debugging, a feature that many on the team use (including me).