### PR TITLE
Infer correct type with Promise.all and Promise.allSettled on Array subclasses

### DIFF
--- a/src/lib/es2015.promise.d.ts
+++ b/src/lib/es2015.promise.d.ts
@@ -18,7 +18,11 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T extends readonly unknown[] | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]> }>;
+    all<T extends [unknown] | ArrayLike<unknown> | Iterable<unknown>>(values: T): Promise<
+        T extends {[P in 0]: unknown} ? 
+            {-readonly [P in keyof T]: Awaited<T[P]>} : 
+                T extends ArrayLike<infer S> | Iterable<infer S> ? Awaited<S>[] : never 
+    >
 
     // see: lib.es2015.iterable.d.ts
     // all<T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>;

--- a/src/lib/es2020.promise.d.ts
+++ b/src/lib/es2020.promise.d.ts
@@ -17,13 +17,9 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    allSettled<T extends readonly unknown[] | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>> }>;
-
-    /**
-     * Creates a Promise that is resolved with an array of results when all
-     * of the provided Promises resolve or reject.
-     * @param values An array of Promises.
-     * @returns A new Promise.
-     */
-    allSettled<T>(values: Iterable<T | PromiseLike<T>>): Promise<PromiseSettledResult<Awaited<T>>[]>;
+    allSettled<T extends [unknown] | ArrayLike<unknown> | Iterable<unknown>>(values: T): Promise<
+        T extends {[P in 0]: unknown} ? 
+            {-readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>} : 
+                T extends ArrayLike<infer S> | Iterable<infer S> ? PromiseSettledResult<Awaited<S>>[] : never 
+    >
 }

--- a/tests/cases/compiler/correctOrderOfPromiseMethod.ts
+++ b/tests/cases/compiler/correctOrderOfPromiseMethod.ts
@@ -29,4 +29,4 @@ async function countEverything(): Promise<number> {
 
 // #31179
 
-const expected: Promise<["a", "b", "c"]> = Promise.all(undefined as readonly ["a", "b", "c"]);
+const expected: Promise<["a", "b", "c"]> = Promise.all(undefined as unknown as readonly ["a", "b", "c"]);


### PR DESCRIPTION
Fixes #51993

[TESTS](https://www.typescriptlang.org/play?target=99#code/CYUwxgNghgTiAEkoGdnwIIxlAngYQAsBLCYAHgBUA+eEADwBcQA7YNTbHSmgbwF8AUANBI48AGYBXZmAZEA9s3hQIESrUYs28ANrSA1s3kB3ZgF14AHwxZcAGSL6QZA0dM1rASSbYARhGdXE2YqKgAKADcVSRBkAC54CgBKBIAFGHkAWyJkZwF4AsSNJlY0Hh1U+CIlAAYzBKDTPngAfnh8ws6eAFo4KGBFCBxdSur4Jxx5cUT6jGMoIiZyCgqzKmaEjs7tovoS7Q57R2dq8RAYeABlD3hvc6h-E+Yzi+vWuYWlsmudCwTmEARc7tKhCETQMRSGRyRTKVSXEAMBgBZbFLRoPTMQzBCzWQ44BxOFxYtwhKy3HwPALE7HucJRCAxeKJFLwdJZHJ5ToUNGleDlUa1WaNZjNNpbbY9PoDZhDEZVJQTKYzNIZbK5BFIlEAJVikggDDI6HmixAy1WoQ27R2Ox5e3RNk4hKeLyuNzufmpp2Bbza7PVIE1yLNuuQ+sNxs+Zu+oV+8H+gOBAlBAgA9Kn4AAhEAEKARBQXOCZKDMHKIeRYcAMeDGRYEeBGGDFiDKWw4NAl4DwBiSAAOAWQwnAEIQYEUyGrsE4qo5uTIzEkmV85yovyHolH48nbYAqqXFAkwv7OWQJzBqgBzG7HucLpcrpJr8GwTfMCfdvsBBIVNUnu-LmAqAAGjZX85zPS9gNA2dnF8eR5ACEsqAsIQVAgMIp1wJIJQAOgYAgWDCMB4AAXhoMBsPTG0dgAPRaAQbxAHC0IwttsM6PCCOYIjSPIyiM2ozo6NQ+FEWDYBWM4djCk4wjiLIxB+MEoT6MY5jRK1M1JKw3D8Lk3jFLTATlPgYSBBYzCcD3BRmGkgpZO4+S+KMkyCmEtSLN3fdbN0rieIUiiXNcsy0KDFFtKs7y7PgBz-OcqjgtUsCmNCsTwss6zFGi2KnMMhKTJC1Qwh7fsQGyvTHIMwL8uU9zkvU9CSoCcq-Ny6rjNq+jzI08Tis-MrfP0gKlMShj6tSzSJKagaOIquK8o6wTCvQn8YJwuBkAQoEwgARiSEC1I2raQDCAByABHYwQFOpIzBaob4sW6i6rWljVoDdbYmO3b9ugj6jogbaLqum67sGyrhqCgquom3r3s5T7NsBk69oO+qAaBy7rtu+6Ice1zTKS16evC+HckR77Ub+hGMZO4HsbB2bWqqkboaEFyADEiDoWJuxwXtee9Ssu3ENVHVweAw18JBUF59cR3LN9qzAYhSASfFCBIchGNPBhz2YK9QWfMQxyVxBVeATLmHVttNdIMgdYgg3r2S+dFwA0IRPQlWtdx+b2oJl6PpYn3SD9trWc6qHXIAPzj+OE8TpPk5T1O0-TjPM6z7P469sKtND4Bw5Z6OlqJ4OSYLi3i8hmqy9L5Sc6b5uW9btuM69oiLatmv8dGjyisLnvwf9yP67rxv26n6eZ9nuO87SquteHpmHoWwPy4R2HwqHqKR4jhubWEifBLns-z4v1OBCAA)

This allows using `Array` subclasses with `Promise.all` and `Promise.allSettled` without breaking existing behavior.