### PR TITLE
Add a regression test for mapped type with as clause that bypassed interface extension check

### DIFF
--- a/tests/baselines/reference/genericMappedTypeAsClause.errors.txt
+++ b/tests/baselines/reference/genericMappedTypeAsClause.errors.txt
@@ -6,9 +6,10 @@ tests/cases/compiler/genericMappedTypeAsClause.ts(17,11): error TS2322: Type 'bo
 tests/cases/compiler/genericMappedTypeAsClause.ts(18,34): error TS2322: Type '{ a: string; b: number; }' is not assignable to type 'MappedModel<T>'.
   Object literal may only specify known properties, and 'a' does not exist in type 'MappedModel<T>'.
 tests/cases/compiler/genericMappedTypeAsClause.ts(19,11): error TS2322: Type 'undefined' is not assignable to type 'MappedModel<T>'.
+tests/cases/compiler/genericMappedTypeAsClause.ts(25,60): error TS2312: An interface can only extend an object type or intersection of object types with statically known members.
 
 
-==== tests/cases/compiler/genericMappedTypeAsClause.ts (7 errors) ====
+==== tests/cases/compiler/genericMappedTypeAsClause.ts (8 errors) ====
     type Model = {
         a: string;
         b: number;
@@ -45,4 +46,11 @@ tests/cases/compiler/genericMappedTypeAsClause.ts(19,11): error TS2322: Type 'un
               ~~
 !!! error TS2322: Type 'undefined' is not assignable to type 'MappedModel<T>'.
     }
+    
+    // repro from #43189
+    
+    type RemapRecord<K extends keyof any, V> = { [_ in never as K]: V }
+    interface RecordInterface2<K extends keyof any, V> extends RemapRecord<K, V> {} // should error
+                                                               ~~~~~~~~~~~~~~~~~
+!!! error TS2312: An interface can only extend an object type or intersection of object types with statically known members.
     

--- a/tests/baselines/reference/genericMappedTypeAsClause.js
+++ b/tests/baselines/reference/genericMappedTypeAsClause.js
@@ -20,6 +20,11 @@ function f1<T extends string>() {
     const x6: MappedModel<T> = undefined;  // Error
 }
 
+// repro from #43189
+
+type RemapRecord<K extends keyof any, V> = { [_ in never as K]: V }
+interface RecordInterface2<K extends keyof any, V> extends RemapRecord<K, V> {} // should error
+
 
 //// [genericMappedTypeAsClause.js]
 "use strict";

--- a/tests/baselines/reference/genericMappedTypeAsClause.symbols
+++ b/tests/baselines/reference/genericMappedTypeAsClause.symbols
@@ -73,3 +73,21 @@ function f1<T extends string>() {
 >undefined : Symbol(undefined)
 }
 
+// repro from #43189
+
+type RemapRecord<K extends keyof any, V> = { [_ in never as K]: V }
+>RemapRecord : Symbol(RemapRecord, Decl(genericMappedTypeAsClause.ts, 19, 1))
+>K : Symbol(K, Decl(genericMappedTypeAsClause.ts, 23, 17))
+>V : Symbol(V, Decl(genericMappedTypeAsClause.ts, 23, 37))
+>_ : Symbol(_, Decl(genericMappedTypeAsClause.ts, 23, 46))
+>K : Symbol(K, Decl(genericMappedTypeAsClause.ts, 23, 17))
+>V : Symbol(V, Decl(genericMappedTypeAsClause.ts, 23, 37))
+
+interface RecordInterface2<K extends keyof any, V> extends RemapRecord<K, V> {} // should error
+>RecordInterface2 : Symbol(RecordInterface2, Decl(genericMappedTypeAsClause.ts, 23, 67))
+>K : Symbol(K, Decl(genericMappedTypeAsClause.ts, 24, 27))
+>V : Symbol(V, Decl(genericMappedTypeAsClause.ts, 24, 47))
+>RemapRecord : Symbol(RemapRecord, Decl(genericMappedTypeAsClause.ts, 19, 1))
+>K : Symbol(K, Decl(genericMappedTypeAsClause.ts, 24, 27))
+>V : Symbol(V, Decl(genericMappedTypeAsClause.ts, 24, 47))
+

--- a/tests/baselines/reference/genericMappedTypeAsClause.types
+++ b/tests/baselines/reference/genericMappedTypeAsClause.types
@@ -65,3 +65,10 @@ function f1<T extends string>() {
 >undefined : undefined
 }
 
+// repro from #43189
+
+type RemapRecord<K extends keyof any, V> = { [_ in never as K]: V }
+>RemapRecord : RemapRecord<K, V>
+
+interface RecordInterface2<K extends keyof any, V> extends RemapRecord<K, V> {} // should error
+

--- a/tests/cases/compiler/genericMappedTypeAsClause.ts
+++ b/tests/cases/compiler/genericMappedTypeAsClause.ts
@@ -20,3 +20,8 @@ function f1<T extends string>() {
     const x5: MappedModel<T> = { a: 'bar', b: 42 };  // Error
     const x6: MappedModel<T> = undefined;  // Error
 }
+
+// repro from #43189
+
+type RemapRecord<K extends keyof any, V> = { [_ in never as K]: V }
+interface RecordInterface2<K extends keyof any, V> extends RemapRecord<K, V> {} // should error


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/43189

it most likely got fixed by https://github.com/microsoft/TypeScript/pull/51050