### PR TITLE
Fix debug assert in getConstructorDefinedThisAssignmentTypes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10491,6 +10491,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         if (!type) {
             let types: Type[] | undefined;
+            let declarationsForTypes: Declaration[] | undefined;
             if (symbol.declarations) {
                 let jsdocType: Type | undefined;
                 for (const declaration of symbol.declarations) {
@@ -10516,7 +10517,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         jsdocType = getAnnotatedTypeForAssignmentDeclaration(jsdocType, expression, symbol, declaration);
                     }
                     if (!jsdocType) {
-                        (types || (types = [])).push((isBinaryExpression(expression) || isCallExpression(expression)) ? getInitializerTypeFromAssignmentDeclaration(symbol, resolvedSymbol, expression, kind) : neverType);
+                        types = append(types, (isBinaryExpression(expression) || isCallExpression(expression)) ? getInitializerTypeFromAssignmentDeclaration(symbol, resolvedSymbol, expression, kind) : neverType);
+                        declarationsForTypes = append(declarationsForTypes, declaration);
                     }
                 }
                 type = jsdocType;
@@ -10525,7 +10527,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (!length(types)) {
                     return errorType; // No types from any declarations :(
                 }
-                let constructorTypes = definedInConstructor && symbol.declarations ? getConstructorDefinedThisAssignmentTypes(types!, symbol.declarations) : undefined;
+                let constructorTypes = definedInConstructor && declarationsForTypes ? getConstructorDefinedThisAssignmentTypes(types!, declarationsForTypes) : undefined;
                 // use only the constructor types unless they were only assigned null | undefined (including widening variants)
                 if (definedInMethod) {
                     const propType = getTypeOfPropertyInBaseClass(symbol);

--- a/tests/baselines/reference/quickInfoOnJsDocPropertyWithAmbientDeclaration.baseline
+++ b/tests/baselines/reference/quickInfoOnJsDocPropertyWithAmbientDeclaration.baseline
@@ -1,0 +1,39 @@
+=== /test.js ===
+// class Foo {
+//     constructor() {
+//         this.prop = { };
+//     }
+// 
+//     declare prop: string;
+//     method() {
+//         this.prop.foo
+//                   ^^^
+// | ----------------------------------------------------------------------
+// | any
+// | ----------------------------------------------------------------------
+//     }
+// }
+
+[
+  {
+    "marker": {
+      "fileName": "/test.js",
+      "position": 126,
+      "name": ""
+    },
+    "item": {
+      "kind": "",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 123,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "any",
+          "kind": "keyword"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/quickInfoOnJsDocPropertyWithAmbientDeclaration.ts
+++ b/tests/cases/fourslash/quickInfoOnJsDocPropertyWithAmbientDeclaration.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @noLib: true
+// @allowJs: true
+// @filename: /test.js
+////class Foo {
+////    constructor() {
+////        this.prop = { };
+////    }
+////
+////    declare prop: string;
+////    method() {
+////        this.prop.foo/**/
+////    }
+////}
+
+verify.baselineQuickInfo();


### PR DESCRIPTION
Fixes #51521

It turns out the above has been lingering around for a while; this one shows up in the top100 tsserver traces somewhat often, i.e. https://github.com/microsoft/TypeScript/pull/52317#issuecomment-1397828761

The requests all happen in babel's testing artifacts, which have the extension `js` but are in fact not JS. The one in the repro contains TypeScript code.

It seems like the bug is clear; this loop iterates over declarations to build an array of types, except that sometimes it can `continue` and skip over a declaration it doesn't like. But then, we pass that (smaller) array of types along with the original declaration array. The two need to be the same size as they are effectively zipped, but the loop explicitly doesn't guarantee that the two are going to be the same length. So, we can just build the list of declarations we actually cared about and then provide that instead.

~But, I have absolutely no clue how to actually test this; it takes tsreplay 700 some requests to get the files into the right state for this to appear and I quite know how to reduce that when I can't reproduce it myself in the editor.~