### PR TITLE
Add more precise typing for autoComplete HTML attribute

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -7081,7 +7081,7 @@ interface HTMLInputElement extends HTMLElement {
     /** Sets or retrieves a text alternative to the graphic. */
     alt: string;
     /** Specifies whether autocomplete is applied to an editable text field. */
-    autocomplete: string;
+    autocomplete: AutoComplete;
     capture: string;
     /** Sets or retrieves the state of the check box or radio button. */
     checked: boolean;
@@ -18359,6 +18359,7 @@ type AudioContextLatencyCategory = "balanced" | "interactive" | "playback";
 type AudioContextState = "closed" | "running" | "suspended";
 type AuthenticatorAttachment = "cross-platform" | "platform";
 type AuthenticatorTransport = "ble" | "hybrid" | "internal" | "nfc" | "usb";
+type AutoComplete = 'off' | 'on' | 'name' | 'honorific-prefix' | 'given-name' | 'family-name' | 'honorific-suffix' | 'nickname' | 'email' | 'username' | 'new-password' | 'current-password' | 'one-time-code' | 'organization-title' | 'organization' | 'street-address' | 'address-line1' | 'address-line2' | 'address-line3' | 'address-level4' | 'address-level3' | 'address-level2' | 'address-level1' | 'country' | 'country-name' | 'postal-code' | 'cc-name' | 'cc-given-name' | 'cc-additional-name' | 'cc-family-name' | 'cc-number' | 'cc-exp' | 'cc-exp-month' | 'cc-exp-year' | 'cc-csc' | 'cc-type' | 'transaction-currency' | 'transaction-amount' | 'language' | 'bday' | 'bday-day' | 'bday-month' | 'bday-year' | 'sex' | 'tel' | 'tel-country-code' | 'tel-national' | 'tel-area-code' | 'tel-local' | 'tel-extension' | 'impp' | 'url' | 'photo' | (string & {});
 type AutoKeyword = "auto";
 type AutomationRate = "a-rate" | "k-rate";
 type BinaryType = "arraybuffer" | "blob";


### PR DESCRIPTION
Add more precise typing for autoComplete HTML attribute instead of just `?string`.

This will allow to autocomplete… the `autoComplete` attribute in vscode for example.

![autoComplete autocomplete in vscode](https://user-images.githubusercontent.com/58247/211378145-c01c665b-9f4b-4918-83cc-16532f555935.png)

The list is quite long and it's not easy remembering the spelling of each one of them (first_name or given-name? password or current-password?), and it would improve the UX of sites if they were more appropriately used (for example, some people may think that the input's `type` and/or `name` attributes may be enough for fields like email or password, but knowing to use `autoComplete="new-password"` or `one-time-code` can be really useful).

I can also add a description above the `autoComplete` line, something like that:

```ts
    /** See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
     * and https://html.spec.whatwg.org/multipage/forms.html#autofill
     * for more information and examples. */
```

and I can even add [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values)'s descriptions above each value, as they are really well explained and some of them may not always be intuitive at first glance. I didn't add them for now, as it looks like the list is kept quite compact.

Please tell me if I need to make any changes or improvements.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #52168
