### PR TITLE
Fix quote style of string literal in exhaustive case completions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1053,7 +1053,7 @@ function getExhaustiveCaseSnippets(
                         elements.push(factory.createNumericLiteral(type.value));
                         break;
                     case "string":
-                        elements.push(factory.createStringLiteral(type.value));
+                        elements.push(factory.createStringLiteral(type.value, quotePreference === QuotePreference.Single));
                         break;
                 }
             }

--- a/tests/cases/fourslash/exhaustiveCaseCompletions6.ts
+++ b/tests/cases/fourslash/exhaustiveCaseCompletions6.ts
@@ -1,0 +1,32 @@
+/// <reference path="fourslash.ts" />
+
+// Quote preferences.
+
+// @newline: LF
+//// declare const p: 'A' | 'B' | 'C';
+//// 
+//// switch (p) {
+////     /*1*/
+//// }
+
+verify.completions(
+    {
+        marker: "1",
+        isNewIdentifierLocation: false,
+        includes: [
+            {
+                name: `case 'A': ...`,
+                source: completion.CompletionSource.SwitchCases,
+                sortText: completion.SortText.GlobalsOrKeywords,
+                insertText:
+`case 'A':
+case 'B':
+case 'C':`,
+            },
+        ],
+        preferences: {
+            includeCompletionsWithInsertText: true,
+            quotePreference: "single",
+        },
+    },
+);


### PR DESCRIPTION
Didn't open an issue, but @andrewbranch found this bug while using the feature.
