### PR TITLE
Update to esbuild 0.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "chokidar": "^3.5.3",
                 "del": "^6.1.1",
                 "diff": "^5.1.0",
-                "esbuild": "^0.17.0",
+                "esbuild": "^0.17.2",
                 "eslint": "^8.22.0",
                 "eslint-formatter-autolinkable-stylish": "^1.2.0",
                 "eslint-plugin-import": "^2.26.0",
@@ -59,9 +59,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.0.tgz",
-            "integrity": "sha512-hlbX5ym1V5kIKvnwFhm6rhar7MNqfJrZyYTNfk6+WS1uQfQmszFgXeyPH2beP3lSCumZyqX0zMBfOqftOpZ7GA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.2.tgz",
+            "integrity": "sha512-Art7v3xYfqH1gEMUSP0Nx67pNAlC/Y3qSg3mOw8Wg7MP9bJLXL0DrmJaV1Qz1o4FwagtvDgkVOeBDpZgxdj13Q==",
             "cpu": [
                 "arm"
             ],
@@ -75,9 +75,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.0.tgz",
-            "integrity": "sha512-77GVyD7ToESy/7+9eI8z62GGBdS/hsqsrpM+JA4kascky86wHbN29EEFpkVvxajPL7k6mbLJ5VBQABdj7n9FhQ==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.2.tgz",
+            "integrity": "sha512-QSkmYISXr2uFoR+NdmmKyR5svYb0cXDCfzwNblLsrC8wTpx/I1L7u/zrjrf4aLoHoRTycZFIewJwBiUrO5DWtQ==",
             "cpu": [
                 "arm64"
             ],
@@ -91,9 +91,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.0.tgz",
-            "integrity": "sha512-TroxZdZhtAz0JyD0yahtjcbKuIXrBEAoAazaYSeR2e2tUtp9uXrcbpwFJF6oxxOiOOne6y7l4hx4YVnMW/tdFw==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.2.tgz",
+            "integrity": "sha512-5VOaFBI0RK8jJVDHdeU1YJmpxXoOf1RPoiOBhk/Tvpulw7R1SwCsxHvC3eDQcoF0gV7YM4V2wJO0PR9tem6gCQ==",
             "cpu": [
                 "x64"
             ],
@@ -107,9 +107,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.0.tgz",
-            "integrity": "sha512-wP/v4cgdWt1m8TS/WmbaBc3NZON10eCbm6XepdVc3zJuqruHCzCKcC9dTSTEk50zX04REcRcbIbdhTMciQoFIg==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.2.tgz",
+            "integrity": "sha512-iQJu1Zn1Wi91D5x/sslEn/jwae1tgSAEHK0R/kYzIr5jO992IJwDDuWhSGll23jHt18RECxahhGG0BWY/bVUTw==",
             "cpu": [
                 "arm64"
             ],
@@ -123,9 +123,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.0.tgz",
-            "integrity": "sha512-R4WB6D6V9KGO/3LVTT8UlwRJO26IBFatOdo/bRXksfJR0vyOi2/lgmAAMBSpgcnnwvts9QsWiyM++mTTlwRseA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.2.tgz",
+            "integrity": "sha512-j750nyrwoRZd3VnPo5sd12/5U27TxFGmvmoDv93G2jiaGJPYKJ/+5IfRAvHahGePTUIRPyOlE5YLFw9MlzuBnw==",
             "cpu": [
                 "x64"
             ],
@@ -139,9 +139,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.0.tgz",
-            "integrity": "sha512-FO7+UEZv79gen2df8StFYFHZPI9ADozpFepLZCxY+O8sYLDa1rirvenmLwJiOHmeQRJ5orYedFeLk1PFlZ6t8Q==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.2.tgz",
+            "integrity": "sha512-ti7GU+/KUQQXEPmSUep7efZpA3KR2SkKsVuSL2FE7Yxka9apuqKfymAgQmVPMxstzAgCRBIu8uEu0KFmTfs3/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -155,9 +155,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.0.tgz",
-            "integrity": "sha512-qCsNRsVTaC3ekwZcb2sa7l1gwCtJK3EqCWyDgpoQocYf3lRpbAzaCvqZSF2+NOO64cV+JbedXPsFiXU1aaVcIg==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.2.tgz",
+            "integrity": "sha512-NgooSKWSnrNKRuiumY1dg7KAGpsyXIMcwyOXN9imnqe8VFjqqrEOMqZRik0C1wlfLjiSCuMsj+YUSmBMAJMt0A==",
             "cpu": [
                 "x64"
             ],
@@ -171,9 +171,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.0.tgz",
-            "integrity": "sha512-Y2G2NU6155gcfNKvrakVmZV5xUAEhXjsN/uKtbKKRnvee0mHUuaT3OdQJDJKjHVGr6B0898pc3slRpI1PqspoQ==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.2.tgz",
+            "integrity": "sha512-8dfrRTd39n+THdAetwQKNwK6zBPR5oPjMtgRNXvRq8gsn/J5o69zTaOWVi3QO09BljqdShxU2dxDA09lDhdIqQ==",
             "cpu": [
                 "arm"
             ],
@@ -187,9 +187,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.0.tgz",
-            "integrity": "sha512-js4Vlch5XJQYISbDVJd2hsI/MsfVUz6d/FrclCE73WkQmniH37vFpuQI42ntWAeBghDIfaPZ6f9GilhwGzVFUg==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.2.tgz",
+            "integrity": "sha512-jcJ4cxwQyqEqgDwkqj7820nKx9cM5WBPCCU4oUXvTeG+DkkJE6/P75od0VPHmItFfEJu+/2vV85ebvFVomZcBg==",
             "cpu": [
                 "arm64"
             ],
@@ -203,9 +203,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.0.tgz",
-            "integrity": "sha512-7tl/jSPkF59R3zeFDB2/09zLGhcM7DM+tCoOqjJbQjuL6qbMWomGT2RglCqRFpCSdzBx0hukmPPgUAMlmdj0sQ==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.2.tgz",
+            "integrity": "sha512-dXZ3m++zaRVD2fqOUPP8QTh1Lfg6WO6uZDo/QJ3KdfnIR7dDToDtaA12AgKYvCed9Nuzf/gpKs/7/f6I02b/sg==",
             "cpu": [
                 "ia32"
             ],
@@ -219,9 +219,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.0.tgz",
-            "integrity": "sha512-OG356F7dIVVF+EXJx5UfzFr1I5l6ES53GlMNSr3U1MhlaVyrP9um5PnrSJ+7TSDAzUC7YGjxb2GQWqHLd5XFoA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.2.tgz",
+            "integrity": "sha512-/vntXkzSe9TUp0Rh35Wgye1EOhDtmIMjwC4rtahHcALmDXL+iuQGvwGFvXrP+sBigia/ltLryMAvCiqGV6plqw==",
             "cpu": [
                 "loong64"
             ],
@@ -235,9 +235,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.0.tgz",
-            "integrity": "sha512-LWQJgGpxrjh2x08UYf6G5R+Km7zhkpCvKXtFQ6SX0fimDvy1C8kslgFHGxLS0wjGV8C4BNnENW/HNy57+RB7iA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.2.tgz",
+            "integrity": "sha512-guYcNHjMRO1BMxWAeb8LDfgQaU8oeUO65xtlclwBD+hX3163KBifEHyao1hK96J10BP9n0UmZug6GhtGZaNm2Q==",
             "cpu": [
                 "mips64el"
             ],
@@ -251,9 +251,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.0.tgz",
-            "integrity": "sha512-f40N8fKiTQslUcUuhof2/syOQ+DC9Mqdnm9d063pew+Ptv9r6dBNLQCz4300MOfCLAbb0SdnrcMSzHbMehXWLw==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.2.tgz",
+            "integrity": "sha512-fzHTnIGIVqgUGZcFnnisguKD4UneF4uwWwkG+i8kBspMDdU1wJ0jha1VdtxWP7Ob1KGxuXcoUlrQkCVO+Z5iOw==",
             "cpu": [
                 "ppc64"
             ],
@@ -267,9 +267,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.0.tgz",
-            "integrity": "sha512-sc/pvLexRvxgEbmeq7LfLGnzUBFi/E2MGbnQj3CG8tnQ90tWPTi+9CbZEgIADhj6CAlCCmqxpUclIV1CRVUOTw==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.2.tgz",
+            "integrity": "sha512-Sa+z7csvNVeAsTD83tVSggOb8CAU7EdDuihC8WhtoJfuDVkF5+Vi0imaiCjXQ7Ci5rz/a8IJ1H1MWX3eI9AmuQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -283,9 +283,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.0.tgz",
-            "integrity": "sha512-7xq9/kY0vunCL2vjHKdHGI+660pCdeEC6K6TWBVvbTGXvT8s/qacfxMgr8PCeQRbNUZLOA13G6/G1+c0lYXO1A==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.2.tgz",
+            "integrity": "sha512-jUFCO+/VA1Y/oeauSNBubp2UtGu4xjBUEFVgMPm0qLuw6xw18yOagKwBOPVmyE3ZSFqGd9BAPZM/JrtadgBryA==",
             "cpu": [
                 "s390x"
             ],
@@ -299,9 +299,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.0.tgz",
-            "integrity": "sha512-o7FhBLONk1mLT2ytlj/j/WuJcPdhWcVpysSJn1s9+zRdLwLKveipbPi5SIasJIqMq0T4CkQW76pxJYMqz9HrQA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.2.tgz",
+            "integrity": "sha512-naygxkSmr6x9tuvpa8iGefnXo3Rc3Noz7c4+Dn0MSfSWJwLaN2YR686e7HkI09irfjDdU5UAq9wcxUwjkYQNUA==",
             "cpu": [
                 "x64"
             ],
@@ -315,9 +315,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.0.tgz",
-            "integrity": "sha512-V6xXsv71b8vwFCW/ky82Rs//SbyA+ORty6A7Mzkg33/4NbYZ/1Vcbk7qAN5oi0i/gS4Q0+7dYT7NqaiVZ7+Xjw==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.2.tgz",
+            "integrity": "sha512-Hagbdq4EpiG9XXJY6Ozfrl2RN5jkXZXd6BD39f43tWz0d8yyOrRZlofM1eA6JYQbdv6c8BUsUOcgopavIqwx4Q==",
             "cpu": [
                 "x64"
             ],
@@ -331,9 +331,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.0.tgz",
-            "integrity": "sha512-StlQor6A0Y9SSDxraytr46Qbz25zsSDmsG3MCaNkBnABKHP3QsngOCfdBikqHVVrXeK0KOTmtX92/ncTGULYgQ==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.2.tgz",
+            "integrity": "sha512-Pkby+VEXY7+aWP8J2RUCfqWbbZz2M1GavRGGnE2kEPzwarba/BOk3B45PSaKwc3iKdK2rgCPCTjC/p9JoKNejA==",
             "cpu": [
                 "x64"
             ],
@@ -347,9 +347,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.0.tgz",
-            "integrity": "sha512-K64Wqw57j8KrwjR3QjsuzN/qDGK6Cno6QYtIlWAmGab5iYPBZCWz7HFtF2a86/130LmUsdXqOID7J0SmjjRFIQ==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.2.tgz",
+            "integrity": "sha512-WAyg4dBTUsAPJ9cRnuQ23cwJWYRhP4e4y0M/l2+EpRjWW+g1MNAXKQQNNhRQ71zc8UixRVrqj+43ReHeZC8mJQ==",
             "cpu": [
                 "x64"
             ],
@@ -363,9 +363,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.0.tgz",
-            "integrity": "sha512-hly6iSWAf0hf3aHD18/qW7iFQbg9KAQ0RFGG9plcxkhL4uGw43O+lETGcSO/PylNleFowP/UztpF6U4oCYgpPw==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.2.tgz",
+            "integrity": "sha512-rMbO3gPpxuENd+AnZLgo4J/g+BkwxT3NK7nYpSZ0KlYtSdlxYMIMG5pznX7a1ISZKo67aGStne+K41jdkBywpA==",
             "cpu": [
                 "arm64"
             ],
@@ -379,9 +379,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.0.tgz",
-            "integrity": "sha512-aL4EWPh0nyC5uYRfn+CHkTgawd4DjtmwquthNDmGf6Ht6+mUc+bQXyZNH1QIw8x20hSqFc4Tf36aLLWP/TPR3g==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.2.tgz",
+            "integrity": "sha512-73dWKDMhFk+4owS19OjEVbEDGFPRS1fyga3qOu5HPd5eTxJTjtlVTT/fG/S7AchA0vXS7hOqY70AAir1CkmICg==",
             "cpu": [
                 "ia32"
             ],
@@ -395,9 +395,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.0.tgz",
-            "integrity": "sha512-W6IIQ9Rt43I/GqfXeBFLk0TvowKBoirs9sw2LPfhHax6ayMlW5PhFzSJ76I1ac9Pk/aRcSMrHWvVyZs8ZPK2wA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.2.tgz",
+            "integrity": "sha512-QFJlhf73HCBjTqAWWSIlD8JQBtmue0Dd6UV+KGccycJ3HKj1dCkXdRKJGwc5bZWiI9hrxcWsVEa1kVFaltC4vQ==",
             "cpu": [
                 "x64"
             ],
@@ -1780,9 +1780,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.0.tgz",
-            "integrity": "sha512-4yGk3rD95iS/wGzrx0Ji5czZcx1j2wvfF1iAJaX2FIYLB6sU6wYkDeplpZHzfwQw2yXGXsAoxmO6LnMQkl04Kg==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.2.tgz",
+            "integrity": "sha512-odaHSgtYafOXt2nSISwdWlfRkb4ceMX3akY1mWspQpT08jsqVYEK1XtVusr250Rmbx8AVNWjMPI/yyvKqxOKMw==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -1792,28 +1792,28 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.17.0",
-                "@esbuild/android-arm64": "0.17.0",
-                "@esbuild/android-x64": "0.17.0",
-                "@esbuild/darwin-arm64": "0.17.0",
-                "@esbuild/darwin-x64": "0.17.0",
-                "@esbuild/freebsd-arm64": "0.17.0",
-                "@esbuild/freebsd-x64": "0.17.0",
-                "@esbuild/linux-arm": "0.17.0",
-                "@esbuild/linux-arm64": "0.17.0",
-                "@esbuild/linux-ia32": "0.17.0",
-                "@esbuild/linux-loong64": "0.17.0",
-                "@esbuild/linux-mips64el": "0.17.0",
-                "@esbuild/linux-ppc64": "0.17.0",
-                "@esbuild/linux-riscv64": "0.17.0",
-                "@esbuild/linux-s390x": "0.17.0",
-                "@esbuild/linux-x64": "0.17.0",
-                "@esbuild/netbsd-x64": "0.17.0",
-                "@esbuild/openbsd-x64": "0.17.0",
-                "@esbuild/sunos-x64": "0.17.0",
-                "@esbuild/win32-arm64": "0.17.0",
-                "@esbuild/win32-ia32": "0.17.0",
-                "@esbuild/win32-x64": "0.17.0"
+                "@esbuild/android-arm": "0.17.2",
+                "@esbuild/android-arm64": "0.17.2",
+                "@esbuild/android-x64": "0.17.2",
+                "@esbuild/darwin-arm64": "0.17.2",
+                "@esbuild/darwin-x64": "0.17.2",
+                "@esbuild/freebsd-arm64": "0.17.2",
+                "@esbuild/freebsd-x64": "0.17.2",
+                "@esbuild/linux-arm": "0.17.2",
+                "@esbuild/linux-arm64": "0.17.2",
+                "@esbuild/linux-ia32": "0.17.2",
+                "@esbuild/linux-loong64": "0.17.2",
+                "@esbuild/linux-mips64el": "0.17.2",
+                "@esbuild/linux-ppc64": "0.17.2",
+                "@esbuild/linux-riscv64": "0.17.2",
+                "@esbuild/linux-s390x": "0.17.2",
+                "@esbuild/linux-x64": "0.17.2",
+                "@esbuild/netbsd-x64": "0.17.2",
+                "@esbuild/openbsd-x64": "0.17.2",
+                "@esbuild/sunos-x64": "0.17.2",
+                "@esbuild/win32-arm64": "0.17.2",
+                "@esbuild/win32-ia32": "0.17.2",
+                "@esbuild/win32-x64": "0.17.2"
             }
         },
         "node_modules/escalade": {
@@ -4659,156 +4659,156 @@
     },
     "dependencies": {
         "@esbuild/android-arm": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.0.tgz",
-            "integrity": "sha512-hlbX5ym1V5kIKvnwFhm6rhar7MNqfJrZyYTNfk6+WS1uQfQmszFgXeyPH2beP3lSCumZyqX0zMBfOqftOpZ7GA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.2.tgz",
+            "integrity": "sha512-Art7v3xYfqH1gEMUSP0Nx67pNAlC/Y3qSg3mOw8Wg7MP9bJLXL0DrmJaV1Qz1o4FwagtvDgkVOeBDpZgxdj13Q==",
             "dev": true,
             "optional": true
         },
         "@esbuild/android-arm64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.0.tgz",
-            "integrity": "sha512-77GVyD7ToESy/7+9eI8z62GGBdS/hsqsrpM+JA4kascky86wHbN29EEFpkVvxajPL7k6mbLJ5VBQABdj7n9FhQ==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.2.tgz",
+            "integrity": "sha512-QSkmYISXr2uFoR+NdmmKyR5svYb0cXDCfzwNblLsrC8wTpx/I1L7u/zrjrf4aLoHoRTycZFIewJwBiUrO5DWtQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/android-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.0.tgz",
-            "integrity": "sha512-TroxZdZhtAz0JyD0yahtjcbKuIXrBEAoAazaYSeR2e2tUtp9uXrcbpwFJF6oxxOiOOne6y7l4hx4YVnMW/tdFw==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.2.tgz",
+            "integrity": "sha512-5VOaFBI0RK8jJVDHdeU1YJmpxXoOf1RPoiOBhk/Tvpulw7R1SwCsxHvC3eDQcoF0gV7YM4V2wJO0PR9tem6gCQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/darwin-arm64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.0.tgz",
-            "integrity": "sha512-wP/v4cgdWt1m8TS/WmbaBc3NZON10eCbm6XepdVc3zJuqruHCzCKcC9dTSTEk50zX04REcRcbIbdhTMciQoFIg==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.2.tgz",
+            "integrity": "sha512-iQJu1Zn1Wi91D5x/sslEn/jwae1tgSAEHK0R/kYzIr5jO992IJwDDuWhSGll23jHt18RECxahhGG0BWY/bVUTw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/darwin-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.0.tgz",
-            "integrity": "sha512-R4WB6D6V9KGO/3LVTT8UlwRJO26IBFatOdo/bRXksfJR0vyOi2/lgmAAMBSpgcnnwvts9QsWiyM++mTTlwRseA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.2.tgz",
+            "integrity": "sha512-j750nyrwoRZd3VnPo5sd12/5U27TxFGmvmoDv93G2jiaGJPYKJ/+5IfRAvHahGePTUIRPyOlE5YLFw9MlzuBnw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/freebsd-arm64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.0.tgz",
-            "integrity": "sha512-FO7+UEZv79gen2df8StFYFHZPI9ADozpFepLZCxY+O8sYLDa1rirvenmLwJiOHmeQRJ5orYedFeLk1PFlZ6t8Q==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.2.tgz",
+            "integrity": "sha512-ti7GU+/KUQQXEPmSUep7efZpA3KR2SkKsVuSL2FE7Yxka9apuqKfymAgQmVPMxstzAgCRBIu8uEu0KFmTfs3/Q==",
             "dev": true,
             "optional": true
         },
         "@esbuild/freebsd-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.0.tgz",
-            "integrity": "sha512-qCsNRsVTaC3ekwZcb2sa7l1gwCtJK3EqCWyDgpoQocYf3lRpbAzaCvqZSF2+NOO64cV+JbedXPsFiXU1aaVcIg==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.2.tgz",
+            "integrity": "sha512-NgooSKWSnrNKRuiumY1dg7KAGpsyXIMcwyOXN9imnqe8VFjqqrEOMqZRik0C1wlfLjiSCuMsj+YUSmBMAJMt0A==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-arm": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.0.tgz",
-            "integrity": "sha512-Y2G2NU6155gcfNKvrakVmZV5xUAEhXjsN/uKtbKKRnvee0mHUuaT3OdQJDJKjHVGr6B0898pc3slRpI1PqspoQ==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.2.tgz",
+            "integrity": "sha512-8dfrRTd39n+THdAetwQKNwK6zBPR5oPjMtgRNXvRq8gsn/J5o69zTaOWVi3QO09BljqdShxU2dxDA09lDhdIqQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-arm64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.0.tgz",
-            "integrity": "sha512-js4Vlch5XJQYISbDVJd2hsI/MsfVUz6d/FrclCE73WkQmniH37vFpuQI42ntWAeBghDIfaPZ6f9GilhwGzVFUg==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.2.tgz",
+            "integrity": "sha512-jcJ4cxwQyqEqgDwkqj7820nKx9cM5WBPCCU4oUXvTeG+DkkJE6/P75od0VPHmItFfEJu+/2vV85ebvFVomZcBg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-ia32": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.0.tgz",
-            "integrity": "sha512-7tl/jSPkF59R3zeFDB2/09zLGhcM7DM+tCoOqjJbQjuL6qbMWomGT2RglCqRFpCSdzBx0hukmPPgUAMlmdj0sQ==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.2.tgz",
+            "integrity": "sha512-dXZ3m++zaRVD2fqOUPP8QTh1Lfg6WO6uZDo/QJ3KdfnIR7dDToDtaA12AgKYvCed9Nuzf/gpKs/7/f6I02b/sg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-loong64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.0.tgz",
-            "integrity": "sha512-OG356F7dIVVF+EXJx5UfzFr1I5l6ES53GlMNSr3U1MhlaVyrP9um5PnrSJ+7TSDAzUC7YGjxb2GQWqHLd5XFoA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.2.tgz",
+            "integrity": "sha512-/vntXkzSe9TUp0Rh35Wgye1EOhDtmIMjwC4rtahHcALmDXL+iuQGvwGFvXrP+sBigia/ltLryMAvCiqGV6plqw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-mips64el": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.0.tgz",
-            "integrity": "sha512-LWQJgGpxrjh2x08UYf6G5R+Km7zhkpCvKXtFQ6SX0fimDvy1C8kslgFHGxLS0wjGV8C4BNnENW/HNy57+RB7iA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.2.tgz",
+            "integrity": "sha512-guYcNHjMRO1BMxWAeb8LDfgQaU8oeUO65xtlclwBD+hX3163KBifEHyao1hK96J10BP9n0UmZug6GhtGZaNm2Q==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-ppc64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.0.tgz",
-            "integrity": "sha512-f40N8fKiTQslUcUuhof2/syOQ+DC9Mqdnm9d063pew+Ptv9r6dBNLQCz4300MOfCLAbb0SdnrcMSzHbMehXWLw==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.2.tgz",
+            "integrity": "sha512-fzHTnIGIVqgUGZcFnnisguKD4UneF4uwWwkG+i8kBspMDdU1wJ0jha1VdtxWP7Ob1KGxuXcoUlrQkCVO+Z5iOw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-riscv64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.0.tgz",
-            "integrity": "sha512-sc/pvLexRvxgEbmeq7LfLGnzUBFi/E2MGbnQj3CG8tnQ90tWPTi+9CbZEgIADhj6CAlCCmqxpUclIV1CRVUOTw==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.2.tgz",
+            "integrity": "sha512-Sa+z7csvNVeAsTD83tVSggOb8CAU7EdDuihC8WhtoJfuDVkF5+Vi0imaiCjXQ7Ci5rz/a8IJ1H1MWX3eI9AmuQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-s390x": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.0.tgz",
-            "integrity": "sha512-7xq9/kY0vunCL2vjHKdHGI+660pCdeEC6K6TWBVvbTGXvT8s/qacfxMgr8PCeQRbNUZLOA13G6/G1+c0lYXO1A==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.2.tgz",
+            "integrity": "sha512-jUFCO+/VA1Y/oeauSNBubp2UtGu4xjBUEFVgMPm0qLuw6xw18yOagKwBOPVmyE3ZSFqGd9BAPZM/JrtadgBryA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.0.tgz",
-            "integrity": "sha512-o7FhBLONk1mLT2ytlj/j/WuJcPdhWcVpysSJn1s9+zRdLwLKveipbPi5SIasJIqMq0T4CkQW76pxJYMqz9HrQA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.2.tgz",
+            "integrity": "sha512-naygxkSmr6x9tuvpa8iGefnXo3Rc3Noz7c4+Dn0MSfSWJwLaN2YR686e7HkI09irfjDdU5UAq9wcxUwjkYQNUA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/netbsd-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.0.tgz",
-            "integrity": "sha512-V6xXsv71b8vwFCW/ky82Rs//SbyA+ORty6A7Mzkg33/4NbYZ/1Vcbk7qAN5oi0i/gS4Q0+7dYT7NqaiVZ7+Xjw==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.2.tgz",
+            "integrity": "sha512-Hagbdq4EpiG9XXJY6Ozfrl2RN5jkXZXd6BD39f43tWz0d8yyOrRZlofM1eA6JYQbdv6c8BUsUOcgopavIqwx4Q==",
             "dev": true,
             "optional": true
         },
         "@esbuild/openbsd-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.0.tgz",
-            "integrity": "sha512-StlQor6A0Y9SSDxraytr46Qbz25zsSDmsG3MCaNkBnABKHP3QsngOCfdBikqHVVrXeK0KOTmtX92/ncTGULYgQ==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.2.tgz",
+            "integrity": "sha512-Pkby+VEXY7+aWP8J2RUCfqWbbZz2M1GavRGGnE2kEPzwarba/BOk3B45PSaKwc3iKdK2rgCPCTjC/p9JoKNejA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/sunos-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.0.tgz",
-            "integrity": "sha512-K64Wqw57j8KrwjR3QjsuzN/qDGK6Cno6QYtIlWAmGab5iYPBZCWz7HFtF2a86/130LmUsdXqOID7J0SmjjRFIQ==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.2.tgz",
+            "integrity": "sha512-WAyg4dBTUsAPJ9cRnuQ23cwJWYRhP4e4y0M/l2+EpRjWW+g1MNAXKQQNNhRQ71zc8UixRVrqj+43ReHeZC8mJQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-arm64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.0.tgz",
-            "integrity": "sha512-hly6iSWAf0hf3aHD18/qW7iFQbg9KAQ0RFGG9plcxkhL4uGw43O+lETGcSO/PylNleFowP/UztpF6U4oCYgpPw==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.2.tgz",
+            "integrity": "sha512-rMbO3gPpxuENd+AnZLgo4J/g+BkwxT3NK7nYpSZ0KlYtSdlxYMIMG5pznX7a1ISZKo67aGStne+K41jdkBywpA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-ia32": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.0.tgz",
-            "integrity": "sha512-aL4EWPh0nyC5uYRfn+CHkTgawd4DjtmwquthNDmGf6Ht6+mUc+bQXyZNH1QIw8x20hSqFc4Tf36aLLWP/TPR3g==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.2.tgz",
+            "integrity": "sha512-73dWKDMhFk+4owS19OjEVbEDGFPRS1fyga3qOu5HPd5eTxJTjtlVTT/fG/S7AchA0vXS7hOqY70AAir1CkmICg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-x64": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.0.tgz",
-            "integrity": "sha512-W6IIQ9Rt43I/GqfXeBFLk0TvowKBoirs9sw2LPfhHax6ayMlW5PhFzSJ76I1ac9Pk/aRcSMrHWvVyZs8ZPK2wA==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.2.tgz",
+            "integrity": "sha512-QFJlhf73HCBjTqAWWSIlD8JQBtmue0Dd6UV+KGccycJ3HKj1dCkXdRKJGwc5bZWiI9hrxcWsVEa1kVFaltC4vQ==",
             "dev": true,
             "optional": true
         },
@@ -5826,33 +5826,33 @@
             }
         },
         "esbuild": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.0.tgz",
-            "integrity": "sha512-4yGk3rD95iS/wGzrx0Ji5czZcx1j2wvfF1iAJaX2FIYLB6sU6wYkDeplpZHzfwQw2yXGXsAoxmO6LnMQkl04Kg==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.2.tgz",
+            "integrity": "sha512-odaHSgtYafOXt2nSISwdWlfRkb4ceMX3akY1mWspQpT08jsqVYEK1XtVusr250Rmbx8AVNWjMPI/yyvKqxOKMw==",
             "dev": true,
             "requires": {
-                "@esbuild/android-arm": "0.17.0",
-                "@esbuild/android-arm64": "0.17.0",
-                "@esbuild/android-x64": "0.17.0",
-                "@esbuild/darwin-arm64": "0.17.0",
-                "@esbuild/darwin-x64": "0.17.0",
-                "@esbuild/freebsd-arm64": "0.17.0",
-                "@esbuild/freebsd-x64": "0.17.0",
-                "@esbuild/linux-arm": "0.17.0",
-                "@esbuild/linux-arm64": "0.17.0",
-                "@esbuild/linux-ia32": "0.17.0",
-                "@esbuild/linux-loong64": "0.17.0",
-                "@esbuild/linux-mips64el": "0.17.0",
-                "@esbuild/linux-ppc64": "0.17.0",
-                "@esbuild/linux-riscv64": "0.17.0",
-                "@esbuild/linux-s390x": "0.17.0",
-                "@esbuild/linux-x64": "0.17.0",
-                "@esbuild/netbsd-x64": "0.17.0",
-                "@esbuild/openbsd-x64": "0.17.0",
-                "@esbuild/sunos-x64": "0.17.0",
-                "@esbuild/win32-arm64": "0.17.0",
-                "@esbuild/win32-ia32": "0.17.0",
-                "@esbuild/win32-x64": "0.17.0"
+                "@esbuild/android-arm": "0.17.2",
+                "@esbuild/android-arm64": "0.17.2",
+                "@esbuild/android-x64": "0.17.2",
+                "@esbuild/darwin-arm64": "0.17.2",
+                "@esbuild/darwin-x64": "0.17.2",
+                "@esbuild/freebsd-arm64": "0.17.2",
+                "@esbuild/freebsd-x64": "0.17.2",
+                "@esbuild/linux-arm": "0.17.2",
+                "@esbuild/linux-arm64": "0.17.2",
+                "@esbuild/linux-ia32": "0.17.2",
+                "@esbuild/linux-loong64": "0.17.2",
+                "@esbuild/linux-mips64el": "0.17.2",
+                "@esbuild/linux-ppc64": "0.17.2",
+                "@esbuild/linux-riscv64": "0.17.2",
+                "@esbuild/linux-s390x": "0.17.2",
+                "@esbuild/linux-x64": "0.17.2",
+                "@esbuild/netbsd-x64": "0.17.2",
+                "@esbuild/openbsd-x64": "0.17.2",
+                "@esbuild/sunos-x64": "0.17.2",
+                "@esbuild/win32-arm64": "0.17.2",
+                "@esbuild/win32-ia32": "0.17.2",
+                "@esbuild/win32-x64": "0.17.2"
             }
         },
         "escalade": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "chokidar": "^3.5.3",
                 "del": "^6.1.1",
                 "diff": "^5.1.0",
-                "esbuild": "^0.16.5",
+                "esbuild": "^0.17.0",
                 "eslint": "^8.22.0",
                 "eslint-formatter-autolinkable-stylish": "^1.2.0",
                 "eslint-plugin-import": "^2.26.0",
@@ -59,9 +59,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
-            "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.0.tgz",
+            "integrity": "sha512-hlbX5ym1V5kIKvnwFhm6rhar7MNqfJrZyYTNfk6+WS1uQfQmszFgXeyPH2beP3lSCumZyqX0zMBfOqftOpZ7GA==",
             "cpu": [
                 "arm"
             ],
@@ -75,9 +75,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
-            "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.0.tgz",
+            "integrity": "sha512-77GVyD7ToESy/7+9eI8z62GGBdS/hsqsrpM+JA4kascky86wHbN29EEFpkVvxajPL7k6mbLJ5VBQABdj7n9FhQ==",
             "cpu": [
                 "arm64"
             ],
@@ -91,9 +91,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
-            "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.0.tgz",
+            "integrity": "sha512-TroxZdZhtAz0JyD0yahtjcbKuIXrBEAoAazaYSeR2e2tUtp9uXrcbpwFJF6oxxOiOOne6y7l4hx4YVnMW/tdFw==",
             "cpu": [
                 "x64"
             ],
@@ -107,9 +107,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
-            "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.0.tgz",
+            "integrity": "sha512-wP/v4cgdWt1m8TS/WmbaBc3NZON10eCbm6XepdVc3zJuqruHCzCKcC9dTSTEk50zX04REcRcbIbdhTMciQoFIg==",
             "cpu": [
                 "arm64"
             ],
@@ -123,9 +123,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
-            "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.0.tgz",
+            "integrity": "sha512-R4WB6D6V9KGO/3LVTT8UlwRJO26IBFatOdo/bRXksfJR0vyOi2/lgmAAMBSpgcnnwvts9QsWiyM++mTTlwRseA==",
             "cpu": [
                 "x64"
             ],
@@ -139,9 +139,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
-            "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.0.tgz",
+            "integrity": "sha512-FO7+UEZv79gen2df8StFYFHZPI9ADozpFepLZCxY+O8sYLDa1rirvenmLwJiOHmeQRJ5orYedFeLk1PFlZ6t8Q==",
             "cpu": [
                 "arm64"
             ],
@@ -155,9 +155,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
-            "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.0.tgz",
+            "integrity": "sha512-qCsNRsVTaC3ekwZcb2sa7l1gwCtJK3EqCWyDgpoQocYf3lRpbAzaCvqZSF2+NOO64cV+JbedXPsFiXU1aaVcIg==",
             "cpu": [
                 "x64"
             ],
@@ -171,9 +171,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
-            "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.0.tgz",
+            "integrity": "sha512-Y2G2NU6155gcfNKvrakVmZV5xUAEhXjsN/uKtbKKRnvee0mHUuaT3OdQJDJKjHVGr6B0898pc3slRpI1PqspoQ==",
             "cpu": [
                 "arm"
             ],
@@ -187,9 +187,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
-            "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.0.tgz",
+            "integrity": "sha512-js4Vlch5XJQYISbDVJd2hsI/MsfVUz6d/FrclCE73WkQmniH37vFpuQI42ntWAeBghDIfaPZ6f9GilhwGzVFUg==",
             "cpu": [
                 "arm64"
             ],
@@ -203,9 +203,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
-            "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.0.tgz",
+            "integrity": "sha512-7tl/jSPkF59R3zeFDB2/09zLGhcM7DM+tCoOqjJbQjuL6qbMWomGT2RglCqRFpCSdzBx0hukmPPgUAMlmdj0sQ==",
             "cpu": [
                 "ia32"
             ],
@@ -219,9 +219,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
-            "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.0.tgz",
+            "integrity": "sha512-OG356F7dIVVF+EXJx5UfzFr1I5l6ES53GlMNSr3U1MhlaVyrP9um5PnrSJ+7TSDAzUC7YGjxb2GQWqHLd5XFoA==",
             "cpu": [
                 "loong64"
             ],
@@ -235,9 +235,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
-            "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.0.tgz",
+            "integrity": "sha512-LWQJgGpxrjh2x08UYf6G5R+Km7zhkpCvKXtFQ6SX0fimDvy1C8kslgFHGxLS0wjGV8C4BNnENW/HNy57+RB7iA==",
             "cpu": [
                 "mips64el"
             ],
@@ -251,9 +251,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
-            "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.0.tgz",
+            "integrity": "sha512-f40N8fKiTQslUcUuhof2/syOQ+DC9Mqdnm9d063pew+Ptv9r6dBNLQCz4300MOfCLAbb0SdnrcMSzHbMehXWLw==",
             "cpu": [
                 "ppc64"
             ],
@@ -267,9 +267,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
-            "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.0.tgz",
+            "integrity": "sha512-sc/pvLexRvxgEbmeq7LfLGnzUBFi/E2MGbnQj3CG8tnQ90tWPTi+9CbZEgIADhj6CAlCCmqxpUclIV1CRVUOTw==",
             "cpu": [
                 "riscv64"
             ],
@@ -283,9 +283,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
-            "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.0.tgz",
+            "integrity": "sha512-7xq9/kY0vunCL2vjHKdHGI+660pCdeEC6K6TWBVvbTGXvT8s/qacfxMgr8PCeQRbNUZLOA13G6/G1+c0lYXO1A==",
             "cpu": [
                 "s390x"
             ],
@@ -299,9 +299,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
-            "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.0.tgz",
+            "integrity": "sha512-o7FhBLONk1mLT2ytlj/j/WuJcPdhWcVpysSJn1s9+zRdLwLKveipbPi5SIasJIqMq0T4CkQW76pxJYMqz9HrQA==",
             "cpu": [
                 "x64"
             ],
@@ -315,9 +315,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
-            "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.0.tgz",
+            "integrity": "sha512-V6xXsv71b8vwFCW/ky82Rs//SbyA+ORty6A7Mzkg33/4NbYZ/1Vcbk7qAN5oi0i/gS4Q0+7dYT7NqaiVZ7+Xjw==",
             "cpu": [
                 "x64"
             ],
@@ -331,9 +331,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
-            "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.0.tgz",
+            "integrity": "sha512-StlQor6A0Y9SSDxraytr46Qbz25zsSDmsG3MCaNkBnABKHP3QsngOCfdBikqHVVrXeK0KOTmtX92/ncTGULYgQ==",
             "cpu": [
                 "x64"
             ],
@@ -347,9 +347,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
-            "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.0.tgz",
+            "integrity": "sha512-K64Wqw57j8KrwjR3QjsuzN/qDGK6Cno6QYtIlWAmGab5iYPBZCWz7HFtF2a86/130LmUsdXqOID7J0SmjjRFIQ==",
             "cpu": [
                 "x64"
             ],
@@ -363,9 +363,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
-            "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.0.tgz",
+            "integrity": "sha512-hly6iSWAf0hf3aHD18/qW7iFQbg9KAQ0RFGG9plcxkhL4uGw43O+lETGcSO/PylNleFowP/UztpF6U4oCYgpPw==",
             "cpu": [
                 "arm64"
             ],
@@ -379,9 +379,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
-            "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.0.tgz",
+            "integrity": "sha512-aL4EWPh0nyC5uYRfn+CHkTgawd4DjtmwquthNDmGf6Ht6+mUc+bQXyZNH1QIw8x20hSqFc4Tf36aLLWP/TPR3g==",
             "cpu": [
                 "ia32"
             ],
@@ -395,9 +395,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
-            "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.0.tgz",
+            "integrity": "sha512-W6IIQ9Rt43I/GqfXeBFLk0TvowKBoirs9sw2LPfhHax6ayMlW5PhFzSJ76I1ac9Pk/aRcSMrHWvVyZs8ZPK2wA==",
             "cpu": [
                 "x64"
             ],
@@ -1780,9 +1780,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
-            "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.0.tgz",
+            "integrity": "sha512-4yGk3rD95iS/wGzrx0Ji5czZcx1j2wvfF1iAJaX2FIYLB6sU6wYkDeplpZHzfwQw2yXGXsAoxmO6LnMQkl04Kg==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -1792,28 +1792,28 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.16.17",
-                "@esbuild/android-arm64": "0.16.17",
-                "@esbuild/android-x64": "0.16.17",
-                "@esbuild/darwin-arm64": "0.16.17",
-                "@esbuild/darwin-x64": "0.16.17",
-                "@esbuild/freebsd-arm64": "0.16.17",
-                "@esbuild/freebsd-x64": "0.16.17",
-                "@esbuild/linux-arm": "0.16.17",
-                "@esbuild/linux-arm64": "0.16.17",
-                "@esbuild/linux-ia32": "0.16.17",
-                "@esbuild/linux-loong64": "0.16.17",
-                "@esbuild/linux-mips64el": "0.16.17",
-                "@esbuild/linux-ppc64": "0.16.17",
-                "@esbuild/linux-riscv64": "0.16.17",
-                "@esbuild/linux-s390x": "0.16.17",
-                "@esbuild/linux-x64": "0.16.17",
-                "@esbuild/netbsd-x64": "0.16.17",
-                "@esbuild/openbsd-x64": "0.16.17",
-                "@esbuild/sunos-x64": "0.16.17",
-                "@esbuild/win32-arm64": "0.16.17",
-                "@esbuild/win32-ia32": "0.16.17",
-                "@esbuild/win32-x64": "0.16.17"
+                "@esbuild/android-arm": "0.17.0",
+                "@esbuild/android-arm64": "0.17.0",
+                "@esbuild/android-x64": "0.17.0",
+                "@esbuild/darwin-arm64": "0.17.0",
+                "@esbuild/darwin-x64": "0.17.0",
+                "@esbuild/freebsd-arm64": "0.17.0",
+                "@esbuild/freebsd-x64": "0.17.0",
+                "@esbuild/linux-arm": "0.17.0",
+                "@esbuild/linux-arm64": "0.17.0",
+                "@esbuild/linux-ia32": "0.17.0",
+                "@esbuild/linux-loong64": "0.17.0",
+                "@esbuild/linux-mips64el": "0.17.0",
+                "@esbuild/linux-ppc64": "0.17.0",
+                "@esbuild/linux-riscv64": "0.17.0",
+                "@esbuild/linux-s390x": "0.17.0",
+                "@esbuild/linux-x64": "0.17.0",
+                "@esbuild/netbsd-x64": "0.17.0",
+                "@esbuild/openbsd-x64": "0.17.0",
+                "@esbuild/sunos-x64": "0.17.0",
+                "@esbuild/win32-arm64": "0.17.0",
+                "@esbuild/win32-ia32": "0.17.0",
+                "@esbuild/win32-x64": "0.17.0"
             }
         },
         "node_modules/escalade": {
@@ -4659,156 +4659,156 @@
     },
     "dependencies": {
         "@esbuild/android-arm": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
-            "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.0.tgz",
+            "integrity": "sha512-hlbX5ym1V5kIKvnwFhm6rhar7MNqfJrZyYTNfk6+WS1uQfQmszFgXeyPH2beP3lSCumZyqX0zMBfOqftOpZ7GA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/android-arm64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
-            "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.0.tgz",
+            "integrity": "sha512-77GVyD7ToESy/7+9eI8z62GGBdS/hsqsrpM+JA4kascky86wHbN29EEFpkVvxajPL7k6mbLJ5VBQABdj7n9FhQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/android-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
-            "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.0.tgz",
+            "integrity": "sha512-TroxZdZhtAz0JyD0yahtjcbKuIXrBEAoAazaYSeR2e2tUtp9uXrcbpwFJF6oxxOiOOne6y7l4hx4YVnMW/tdFw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/darwin-arm64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
-            "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.0.tgz",
+            "integrity": "sha512-wP/v4cgdWt1m8TS/WmbaBc3NZON10eCbm6XepdVc3zJuqruHCzCKcC9dTSTEk50zX04REcRcbIbdhTMciQoFIg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/darwin-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
-            "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.0.tgz",
+            "integrity": "sha512-R4WB6D6V9KGO/3LVTT8UlwRJO26IBFatOdo/bRXksfJR0vyOi2/lgmAAMBSpgcnnwvts9QsWiyM++mTTlwRseA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/freebsd-arm64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
-            "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.0.tgz",
+            "integrity": "sha512-FO7+UEZv79gen2df8StFYFHZPI9ADozpFepLZCxY+O8sYLDa1rirvenmLwJiOHmeQRJ5orYedFeLk1PFlZ6t8Q==",
             "dev": true,
             "optional": true
         },
         "@esbuild/freebsd-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
-            "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.0.tgz",
+            "integrity": "sha512-qCsNRsVTaC3ekwZcb2sa7l1gwCtJK3EqCWyDgpoQocYf3lRpbAzaCvqZSF2+NOO64cV+JbedXPsFiXU1aaVcIg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-arm": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
-            "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.0.tgz",
+            "integrity": "sha512-Y2G2NU6155gcfNKvrakVmZV5xUAEhXjsN/uKtbKKRnvee0mHUuaT3OdQJDJKjHVGr6B0898pc3slRpI1PqspoQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-arm64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
-            "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.0.tgz",
+            "integrity": "sha512-js4Vlch5XJQYISbDVJd2hsI/MsfVUz6d/FrclCE73WkQmniH37vFpuQI42ntWAeBghDIfaPZ6f9GilhwGzVFUg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-ia32": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
-            "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.0.tgz",
+            "integrity": "sha512-7tl/jSPkF59R3zeFDB2/09zLGhcM7DM+tCoOqjJbQjuL6qbMWomGT2RglCqRFpCSdzBx0hukmPPgUAMlmdj0sQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-loong64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
-            "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.0.tgz",
+            "integrity": "sha512-OG356F7dIVVF+EXJx5UfzFr1I5l6ES53GlMNSr3U1MhlaVyrP9um5PnrSJ+7TSDAzUC7YGjxb2GQWqHLd5XFoA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-mips64el": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
-            "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.0.tgz",
+            "integrity": "sha512-LWQJgGpxrjh2x08UYf6G5R+Km7zhkpCvKXtFQ6SX0fimDvy1C8kslgFHGxLS0wjGV8C4BNnENW/HNy57+RB7iA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-ppc64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
-            "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.0.tgz",
+            "integrity": "sha512-f40N8fKiTQslUcUuhof2/syOQ+DC9Mqdnm9d063pew+Ptv9r6dBNLQCz4300MOfCLAbb0SdnrcMSzHbMehXWLw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-riscv64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
-            "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.0.tgz",
+            "integrity": "sha512-sc/pvLexRvxgEbmeq7LfLGnzUBFi/E2MGbnQj3CG8tnQ90tWPTi+9CbZEgIADhj6CAlCCmqxpUclIV1CRVUOTw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-s390x": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
-            "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.0.tgz",
+            "integrity": "sha512-7xq9/kY0vunCL2vjHKdHGI+660pCdeEC6K6TWBVvbTGXvT8s/qacfxMgr8PCeQRbNUZLOA13G6/G1+c0lYXO1A==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
-            "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.0.tgz",
+            "integrity": "sha512-o7FhBLONk1mLT2ytlj/j/WuJcPdhWcVpysSJn1s9+zRdLwLKveipbPi5SIasJIqMq0T4CkQW76pxJYMqz9HrQA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/netbsd-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
-            "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.0.tgz",
+            "integrity": "sha512-V6xXsv71b8vwFCW/ky82Rs//SbyA+ORty6A7Mzkg33/4NbYZ/1Vcbk7qAN5oi0i/gS4Q0+7dYT7NqaiVZ7+Xjw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/openbsd-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
-            "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.0.tgz",
+            "integrity": "sha512-StlQor6A0Y9SSDxraytr46Qbz25zsSDmsG3MCaNkBnABKHP3QsngOCfdBikqHVVrXeK0KOTmtX92/ncTGULYgQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/sunos-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
-            "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.0.tgz",
+            "integrity": "sha512-K64Wqw57j8KrwjR3QjsuzN/qDGK6Cno6QYtIlWAmGab5iYPBZCWz7HFtF2a86/130LmUsdXqOID7J0SmjjRFIQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-arm64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
-            "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.0.tgz",
+            "integrity": "sha512-hly6iSWAf0hf3aHD18/qW7iFQbg9KAQ0RFGG9plcxkhL4uGw43O+lETGcSO/PylNleFowP/UztpF6U4oCYgpPw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-ia32": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
-            "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.0.tgz",
+            "integrity": "sha512-aL4EWPh0nyC5uYRfn+CHkTgawd4DjtmwquthNDmGf6Ht6+mUc+bQXyZNH1QIw8x20hSqFc4Tf36aLLWP/TPR3g==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-x64": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
-            "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.0.tgz",
+            "integrity": "sha512-W6IIQ9Rt43I/GqfXeBFLk0TvowKBoirs9sw2LPfhHax6ayMlW5PhFzSJ76I1ac9Pk/aRcSMrHWvVyZs8ZPK2wA==",
             "dev": true,
             "optional": true
         },
@@ -5826,33 +5826,33 @@
             }
         },
         "esbuild": {
-            "version": "0.16.17",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
-            "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.0.tgz",
+            "integrity": "sha512-4yGk3rD95iS/wGzrx0Ji5czZcx1j2wvfF1iAJaX2FIYLB6sU6wYkDeplpZHzfwQw2yXGXsAoxmO6LnMQkl04Kg==",
             "dev": true,
             "requires": {
-                "@esbuild/android-arm": "0.16.17",
-                "@esbuild/android-arm64": "0.16.17",
-                "@esbuild/android-x64": "0.16.17",
-                "@esbuild/darwin-arm64": "0.16.17",
-                "@esbuild/darwin-x64": "0.16.17",
-                "@esbuild/freebsd-arm64": "0.16.17",
-                "@esbuild/freebsd-x64": "0.16.17",
-                "@esbuild/linux-arm": "0.16.17",
-                "@esbuild/linux-arm64": "0.16.17",
-                "@esbuild/linux-ia32": "0.16.17",
-                "@esbuild/linux-loong64": "0.16.17",
-                "@esbuild/linux-mips64el": "0.16.17",
-                "@esbuild/linux-ppc64": "0.16.17",
-                "@esbuild/linux-riscv64": "0.16.17",
-                "@esbuild/linux-s390x": "0.16.17",
-                "@esbuild/linux-x64": "0.16.17",
-                "@esbuild/netbsd-x64": "0.16.17",
-                "@esbuild/openbsd-x64": "0.16.17",
-                "@esbuild/sunos-x64": "0.16.17",
-                "@esbuild/win32-arm64": "0.16.17",
-                "@esbuild/win32-ia32": "0.16.17",
-                "@esbuild/win32-x64": "0.16.17"
+                "@esbuild/android-arm": "0.17.0",
+                "@esbuild/android-arm64": "0.17.0",
+                "@esbuild/android-x64": "0.17.0",
+                "@esbuild/darwin-arm64": "0.17.0",
+                "@esbuild/darwin-x64": "0.17.0",
+                "@esbuild/freebsd-arm64": "0.17.0",
+                "@esbuild/freebsd-x64": "0.17.0",
+                "@esbuild/linux-arm": "0.17.0",
+                "@esbuild/linux-arm64": "0.17.0",
+                "@esbuild/linux-ia32": "0.17.0",
+                "@esbuild/linux-loong64": "0.17.0",
+                "@esbuild/linux-mips64el": "0.17.0",
+                "@esbuild/linux-ppc64": "0.17.0",
+                "@esbuild/linux-riscv64": "0.17.0",
+                "@esbuild/linux-s390x": "0.17.0",
+                "@esbuild/linux-x64": "0.17.0",
+                "@esbuild/netbsd-x64": "0.17.0",
+                "@esbuild/openbsd-x64": "0.17.0",
+                "@esbuild/sunos-x64": "0.17.0",
+                "@esbuild/win32-arm64": "0.17.0",
+                "@esbuild/win32-ia32": "0.17.0",
+                "@esbuild/win32-x64": "0.17.0"
             }
         },
         "escalade": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "chokidar": "^3.5.3",
         "del": "^6.1.1",
         "diff": "^5.1.0",
-        "esbuild": "^0.16.5",
+        "esbuild": "^0.17.0",
         "eslint": "^8.22.0",
         "eslint-formatter-autolinkable-stylish": "^1.2.0",
         "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "chokidar": "^3.5.3",
         "del": "^6.1.1",
         "diff": "^5.1.0",
-        "esbuild": "^0.17.0",
+        "esbuild": "^0.17.2",
         "eslint": "^8.22.0",
         "eslint-formatter-autolinkable-stylish": "^1.2.0",
         "eslint-plugin-import": "^2.26.0",


### PR DESCRIPTION
This release contains breaking changes to esbuild's API; for us, this affects our watch mode, which I have updated per the release note's upgrade guide: https://github.com/evanw/esbuild/releases/tag/v0.17.0

No changes to our bundled output, not that we don't already see those thanks to automatically getting patch releases.