### PR TITLE
Enable noImplicitOverride

### DIFF
--- a/src/harness/evaluatorImpl.ts
+++ b/src/harness/evaluatorImpl.ts
@@ -147,7 +147,7 @@ class CommonJsLoader extends Loader<CommonJSModule> {
         return this.resolveIndex(dir);
     }
 
-    protected resolve(id: string, base: string) {
+    protected override resolve(id: string, base: string) {
         const file = vpath.resolve(base, id);
         const resolved = this.resolveAsFile(file) || this.resolveAsDirectory(file);
         if (!resolved) throw new Error(`Module '${id}' could not be found.`);

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -295,11 +295,11 @@ class NativeLanguageServiceHost extends LanguageServiceAdapterHost implements ts
         return script ? script.version.toString() : undefined!; // TODO: GH#18217
     }
 
-    directoryExists(dirName: string): boolean {
+    override directoryExists(dirName: string): boolean {
         return this.sys.directoryExists(dirName);
     }
 
-    fileExists(fileName: string): boolean {
+    override fileExists(fileName: string): boolean {
         return this.sys.fileExists(fileName);
     }
 
@@ -307,11 +307,11 @@ class NativeLanguageServiceHost extends LanguageServiceAdapterHost implements ts
         return this.sys.readDirectory(path, extensions, exclude, include, depth);
     }
 
-    readFile(path: string): string | undefined {
+    override readFile(path: string): string | undefined {
         return this.sys.readFile(path);
     }
 
-    realpath(path: string): string {
+    override realpath(path: string): string {
         return this.sys.realpath(path);
     }
 
@@ -389,11 +389,11 @@ class ShimLanguageServiceHost extends LanguageServiceAdapterHost implements ts.L
         }
     }
 
-    getFilenames(): string[] { return this.nativeHost.getFilenames(); }
-    getScriptInfo(fileName: string): ScriptInfo | undefined { return this.nativeHost.getScriptInfo(fileName); }
-    addScript(fileName: string, content: string, isRootFile: boolean): void { this.nativeHost.addScript(fileName, content, isRootFile); }
-    editScript(fileName: string, start: number, end: number, newText: string): void { this.nativeHost.editScript(fileName, start, end, newText); }
-    positionToLineAndCharacter(fileName: string, position: number): ts.LineAndCharacter { return this.nativeHost.positionToLineAndCharacter(fileName, position); }
+    override getFilenames(): string[] { return this.nativeHost.getFilenames(); }
+    override getScriptInfo(fileName: string): ScriptInfo | undefined { return this.nativeHost.getScriptInfo(fileName); }
+    override addScript(fileName: string, content: string, isRootFile: boolean): void { this.nativeHost.addScript(fileName, content, isRootFile); }
+    override editScript(fileName: string, start: number, end: number, newText: string): void { this.nativeHost.editScript(fileName, start, end, newText); }
+    override positionToLineAndCharacter(fileName: string, position: number): ts.LineAndCharacter { return this.nativeHost.positionToLineAndCharacter(fileName, position); }
 
     getCompilationSettings(): string { return JSON.stringify(this.nativeHost.getCompilationSettings()); }
     getCancellationToken(): ts.HostCancellationToken { return this.nativeHost.getCancellationToken(); }
@@ -412,15 +412,15 @@ class ShimLanguageServiceHost extends LanguageServiceAdapterHost implements ts.L
     readDirectory = ts.notImplemented;
     readDirectoryNames = ts.notImplemented;
     readFileNames = ts.notImplemented;
-    fileExists(fileName: string) { return this.getScriptInfo(fileName) !== undefined; }
-    readFile(fileName: string) {
+    override fileExists(fileName: string) { return this.getScriptInfo(fileName) !== undefined; }
+    override readFile(fileName: string) {
         const snapshot = this.nativeHost.getScriptSnapshot(fileName);
         return snapshot && ts.getSnapshotText(snapshot);
     }
     log(s: string): void { this.nativeHost.log(s); }
     trace(s: string): void { this.nativeHost.trace(s); }
     error(s: string): void { this.nativeHost.error(s); }
-    directoryExists(): boolean {
+    override directoryExists(): boolean {
         // for tests pessimistically assume that directory always exists
         return true;
     }
@@ -746,12 +746,12 @@ class SessionClientHost extends NativeLanguageServiceHost implements ts.server.S
         this.client = client;
     }
 
-    openFile(fileName: string, content?: string, scriptKindName?: "TS" | "JS" | "TSX" | "JSX"): void {
+    override openFile(fileName: string, content?: string, scriptKindName?: "TS" | "JS" | "TSX" | "JSX"): void {
         super.openFile(fileName, content, scriptKindName);
         this.client.openFile(fileName, content, scriptKindName);
     }
 
-    editScript(fileName: string, start: number, end: number, newText: string) {
+    override editScript(fileName: string, start: number, end: number, newText: string) {
         const changeArgs = this.client.createChangeFileRequestArgs(fileName, start, end, newText);
         super.editScript(fileName, start, end, newText);
         this.client.changeFile(fileName, changeArgs);

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2124,7 +2124,7 @@ export class InferredProject extends Project {
         }
     }
 
-    setCompilerOptions(options?: CompilerOptions) {
+    override setCompilerOptions(options?: CompilerOptions) {
         // Avoid manipulating the given options directly
         if (!options && !this.getCompilationSettings()) {
             return;
@@ -2180,7 +2180,7 @@ export class InferredProject extends Project {
         this.enableGlobalPlugins(this.getCompilerOptions(), pluginConfigOverrides);
     }
 
-    addRoot(info: ScriptInfo) {
+    override addRoot(info: ScriptInfo) {
         Debug.assert(info.isScriptOpen());
         this.projectService.startWatchingConfigFilesForInferredProjectRoot(info);
         if (!this._isJsInferredProject && info.isJavaScript()) {
@@ -2189,7 +2189,7 @@ export class InferredProject extends Project {
         super.addRoot(info);
     }
 
-    removeRoot(info: ScriptInfo) {
+    override removeRoot(info: ScriptInfo) {
         this.projectService.stopWatchingConfigFilesForInferredProjectRoot(info);
         super.removeRoot(info);
         if (this._isJsInferredProject && info.isJavaScript()) {
@@ -2200,7 +2200,7 @@ export class InferredProject extends Project {
     }
 
     /** @internal */
-    isOrphan() {
+    override isOrphan() {
         return !this.hasRoots();
     }
 
@@ -2212,12 +2212,12 @@ export class InferredProject extends Project {
             this.getRootScriptInfos().length === 1;
     }
 
-    close() {
+    override close() {
         forEach(this.getRootScriptInfos(), info => this.projectService.stopWatchingConfigFilesForInferredProjectRoot(info));
         super.close();
     }
 
-    getTypeAcquisition(): TypeAcquisition {
+    override getTypeAcquisition(): TypeAcquisition {
         return this.typeAcquisition || {
             enable: allRootFilesAreJsOrDts(this),
             include: ts.emptyArray,
@@ -2241,12 +2241,12 @@ class AuxiliaryProject extends Project {
             /*currentDirectory*/ undefined);
     }
 
-    isOrphan(): boolean {
+    override isOrphan(): boolean {
         return true;
     }
 
     /** @internal */
-    scheduleInvalidateResolutionsOfFailedLookupLocations(): void {
+    override scheduleInvalidateResolutionsOfFailedLookupLocations(): void {
         // Invalidation will happen on-demand as part of updateGraph
         return;
     }
@@ -2436,11 +2436,11 @@ export class AutoImportProviderProject extends Project {
         return !some(this.rootFileNames);
     }
 
-    isOrphan() {
+    override isOrphan() {
         return true;
     }
 
-    updateGraph() {
+    override updateGraph() {
         let rootFileNames = this.rootFileNames;
         if (!rootFileNames) {
             rootFileNames = AutoImportProviderProject.getRootFileNames(
@@ -2461,62 +2461,62 @@ export class AutoImportProviderProject extends Project {
     }
 
     /** @internal */
-    scheduleInvalidateResolutionsOfFailedLookupLocations(): void {
+    override scheduleInvalidateResolutionsOfFailedLookupLocations(): void {
         // Invalidation will happen on-demand as part of updateGraph
         return;
     }
 
-    hasRoots() {
+    override hasRoots() {
         return !!this.rootFileNames?.length;
     }
 
-    markAsDirty() {
+    override markAsDirty() {
         this.rootFileNames = undefined;
         super.markAsDirty();
     }
 
-    getScriptFileNames() {
+    override getScriptFileNames() {
         return this.rootFileNames || ts.emptyArray;
     }
 
-    getLanguageService(): never {
+    override getLanguageService(): never {
         throw new Error("AutoImportProviderProject language service should never be used. To get the program, use `project.getCurrentProgram()`.");
     }
 
     /** @internal */
-    onAutoImportProviderSettingsChanged(): never {
+    override onAutoImportProviderSettingsChanged(): never {
         throw new Error("AutoImportProviderProject is an auto import provider; use `markAsDirty()` instead.");
     }
 
     /** @internal */
-    onPackageJsonChange(): never {
+    override onPackageJsonChange(): never {
         throw new Error("package.json changes should be notified on an AutoImportProvider's host project");
     }
 
-    getModuleResolutionHostForAutoImportProvider(): never {
+    override getModuleResolutionHostForAutoImportProvider(): never {
         throw new Error("AutoImportProviderProject cannot provide its own host; use `hostProject.getModuleResolutionHostForAutomImportProvider()` instead.");
     }
 
-    getProjectReferences() {
+    override getProjectReferences() {
         return this.hostProject.getProjectReferences();
     }
 
     /** @internal */
-    includePackageJsonAutoImports() {
+    override includePackageJsonAutoImports() {
         return PackageJsonAutoImportPreference.Off;
     }
 
-    getTypeAcquisition(): TypeAcquisition {
+    override getTypeAcquisition(): TypeAcquisition {
         return { enable: false };
     }
 
     /** @internal */
-    getSymlinkCache() {
+    override getSymlinkCache() {
         return this.hostProject.getSymlinkCache();
     }
 
     /** @internal */
-    getModuleResolutionCache() {
+    override getModuleResolutionCache() {
         return this.hostProject.getCurrentProgram()?.getModuleResolutionCache();
     }
 }
@@ -2554,7 +2554,7 @@ export class ConfiguredProject extends Project {
     projectOptions?: ProjectOptions | true;
 
     /** @internal */
-    isInitialLoadPending: () => boolean = returnTrue;
+    override isInitialLoadPending: () => boolean = returnTrue;
 
     /** @internal */
     sendLoadingProjectFinish = false;
@@ -2593,12 +2593,12 @@ export class ConfiguredProject extends Project {
     }
 
     /** @internal */
-    useSourceOfProjectReferenceRedirect() {
+    override useSourceOfProjectReferenceRedirect() {
         return this.languageServiceEnabled;
     }
 
     /** @internal */
-    getParsedCommandLine(fileName: string) {
+    override getParsedCommandLine(fileName: string) {
         const configFileName = asNormalizedPath(normalizePath(fileName));
         const canonicalConfigFilePath = asNormalizedPath(this.projectService.toCanonicalFileName(configFileName));
         // Ensure the config file existience info is cached
@@ -2630,7 +2630,7 @@ export class ConfiguredProject extends Project {
      * If the project has reload from disk pending, it reloads (and then updates graph as part of that) instead of just updating the graph
      * @returns: true if set of files in the project stays the same and false - otherwise.
      */
-    updateGraph(): boolean {
+    override updateGraph(): boolean {
         const isInitialLoad = this.isInitialLoadPending();
         this.isInitialLoadPending = returnFalse;
         const reloadLevel = this.pendingReload;
@@ -2658,7 +2658,7 @@ export class ConfiguredProject extends Project {
     }
 
     /** @internal */
-    getCachedDirectoryStructureHost() {
+    override getCachedDirectoryStructureHost() {
         return this.directoryStructureHost as CachedDirectoryStructureHost;
     }
 
@@ -2666,7 +2666,7 @@ export class ConfiguredProject extends Project {
         return asNormalizedPath(this.getProjectName());
     }
 
-    getProjectReferences(): readonly ProjectReference[] | undefined {
+    override getProjectReferences(): readonly ProjectReference[] | undefined {
         return this.projectReferences;
     }
 
@@ -2682,7 +2682,7 @@ export class ConfiguredProject extends Project {
     }
 
     /** @internal */
-    getResolvedProjectReferenceToRedirect(fileName: string): ResolvedProjectReference | undefined {
+    override getResolvedProjectReferenceToRedirect(fileName: string): ResolvedProjectReference | undefined {
         const program = this.getCurrentProgram();
         return program && program.getResolvedProjectReferenceToRedirect(fileName);
     }
@@ -2724,22 +2724,22 @@ export class ConfiguredProject extends Project {
     /**
      * Get the errors that dont have any file name associated
      */
-    getGlobalProjectErrors(): readonly Diagnostic[] {
+    override getGlobalProjectErrors(): readonly Diagnostic[] {
         return filter(this.projectErrors, diagnostic => !diagnostic.file) || emptyArray;
     }
 
     /**
      * Get all the project errors
      */
-    getAllProjectErrors(): readonly Diagnostic[] {
+    override getAllProjectErrors(): readonly Diagnostic[] {
         return this.projectErrors || emptyArray;
     }
 
-    setProjectErrors(projectErrors: Diagnostic[]) {
+    override setProjectErrors(projectErrors: Diagnostic[]) {
         this.projectErrors = projectErrors;
     }
 
-    close() {
+    override close() {
         this.projectService.configFileExistenceInfoCache.forEach((_configFileExistenceInfo, canonicalConfigFilePath) =>
             this.releaseParsedConfig(canonicalConfigFilePath));
         this.projectErrors = undefined;
@@ -2848,7 +2848,7 @@ export class ExternalProject extends Project {
         documentRegistry: DocumentRegistry,
         compilerOptions: CompilerOptions,
         lastFileExceededProgramSize: string | undefined,
-        public compileOnSaveEnabled: boolean,
+        public override compileOnSaveEnabled: boolean,
         projectFilePath?: string,
         pluginConfigOverrides?: Map<string, any>,
         watchOptions?: WatchOptions) {
@@ -2866,13 +2866,13 @@ export class ExternalProject extends Project {
         this.enableGlobalPlugins(this.getCompilerOptions(), pluginConfigOverrides);
     }
 
-    updateGraph() {
+    override updateGraph() {
         const result = super.updateGraph();
         this.projectService.sendProjectTelemetry(this);
         return result;
     }
 
-    getExcludedFiles() {
+    override getExcludedFiles() {
         return this.excludedFiles;
     }
 }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -722,7 +722,7 @@ class SymbolObject implements Symbol {
 }
 
 class TokenObject<TKind extends SyntaxKind> extends TokenOrIdentifierObject implements Token<TKind> {
-    public kind: TKind;
+    public override kind: TKind;
 
     constructor(kind: TKind, pos: number, end: number) {
         super(pos, end);
@@ -731,7 +731,7 @@ class TokenObject<TKind extends SyntaxKind> extends TokenOrIdentifierObject impl
 }
 
 class IdentifierObject extends TokenOrIdentifierObject implements Identifier {
-    public kind: SyntaxKind.Identifier = SyntaxKind.Identifier;
+    public override kind: SyntaxKind.Identifier = SyntaxKind.Identifier;
     public escapedText!: __String;
     declare _primaryExpressionBrand: any;
     declare _memberExpressionBrand: any;
@@ -753,7 +753,7 @@ class IdentifierObject extends TokenOrIdentifierObject implements Identifier {
 }
 IdentifierObject.prototype.kind = SyntaxKind.Identifier;
 class PrivateIdentifierObject extends TokenOrIdentifierObject implements PrivateIdentifier {
-    public kind: SyntaxKind.PrivateIdentifier = SyntaxKind.PrivateIdentifier;
+    public override kind: SyntaxKind.PrivateIdentifier = SyntaxKind.PrivateIdentifier;
     public escapedText!: __String;
     declare _primaryExpressionBrand: any;
     declare _memberExpressionBrand: any;
@@ -992,7 +992,7 @@ function findBaseOfDeclaration<T>(checker: TypeChecker, declaration: Declaration
 }
 
 class SourceFileObject extends NodeObject implements SourceFile {
-    public kind: SyntaxKind.SourceFile = SyntaxKind.SourceFile;
+    public override kind: SyntaxKind.SourceFile = SyntaxKind.SourceFile;
     declare _declarationBrand: any;
     declare _localsContainerBrand: any;
     public fileName!: string;

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -743,7 +743,7 @@ class LanguageServiceShimObject extends ShimBase implements LanguageServiceShim 
      * Ensure (almost) deterministic release of internal Javascript resources when
      * some external native objects holds onto us (e.g. Com/Interop).
      */
-    public dispose(dummy: {}): void {
+    public override dispose(dummy: {}): void {
         this.logger.log("dispose()");
         this.languageService.dispose();
         this.languageService = null!; // eslint-disable-line no-null/no-null

--- a/src/testRunner/externalCompileRunner.ts
+++ b/src/testRunner/externalCompileRunner.ts
@@ -135,7 +135,7 @@ export class DockerfileRunner extends ExternalCompileRunnerBase {
     kind(): TestRunnerKind {
         return "docker";
     }
-    initializeTests(): void {
+    override initializeTests(): void {
         // Read in and evaluate the test list
         const testList = this.tests && this.tests.length ? this.tests : this.getTestFiles();
 
@@ -289,7 +289,7 @@ function compareErrorStrings(a: string[], b: string[]) {
 
 export class DefinitelyTypedRunner extends ExternalCompileRunnerBase {
     readonly testDir = "../DefinitelyTyped/types/";
-    workingDirectory = this.testDir;
+    override workingDirectory = this.testDir;
     kind(): TestRunnerKind {
         return "dt";
     }

--- a/src/testRunner/parallel/host.ts
+++ b/src/testRunner/parallel/host.ts
@@ -56,12 +56,12 @@ export function start() {
             this.pending = false;
             this.delayed = false;
         }
-        addSuite(suite: RemoteSuite) {
+        override addSuite(suite: RemoteSuite) {
             super.addSuite(suite);
             this.suiteMap.set(suite.title, suite);
             return this;
         }
-        addTest(test: RemoteTest) {
+        override addTest(test: RemoteTest) {
             return super.addTest(test);
         }
     }

--- a/src/testRunner/parallel/worker.ts
+++ b/src/testRunner/parallel/worker.ts
@@ -56,14 +56,14 @@ export function start() {
      */
     function Timeout<T extends typeof Mocha.Runnable>(base: T) {
         return class extends (base as typeof Mocha.Runnable) {
-            resetTimeout() {
+            override resetTimeout() {
                 this.clearTimeout();
                 if (this.timeout() > 0) {
                     sendMessage({ type: "timeout", payload: { duration: this.timeout() || 1e9 } });
                     this.timer = true;
                 }
             }
-            clearTimeout() {
+            override clearTimeout() {
                 if (this.timer) {
                     sendMessage({ type: "timeout", payload: { duration: "reset" } });
                     this.timer = false;
@@ -77,7 +77,7 @@ export function start() {
      */
     function Clone<T extends typeof Mocha.Suite | typeof Mocha.Test>(base: T) {
         return class extends (base as new (...args: any[]) => { clone(): any; }) {
-            clone() {
+            override clone() {
                 const cloned = super.clone();
                 Object.setPrototypeOf(cloned, this.constructor.prototype);
                 return cloned;
@@ -89,7 +89,7 @@ export function start() {
      * A `Mocha.Suite` subclass to support parallel test execution in a worker.
      */
     class Suite extends mixin(Mocha.Suite, Clone) {
-        _createHook(title: string, fn?: Mocha.Func | Mocha.AsyncFunc) {
+        override _createHook(title: string, fn?: Mocha.Func | Mocha.AsyncFunc) {
             const hook = super._createHook(title, fn);
             Object.setPrototypeOf(hook, Hook.prototype);
             return hook;

--- a/src/testRunner/projectsRunner.ts
+++ b/src/testRunner/projectsRunner.ts
@@ -89,11 +89,11 @@ class ProjectCompilerHost extends fakes.CompilerHost {
         this._testCase = testCase;
     }
 
-    public get parseConfigHost(): fakes.ParseConfigHost {
+    public override get parseConfigHost(): fakes.ParseConfigHost {
         return this._projectParseConfigHost || (this._projectParseConfigHost = new ProjectParseConfigHost(this.sys, this._testCase));
     }
 
-    public getDefaultLibFileName(_options: ts.CompilerOptions) {
+    public override getDefaultLibFileName(_options: ts.CompilerOptions) {
         return vpath.resolve(this.getDefaultLibLocation(), "lib.es5.d.ts");
     }
 }
@@ -106,7 +106,7 @@ class ProjectParseConfigHost extends fakes.ParseConfigHost {
         this._testCase = testCase;
     }
 
-    public readDirectory(path: string, extensions: string[], excludes: string[], includes: string[], depth: number): string[] {
+    public override readDirectory(path: string, extensions: string[], excludes: string[], includes: string[], depth: number): string[] {
         const result = super.readDirectory(path, extensions, excludes, includes, depth);
         const projectRoot = vpath.resolve(vfs.srcFolder, this._testCase.projectRoot);
         return result.map(item => vpath.relative(

--- a/src/testRunner/unittests/tsserver/helpers.ts
+++ b/src/testRunner/unittests/tsserver/helpers.ts
@@ -403,7 +403,7 @@ export class TestSession extends ts.server.Session {
     private seq = 0;
     public events: ts.server.protocol.Event[] = [];
     public testhost: TestSessionAndServiceHost;
-    public logger: Logger;
+    public override logger: Logger;
 
     constructor(opts: TestSessionOptions) {
         super(opts);
@@ -426,7 +426,7 @@ export class TestSession extends ts.server.Session {
         return this.seq + 1;
     }
 
-    public executeCommand(request: ts.server.protocol.Request) {
+    public override executeCommand(request: ts.server.protocol.Request) {
         return this.baseline("response", super.executeCommand(this.baseline("request", request)));
     }
 
@@ -438,7 +438,7 @@ export class TestSession extends ts.server.Session {
         return this.executeCommand(request);
     }
 
-    public event<T extends object>(body: T, eventName: string) {
+    public override event<T extends object>(body: T, eventName: string) {
         this.events.push(ts.server.toEvent(eventName, body));
         super.event(body, eventName);
     }
@@ -522,7 +522,7 @@ export interface TestProjectServiceOptions extends ts.server.ProjectServiceOptio
 
 export class TestProjectService extends ts.server.ProjectService {
     public testhost: TestSessionAndServiceHost;
-    constructor(host: TestServerHost, public logger: Logger, cancellationToken: ts.HostCancellationToken, useSingleInferredProject: boolean,
+    constructor(host: TestServerHost, public override logger: Logger, cancellationToken: ts.HostCancellationToken, useSingleInferredProject: boolean,
         typingsInstaller: ts.server.ITypingsInstaller, opts: Partial<TestProjectServiceOptions> = {}) {
         super({
             host,

--- a/src/testRunner/unittests/tsserver/session.ts
+++ b/src/testRunner/unittests/tsserver/session.ts
@@ -481,7 +481,7 @@ describe("unittests:: tsserver:: Session:: exceptions", () => {
             });
             this.addProtocolHandler(command, this.exceptionRaisingHandler);
         }
-        send(msg: ts.server.protocol.Message) {
+        override send(msg: ts.server.protocol.Message) {
             this.lastSent = msg;
         }
     }
@@ -530,7 +530,7 @@ describe("unittests:: tsserver:: Session:: how Session is extendable via subclas
                 return { response: undefined, responseRequired: true };
             });
         }
-        send(msg: ts.server.protocol.Message) {
+        override send(msg: ts.server.protocol.Message) {
             this.lastSent = msg;
         }
     }
@@ -600,7 +600,7 @@ describe("unittests:: tsserver:: Session:: an example of using the Session API t
             }));
         }
 
-        send(msg: ts.server.protocol.Message) {
+        override send(msg: ts.server.protocol.Message) {
             this.client.handle(msg);
         }
 

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -92,7 +92,7 @@ describe("unittests:: tsserver:: typingsInstaller:: local module", () => {
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("config"), globalTypingsCacheLocation: typesCache });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, _cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, _cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 assert(false, "should not be called");
             }
         })();
@@ -140,7 +140,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings = ["@types/jquery"];
                 const typingFiles = [jquery];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -184,7 +184,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings = ["@types/jquery"];
                 const typingFiles = [jquery];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -218,10 +218,10 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery") }, { isEnabled: () => true, writeLine: msg => messages.push(msg) });
             }
-            enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
+            override enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
                 super.enqueueInstallTypingsRequest(project, typeAcquisition, unresolvedImports);
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
                 const installedTypings: string[] = [];
                 const typingFiles: File[] = [];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -258,7 +258,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host);
             }
-            enqueueInstallTypingsRequest() {
+            override enqueueInstallTypingsRequest() {
                 assert(false, "auto discovery should not be enabled");
             }
         })();
@@ -290,7 +290,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("node") });
             }
-            installWorker() {
+            override installWorker() {
                 assert(false, "nothing should get installed");
             }
         })();
@@ -317,7 +317,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery") });
             }
-            enqueueInstallTypingsRequest() {
+            override enqueueInstallTypingsRequest() {
                 assert(false, "auto discovery should not be enabled");
             }
         })();
@@ -351,11 +351,11 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery") });
             }
-            enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
+            override enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
                 enqueueIsCalled = true;
                 super.enqueueInstallTypingsRequest(project, typeAcquisition, unresolvedImports);
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
                 const installedTypings = ["@types/node"];
                 const typingFiles = [jquery];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -409,7 +409,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("lodash", "react") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
                 const installedTypings = ["@types/lodash", "@types/react"];
                 const typingFiles = [lodashDts, reactDts];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -450,10 +450,10 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery") });
             }
-            enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
+            override enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
                 super.enqueueInstallTypingsRequest(project, typeAcquisition, unresolvedImports);
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
                 const installedTypings: string[] = [];
                 const typingFiles: File[] = [];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -490,10 +490,10 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery") }, { isEnabled: () => true, writeLine: msg => messages.push(msg) });
             }
-            enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
+            override enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
                 super.enqueueInstallTypingsRequest(project, typeAcquisition, unresolvedImports);
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
                 const installedTypings: string[] = [];
                 const typingFiles: File[] = [];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -537,10 +537,10 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery") });
             }
-            enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
+            override enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
                 super.enqueueInstallTypingsRequest(project, typeAcquisition, unresolvedImports);
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
                 const installedTypings: string[] = [];
                 const typingFiles: File[] = [];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -616,7 +616,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery", "commander", "moment", "express") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
                 const installedTypings = ["@types/commander", "@types/express", "@types/jquery", "@types/moment"];
                 const typingFiles = [commander, express, jquery, moment];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -699,7 +699,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { throttleLimit: 3, typesRegistry: createTypesRegistry("commander", "express", "jquery", "moment", "lodash") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
                 const installedTypings = ["@types/commander", "@types/express", "@types/jquery", "@types/moment", "@types/lodash"];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
             }
@@ -778,7 +778,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { throttleLimit: 1, typesRegistry: createTypesRegistry("commander", "jquery", "lodash", "cordova", "gulp", "grunt") });
             }
-            installWorker(_requestId: number, args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
+            override installWorker(_requestId: number, args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction): void {
                 let typingFiles: (File & { typings: string })[] = [];
                 if (args.indexOf(ts.server.typingsInstaller.typingsName("commander")) >= 0) {
                     typingFiles = [commander, jquery, lodash, cordova];
@@ -876,7 +876,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { globalTypingsCacheLocation: "/tmp", typesRegistry: createTypesRegistry("zkat__cacache", "nested", "commander") });
             }
-            installWorker(_requestId: number, args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 assert.deepEqual(args, [`@types/zkat__cacache@ts${ts.versionMajorMinor}`]);
                 const installedTypings = ["@types/zkat__cacache"];
                 const typingFiles = [cacacheDTS];
@@ -953,7 +953,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { globalTypingsCacheLocation: "/tmp", typesRegistry: createTypesRegistry("jquery", "nested", "commander") });
             }
-            installWorker(_requestId: number, args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 assert.deepEqual(args, [`@types/jquery@ts${ts.versionMajorMinor}`]);
                 const installedTypings = ["@types/jquery"];
                 const typingFiles = [jqueryDTS];
@@ -1037,7 +1037,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { globalTypingsCacheLocation: "/tmp", typesRegistry: createTypesRegistry("jquery") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings = ["@types/jquery"];
                 const typingFiles = [jqueryDTS];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -1083,7 +1083,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { globalTypingsCacheLocation: "/tmp", typesRegistry: createTypesRegistry("jquery") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings = ["@types/jquery"];
                 const typingFiles = [jqueryDTS];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -1127,7 +1127,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { globalTypingsCacheLocation: cachePath, typesRegistry: createTypesRegistry("commander") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings = ["@types/commander"];
                 const typingFiles = [commander];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -1173,7 +1173,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { globalTypingsCacheLocation: cachePath, typesRegistry: createTypesRegistry("node", "commander") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings = ["@types/node", "@types/commander", `@types/${emberComponentDirectory}`];
                 const typingFiles = [node, commander, emberComponent];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -1214,7 +1214,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { globalTypingsCacheLocation: cachePath, typesRegistry: createTypesRegistry(...typeNames) });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings = typeNames.map(name => `@types/${name}`);
                 const typingFiles = typeNames.map((name): File => ({ path: typePath(name), content: "" }));
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -1253,7 +1253,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { globalTypingsCacheLocation: "/tmp", typesRegistry: createTypesRegistry("foo") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 executeCommand(this, host, ["foo"], [], cb);
             }
         })();
@@ -1362,7 +1362,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings = ["@types/jquery"];
                 const typingFiles = [jquery];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -1434,7 +1434,7 @@ describe("unittests:: tsserver:: typingsInstaller:: General functionality", () =
             constructor() {
                 super(host, { typesRegistry: createTypesRegistry("jquery") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings: string[] = [];
                 const typingFiles: File[] = [];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
@@ -1522,7 +1522,7 @@ describe("unittests:: tsserver:: typingsInstaller:: Invalid package names", () =
             constructor() {
                 super(host, { globalTypingsCacheLocation: "/tmp" }, { isEnabled: () => true, writeLine: msg => messages.push(msg) });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, _cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, _cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 assert(false, "runCommand should not be invoked");
             }
         })();
@@ -1792,12 +1792,12 @@ describe("unittests:: tsserver:: typingsInstaller:: telemetry events", () => {
             constructor() {
                 super(host, { globalTypingsCacheLocation: cachePath, typesRegistry: createTypesRegistry("commander") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings = ["@types/commander"];
                 const typingFiles = [commander];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
             }
-            sendResponse(response: ts.server.SetTypings | ts.server.InvalidateCachedTypings | ts.server.BeginInstallTypes | ts.server.EndInstallTypes) {
+            override sendResponse(response: ts.server.SetTypings | ts.server.InvalidateCachedTypings | ts.server.BeginInstallTypes | ts.server.EndInstallTypes) {
                 if (response.kind === ts.server.EventBeginInstallTypes) {
                     return;
                 }
@@ -1853,12 +1853,12 @@ describe("unittests:: tsserver:: typingsInstaller:: progress notifications", () 
             constructor() {
                 super(host, { globalTypingsCacheLocation: cachePath, typesRegistry: createTypesRegistry("commander") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 const installedTypings = ["@types/commander"];
                 const typingFiles = [commander];
                 executeCommand(this, host, installedTypings, typingFiles, cb);
             }
-            sendResponse(response: ts.server.SetTypings | ts.server.InvalidateCachedTypings | ts.server.BeginInstallTypes | ts.server.EndInstallTypes) {
+            override sendResponse(response: ts.server.SetTypings | ts.server.InvalidateCachedTypings | ts.server.BeginInstallTypes | ts.server.EndInstallTypes) {
                 if (response.kind === ts.server.EventBeginInstallTypes) {
                     beginEvent = response;
                     return;
@@ -1901,10 +1901,10 @@ describe("unittests:: tsserver:: typingsInstaller:: progress notifications", () 
             constructor() {
                 super(host, { globalTypingsCacheLocation: cachePath, typesRegistry: createTypesRegistry("commander") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 executeCommand(this, host, "", [], cb);
             }
-            sendResponse(response: ts.server.SetTypings | ts.server.InvalidateCachedTypings | ts.server.BeginInstallTypes | ts.server.EndInstallTypes) {
+            override sendResponse(response: ts.server.SetTypings | ts.server.InvalidateCachedTypings | ts.server.BeginInstallTypes | ts.server.EndInstallTypes) {
                 if (response.kind === ts.server.EventBeginInstallTypes) {
                     beginEvent = response;
                     return;
@@ -1984,7 +1984,7 @@ describe("unittests:: tsserver:: typingsInstaller:: recomputing resolutions of u
             constructor() {
                 super(host, { globalTypingsCacheLocation, typesRegistry: createTypesRegistry("foo") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 executeCommand(this, host, typingNames, typingFiles, cb);
             }
         })();
@@ -2069,7 +2069,7 @@ declare module "stream" {
             constructor() {
                 super(host, { globalTypingsCacheLocation, typesRegistry: createTypesRegistry("node") });
             }
-            installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
+            override installWorker(_requestId: number, _args: string[], _cwd: string, cb: ts.server.typingsInstaller.RequestCompletedAction) {
                 executeCommand(this, host, ["node"], [nodeTyping], cb);
             }
         })();

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -19,6 +19,7 @@
         "strict": true,
         "strictBindCallApply": false,
         "useUnknownInCatchVariables": false,
+        "noImplicitOverride": true,
 
         "noUnusedLocals": true,
         "noUnusedParameters": true,

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -840,7 +840,7 @@ function startNodeSession(options: StartSessionOptions, logger: Logger, cancella
             this.constructed = true;
         }
 
-        event<T extends object>(body: T, eventName: string): void {
+        override event<T extends object>(body: T, eventName: string): void {
             Debug.assert(!!this.constructed, "Should only call `IOSession.prototype.event` on an initialized IOSession");
 
             if (this.canUseEvents && this.eventPort) {
@@ -865,7 +865,7 @@ function startNodeSession(options: StartSessionOptions, logger: Logger, cancella
             this.eventSocket!.write(formatMessage(toEvent(eventName, body), this.logger, this.byteLength, this.host.newLine), "utf8");
         }
 
-        exit() {
+        override exit() {
             this.logger.info("Exiting...");
             this.projectService.closeLog();
             tracing?.stopTracing();
@@ -886,7 +886,7 @@ function startNodeSession(options: StartSessionOptions, logger: Logger, cancella
 
     class IpcIOSession extends IOSession {
 
-        protected writeMessage(msg: protocol.Message): void {
+        protected override writeMessage(msg: protocol.Message): void {
             const verboseLogging = logger.hasLevel(LogLevel.verbose);
             if (verboseLogging) {
                 const json = JSON.stringify(msg);
@@ -896,15 +896,15 @@ function startNodeSession(options: StartSessionOptions, logger: Logger, cancella
             process.send!(msg);
         }
 
-        protected parseMessage(message: any): protocol.Request {
+        protected override parseMessage(message: any): protocol.Request {
             return message as protocol.Request;
         }
 
-        protected toStringMessage(message: any) {
+        protected override toStringMessage(message: any) {
             return JSON.stringify(message, undefined, 2);
         }
 
-        public listen() {
+        public override listen() {
             process.on("message", (e: any) => {
                 this.onMessage(e);
             });


### PR DESCRIPTION
Generally speaking, this is good practice when using classes as to not accidentally rename a method/property in a parent but not its children.

(Now that SFT is in, I'm tightening up other rules as well.)