### PR TITLE
Add an extra test case for circular base type

### DIFF
--- a/tests/baselines/reference/circularBaseTypes.errors.txt
+++ b/tests/baselines/reference/circularBaseTypes.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/compiler/circularBaseTypes.ts(4,11): error TS2310: Type 'M2' recursively references itself as a base type.
 tests/cases/compiler/circularBaseTypes.ts(5,6): error TS2456: Type alias 'M3' circularly references itself.
+tests/cases/compiler/circularBaseTypes.ts(13,21): error TS2313: Type parameter 'K' has a circular constraint.
+tests/cases/compiler/circularBaseTypes.ts(14,11): error TS2310: Type 'Y' recursively references itself as a base type.
 
 
-==== tests/cases/compiler/circularBaseTypes.ts (2 errors) ====
+==== tests/cases/compiler/circularBaseTypes.ts (4 errors) ====
     // Repro from #38098
     
     type M<T> = { value: T };
@@ -15,5 +17,17 @@ tests/cases/compiler/circularBaseTypes.ts(5,6): error TS2456: Type alias 'M3' ci
     
     function f(m: M3) {
       return m.value;
+    }
+    
+    // Repro from #32581
+    
+    type X<T> = { [K in keyof T]: string } & { b: string };
+                        ~~~~~~~
+!!! error TS2313: Type parameter 'K' has a circular constraint.
+!!! related TS2751 tests/cases/compiler/circularBaseTypes.ts:14:11: Circularity originates in type at this location.
+    interface Y extends X<Y> {
+              ~
+!!! error TS2310: Type 'Y' recursively references itself as a base type.
+      a: "";
     }
     

--- a/tests/baselines/reference/circularBaseTypes.js
+++ b/tests/baselines/reference/circularBaseTypes.js
@@ -9,6 +9,13 @@ function f(m: M3) {
   return m.value;
 }
 
+// Repro from #32581
+
+type X<T> = { [K in keyof T]: string } & { b: string };
+interface Y extends X<Y> {
+  a: "";
+}
+
 
 //// [circularBaseTypes.js]
 "use strict";
@@ -27,3 +34,11 @@ interface M2 extends M<M3> {
 }
 type M3 = M2[keyof M2];
 declare function f(m: M3): any;
+type X<T> = {
+    [K in keyof T]: string;
+} & {
+    b: string;
+};
+interface Y extends X<Y> {
+    a: "";
+}

--- a/tests/baselines/reference/circularBaseTypes.symbols
+++ b/tests/baselines/reference/circularBaseTypes.symbols
@@ -26,3 +26,21 @@ function f(m: M3) {
 >m : Symbol(m, Decl(circularBaseTypes.ts, 6, 11))
 }
 
+// Repro from #32581
+
+type X<T> = { [K in keyof T]: string } & { b: string };
+>X : Symbol(X, Decl(circularBaseTypes.ts, 8, 1))
+>T : Symbol(T, Decl(circularBaseTypes.ts, 12, 7))
+>K : Symbol(K, Decl(circularBaseTypes.ts, 12, 15))
+>T : Symbol(T, Decl(circularBaseTypes.ts, 12, 7))
+>b : Symbol(b, Decl(circularBaseTypes.ts, 12, 42))
+
+interface Y extends X<Y> {
+>Y : Symbol(Y, Decl(circularBaseTypes.ts, 12, 55))
+>X : Symbol(X, Decl(circularBaseTypes.ts, 8, 1))
+>Y : Symbol(Y, Decl(circularBaseTypes.ts, 12, 55))
+
+  a: "";
+>a : Symbol(Y.a, Decl(circularBaseTypes.ts, 13, 26))
+}
+

--- a/tests/baselines/reference/circularBaseTypes.types
+++ b/tests/baselines/reference/circularBaseTypes.types
@@ -19,3 +19,14 @@ function f(m: M3) {
 >value : any
 }
 
+// Repro from #32581
+
+type X<T> = { [K in keyof T]: string } & { b: string };
+>X : X<T>
+>b : string
+
+interface Y extends X<Y> {
+  a: "";
+>a : ""
+}
+

--- a/tests/cases/compiler/circularBaseTypes.ts
+++ b/tests/cases/compiler/circularBaseTypes.ts
@@ -10,3 +10,10 @@ type M3 = M2[keyof M2];  // Error
 function f(m: M3) {
   return m.value;
 }
+
+// Repro from #32581
+
+type X<T> = { [K in keyof T]: string } & { b: string };
+interface Y extends X<Y> {
+  a: "";
+}


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/32581

this was likely fixed by https://github.com/microsoft/TypeScript/pull/39675