### PR TITLE
Defer conditional types with multi-element tuple types in `extends` clause

### DIFF
--- a/tests/baselines/reference/deferredConditionalTypes.js
+++ b/tests/baselines/reference/deferredConditionalTypes.js
@@ -1,0 +1,23 @@
+//// [deferredConditionalTypes.ts]
+type T0<X, Y> = X extends Y ? true : false;  // Deferred
+type T1<X, Y> = [X] extends [Y] ? true : false;  // Deferred
+type T2<X, Y> = [X, X] extends [Y, Y] ? true : false;  // Deferred
+type T3<X, Y> = [X, X, X] extends [Y, Y, Y] ? true : false;  // Deferred
+
+type T4<X, Y> = [X] extends [Y, Y] ? true : false;  // false
+type T5<X, Y> = [X, X] extends [Y] ? true : false;  // false
+
+// Repro from #52068
+
+type Or<A extends boolean, B extends boolean> = [A, B] extends [false, false] ? false : true;
+type And<A extends boolean, B extends boolean> = [A, B] extends [true, true] ? true : false;
+type Not<T extends boolean> = T extends true ? false : true;
+type Extends<A, B> = A extends B ? true : false;
+
+type IsNumberLiteral<T> = And<Extends<T, number>, Not<Extends<number, T>>>;
+
+type IsLiteral<T> = Or<false, IsNumberLiteral<T>>;
+
+
+//// [deferredConditionalTypes.js]
+"use strict";

--- a/tests/baselines/reference/deferredConditionalTypes.js
+++ b/tests/baselines/reference/deferredConditionalTypes.js
@@ -1,11 +1,15 @@
 //// [deferredConditionalTypes.ts]
-type T0<X, Y> = X extends Y ? true : false;  // Deferred
-type T1<X, Y> = [X] extends [Y] ? true : false;  // Deferred
-type T2<X, Y> = [X, X] extends [Y, Y] ? true : false;  // Deferred
-type T3<X, Y> = [X, X, X] extends [Y, Y, Y] ? true : false;  // Deferred
+type A<T> = { x: T } extends { x: 0 } ? 1 : 0;
 
-type T4<X, Y> = [X] extends [Y, Y] ? true : false;  // false
-type T5<X, Y> = [X, X] extends [Y] ? true : false;  // false
+type T0<T> = A<T> extends 0 ? 1 : 0;  // Deferred
+type T1<T> = [A<T>] extends [0] ? 1 : 0;  // Deferred
+type T2<T> = [A<T>, A<T>] extends [0, 0] ? 1 : 0;  // Deferred
+type T3<T> = [A<T>, A<T>, A<T>] extends [0, 0, 0] ? 1 : 0;  // Deferred
+
+type T4<T> = [A<T>] extends [0, 0] ? 1 : 0;  // 0
+type T5<T> = [A<T>, A<T>] extends [0] ? 1 : 0;  // 0
+
+type T6<T> = { y: A<T> } extends { y: 0 } ? 1 : 0;  // 0, but should be deferred
 
 // Repro from #52068
 
@@ -17,6 +21,24 @@ type Extends<A, B> = A extends B ? true : false;
 type IsNumberLiteral<T> = And<Extends<T, number>, Not<Extends<number, T>>>;
 
 type IsLiteral<T> = Or<false, IsNumberLiteral<T>>;
+
+// Repro from #51145#issuecomment-1276804047
+
+type Values<O extends object> =
+  O extends any[] 
+    ? O[number]
+    : O[keyof O]
+
+type Equals<A, B> = [A, B] extends [B, A] ? true : false;
+
+type FilterByStringValue<O extends object> = {
+  [K in keyof O as Equals<O[K], string> extends true ? K : never]: any
+}
+
+type FilteredValuesMatchNever<O extends object>
+  = Equals<Values<FilterByStringValue<[O]>>, never>
+
+type FilteredRes1 = FilteredValuesMatchNever<[]>
 
 
 //// [deferredConditionalTypes.js]

--- a/tests/baselines/reference/deferredConditionalTypes.symbols
+++ b/tests/baselines/reference/deferredConditionalTypes.symbols
@@ -1,0 +1,96 @@
+=== tests/cases/compiler/deferredConditionalTypes.ts ===
+type T0<X, Y> = X extends Y ? true : false;  // Deferred
+>T0 : Symbol(T0, Decl(deferredConditionalTypes.ts, 0, 0))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 0, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 0, 10))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 0, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 0, 10))
+
+type T1<X, Y> = [X] extends [Y] ? true : false;  // Deferred
+>T1 : Symbol(T1, Decl(deferredConditionalTypes.ts, 0, 43))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 1, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 1, 10))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 1, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 1, 10))
+
+type T2<X, Y> = [X, X] extends [Y, Y] ? true : false;  // Deferred
+>T2 : Symbol(T2, Decl(deferredConditionalTypes.ts, 1, 47))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 2, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 2, 10))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 2, 8))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 2, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 2, 10))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 2, 10))
+
+type T3<X, Y> = [X, X, X] extends [Y, Y, Y] ? true : false;  // Deferred
+>T3 : Symbol(T3, Decl(deferredConditionalTypes.ts, 2, 53))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 3, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 3, 10))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 3, 8))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 3, 8))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 3, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 3, 10))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 3, 10))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 3, 10))
+
+type T4<X, Y> = [X] extends [Y, Y] ? true : false;  // false
+>T4 : Symbol(T4, Decl(deferredConditionalTypes.ts, 3, 59))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 5, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 5, 10))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 5, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 5, 10))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 5, 10))
+
+type T5<X, Y> = [X, X] extends [Y] ? true : false;  // false
+>T5 : Symbol(T5, Decl(deferredConditionalTypes.ts, 5, 50))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 6, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 6, 10))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 6, 8))
+>X : Symbol(X, Decl(deferredConditionalTypes.ts, 6, 8))
+>Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 6, 10))
+
+// Repro from #52068
+
+type Or<A extends boolean, B extends boolean> = [A, B] extends [false, false] ? false : true;
+>Or : Symbol(Or, Decl(deferredConditionalTypes.ts, 6, 50))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 10, 8))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 10, 26))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 10, 8))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 10, 26))
+
+type And<A extends boolean, B extends boolean> = [A, B] extends [true, true] ? true : false;
+>And : Symbol(And, Decl(deferredConditionalTypes.ts, 10, 93))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 11, 9))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 11, 27))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 11, 9))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 11, 27))
+
+type Not<T extends boolean> = T extends true ? false : true;
+>Not : Symbol(Not, Decl(deferredConditionalTypes.ts, 11, 92))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 12, 9))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 12, 9))
+
+type Extends<A, B> = A extends B ? true : false;
+>Extends : Symbol(Extends, Decl(deferredConditionalTypes.ts, 12, 60))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 13, 13))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 13, 15))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 13, 13))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 13, 15))
+
+type IsNumberLiteral<T> = And<Extends<T, number>, Not<Extends<number, T>>>;
+>IsNumberLiteral : Symbol(IsNumberLiteral, Decl(deferredConditionalTypes.ts, 13, 48))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 15, 21))
+>And : Symbol(And, Decl(deferredConditionalTypes.ts, 10, 93))
+>Extends : Symbol(Extends, Decl(deferredConditionalTypes.ts, 12, 60))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 15, 21))
+>Not : Symbol(Not, Decl(deferredConditionalTypes.ts, 11, 92))
+>Extends : Symbol(Extends, Decl(deferredConditionalTypes.ts, 12, 60))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 15, 21))
+
+type IsLiteral<T> = Or<false, IsNumberLiteral<T>>;
+>IsLiteral : Symbol(IsLiteral, Decl(deferredConditionalTypes.ts, 15, 75))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 17, 15))
+>Or : Symbol(Or, Decl(deferredConditionalTypes.ts, 6, 50))
+>IsNumberLiteral : Symbol(IsNumberLiteral, Decl(deferredConditionalTypes.ts, 13, 48))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 17, 15))
+

--- a/tests/baselines/reference/deferredConditionalTypes.symbols
+++ b/tests/baselines/reference/deferredConditionalTypes.symbols
@@ -1,96 +1,157 @@
 === tests/cases/compiler/deferredConditionalTypes.ts ===
-type T0<X, Y> = X extends Y ? true : false;  // Deferred
->T0 : Symbol(T0, Decl(deferredConditionalTypes.ts, 0, 0))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 0, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 0, 10))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 0, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 0, 10))
+type A<T> = { x: T } extends { x: 0 } ? 1 : 0;
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 0, 7))
+>x : Symbol(x, Decl(deferredConditionalTypes.ts, 0, 13))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 0, 7))
+>x : Symbol(x, Decl(deferredConditionalTypes.ts, 0, 30))
 
-type T1<X, Y> = [X] extends [Y] ? true : false;  // Deferred
->T1 : Symbol(T1, Decl(deferredConditionalTypes.ts, 0, 43))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 1, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 1, 10))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 1, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 1, 10))
+type T0<T> = A<T> extends 0 ? 1 : 0;  // Deferred
+>T0 : Symbol(T0, Decl(deferredConditionalTypes.ts, 0, 46))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 2, 8))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 2, 8))
 
-type T2<X, Y> = [X, X] extends [Y, Y] ? true : false;  // Deferred
->T2 : Symbol(T2, Decl(deferredConditionalTypes.ts, 1, 47))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 2, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 2, 10))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 2, 8))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 2, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 2, 10))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 2, 10))
+type T1<T> = [A<T>] extends [0] ? 1 : 0;  // Deferred
+>T1 : Symbol(T1, Decl(deferredConditionalTypes.ts, 2, 36))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 3, 8))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 3, 8))
 
-type T3<X, Y> = [X, X, X] extends [Y, Y, Y] ? true : false;  // Deferred
->T3 : Symbol(T3, Decl(deferredConditionalTypes.ts, 2, 53))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 3, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 3, 10))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 3, 8))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 3, 8))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 3, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 3, 10))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 3, 10))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 3, 10))
+type T2<T> = [A<T>, A<T>] extends [0, 0] ? 1 : 0;  // Deferred
+>T2 : Symbol(T2, Decl(deferredConditionalTypes.ts, 3, 40))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 4, 8))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 4, 8))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 4, 8))
 
-type T4<X, Y> = [X] extends [Y, Y] ? true : false;  // false
->T4 : Symbol(T4, Decl(deferredConditionalTypes.ts, 3, 59))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 5, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 5, 10))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 5, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 5, 10))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 5, 10))
+type T3<T> = [A<T>, A<T>, A<T>] extends [0, 0, 0] ? 1 : 0;  // Deferred
+>T3 : Symbol(T3, Decl(deferredConditionalTypes.ts, 4, 49))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 5, 8))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 5, 8))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 5, 8))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 5, 8))
 
-type T5<X, Y> = [X, X] extends [Y] ? true : false;  // false
->T5 : Symbol(T5, Decl(deferredConditionalTypes.ts, 5, 50))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 6, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 6, 10))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 6, 8))
->X : Symbol(X, Decl(deferredConditionalTypes.ts, 6, 8))
->Y : Symbol(Y, Decl(deferredConditionalTypes.ts, 6, 10))
+type T4<T> = [A<T>] extends [0, 0] ? 1 : 0;  // 0
+>T4 : Symbol(T4, Decl(deferredConditionalTypes.ts, 5, 58))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 7, 8))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 7, 8))
+
+type T5<T> = [A<T>, A<T>] extends [0] ? 1 : 0;  // 0
+>T5 : Symbol(T5, Decl(deferredConditionalTypes.ts, 7, 43))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 8, 8))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 8, 8))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 8, 8))
+
+type T6<T> = { y: A<T> } extends { y: 0 } ? 1 : 0;  // 0, but should be deferred
+>T6 : Symbol(T6, Decl(deferredConditionalTypes.ts, 8, 46))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 10, 8))
+>y : Symbol(y, Decl(deferredConditionalTypes.ts, 10, 14))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 0, 0))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 10, 8))
+>y : Symbol(y, Decl(deferredConditionalTypes.ts, 10, 34))
 
 // Repro from #52068
 
 type Or<A extends boolean, B extends boolean> = [A, B] extends [false, false] ? false : true;
->Or : Symbol(Or, Decl(deferredConditionalTypes.ts, 6, 50))
->A : Symbol(A, Decl(deferredConditionalTypes.ts, 10, 8))
->B : Symbol(B, Decl(deferredConditionalTypes.ts, 10, 26))
->A : Symbol(A, Decl(deferredConditionalTypes.ts, 10, 8))
->B : Symbol(B, Decl(deferredConditionalTypes.ts, 10, 26))
+>Or : Symbol(Or, Decl(deferredConditionalTypes.ts, 10, 50))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 14, 8))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 14, 26))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 14, 8))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 14, 26))
 
 type And<A extends boolean, B extends boolean> = [A, B] extends [true, true] ? true : false;
->And : Symbol(And, Decl(deferredConditionalTypes.ts, 10, 93))
->A : Symbol(A, Decl(deferredConditionalTypes.ts, 11, 9))
->B : Symbol(B, Decl(deferredConditionalTypes.ts, 11, 27))
->A : Symbol(A, Decl(deferredConditionalTypes.ts, 11, 9))
->B : Symbol(B, Decl(deferredConditionalTypes.ts, 11, 27))
+>And : Symbol(And, Decl(deferredConditionalTypes.ts, 14, 93))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 15, 9))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 15, 27))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 15, 9))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 15, 27))
 
 type Not<T extends boolean> = T extends true ? false : true;
->Not : Symbol(Not, Decl(deferredConditionalTypes.ts, 11, 92))
->T : Symbol(T, Decl(deferredConditionalTypes.ts, 12, 9))
->T : Symbol(T, Decl(deferredConditionalTypes.ts, 12, 9))
+>Not : Symbol(Not, Decl(deferredConditionalTypes.ts, 15, 92))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 16, 9))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 16, 9))
 
 type Extends<A, B> = A extends B ? true : false;
->Extends : Symbol(Extends, Decl(deferredConditionalTypes.ts, 12, 60))
->A : Symbol(A, Decl(deferredConditionalTypes.ts, 13, 13))
->B : Symbol(B, Decl(deferredConditionalTypes.ts, 13, 15))
->A : Symbol(A, Decl(deferredConditionalTypes.ts, 13, 13))
->B : Symbol(B, Decl(deferredConditionalTypes.ts, 13, 15))
+>Extends : Symbol(Extends, Decl(deferredConditionalTypes.ts, 16, 60))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 17, 13))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 17, 15))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 17, 13))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 17, 15))
 
 type IsNumberLiteral<T> = And<Extends<T, number>, Not<Extends<number, T>>>;
->IsNumberLiteral : Symbol(IsNumberLiteral, Decl(deferredConditionalTypes.ts, 13, 48))
->T : Symbol(T, Decl(deferredConditionalTypes.ts, 15, 21))
->And : Symbol(And, Decl(deferredConditionalTypes.ts, 10, 93))
->Extends : Symbol(Extends, Decl(deferredConditionalTypes.ts, 12, 60))
->T : Symbol(T, Decl(deferredConditionalTypes.ts, 15, 21))
->Not : Symbol(Not, Decl(deferredConditionalTypes.ts, 11, 92))
->Extends : Symbol(Extends, Decl(deferredConditionalTypes.ts, 12, 60))
->T : Symbol(T, Decl(deferredConditionalTypes.ts, 15, 21))
+>IsNumberLiteral : Symbol(IsNumberLiteral, Decl(deferredConditionalTypes.ts, 17, 48))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 19, 21))
+>And : Symbol(And, Decl(deferredConditionalTypes.ts, 14, 93))
+>Extends : Symbol(Extends, Decl(deferredConditionalTypes.ts, 16, 60))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 19, 21))
+>Not : Symbol(Not, Decl(deferredConditionalTypes.ts, 15, 92))
+>Extends : Symbol(Extends, Decl(deferredConditionalTypes.ts, 16, 60))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 19, 21))
 
 type IsLiteral<T> = Or<false, IsNumberLiteral<T>>;
->IsLiteral : Symbol(IsLiteral, Decl(deferredConditionalTypes.ts, 15, 75))
->T : Symbol(T, Decl(deferredConditionalTypes.ts, 17, 15))
->Or : Symbol(Or, Decl(deferredConditionalTypes.ts, 6, 50))
->IsNumberLiteral : Symbol(IsNumberLiteral, Decl(deferredConditionalTypes.ts, 13, 48))
->T : Symbol(T, Decl(deferredConditionalTypes.ts, 17, 15))
+>IsLiteral : Symbol(IsLiteral, Decl(deferredConditionalTypes.ts, 19, 75))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 21, 15))
+>Or : Symbol(Or, Decl(deferredConditionalTypes.ts, 10, 50))
+>IsNumberLiteral : Symbol(IsNumberLiteral, Decl(deferredConditionalTypes.ts, 17, 48))
+>T : Symbol(T, Decl(deferredConditionalTypes.ts, 21, 15))
+
+// Repro from #51145#issuecomment-1276804047
+
+type Values<O extends object> =
+>Values : Symbol(Values, Decl(deferredConditionalTypes.ts, 21, 50))
+>O : Symbol(O, Decl(deferredConditionalTypes.ts, 25, 12))
+
+  O extends any[] 
+>O : Symbol(O, Decl(deferredConditionalTypes.ts, 25, 12))
+
+    ? O[number]
+>O : Symbol(O, Decl(deferredConditionalTypes.ts, 25, 12))
+
+    : O[keyof O]
+>O : Symbol(O, Decl(deferredConditionalTypes.ts, 25, 12))
+>O : Symbol(O, Decl(deferredConditionalTypes.ts, 25, 12))
+
+type Equals<A, B> = [A, B] extends [B, A] ? true : false;
+>Equals : Symbol(Equals, Decl(deferredConditionalTypes.ts, 28, 16))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 30, 12))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 30, 14))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 30, 12))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 30, 14))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 30, 14))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 30, 12))
+
+type FilterByStringValue<O extends object> = {
+>FilterByStringValue : Symbol(FilterByStringValue, Decl(deferredConditionalTypes.ts, 30, 57))
+>O : Symbol(O, Decl(deferredConditionalTypes.ts, 32, 25))
+
+  [K in keyof O as Equals<O[K], string> extends true ? K : never]: any
+>K : Symbol(K, Decl(deferredConditionalTypes.ts, 33, 3))
+>O : Symbol(O, Decl(deferredConditionalTypes.ts, 32, 25))
+>Equals : Symbol(Equals, Decl(deferredConditionalTypes.ts, 28, 16))
+>O : Symbol(O, Decl(deferredConditionalTypes.ts, 32, 25))
+>K : Symbol(K, Decl(deferredConditionalTypes.ts, 33, 3))
+>K : Symbol(K, Decl(deferredConditionalTypes.ts, 33, 3))
+}
+
+type FilteredValuesMatchNever<O extends object>
+>FilteredValuesMatchNever : Symbol(FilteredValuesMatchNever, Decl(deferredConditionalTypes.ts, 34, 1))
+>O : Symbol(O, Decl(deferredConditionalTypes.ts, 36, 30))
+
+  = Equals<Values<FilterByStringValue<[O]>>, never>
+>Equals : Symbol(Equals, Decl(deferredConditionalTypes.ts, 28, 16))
+>Values : Symbol(Values, Decl(deferredConditionalTypes.ts, 21, 50))
+>FilterByStringValue : Symbol(FilterByStringValue, Decl(deferredConditionalTypes.ts, 30, 57))
+>O : Symbol(O, Decl(deferredConditionalTypes.ts, 36, 30))
+
+type FilteredRes1 = FilteredValuesMatchNever<[]>
+>FilteredRes1 : Symbol(FilteredRes1, Decl(deferredConditionalTypes.ts, 37, 51))
+>FilteredValuesMatchNever : Symbol(FilteredValuesMatchNever, Decl(deferredConditionalTypes.ts, 34, 1))
 

--- a/tests/baselines/reference/deferredConditionalTypes.types
+++ b/tests/baselines/reference/deferredConditionalTypes.types
@@ -1,0 +1,65 @@
+=== tests/cases/compiler/deferredConditionalTypes.ts ===
+type T0<X, Y> = X extends Y ? true : false;  // Deferred
+>T0 : T0<X, Y>
+>true : true
+>false : false
+
+type T1<X, Y> = [X] extends [Y] ? true : false;  // Deferred
+>T1 : T1<X, Y>
+>true : true
+>false : false
+
+type T2<X, Y> = [X, X] extends [Y, Y] ? true : false;  // Deferred
+>T2 : T2<X, Y>
+>true : true
+>false : false
+
+type T3<X, Y> = [X, X, X] extends [Y, Y, Y] ? true : false;  // Deferred
+>T3 : T3<X, Y>
+>true : true
+>false : false
+
+type T4<X, Y> = [X] extends [Y, Y] ? true : false;  // false
+>T4 : false
+>true : true
+>false : false
+
+type T5<X, Y> = [X, X] extends [Y] ? true : false;  // false
+>T5 : false
+>true : true
+>false : false
+
+// Repro from #52068
+
+type Or<A extends boolean, B extends boolean> = [A, B] extends [false, false] ? false : true;
+>Or : Or<A, B>
+>false : false
+>false : false
+>false : false
+>true : true
+
+type And<A extends boolean, B extends boolean> = [A, B] extends [true, true] ? true : false;
+>And : And<A, B>
+>true : true
+>true : true
+>true : true
+>false : false
+
+type Not<T extends boolean> = T extends true ? false : true;
+>Not : Not<T>
+>true : true
+>false : false
+>true : true
+
+type Extends<A, B> = A extends B ? true : false;
+>Extends : Extends<A, B>
+>true : true
+>false : false
+
+type IsNumberLiteral<T> = And<Extends<T, number>, Not<Extends<number, T>>>;
+>IsNumberLiteral : IsNumberLiteral<T>
+
+type IsLiteral<T> = Or<false, IsNumberLiteral<T>>;
+>IsLiteral : IsLiteral<T>
+>false : false
+

--- a/tests/baselines/reference/deferredConditionalTypes.types
+++ b/tests/baselines/reference/deferredConditionalTypes.types
@@ -1,33 +1,31 @@
 === tests/cases/compiler/deferredConditionalTypes.ts ===
-type T0<X, Y> = X extends Y ? true : false;  // Deferred
->T0 : T0<X, Y>
->true : true
->false : false
+type A<T> = { x: T } extends { x: 0 } ? 1 : 0;
+>A : A<T>
+>x : T
+>x : 0
 
-type T1<X, Y> = [X] extends [Y] ? true : false;  // Deferred
->T1 : T1<X, Y>
->true : true
->false : false
+type T0<T> = A<T> extends 0 ? 1 : 0;  // Deferred
+>T0 : T0<T>
 
-type T2<X, Y> = [X, X] extends [Y, Y] ? true : false;  // Deferred
->T2 : T2<X, Y>
->true : true
->false : false
+type T1<T> = [A<T>] extends [0] ? 1 : 0;  // Deferred
+>T1 : T1<T>
 
-type T3<X, Y> = [X, X, X] extends [Y, Y, Y] ? true : false;  // Deferred
->T3 : T3<X, Y>
->true : true
->false : false
+type T2<T> = [A<T>, A<T>] extends [0, 0] ? 1 : 0;  // Deferred
+>T2 : T2<T>
 
-type T4<X, Y> = [X] extends [Y, Y] ? true : false;  // false
->T4 : false
->true : true
->false : false
+type T3<T> = [A<T>, A<T>, A<T>] extends [0, 0, 0] ? 1 : 0;  // Deferred
+>T3 : T3<T>
 
-type T5<X, Y> = [X, X] extends [Y] ? true : false;  // false
->T5 : false
->true : true
->false : false
+type T4<T> = [A<T>] extends [0, 0] ? 1 : 0;  // 0
+>T4 : 0
+
+type T5<T> = [A<T>, A<T>] extends [0] ? 1 : 0;  // 0
+>T5 : 0
+
+type T6<T> = { y: A<T> } extends { y: 0 } ? 1 : 0;  // 0, but should be deferred
+>T6 : 0
+>y : A<T>
+>y : 0
 
 // Repro from #52068
 
@@ -62,4 +60,33 @@ type IsNumberLiteral<T> = And<Extends<T, number>, Not<Extends<number, T>>>;
 type IsLiteral<T> = Or<false, IsNumberLiteral<T>>;
 >IsLiteral : IsLiteral<T>
 >false : false
+
+// Repro from #51145#issuecomment-1276804047
+
+type Values<O extends object> =
+>Values : Values<O>
+
+  O extends any[] 
+    ? O[number]
+    : O[keyof O]
+
+type Equals<A, B> = [A, B] extends [B, A] ? true : false;
+>Equals : Equals<A, B>
+>true : true
+>false : false
+
+type FilterByStringValue<O extends object> = {
+>FilterByStringValue : FilterByStringValue<O>
+
+  [K in keyof O as Equals<O[K], string> extends true ? K : never]: any
+>true : true
+}
+
+type FilteredValuesMatchNever<O extends object>
+>FilteredValuesMatchNever : FilteredValuesMatchNever<O>
+
+  = Equals<Values<FilterByStringValue<[O]>>, never>
+
+type FilteredRes1 = FilteredValuesMatchNever<[]>
+>FilteredRes1 : true
 

--- a/tests/cases/compiler/deferredConditionalTypes.ts
+++ b/tests/cases/compiler/deferredConditionalTypes.ts
@@ -1,0 +1,20 @@
+// @strict: true
+
+type T0<X, Y> = X extends Y ? true : false;  // Deferred
+type T1<X, Y> = [X] extends [Y] ? true : false;  // Deferred
+type T2<X, Y> = [X, X] extends [Y, Y] ? true : false;  // Deferred
+type T3<X, Y> = [X, X, X] extends [Y, Y, Y] ? true : false;  // Deferred
+
+type T4<X, Y> = [X] extends [Y, Y] ? true : false;  // false
+type T5<X, Y> = [X, X] extends [Y] ? true : false;  // false
+
+// Repro from #52068
+
+type Or<A extends boolean, B extends boolean> = [A, B] extends [false, false] ? false : true;
+type And<A extends boolean, B extends boolean> = [A, B] extends [true, true] ? true : false;
+type Not<T extends boolean> = T extends true ? false : true;
+type Extends<A, B> = A extends B ? true : false;
+
+type IsNumberLiteral<T> = And<Extends<T, number>, Not<Extends<number, T>>>;
+
+type IsLiteral<T> = Or<false, IsNumberLiteral<T>>;

--- a/tests/cases/compiler/deferredConditionalTypes.ts
+++ b/tests/cases/compiler/deferredConditionalTypes.ts
@@ -1,12 +1,16 @@
 // @strict: true
 
-type T0<X, Y> = X extends Y ? true : false;  // Deferred
-type T1<X, Y> = [X] extends [Y] ? true : false;  // Deferred
-type T2<X, Y> = [X, X] extends [Y, Y] ? true : false;  // Deferred
-type T3<X, Y> = [X, X, X] extends [Y, Y, Y] ? true : false;  // Deferred
+type A<T> = { x: T } extends { x: 0 } ? 1 : 0;
 
-type T4<X, Y> = [X] extends [Y, Y] ? true : false;  // false
-type T5<X, Y> = [X, X] extends [Y] ? true : false;  // false
+type T0<T> = A<T> extends 0 ? 1 : 0;  // Deferred
+type T1<T> = [A<T>] extends [0] ? 1 : 0;  // Deferred
+type T2<T> = [A<T>, A<T>] extends [0, 0] ? 1 : 0;  // Deferred
+type T3<T> = [A<T>, A<T>, A<T>] extends [0, 0, 0] ? 1 : 0;  // Deferred
+
+type T4<T> = [A<T>] extends [0, 0] ? 1 : 0;  // 0
+type T5<T> = [A<T>, A<T>] extends [0] ? 1 : 0;  // 0
+
+type T6<T> = { y: A<T> } extends { y: 0 } ? 1 : 0;  // 0, but should be deferred
 
 // Repro from #52068
 
@@ -18,3 +22,21 @@ type Extends<A, B> = A extends B ? true : false;
 type IsNumberLiteral<T> = And<Extends<T, number>, Not<Extends<number, T>>>;
 
 type IsLiteral<T> = Or<false, IsNumberLiteral<T>>;
+
+// Repro from #51145#issuecomment-1276804047
+
+type Values<O extends object> =
+  O extends any[] 
+    ? O[number]
+    : O[keyof O]
+
+type Equals<A, B> = [A, B] extends [B, A] ? true : false;
+
+type FilterByStringValue<O extends object> = {
+  [K in keyof O as Equals<O[K], string> extends true ? K : never]: any
+}
+
+type FilteredValuesMatchNever<O extends object>
+  = Equals<Values<FilterByStringValue<[O]>>, never>
+
+type FilteredRes1 = FilteredValuesMatchNever<[]>


### PR DESCRIPTION
Fixes #52068.