### PR TITLE
Make GitHub render json as jsonc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.js linguist-language=TypeScript
+**/*.json linguist-language=jsonc
 * -text


### PR DESCRIPTION
I'm a bit tired of diffs in json files looking like this:

![image](https://user-images.githubusercontent.com/5341706/213787861-0bde1182-f92c-41be-a038-73e465f12c60.png)

Just tell GitHub to treat JSON files as JSONC. (Copied from https://github.com/microsoft/vscode/blob/main/.gitattributes)