### PR TITLE
Replace `missingType` with `undefinedType` in the `IndexedAccessTypeNode`'s type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16855,7 +16855,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 const propType = getTypeOfSymbol(prop);
                 return accessExpression && getAssignmentTargetKind(accessExpression) !== AssignmentKind.Definite ? getFlowTypeOfReference(accessExpression, propType) :
-                    accessNode && isIndexedAccessTypeNode(accessNode) ? mapType(propType, type => type === missingType ? undefinedType : type) :
+                    accessNode && isIndexedAccessTypeNode(accessNode) && containsMissingType(propType) ? getUnionType([propType, undefinedType]) :
                     propType;
             }
             if (everyType(objectType, isTupleType) && isNumericLiteralName(propName)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16856,6 +16856,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const propType = getTypeOfSymbol(prop);
                 return accessExpression && getAssignmentTargetKind(accessExpression) !== AssignmentKind.Definite ?
                     getFlowTypeOfReference(accessExpression, propType) :
+                    accessNode && isIndexedAccessTypeNode(accessNode) ?
+                    mapType(propType, type => type === missingType ? undefinedType : type) :
                     propType;
             }
             if (everyType(objectType, isTupleType) && isNumericLiteralName(propName)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16854,10 +16854,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
                 const propType = getTypeOfSymbol(prop);
-                return accessExpression && getAssignmentTargetKind(accessExpression) !== AssignmentKind.Definite ?
-                    getFlowTypeOfReference(accessExpression, propType) :
-                    accessNode && isIndexedAccessTypeNode(accessNode) ?
-                    mapType(propType, type => type === missingType ? undefinedType : type) :
+                return accessExpression && getAssignmentTargetKind(accessExpression) !== AssignmentKind.Definite ? getFlowTypeOfReference(accessExpression, propType) :
+                    accessNode && isIndexedAccessTypeNode(accessNode) ? mapType(propType, type => type === missingType ? undefinedType : type) :
                     propType;
             }
             if (everyType(objectType, isTupleType) && isNumericLiteralName(propName)) {

--- a/tests/baselines/reference/typePredicateAcceptingPartialOfRefinedType.symbols
+++ b/tests/baselines/reference/typePredicateAcceptingPartialOfRefinedType.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts ===
+// repro #51953
+
+interface Test {
+>Test : Symbol(Test, Decl(typePredicateAcceptingPartialOfRefinedType.ts, 0, 0))
+
+  testy?: string;
+>testy : Symbol(Test.testy, Decl(typePredicateAcceptingPartialOfRefinedType.ts, 2, 16))
+}
+
+interface Options {
+>Options : Symbol(Options, Decl(typePredicateAcceptingPartialOfRefinedType.ts, 4, 1))
+
+  test: Test['testy'];
+>test : Symbol(Options.test, Decl(typePredicateAcceptingPartialOfRefinedType.ts, 6, 19))
+>Test : Symbol(Test, Decl(typePredicateAcceptingPartialOfRefinedType.ts, 0, 0))
+}
+
+declare function includesAllRequiredOptions(options: Partial<Options>): options is Options;
+>includesAllRequiredOptions : Symbol(includesAllRequiredOptions, Decl(typePredicateAcceptingPartialOfRefinedType.ts, 8, 1))
+>options : Symbol(options, Decl(typePredicateAcceptingPartialOfRefinedType.ts, 10, 44))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Options : Symbol(Options, Decl(typePredicateAcceptingPartialOfRefinedType.ts, 4, 1))
+>options : Symbol(options, Decl(typePredicateAcceptingPartialOfRefinedType.ts, 10, 44))
+>Options : Symbol(Options, Decl(typePredicateAcceptingPartialOfRefinedType.ts, 4, 1))
+

--- a/tests/baselines/reference/typePredicateAcceptingPartialOfRefinedType.types
+++ b/tests/baselines/reference/typePredicateAcceptingPartialOfRefinedType.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts ===
+// repro #51953
+
+interface Test {
+  testy?: string;
+>testy : string | undefined
+}
+
+interface Options {
+  test: Test['testy'];
+>test : string | undefined
+}
+
+declare function includesAllRequiredOptions(options: Partial<Options>): options is Options;
+>includesAllRequiredOptions : (options: Partial<Options>) => options is Options
+>options : Partial<Options>
+

--- a/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
+++ b/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
@@ -1,0 +1,15 @@
+// @strict: true
+// @exactOptionalPropertyTypes: true
+// @noEmit: true
+
+// repro #51953
+
+interface Test {
+  testy?: string;
+}
+
+interface Options {
+  test: Test['testy'];
+}
+
+declare function includesAllRequiredOptions(options: Partial<Options>): options is Options;


### PR DESCRIPTION
fixes #51953

cc @sandersn 