### PR TITLE
Don’t let unsorted import groups eagerly derail sort detection

### DIFF
--- a/tests/cases/fourslash/organizeImports17.ts
+++ b/tests/cases/fourslash/organizeImports17.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+//// import { Both } from "module-specifiers-unsorted";
+//// import { case, Insensitively, sorted } from "aardvark";
+
+verify.organizeImports(
+`import { case, Insensitively, sorted } from "aardvark";
+import { Both } from "module-specifiers-unsorted";
+`,
+    ts.OrganizeImportsMode.SortAndCombine,
+    {
+        organizeImportsIgnoreCase: "auto",
+    }
+);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Makes the import sort detection in #51733 a bit smarter; seeing an unsorted list won’t eagerly return that there is no preferred sort strategy.
