### PR TITLE
Issue error on export= in esm mode declaration file

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3904,7 +3904,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const hasDefaultOnly = isOnlyImportedAsDefault(specifier);
         const hasSyntheticDefault = canHaveSyntheticDefault(file, moduleSymbol, dontResolveAlias, specifier);
         if (!exportDefaultSymbol && !hasSyntheticDefault && !hasDefaultOnly) {
-            if (hasExportAssignmentSymbol(moduleSymbol)) {
+            if (hasExportAssignmentSymbol(moduleSymbol) && !(getAllowSyntheticDefaultImports(compilerOptions) || getESModuleInterop(compilerOptions))) {
                 const compilerOptionName = moduleKind >= ModuleKind.ES2015 ? "allowSyntheticDefaultImports" : "esModuleInterop";
                 const exportEqualsSymbol = moduleSymbol.exports!.get(InternalSymbolName.ExportEquals);
                 const exportAssignment = exportEqualsSymbol!.valueDeclaration;
@@ -43033,16 +43033,19 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             grammarErrorOnNode(node.expression, Diagnostics.The_expression_of_an_export_assignment_must_be_an_identifier_or_qualified_name_in_an_ambient_context);
         }
 
-        if (node.isExportEquals && !(node.flags & NodeFlags.Ambient)) {
-            if (moduleKind >= ModuleKind.ES2015 && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS) {
+        if (node.isExportEquals) {
+            // Forbid export= in esm implementation files, and esm mode declaration files
+            if (moduleKind >= ModuleKind.ES2015 &&
+                ((node.flags & NodeFlags.Ambient && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.ESNext) ||
+                (!(node.flags & NodeFlags.Ambient) && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS))) {
                 // export assignment is not supported in es6 modules
                 grammarErrorOnNode(node, Diagnostics.Export_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_export_default_or_another_module_format_instead);
             }
-            else if (moduleKind === ModuleKind.System) {
+            else if (moduleKind === ModuleKind.System && !(node.flags & NodeFlags.Ambient)) {
                 // system modules does not support export assignment
                 grammarErrorOnNode(node, Diagnostics.Export_assignment_is_not_supported_when_module_flag_is_system);
             }
-            else if (getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Bundler) {
+            else if (getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Bundler && !(node.flags & NodeFlags.Ambient)) {
                 grammarErrorOnNode(node, Diagnostics.Export_assignment_cannot_be_used_when_moduleResolution_is_set_to_bundler_Consider_using_export_default_or_another_module_format_instead);
             }
         }

--- a/tests/baselines/reference/esmModeDeclarationFileWithExportAssignment.errors.txt
+++ b/tests/baselines/reference/esmModeDeclarationFileWithExportAssignment.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/compiler/main.mts(1,8): error TS1192: Module '"tests/cases/compiler/other"' has no default export.
+tests/cases/compiler/other.d.mts(2,1): error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
+
+
+==== tests/cases/compiler/other.d.mts (1 errors) ====
+    declare function example(): 5;
+    export = example;
+    ~~~~~~~~~~~~~~~~~
+!!! error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
+    
+==== tests/cases/compiler/main.mts (1 errors) ====
+    import example from "./other.mjs";
+           ~~~~~~~
+!!! error TS1192: Module '"tests/cases/compiler/other"' has no default export.
+    example();

--- a/tests/baselines/reference/esmModeDeclarationFileWithExportAssignment.js
+++ b/tests/baselines/reference/esmModeDeclarationFileWithExportAssignment.js
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/esmModeDeclarationFileWithExportAssignment.ts] ////
+
+//// [other.d.mts]
+declare function example(): 5;
+export = example;
+
+//// [main.mts]
+import example from "./other.mjs";
+example();
+
+//// [main.mjs]
+import example from "./other.mjs";
+example();

--- a/tests/baselines/reference/esmModeDeclarationFileWithExportAssignment.symbols
+++ b/tests/baselines/reference/esmModeDeclarationFileWithExportAssignment.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/other.d.mts ===
+declare function example(): 5;
+>example : Symbol(example, Decl(other.d.mts, 0, 0))
+
+export = example;
+>example : Symbol(example, Decl(other.d.mts, 0, 0))
+
+=== tests/cases/compiler/main.mts ===
+import example from "./other.mjs";
+>example : Symbol(example, Decl(main.mts, 0, 6))
+
+example();
+>example : Symbol(example, Decl(main.mts, 0, 6))
+

--- a/tests/baselines/reference/esmModeDeclarationFileWithExportAssignment.types
+++ b/tests/baselines/reference/esmModeDeclarationFileWithExportAssignment.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/other.d.mts ===
+declare function example(): 5;
+>example : () => 5
+
+export = example;
+>example : () => 5
+
+=== tests/cases/compiler/main.mts ===
+import example from "./other.mjs";
+>example : any
+
+example();
+>example() : any
+>example : any
+

--- a/tests/cases/compiler/esmModeDeclarationFileWithExportAssignment.ts
+++ b/tests/cases/compiler/esmModeDeclarationFileWithExportAssignment.ts
@@ -1,0 +1,11 @@
+// @target: esnext
+// @module: nodenext
+// @allowSyntheticDefaultImports: true
+// @strict: true
+// @filename: other.d.mts
+declare function example(): 5;
+export = example;
+
+// @filename: main.mts
+import example from "./other.mjs";
+example();


### PR DESCRIPTION
Also, don't mention `allowSyntheticDefaultImports` (or `esModuleInterop`) in the default-is-missing import error message if its already on.

Fixes #51321
