### PR TITLE
Fix issue with ambient property declaration following property assignment in JS

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3524,7 +3524,8 @@ export function isSpecialPropertyDeclaration(expr: PropertyAccessExpression | El
 export function setValueDeclaration(symbol: Symbol, node: Declaration): void {
     const { valueDeclaration } = symbol;
     if (!valueDeclaration ||
-        ((node.flags & NodeFlags.Ambient) ? (!isAssignmentDeclaration(node) && isAssignmentDeclaration(valueDeclaration)) : (valueDeclaration.flags & NodeFlags.Ambient)) ||
+        !(node.flags & NodeFlags.Ambient && !(valueDeclaration.flags & NodeFlags.Ambient)) && (isAssignmentDeclaration(valueDeclaration) && !isAssignmentDeclaration(node)) ||
+        node.kind === SyntaxKind.PropertyDeclaration && isAssignmentDeclaration(valueDeclaration) ||
         (valueDeclaration.kind !== node.kind && isEffectiveModuleDeclaration(valueDeclaration))) {
         // other kinds of value declarations take precedence over modules and assignment declarations
         symbol.valueDeclaration = node;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3524,8 +3524,7 @@ export function isSpecialPropertyDeclaration(expr: PropertyAccessExpression | El
 export function setValueDeclaration(symbol: Symbol, node: Declaration): void {
     const { valueDeclaration } = symbol;
     if (!valueDeclaration ||
-        !(node.flags & NodeFlags.Ambient && !(valueDeclaration.flags & NodeFlags.Ambient)) &&
-        (isAssignmentDeclaration(valueDeclaration) && !isAssignmentDeclaration(node)) ||
+        ((node.flags & NodeFlags.Ambient) ? (!isAssignmentDeclaration(node) && isAssignmentDeclaration(valueDeclaration)) : (valueDeclaration.flags & NodeFlags.Ambient)) ||
         (valueDeclaration.kind !== node.kind && isEffectiveModuleDeclaration(valueDeclaration))) {
         // other kinds of value declarations take precedence over modules and assignment declarations
         symbol.valueDeclaration = node;

--- a/tests/baselines/reference/quickInfoAndSemanticsOnJsPropertyWithAmbientDeclaration.baseline
+++ b/tests/baselines/reference/quickInfoAndSemanticsOnJsPropertyWithAmbientDeclaration.baseline
@@ -1,39 +1,35 @@
-=== /test.js ===
-// class Foo {
-//     constructor() {
-//         this.prop = { };
-//     }
-// 
-//     declare prop: string;
-//     method() {
-//         this.prop.foo
-//                   ^^^
-// | ----------------------------------------------------------------------
-// | any
-// | ----------------------------------------------------------------------
-//     }
-// }
+Syntactic Diagnostics for file '/tests/cases/fourslash/quickInfoAndSemanticsOnJsPropertyWithAmbientDeclaration.ts':
+/test.js(6,5): error TS8009: The 'declare' modifier can only be used in TypeScript files.
+/test.js(6,19): error TS8010: Type annotations can only be used in TypeScript files.
 
-[
-  {
-    "marker": {
-      "fileName": "/test.js",
-      "position": 126,
-      "name": ""
-    },
-    "item": {
-      "kind": "",
-      "kindModifiers": "",
-      "textSpan": {
-        "start": 123,
-        "length": 3
-      },
-      "displayParts": [
-        {
-          "text": "any",
-          "kind": "keyword"
+
+==== /test.js (2 errors) ====
+    class Foo {
+        constructor() {
+            this.prop = { };
         }
-      ]
+    
+        declare prop: string;
+        ~~~~~~~
+!!! error TS8009: The 'declare' modifier can only be used in TypeScript files.
+                      ~~~~~~
+!!! error TS8010: Type annotations can only be used in TypeScript files.
+        method() {
+            this.prop.foo
+        }
     }
-  }
-]
+
+Semantic Diagnostics for file '/tests/cases/fourslash/quickInfoAndSemanticsOnJsPropertyWithAmbientDeclaration.ts':
+
+
+==== /test.js (0 errors) ====
+    class Foo {
+        constructor() {
+            this.prop = { };
+        }
+    
+        declare prop: string;
+        method() {
+            this.prop.foo
+        }
+    }

--- a/tests/baselines/reference/quickInfoAndSemanticsOnJsPropertyWithAmbientDeclaration.baseline
+++ b/tests/baselines/reference/quickInfoAndSemanticsOnJsPropertyWithAmbientDeclaration.baseline
@@ -1,0 +1,39 @@
+=== /test.js ===
+// class Foo {
+//     constructor() {
+//         this.prop = { };
+//     }
+// 
+//     declare prop: string;
+//     method() {
+//         this.prop.foo
+//                   ^^^
+// | ----------------------------------------------------------------------
+// | any
+// | ----------------------------------------------------------------------
+//     }
+// }
+
+[
+  {
+    "marker": {
+      "fileName": "/test.js",
+      "position": 126,
+      "name": ""
+    },
+    "item": {
+      "kind": "",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 123,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "any",
+          "kind": "keyword"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/quickInfoAndSemanticsOnJsPropertyWithAmbientDeclaration.ts
+++ b/tests/cases/fourslash/quickInfoAndSemanticsOnJsPropertyWithAmbientDeclaration.ts
@@ -15,3 +15,4 @@
 ////}
 
 verify.baselineQuickInfo();
+verify.baselineSyntacticAndSemanticDiagnostics();

--- a/tests/cases/fourslash/quickInfoOnJsDocPropertyWithAmbientDeclaration.ts
+++ b/tests/cases/fourslash/quickInfoOnJsDocPropertyWithAmbientDeclaration.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @noLib: true
+// @allowJs: true
+// @filename: /test.js
+////class Foo {
+////    constructor() {
+////        this.prop = { };
+////    }
+////
+////    declare prop: string;
+////    method() {
+////        this.prop.foo/**/
+////    }
+////}
+
+verify.baselineQuickInfo();


### PR DESCRIPTION
Everyone is trying to fix https://github.com/microsoft/TypeScript/issues/51521, so I guess I am too.

This PR tries to fix #51521. It does so by fixing `setValueDeclaration` to defer to property declarations over "assignment declarations" - even in the case of ambients. In the case of code like in the following `.js` file:

```js
class C {
  constructor() {
    this.foo = 10;
  }
  declare foo: number;
}
```

We'll encounter the `this.foo = 10` assignment first, then encounter `declare foo: number;`.

Even though `declare foo: number` is marked as ambient, it is arguably a better value declaration than the JavaScript one.