### PR TITLE
--moduleResolution bundler: Allow import assignment in ambient contexts

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -42778,7 +42778,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // Import equals declaration is deprecated in es6 or above
                     grammarErrorOnNode(node, Diagnostics.Import_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_import_Asterisk_as_ns_from_mod_import_a_from_mod_import_d_from_mod_or_another_module_format_instead);
                 }
-                else if (getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Bundler) {
+                else if (!(node.flags & NodeFlags.Ambient) && getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Bundler) {
                     grammarErrorOnNode(node, Diagnostics.Import_assignment_is_not_allowed_when_moduleResolution_is_set_to_bundler_Consider_using_import_Asterisk_as_ns_from_mod_import_a_from_mod_import_d_from_mod_or_another_module_format_instead);
                 }
             }

--- a/tests/baselines/reference/bundlerSyntaxRestrictions.errors.txt
+++ b/tests/baselines/reference/bundlerSyntaxRestrictions.errors.txt
@@ -8,6 +8,18 @@ error TS2468: Cannot find global value 'Promise'.
 ==== /node_modules/@types/node/index.d.ts (0 errors) ====
     declare var require: (...args: any[]) => any;
     
+==== /ambient.d.ts (0 errors) ====
+    declare module "fs" {
+        export function readFileSync(path: string, encoding?: string): string;
+    }
+    declare module "path" {
+        import fs = require("fs"); // ok
+        namespace path {
+            export const sep: string;
+        }
+        export = path; // ok
+    }
+    
 ==== /mainJs.js (1 errors) ====
     import {} from "./a";
     import("./a");

--- a/tests/baselines/reference/bundlerSyntaxRestrictions.js
+++ b/tests/baselines/reference/bundlerSyntaxRestrictions.js
@@ -3,6 +3,18 @@
 //// [index.d.ts]
 declare var require: (...args: any[]) => any;
 
+//// [ambient.d.ts]
+declare module "fs" {
+    export function readFileSync(path: string, encoding?: string): string;
+}
+declare module "path" {
+    import fs = require("fs"); // ok
+    namespace path {
+        export const sep: string;
+    }
+    export = path; // ok
+}
+
 //// [mainJs.js]
 import {} from "./a";
 import("./a");

--- a/tests/baselines/reference/bundlerSyntaxRestrictions.symbols
+++ b/tests/baselines/reference/bundlerSyntaxRestrictions.symbols
@@ -3,6 +3,31 @@ declare var require: (...args: any[]) => any;
 >require : Symbol(require, Decl(index.d.ts, 0, 11))
 >args : Symbol(args, Decl(index.d.ts, 0, 22))
 
+=== /ambient.d.ts ===
+declare module "fs" {
+>"fs" : Symbol("fs", Decl(ambient.d.ts, 0, 0))
+
+    export function readFileSync(path: string, encoding?: string): string;
+>readFileSync : Symbol(readFileSync, Decl(ambient.d.ts, 0, 21))
+>path : Symbol(path, Decl(ambient.d.ts, 1, 33))
+>encoding : Symbol(encoding, Decl(ambient.d.ts, 1, 46))
+}
+declare module "path" {
+>"path" : Symbol("path", Decl(ambient.d.ts, 2, 1))
+
+    import fs = require("fs"); // ok
+>fs : Symbol(fs, Decl(ambient.d.ts, 3, 23))
+
+    namespace path {
+>path : Symbol(path, Decl(ambient.d.ts, 4, 30))
+
+        export const sep: string;
+>sep : Symbol(sep, Decl(ambient.d.ts, 6, 20))
+    }
+    export = path; // ok
+>path : Symbol(path, Decl(ambient.d.ts, 4, 30))
+}
+
 === /mainJs.js ===
 import {} from "./a";
 import("./a");

--- a/tests/baselines/reference/bundlerSyntaxRestrictions.types
+++ b/tests/baselines/reference/bundlerSyntaxRestrictions.types
@@ -3,6 +3,31 @@ declare var require: (...args: any[]) => any;
 >require : (...args: any[]) => any
 >args : any[]
 
+=== /ambient.d.ts ===
+declare module "fs" {
+>"fs" : typeof import("fs")
+
+    export function readFileSync(path: string, encoding?: string): string;
+>readFileSync : (path: string, encoding?: string) => string
+>path : string
+>encoding : string
+}
+declare module "path" {
+>"path" : typeof import("path")
+
+    import fs = require("fs"); // ok
+>fs : typeof fs
+
+    namespace path {
+>path : typeof path
+
+        export const sep: string;
+>sep : string
+    }
+    export = path; // ok
+>path : typeof path
+}
+
 === /mainJs.js ===
 import {} from "./a";
 import("./a");

--- a/tests/cases/conformance/moduleResolution/bundler/bundlerSyntaxRestrictions.ts
+++ b/tests/cases/conformance/moduleResolution/bundler/bundlerSyntaxRestrictions.ts
@@ -6,6 +6,18 @@
 // @Filename: /node_modules/@types/node/index.d.ts
 declare var require: (...args: any[]) => any;
 
+// @Filename: /ambient.d.ts
+declare module "fs" {
+    export function readFileSync(path: string, encoding?: string): string;
+}
+declare module "path" {
+    import fs = require("fs"); // ok
+    namespace path {
+        export const sep: string;
+    }
+    export = path; // ok
+}
+
 // @Filename: /mainJs.js
 import {} from "./a";
 import("./a");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Adds an overlooked check for ambient context in `--moduleResolution bundler`. I was trying to dogfood the mode in a side project, and immediately got a bunch of errors inside node_modules because of this.
