### PR TITLE
Add a test for optional members completions within an object within an index signature constraint

### DIFF
--- a/tests/cases/fourslash/completionsIndexSignatureConstraint1.ts
+++ b/tests/cases/fourslash/completionsIndexSignatureConstraint1.ts
@@ -1,0 +1,29 @@
+/// <reference path="fourslash.ts" />
+// @strict: true
+////
+//// repro #9900
+////
+//// interface Test {
+////   a?: number;
+////   b?: string;
+//// }
+////
+//// interface TestIndex {
+////   [key: string]: Test;
+//// }
+////
+//// declare function testFunc<T extends TestIndex>(t: T): void;
+////
+//// testFunc({
+////   test: {
+////     /**/
+////   },
+//// });
+
+verify.completions({
+  marker: '',
+  exact: [
+    { name: 'a', sortText: completion.SortText.OptionalMember },
+    { name: 'b', sortText: completion.SortText.OptionalMember },
+  ]
+});


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/9900

this is a test case from https://github.com/microsoft/TypeScript/issues/9900 where the issue was fixed by https://github.com/microsoft/TypeScript/pull/34855 . Since the fixing PR didn't include a test like this, I decided to PR this one, cc @andrewbranch 