### PR TITLE
Remove Push from public API

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2288,7 +2288,7 @@ function convertConfigFileToObject(sourceFile: JsonSourceFile, errors: Push<Diag
 /**
  * Convert the json syntax tree into the json value
  */
-export function convertToObject(sourceFile: JsonSourceFile, errors: Push<Diagnostic>): any {
+export function convertToObject(sourceFile: JsonSourceFile, errors: Diagnostic[]): any {
     return convertToObjectWorker(sourceFile, sourceFile.statements[0]?.expression, errors, /*returnValue*/ true, /*knownRootOptions*/ undefined, /*jsonConversionNotifier*/ undefined);
 }
 
@@ -3177,7 +3177,7 @@ function parseConfig(
     basePath: string,
     configFileName: string | undefined,
     resolutionStack: string[],
-    errors: Push<Diagnostic>,
+    errors: Diagnostic[],
     extendedConfigCache?: Map<string, ExtendedConfigCacheEntry>
 ): ParsedTsconfig {
     basePath = normalizeSlashes(basePath);
@@ -3432,7 +3432,7 @@ function getExtendedConfig(
     extendedConfigPath: string,
     host: ParseConfigHost,
     resolutionStack: string[],
-    errors: Push<Diagnostic>,
+    errors: Diagnostic[],
     extendedConfigCache: Map<string, ExtendedConfigCacheEntry> | undefined,
     result: ExtendsResult
 ): ParsedTsconfig | undefined {

--- a/src/compiler/corePublic.ts
+++ b/src/compiler/corePublic.ts
@@ -44,10 +44,14 @@ export interface Collection<K> extends ReadonlyCollection<K> {
     clear(): void;
 }
 
-/** Array that is only intended to be pushed to, never read. */
+/**
+ * Array that is only intended to be pushed to, never read.
+ *
+ * @internal
+ */
 export interface Push<T> {
     push(...values: T[]): void;
-    /** @internal */ readonly length: number;
+    readonly length: number;
 }
 
 /** @internal */

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -602,7 +602,7 @@ export const supportedLocaleDirectories = ["cs", "de", "es", "fr", "it", "ja", "
 export function validateLocaleAndSetLanguage(
     locale: string,
     sys: { getExecutingFilePath(): string, resolvePath(path: string): string, fileExists(fileName: string): boolean, readFile(fileName: string): string | undefined },
-    errors?: Push<Diagnostic>) {
+    errors?: Diagnostic[]) {
     const lowerCaseLocale = locale.toLowerCase();
     const matchResult = /^([a-z]+)([_\-]([a-z]+))?$/.exec(lowerCaseLocale);
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3966,10 +3966,6 @@ declare namespace ts {
     interface SortedArray<T> extends Array<T> {
         " __sortedArrayBrand": any;
     }
-    /** Array that is only intended to be pushed to, never read. */
-    interface Push<T> {
-        push(...values: T[]): void;
-    }
     type Path = string & {
         __pathBrand: any;
     };
@@ -8558,7 +8554,7 @@ declare namespace ts {
         resolvePath(path: string): string;
         fileExists(fileName: string): boolean;
         readFile(fileName: string): string | undefined;
-    }, errors?: Push<Diagnostic>): void;
+    }, errors?: Diagnostic[]): void;
     function getOriginalNode(node: Node): Node;
     function getOriginalNode<T extends Node>(node: Node, nodeTest: (node: Node) => node is T): T;
     function getOriginalNode(node: Node | undefined): Node | undefined;
@@ -9138,7 +9134,7 @@ declare namespace ts {
     /**
      * Convert the json syntax tree into the json value
      */
-    function convertToObject(sourceFile: JsonSourceFile, errors: Push<Diagnostic>): any;
+    function convertToObject(sourceFile: JsonSourceFile, errors: Diagnostic[]): any;
     /**
      * Parse the contents of a config file (tsconfig.json).
      * @param json The contents of the config file to parse

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -31,10 +31,6 @@ declare namespace ts {
     interface SortedArray<T> extends Array<T> {
         " __sortedArrayBrand": any;
     }
-    /** Array that is only intended to be pushed to, never read. */
-    interface Push<T> {
-        push(...values: T[]): void;
-    }
     type Path = string & {
         __pathBrand: any;
     };
@@ -4623,7 +4619,7 @@ declare namespace ts {
         resolvePath(path: string): string;
         fileExists(fileName: string): boolean;
         readFile(fileName: string): string | undefined;
-    }, errors?: Push<Diagnostic>): void;
+    }, errors?: Diagnostic[]): void;
     function getOriginalNode(node: Node): Node;
     function getOriginalNode<T extends Node>(node: Node, nodeTest: (node: Node) => node is T): T;
     function getOriginalNode(node: Node | undefined): Node | undefined;
@@ -5203,7 +5199,7 @@ declare namespace ts {
     /**
      * Convert the json syntax tree into the json value
      */
-    function convertToObject(sourceFile: JsonSourceFile, errors: Push<Diagnostic>): any;
+    function convertToObject(sourceFile: JsonSourceFile, errors: Diagnostic[]): any;
     /**
      * Parse the contents of a config file (tsconfig.json).
      * @param json The contents of the config file to parse


### PR DESCRIPTION
Pulled out of #51921; this is similar to #51964 in that it's more cleanup of container-y things out of our public API.

It turns out that this interface is only used in two places in our public API, two functions which accept an array to push error diagnostics onto. Looking around the functions near those, it turns out that all other functions use `errors: Diagnostic[]`, not `Push<Diagnostic>` already, so it seems to me like we could just be consistent about requesting an array instead.

I think it also makes sense from the POV that we internally secretly required the `length` property to exist on `Push`, yet it would be totally possible for people to pass in a random object with only `Push` and break things due to that partially-internal interface.

So, this PR just drops it out of the public API and changes the few things needed to make the two public functions use the plain array type.

`Push` is much more heavily used internally than `Collection` or `ReadonlyCollection`, so I don't have any immediate plans to attempt to remove it (whereas the collection types are very easily removable, as in #51921 which I would prefer to not have any public API changes).