### PR TITLE
fix completion text of exported types

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -454,7 +454,7 @@ export function getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker: Typ
         displayParts.push(spacePart());
         displayParts.push(operatorPart(SyntaxKind.EqualsToken));
         displayParts.push(spacePart());
-        addRange(displayParts, typeToDisplayParts(typeChecker, isConstTypeReference(location.parent) ? typeChecker.getTypeAtLocation(location.parent) : typeChecker.getDeclaredTypeOfSymbol(symbol), enclosingDeclaration, TypeFormatFlags.InTypeAlias));
+        addRange(displayParts, typeToDisplayParts(typeChecker, isConstTypeReference(location.parent) ? typeChecker.getTypeAtLocation(location.parent) : typeChecker.getDeclaredTypeOfSymbol(typeChecker.getExportSymbolOfSymbol(symbol)), enclosingDeclaration, TypeFormatFlags.InTypeAlias));
     }
     if (symbolFlags & SymbolFlags.Enum) {
         prefixNextMeaning();

--- a/tests/cases/fourslash/completionsExportedTypeAlias.ts
+++ b/tests/cases/fourslash/completionsExportedTypeAlias.ts
@@ -8,20 +8,23 @@
 ////
 ////const x: Ba/*b*/
 
-verify.completions({
-  marker: "a",
-  includes: [
-      {
-          name: "Foo",
-          text: "type Foo = \"a\" | \"b\""
-      }
-  ],
-},{
-  marker: "b",
-  includes: [
-      {
-          name: "Bar",
-          text: "type Bar = \"c\" | \"d\""
-      }
-  ],
-});
+verify.completions(
+    {
+        marker: 'a',
+        includes: [
+            {
+                name: 'Foo',
+                text: 'type Foo = "a" | "b"'
+            }
+        ]
+    },
+    {
+        marker: 'b',
+        includes: [
+            {
+                name: 'Bar',
+                text: 'type Bar = "c" | "d"'
+            }
+        ]
+    }
+)

--- a/tests/cases/fourslash/completionsExportedTypeAlias.ts
+++ b/tests/cases/fourslash/completionsExportedTypeAlias.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+////export type Foo = 'a' | 'b';
+////
+////const x: Fo/*a*/
+////
+////type Bar = 'c' | 'd';
+////
+////const x: Ba/*b*/
+
+verify.completions({
+  marker: "a",
+  includes: [
+      {
+          name: "Foo",
+          text: "type Foo = \"a\" | \"b\""
+      }
+  ],
+},{
+  marker: "b",
+  includes: [
+      {
+          name: "Bar",
+          text: "type Bar = \"c\" | \"d\""
+      }
+  ],
+});


### PR DESCRIPTION
Fixes #52221 

---

The `symbol` passed to `getSymbolDisplayPartsDocumentationAndSymbolKind` does not have any flags when `export type` is used. Without flags, `getDeclaredTypeOfSymbol` can't find the correct type and returns `errorType`. 

The associated _export symbol_ of `symbol` does hold the correct flags. This PR adds a call to `getExportSymbolOfSymbol` so that the _export symbol_ is passed to `getDeclaredTypeOfSymbol` if it exists.