### PR TITLE
Enable useUnknownInCatchVariables

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2116,7 +2116,7 @@ export function tryReadFile(fileName: string, readFile: (path: string) => string
         text = readFile(fileName);
     }
     catch (e) {
-        return createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, e.message);
+        return createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, e instanceof Error ? e.message : `${e}`);
     }
     return text === undefined ? createCompilerDiagnostic(Diagnostics.Cannot_read_file_0, fileName) : text;
 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -396,7 +396,7 @@ export function createGetSourceFile(
         }
         catch (e) {
             if (onError) {
-                onError(e.message);
+                onError(e instanceof Error ? e.message : `${e}`);
             }
             text = "";
         }
@@ -431,7 +431,7 @@ export function createWriteFileMeasuringIO(
         }
         catch (e) {
             if (onError) {
-                onError(e.message);
+                onError(e instanceof Error ? e.message : `${e}`);
             }
         }
     };

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1199,7 +1199,7 @@ export function createSystemWatchFunctions({
                 // Catch the exception and use polling instead
                 // Eg. on linux the number of watches are limited and one could easily exhaust watches and the exception ENOSPC is thrown when creating watcher at that point
                 // so instead of throwing error, use fs.watchFile
-                hitSystemWatcherLimit ||= e.code === "ENOSPC";
+                hitSystemWatcherLimit ||= (e as { code?: string }).code === "ENOSPC";
                 sysLog(`sysLog:: ${fileOrDirectory}:: Changing to watchFile`);
                 return watchPresentFileSystemEntryWithFsWatchFile();
             }
@@ -1558,7 +1558,7 @@ export let sys: System = (() => {
                         _fs.mkdirSync(directoryName);
                     }
                     catch (e) {
-                        if (e.code !== "EEXIST") {
+                        if (!(e instanceof Error) && (e as { code?: string }).code !== "EEXIST") {
                             // Failed for some other reason (access denied?); still throw
                             throw e;
                         }
@@ -1630,7 +1630,7 @@ export let sys: System = (() => {
                     return { module: require(modulePath), modulePath, error: undefined };
                 }
                 catch (error) {
-                    return { module: undefined, modulePath: undefined, error };
+                    return { module: undefined, modulePath: undefined, error: error as {} };
                 }
             }
         };

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -63,7 +63,7 @@ export namespace tracingEnabled {
                 fs = require("fs");
             }
             catch (e) {
-                throw new Error(`tracing requires having fs\n(original error: ${e.message || e})`);
+                throw new Error(`tracing requires having fs\n(original error: ${e instanceof Error ? e.message : e})`);
             }
         }
 

--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -186,7 +186,7 @@ export class SessionClient implements LanguageService {
                 }
             }
             catch (e) {
-                throw new Error("Malformed response: Failed to parse server response: " + lastMessage + ". \r\n  Error details: " + e.message);
+                throw new Error("Malformed response: Failed to parse server response: " + lastMessage + ". \r\n  Error details: " + (e instanceof Error ? e.message : `${e}`));
             }
         }
 

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -7,6 +7,7 @@ import * as vpath from "./_namespaces/vpath";
 import * as Utils from "./_namespaces/Utils";
 
 import ArrayOrSingle = FourSlashInterface.ArrayOrSingle;
+import { Debug } from "./_namespaces/ts";
 
 export const enum FourSlashTestType {
     Native,
@@ -4172,6 +4173,7 @@ function runCode(code: string, state: TestState, fileName: string): void {
         f(ts, test, goTo, config, verify, edit, debug, format, cancellation, FourSlashInterface.classification, FourSlashInterface.Completion, verifyOperationIsCancelled, ignoreInterpolations);
     }
     catch (err) {
+        Debug.assert(err instanceof Error);
         // ensure 'source-map-support' is triggered while we still have the handler attached by accessing `error.stack`.
         err.stack?.toString();
         throw err;
@@ -4355,7 +4357,7 @@ function recordObjectMarker(fileName: string, location: LocationInformation, tex
         markerValue = JSON.parse("{ " + text + " }");
     }
     catch (e) {
-        reportError(fileName, location.sourceLine, location.sourceColumn, "Unable to parse marker text " + e.message);
+        reportError(fileName, location.sourceLine, location.sourceColumn, "Unable to parse marker text " + (e instanceof Error ? e.message : `${e}`));
     }
 
     if (markerValue === undefined) {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -7,7 +7,6 @@ import * as vpath from "./_namespaces/vpath";
 import * as Utils from "./_namespaces/Utils";
 
 import ArrayOrSingle = FourSlashInterface.ArrayOrSingle;
-import { Debug } from "./_namespaces/ts";
 
 export const enum FourSlashTestType {
     Native,
@@ -4173,7 +4172,7 @@ function runCode(code: string, state: TestState, fileName: string): void {
         f(ts, test, goTo, config, verify, edit, debug, format, cancellation, FourSlashInterface.classification, FourSlashInterface.Completion, verifyOperationIsCancelled, ignoreInterpolations);
     }
     catch (err) {
-        Debug.assert(err instanceof Error);
+        ts.Debug.assert(err instanceof Error);
         // ensure 'source-map-support' is triggered while we still have the handler attached by accessing `error.stack`.
         err.stack?.toString();
         throw err;

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -138,7 +138,7 @@ function createNodeIO(): IO {
             fs.mkdirSync(path);
         }
         catch (e) {
-            if (e.code === "ENOENT") {
+            if ((e as { code?: string }).code === "ENOENT") {
                 createDirectory(vpath.dirname(path));
                 createDirectory(path);
             }
@@ -745,6 +745,7 @@ export namespace Compiler {
             checkBaseLines(/*isSymbolBaseLine*/ false);
         }
         catch (e) {
+            ts.Debug.assert(e instanceof Error);
             typesError = e;
         }
 
@@ -752,6 +753,7 @@ export namespace Compiler {
             checkBaseLines(/*isSymbolBaseLine*/ true);
         }
         catch (e) {
+            ts.Debug.assert(e instanceof Error);
             symbolsError = e;
         }
 
@@ -1448,6 +1450,7 @@ export namespace Baseline {
                     writeComparison(comparison.expected, comparison.actual, relativeFileName, actualFileName);
                 }
                 catch (e) {
+                    ts.Debug.assert(e instanceof Error);
                     errors.push(e);
                 }
                 writtenFiles.set(relativeFileName, true);

--- a/src/harness/vfsUtil.ts
+++ b/src/harness/vfsUtil.ts
@@ -353,7 +353,7 @@ export class FileSystem {
             }
         }
         catch (e) {
-            if (e.code === "ENOENT") return;
+            if ((e as { code?: string }).code === "ENOENT") return;
             throw e;
         }
     }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -416,7 +416,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
             result = await host.importPlugin(resolvedPath, moduleName);
         }
         catch (e) {
-            result = { module: undefined, error: e };
+            result = { module: undefined, error: e as {} };
         }
         if (result.error) {
             const err = result.error.stack || result.error.message || JSON.stringify(result.error);
@@ -955,7 +955,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
             }
             catch (e) {
                 this.projectService.logger.info(`A plugin threw an exception in getExternalFiles: ${e}`);
-                if (e.stack) {
+                if (e instanceof Error && e.stack) {
                     this.projectService.logger.info(e.stack);
                 }
             }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -10,6 +10,7 @@ import {
     createLanguageService,
     createTextChangeRange,
     createTextSpan,
+    Debug,
     Diagnostic,
     diagnosticCategoryName,
     DocCommentTemplateOptions,
@@ -546,7 +547,7 @@ export class LanguageServiceShimHostAdapter implements LanguageServiceHost {
             return JSON.parse(diagnosticMessagesJson);
         }
         catch (e) {
-            this.log(e.description || "diagnosticMessages.generated.json has invalid JSON format");
+            this.log("diagnosticMessages.generated.json has invalid JSON format");
             return null;
         }
         /* eslint-enable no-null/no-null */
@@ -679,9 +680,9 @@ function forwardCall<T>(logger: Logger, actionDescription: string, returnJson: b
         if (err instanceof OperationCanceledException) {
             return JSON.stringify({ canceled: true });
         }
+        Debug.assert(err instanceof Error);
         logInternalError(logger, err);
-        err.description = actionDescription;
-        return JSON.stringify({ error: err });
+        return JSON.stringify({ error: { ...err, description: actionDescription } });
     }
 }
 
@@ -1399,6 +1400,7 @@ export class TypeScriptServicesFactory implements ShimFactory {
             return new LanguageServiceShimObject(this, host, languageService);
         }
         catch (err) {
+            Debug.assert(err instanceof Error);
             logInternalError(host, err);
             throw err;
         }
@@ -1409,6 +1411,7 @@ export class TypeScriptServicesFactory implements ShimFactory {
             return new ClassifierShimObject(this, logger);
         }
         catch (err) {
+            Debug.assert(err instanceof Error);
             logInternalError(logger, err);
             throw err;
         }
@@ -1420,6 +1423,7 @@ export class TypeScriptServicesFactory implements ShimFactory {
             return new CoreServicesShimObject(this, host as Logger, adapter);
         }
         catch (err) {
+            Debug.assert(err instanceof Error);
             logInternalError(host as Logger, err);
             throw err;
         }

--- a/src/testRunner/projectsRunner.ts
+++ b/src/testRunner/projectsRunner.ts
@@ -190,6 +190,7 @@ class ProjectTestCase {
             testFileText = Harness.IO.readFile(testCaseFileName);
         }
         catch (e) {
+            assert(e instanceof Error);
             assert(false, "Unable to open testcase file: " + testCaseFileName + ": " + e.message);
         }
 
@@ -197,6 +198,7 @@ class ProjectTestCase {
             testCase = JSON.parse(testFileText!) as ProjectRunnerTestCase & ts.CompilerOptions;
         }
         catch (e) {
+            assert(e instanceof Error);
             throw assert(false, "Testcase: " + testCaseFileName + " does not contain valid json format: " + e.message);
         }
 
@@ -261,6 +263,7 @@ class ProjectTestCase {
                     Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + diskRelativeName, content as string | null); // TODO: GH#18217
                 }
                 catch (e) {
+                    assert(e instanceof Error);
                     errs.push(e);
                 }
             }

--- a/src/testRunner/unittests/builder.ts
+++ b/src/testRunner/unittests/builder.ts
@@ -122,7 +122,7 @@ function makeAssertChangesWithCancellationToken(getProgram: () => ts.Program): (
         }
         catch (e) {
             assert.isFalse(operationWasCancelled);
-            assert(e instanceof ts.OperationCanceledException, e.toString());
+            assert(e instanceof ts.OperationCanceledException, (e as {}).toString());
             operationWasCancelled = true;
         }
         assert.equal(cancel, operationWasCancelled);

--- a/src/testRunner/unittests/tsserver/cachingFileSystemInformation.ts
+++ b/src/testRunner/unittests/tsserver/cachingFileSystemInformation.ts
@@ -122,7 +122,7 @@ describe("unittests:: tsserver:: CachingFileSystemInformation:: tsserverProjectS
             logSemanticDiagnostics(projectService, project, imported);
         }
         catch (e) {
-            projectService.logger.info(e.message);
+            projectService.logger.info(e instanceof Error ? e.message : `${e}`);
         }
         logCacheAndClear(projectService.logger);
 

--- a/src/testRunner/unittests/tsserver/dynamicFiles.ts
+++ b/src/testRunner/unittests/tsserver/dynamicFiles.ts
@@ -238,6 +238,7 @@ describe("unittests:: tsserver:: dynamicFiles:: ", () => {
                 projectService.openClientFile(file.path, file.content, /*scriptKind*/ undefined, "/user/username/projects/myproject");
             }
             catch (e) {
+                assert(e instanceof Error);
                 assert.strictEqual(
                     e.message.replace(/\r?\n/, "\n"),
                     `Debug Failure. False expression.\nVerbose Debug Information: {"fileName":"^walkThroughSnippet:/Users/UserName/projects/someProject/out/someFile#1.js","currentDirectory":"/user/username/projects/myproject","hostCurrentDirectory":"/","openKeys":[]}\nDynamic files must always be opened with service's current directory or service should support inferred project per projectRootPath.`

--- a/src/testRunner/unittests/tsserver/partialSemanticServer.ts
+++ b/src/testRunner/unittests/tsserver/partialSemanticServer.ts
@@ -87,6 +87,7 @@ import { something } from "something";
             session.executeCommand(request);
         }
         catch (e) {
+            assert(e instanceof Error);
             session.logger.info(e.message);
         }
 
@@ -95,6 +96,7 @@ import { something } from "something";
             project.getLanguageService().getSemanticDiagnostics(file1.path);
         }
         catch (e) {
+            assert(e instanceof Error);
             session.logger.info(e.message);
         }
         baselineTsserverLogs("partialSemanticServer", "throws unsupported commands", session);

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -1584,6 +1584,7 @@ describe("unittests:: tsserver:: Projects", () => {
             service.applyChangesInOpenFiles(/*openFiles*/ undefined, /*changedFiles*/ undefined, [commonFile1.path]);
         }
         catch (e) {
+            assert(e instanceof Error);
             assert.isTrue(e.message.indexOf("Debug Failure. False expression: Found script Info still attached to project") === 0);
         }
     });

--- a/src/testRunner/unittests/tsserver/session.ts
+++ b/src/testRunner/unittests/tsserver/session.ts
@@ -614,6 +614,7 @@ describe("unittests:: tsserver:: Session:: an example of using the Session API t
                 response = this.executeCommand(msg).response as ts.server.protocol.Response;
             }
             catch (e) {
+                assert(e instanceof Error);
                 this.output(undefined, msg.command, msg.seq, e.toString());
                 return;
             }

--- a/src/testRunner/unittests/tsserver/syntacticServer.ts
+++ b/src/testRunner/unittests/tsserver/syntacticServer.ts
@@ -53,6 +53,7 @@ import { something } from "something";
             session.executeCommandSeq(request);
         }
         catch (e) {
+            assert(e instanceof Error);
             session.logger.info(e.message);
         }
     }
@@ -113,6 +114,7 @@ import { something } from "something";
             project.getLanguageService().getSemanticDiagnostics(file1.path);
         }
         catch (e) {
+            assert(e instanceof Error);
             session.logger.info(e.message);
         }
         baselineTsserverLogs("syntacticServer", "throws on unsupported commands", session);

--- a/src/testRunner/unittests/virtualFileSystemWithWatch.ts
+++ b/src/testRunner/unittests/virtualFileSystemWithWatch.ts
@@ -878,6 +878,7 @@ export class TestServerHost implements server.ServerHost, FormatDiagnosticsHost,
             this.timeoutCallbacks.invoke(timeoutId);
         }
         catch (e) {
+            assert(e instanceof Error);
             if (e.message === this.exitMessage) {
                 return;
             }

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -18,7 +18,6 @@
 
         "strict": true,
         "strictBindCallApply": false,
-        "useUnknownInCatchVariables": false,
 
         "noUnusedLocals": true,
         "noUnusedParameters": true,

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -346,7 +346,7 @@ export function initializeNodeSystem(): StartInput {
                 catch (e) {
                     status = false;
                     if (logger.hasLevel(LogLevel.verbose)) {
-                        logger.info(`WatchGuard for path ${path} returned: ${e.message}`);
+                        logger.info(`WatchGuard for path ${path} returned: ${e instanceof Error ? e.message : e}`);
                     }
                 }
                 if (cacheKey) {
@@ -389,7 +389,7 @@ export function initializeNodeSystem(): StartInput {
             return { module: require(resolveJSModule(moduleName, initialDir, sys)), error: undefined };
         }
         catch (error) {
-            return { module: undefined, error };
+            return { module: undefined, error: error as {} };
         }
     };
 
@@ -497,7 +497,7 @@ export function initializeNodeSystem(): StartInput {
             return originalWatchDirectory(path, callback, recursive, options);
         }
         catch (e) {
-            logger.info(`Exception when creating directory watcher: ${e.message}`);
+            logger.info(`Exception when creating directory watcher: ${e instanceof Error ? e.message : e}`);
             return noopFileWatcher;
         }
     }

--- a/src/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/typingsInstaller/nodeTypingsInstaller.ts
@@ -238,7 +238,7 @@ export class NodeTypingsInstaller extends TypingsInstaller {
             return false;
         }
         catch (error) {
-            const { stdout, stderr } = error;
+            const { stdout, stderr } = (error as Error & { stdout?: string; stderr?: string });
             this.log.writeLine(`    Failed. stdout:${indent(sys.newLine, stdout)}${sys.newLine}    stderr:${indent(sys.newLine, stderr)}`);
             return true;
         }


### PR DESCRIPTION
This option is one of the two remaining strictness options we have disabled after enabling strictFunctionTypes.