### PR TITLE
Fix bad baseline on main

### DIFF
--- a/tests/baselines/reference/importedAliasedConditionalTypeInstantiation.js
+++ b/tests/baselines/reference/importedAliasedConditionalTypeInstantiation.js
@@ -47,4 +47,4 @@ type Expected = lambdaTester.Verifier<lambdaTester.HandlerResult<Handler<any, an
 
 //// [index.js]
 "use strict";
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", { value: true });


### PR DESCRIPTION
main started failing after #51771 since its baselines predated the ES3 -> ES5 default change.