### PR TITLE
fix(52050): The space before satisfies after an array expression is removed when auto-formatting the statements

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -57,7 +57,11 @@ export function getAllRules(): RuleSpec[] {
     const anyTokenIncludingEOF = tokenRangeFrom([...allTokens, SyntaxKind.EndOfFileToken]);
     const keywords = tokenRangeFromRange(SyntaxKind.FirstKeyword, SyntaxKind.LastKeyword);
     const binaryOperators = tokenRangeFromRange(SyntaxKind.FirstBinaryOperator, SyntaxKind.LastBinaryOperator);
-    const binaryKeywordOperators = [SyntaxKind.InKeyword, SyntaxKind.InstanceOfKeyword, SyntaxKind.OfKeyword, SyntaxKind.AsKeyword, SyntaxKind.IsKeyword];
+    const binaryKeywordOperators = [
+        SyntaxKind.InKeyword, SyntaxKind.InstanceOfKeyword,
+        SyntaxKind.OfKeyword, SyntaxKind.AsKeyword,
+        SyntaxKind.IsKeyword, SyntaxKind.SatisfiesKeyword,
+    ];
     const unaryPrefixOperators = [SyntaxKind.PlusPlusToken, SyntaxKind.MinusMinusToken, SyntaxKind.TildeToken, SyntaxKind.ExclamationToken];
     const unaryPrefixExpressions = [
         SyntaxKind.NumericLiteral, SyntaxKind.BigIntLiteral, SyntaxKind.Identifier, SyntaxKind.OpenParenToken,
@@ -480,6 +484,7 @@ function isBinaryOpContext(context: FormattingContext): boolean {
         case SyntaxKind.ConditionalExpression:
         case SyntaxKind.ConditionalType:
         case SyntaxKind.AsExpression:
+        case SyntaxKind.SatisfiesExpression:
         case SyntaxKind.ExportSpecifier:
         case SyntaxKind.ImportSpecifier:
         case SyntaxKind.TypePredicate:

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -484,7 +484,6 @@ function isBinaryOpContext(context: FormattingContext): boolean {
         case SyntaxKind.ConditionalExpression:
         case SyntaxKind.ConditionalType:
         case SyntaxKind.AsExpression:
-        case SyntaxKind.SatisfiesExpression:
         case SyntaxKind.ExportSpecifier:
         case SyntaxKind.ImportSpecifier:
         case SyntaxKind.TypePredicate:

--- a/tests/cases/fourslash/formatSatisfiesExpression.ts
+++ b/tests/cases/fourslash/formatSatisfiesExpression.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+////type Foo = "a" | "b" | "c";
+////const foo1 = ["a"] satisfies Foo[];
+////const foo2 = ["a"]satisfies Foo[];
+////const foo3 = ["a"]  satisfies Foo[];
+
+format.document();
+verify.currentFileContentIs(
+`type Foo = "a" | "b" | "c";
+const foo1 = ["a"] satisfies Foo[];
+const foo2 = ["a"] satisfies Foo[];
+const foo3 = ["a"] satisfies Foo[];`
+);


### PR DESCRIPTION
Fixes #52050