### PR TITLE
fix(51963): Invalid property read for find-all-references when exporting non-existent binding

### DIFF
--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -653,6 +653,7 @@ export function getImportOrExportSymbol(node: Node, symbol: Symbol, checker: Typ
 
         // Search on the local symbol in the exporting module, not the exported symbol.
         importedSymbol = skipExportSpecifierSymbol(importedSymbol, checker);
+
         // Similarly, skip past the symbol for 'export ='
         if (importedSymbol.escapedName === "export=") {
             importedSymbol = getExportEqualsLocalSymbol(importedSymbol, checker);
@@ -744,7 +745,7 @@ function skipExportSpecifierSymbol(symbol: Symbol, checker: TypeChecker): Symbol
     if (symbol.declarations) {
         for (const declaration of symbol.declarations) {
             if (isExportSpecifier(declaration) && !declaration.propertyName && !declaration.parent.parent.moduleSpecifier) {
-                return checker.getExportSpecifierLocalTargetSymbol(declaration)!;
+                return checker.getExportSpecifierLocalTargetSymbol(declaration) || symbol;
             }
             else if (isPropertyAccessExpression(declaration) && isModuleExportsAccessExpression(declaration.expression) && !isPrivateIdentifier(declaration.name)) {
                 // Export of form 'module.exports.propName = expr';

--- a/tests/baselines/reference/findAllReferencesNonExistentExportBinding.baseline.jsonc
+++ b/tests/baselines/reference/findAllReferencesNonExistentExportBinding.baseline.jsonc
@@ -1,0 +1,100 @@
+// === /bar.ts ===
+// import { [|Foo|]/*FIND ALL REFS*/ } from "./foo";
+
+// === /foo.ts ===
+// export { [|Foo|] }
+
+[
+  {
+    "definition": {
+      "containerKind": "",
+      "containerName": "",
+      "fileName": "/bar.ts",
+      "kind": "alias",
+      "name": "import Foo",
+      "textSpan": {
+        "start": 9,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "import",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Foo",
+          "kind": "aliasName"
+        }
+      ],
+      "contextSpan": {
+        "start": 0,
+        "length": 28
+      }
+    },
+    "references": [
+      {
+        "textSpan": {
+          "start": 9,
+          "length": 3
+        },
+        "fileName": "/bar.ts",
+        "contextSpan": {
+          "start": 0,
+          "length": 28
+        },
+        "isWriteAccess": true,
+        "isDefinition": true
+      }
+    ]
+  },
+  {
+    "definition": {
+      "containerKind": "",
+      "containerName": "",
+      "fileName": "/foo.ts",
+      "kind": "alias",
+      "name": "export Foo",
+      "textSpan": {
+        "start": 9,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "export",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Foo",
+          "kind": "aliasName"
+        }
+      ],
+      "contextSpan": {
+        "start": 0,
+        "length": 14
+      }
+    },
+    "references": [
+      {
+        "textSpan": {
+          "start": 9,
+          "length": 3
+        },
+        "fileName": "/foo.ts",
+        "contextSpan": {
+          "start": 0,
+          "length": 14
+        },
+        "isWriteAccess": true,
+        "isDefinition": false
+      }
+    ]
+  }
+]

--- a/tests/cases/fourslash/findAllReferencesNonExistentExportBinding.ts
+++ b/tests/cases/fourslash/findAllReferencesNonExistentExportBinding.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "commonjs" } }
+
+// @filename: /bar.ts
+////import { Foo/**/ } from "./foo";
+
+// @filename: /foo.ts
+////export { Foo }
+
+verify.baselineFindAllReferences('');


### PR DESCRIPTION
Fixes #51963
