### PR TITLE
remove rogue debugger statement

### DIFF
--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -192,7 +192,6 @@ export namespace Debug {
     }
 
     export function fail(message?: string, stackCrawlMark?: AnyFunction): never {
-        debugger;
         const e = new Error(message ? `Debug Failure. ${message}` : "Debug Failure.");
         if ((Error as any).captureStackTrace) {
             (Error as any).captureStackTrace(e, stackCrawlMark || fail);


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/51998

When debugging something else I found this rogue debugger in the typescript code. 

~I couldn't find an issue in the backlog that covers this but I figured the PR is just as good as an issue to describe and catalogue the issue 👍~ Turns out the bot wanted me to open an issue so I did.

While opening the issue I found out that this was added a long time ago somewhat intentionally https://github.com/microsoft/TypeScript/pull/5358 so I wonder if there might be an alternative solution to allow people to block here if they wanted to: maybe we could wrap the debugger in an if-statement that checks an ENV variable. That way people who wanted to block on this debugger could run their build with `BLOCK_ON_ASSERT_FAILURE=true` and have the same behaviour as now.


