### PR TITLE
Plumb formatting to getDocCommentTemplateAtPosition

### DIFF
--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -727,7 +727,7 @@ export class SessionClient implements LanguageService {
         return notImplemented();
     }
 
-    getDocCommentTemplateAtPosition(_fileName: string, _position: number, _options?: DocCommentTemplateOptions): TextInsertion {
+    getDocCommentTemplateAtPosition(_fileName: string, _position: number, _options?: DocCommentTemplateOptions, _formatOptions?: FormatCodeSettings): TextInsertion {
         return notImplemented();
     }
 

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -3249,7 +3249,7 @@ export class TestState {
 
     public verifyDocCommentTemplate(expected: ts.TextInsertion | undefined, options?: ts.DocCommentTemplateOptions) {
         const name = "verifyDocCommentTemplate";
-        const actual = this.languageService.getDocCommentTemplateAtPosition(this.activeFile.fileName, this.currentCaretPosition, options || { generateReturnInDocTemplate: true })!;
+        const actual = this.languageService.getDocCommentTemplateAtPosition(this.activeFile.fileName, this.currentCaretPosition, options || { generateReturnInDocTemplate: true }, this.formatCodeSettings)!;
 
         if (expected === undefined) {
             if (actual) {

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -452,7 +452,7 @@ export class Verify extends VerifyNegatable {
 
     public docCommentTemplateAt(marker: string | FourSlash.Marker, expectedOffset: number, expectedText: string, options?: ts.DocCommentTemplateOptions) {
         this.state.goToMarker(marker);
-        this.state.verifyDocCommentTemplate({ newText: expectedText.replace(/\r?\n/g, "\r\n"), caretOffset: expectedOffset }, options);
+        this.state.verifyDocCommentTemplate({ newText: expectedText.replace(/\r?\n/g, ts.testFormatSettings.newLineCharacter!), caretOffset: expectedOffset }, options);
     }
 
     public noDocCommentTemplateAt(marker: string | FourSlash.Marker) {

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -587,8 +587,8 @@ class LanguageServiceShimProxy implements ts.LanguageService {
     getFormattingEditsAfterKeystroke(fileName: string, position: number, key: string, options: ts.FormatCodeOptions): ts.TextChange[] {
         return unwrapJSONCallResult(this.shim.getFormattingEditsAfterKeystroke(fileName, position, key, JSON.stringify(options)));
     }
-    getDocCommentTemplateAtPosition(fileName: string, position: number, options?: ts.DocCommentTemplateOptions): ts.TextInsertion {
-        return unwrapJSONCallResult(this.shim.getDocCommentTemplateAtPosition(fileName, position, options));
+    getDocCommentTemplateAtPosition(fileName: string, position: number, options?: ts.DocCommentTemplateOptions, formatOptions?: ts.FormatCodeSettings): ts.TextInsertion {
+        return unwrapJSONCallResult(this.shim.getDocCommentTemplateAtPosition(fileName, position, options, formatOptions));
     }
     isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean {
         return unwrapJSONCallResult(this.shim.isValidBraceCompletionAtPosition(fileName, position, openingBrace));

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -2083,7 +2083,7 @@ export class Session<TMessage = string> implements EventSender {
     private getDocCommentTemplate(args: protocol.FileLocationRequestArgs) {
         const { file, languageService } = this.getFileAndLanguageServiceForSyntacticOperation(args);
         const position = this.getPositionInFile(args, file);
-        return languageService.getDocCommentTemplateAtPosition(file, position, this.getPreferences(file));
+        return languageService.getDocCommentTemplateAtPosition(file, position, this.getPreferences(file), this.getFormatOptions(file));
     }
 
     private getSpanOfEnclosingComment(args: protocol.SpanOfEnclosingCommentRequestArgs) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2436,8 +2436,9 @@ export function createLanguageService(
             : Promise.reject("Host does not implement `installPackage`");
     }
 
-    function getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions): TextInsertion | undefined {
-        return JsDoc.getDocCommentTemplateAtPosition(getNewLineOrDefaultFromHost(host, /*formatSettings*/ undefined), syntaxTreeCache.getCurrentSourceFile(fileName), position, options);
+    function getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions, formatOptions?: FormatCodeSettings): TextInsertion | undefined {
+        const formatSettings = formatOptions ? formatting.getFormatContext(formatOptions, host).options : undefined;
+        return JsDoc.getDocCommentTemplateAtPosition(getNewLineOrDefaultFromHost(host, formatSettings), syntaxTreeCache.getCurrentSourceFile(fileName), position, options);
     }
 
     function isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean {

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -349,7 +349,7 @@ export interface LanguageServiceShim extends Shim {
     /**
      * Returns JSON-encoded value of the type TextInsertion.
      */
-    getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions): string;
+    getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions, formatOptions?: FormatCodeSettings): string;
 
     /**
      * Returns JSON-encoded boolean to indicate whether we should support brace location
@@ -1091,10 +1091,10 @@ class LanguageServiceShimObject extends ShimBase implements LanguageServiceShim 
             });
     }
 
-    public getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions): string {
+    public getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions, formatOptions?: FormatCodeSettings): string {
         return this.forwardJSONCall(
             `getDocCommentTemplateAtPosition('${fileName}', ${position})`,
-            () => this.languageService.getDocCommentTemplateAtPosition(fileName, position, options)
+            () => this.languageService.getDocCommentTemplateAtPosition(fileName, position, options, formatOptions)
         );
     }
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -604,7 +604,7 @@ export interface LanguageService {
     getFormattingEditsForDocument(fileName: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
     getFormattingEditsAfterKeystroke(fileName: string, position: number, key: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
 
-    getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions): TextInsertion | undefined;
+    getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions, formatOptions?: FormatCodeSettings): TextInsertion | undefined;
 
     isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean;
     /**

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9990,7 +9990,7 @@ declare namespace ts {
         getFormattingEditsForRange(fileName: string, start: number, end: number, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
         getFormattingEditsForDocument(fileName: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
         getFormattingEditsAfterKeystroke(fileName: string, position: number, key: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
-        getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions): TextInsertion | undefined;
+        getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions, formatOptions?: FormatCodeSettings): TextInsertion | undefined;
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean;
         /**
          * This will return a defined result if the position is after the `>` of the opening tag, or somewhere in the text, of a JSXElement with no closing tag.

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6088,7 +6088,7 @@ declare namespace ts {
         getFormattingEditsForRange(fileName: string, start: number, end: number, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
         getFormattingEditsForDocument(fileName: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
         getFormattingEditsAfterKeystroke(fileName: string, position: number, key: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
-        getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions): TextInsertion | undefined;
+        getDocCommentTemplateAtPosition(fileName: string, position: number, options?: DocCommentTemplateOptions, formatOptions?: FormatCodeSettings): TextInsertion | undefined;
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean;
         /**
          * This will return a defined result if the position is after the `>` of the opening tag, or somewhere in the text, of a JSXElement with no closing tag.

--- a/tests/cases/fourslash/docCommentTemplateClassDeclMethods01.ts
+++ b/tests/cases/fourslash/docCommentTemplateClassDeclMethods01.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 const singleLineOffset = 3;
-const multiLineOffset = 12;
+const multiLineOffset = 11;
 
 
 ////class C {

--- a/tests/cases/fourslash/docCommentTemplateClassDeclMethods02.ts
+++ b/tests/cases/fourslash/docCommentTemplateClassDeclMethods02.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-const multiLineOffset = 12;
+const multiLineOffset = 11;
 
 ////class C {
 ////    /*0*/

--- a/tests/cases/fourslash/docCommentTemplateClassDeclProperty01.ts
+++ b/tests/cases/fourslash/docCommentTemplateClassDeclProperty01.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 const singleLineOffset = 3;
-const multiLineOffset = 12;
+const multiLineOffset = 11;
 
 
 ////class C {

--- a/tests/cases/fourslash/docCommentTemplateConstructor01.ts
+++ b/tests/cases/fourslash/docCommentTemplateConstructor01.ts
@@ -13,7 +13,7 @@
 ////    }
 ////}
 
-const newTextOffset = 12;
+const newTextOffset = 11;
 verify.docCommentTemplateAt("0", /*newTextOffset*/ newTextOffset,
    `/**
      * 

--- a/tests/cases/fourslash/docCommentTemplateExportAssignmentJS.ts
+++ b/tests/cases/fourslash/docCommentTemplateExportAssignmentJS.ts
@@ -8,7 +8,7 @@
 //// exports.foo = (a) => {};
 
 
-verify.docCommentTemplateAt("", 8,
+verify.docCommentTemplateAt("", 7,
 `/**
  * 
  * @param {any} a

--- a/tests/cases/fourslash/docCommentTemplateFunctionExpression.ts
+++ b/tests/cases/fourslash/docCommentTemplateFunctionExpression.ts
@@ -4,7 +4,7 @@
 ////const x = /*next*/ function f(p) {}
 
 for (const marker of test.markerNames()) {
-    verify.docCommentTemplateAt(marker, 8,
+    verify.docCommentTemplateAt(marker, 7,
 `/**
  * 
  * @param p

--- a/tests/cases/fourslash/docCommentTemplateFunctionWithParameters.ts
+++ b/tests/cases/fourslash/docCommentTemplateFunctionWithParameters.ts
@@ -7,7 +7,7 @@
 
 const noIndentScaffolding = "/**\n * \n * @param x\n * @param y\n */";
 const oneIndentScaffolding = "/**\n     * \n     * @param x\n     * @param y\n     */";
-const noIndentOffset = 8;
+const noIndentOffset = 7;
 const oneIndentOffset = noIndentOffset + 4;
 
 goTo.marker("0");

--- a/tests/cases/fourslash/docCommentTemplateFunctionWithParameters_js.ts
+++ b/tests/cases/fourslash/docCommentTemplateFunctionWithParameters_js.ts
@@ -4,7 +4,7 @@
 /////*0*/
 ////function f(a, ...b): boolean {}
 
-verify.docCommentTemplateAt("0", 8,
+verify.docCommentTemplateAt("0", 7,
 `/**
  * 
  * @param {any} a

--- a/tests/cases/fourslash/docCommentTemplateInterfacePropertyFunctionType.ts
+++ b/tests/cases/fourslash/docCommentTemplateInterfacePropertyFunctionType.ts
@@ -5,7 +5,7 @@
 ////    foo: (a: number, b: string) => void;
 ////}
 
-verify.docCommentTemplateAt("", 12,
+verify.docCommentTemplateAt("", 11,
    `/**
      * 
      * @param a
@@ -13,7 +13,7 @@ verify.docCommentTemplateAt("", 12,
      * @returns
      */`);
 
-verify.docCommentTemplateAt("", 12,
+verify.docCommentTemplateAt("", 11,
    `/**
      * 
      * @param a

--- a/tests/cases/fourslash/docCommentTemplateInterfacesEnumsAndTypeAliases.ts
+++ b/tests/cases/fourslash/docCommentTemplateInterfacesEnumsAndTypeAliases.ts
@@ -30,7 +30,7 @@ verify.docCommentTemplateAt("interfaceFoo", /*expectedOffset*/ 3,
 verify.docCommentTemplateAt("propertybar", /*expectedOffset*/ 3,
   "/** */");
 
-verify.docCommentTemplateAt("methodbaz", /*expectedOffset*/ 12,
+verify.docCommentTemplateAt("methodbaz", /*expectedOffset*/ 11,
    `/**
      * 
      * @param message

--- a/tests/cases/fourslash/docCommentTemplateJsSpecialPropertyAssignment.ts
+++ b/tests/cases/fourslash/docCommentTemplateJsSpecialPropertyAssignment.ts
@@ -5,14 +5,14 @@
 ////const myNamespace  = {};
 /////*1*/myNamespace.myExport = function(x) {};
 
-verify.docCommentTemplateAt("0", 8,
+verify.docCommentTemplateAt("0", 7,
 `/**
  * 
  * @param {any} a
  */
 `);
 
-verify.docCommentTemplateAt("1", 8,
+verify.docCommentTemplateAt("1", 7,
 `/**
  * 
  * @param {any} x

--- a/tests/cases/fourslash/docCommentTemplateObjectLiteralMethods01.ts
+++ b/tests/cases/fourslash/docCommentTemplateObjectLiteralMethods01.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-const multiLineOffset = 12;
+const multiLineOffset = 11;
 
 ////var x = {
 ////    /*0*/

--- a/tests/cases/fourslash/docCommentTemplatePrototypeMethod.ts
+++ b/tests/cases/fourslash/docCommentTemplatePrototypeMethod.ts
@@ -7,7 +7,7 @@
 ////C.prototype.method = /*next*/ function (p) {}
 
 for (const marker of test.markerNames()) {
-    verify.docCommentTemplateAt(marker, 8,
+    verify.docCommentTemplateAt(marker, 7,
 `/**
  * 
  * @param {any} p

--- a/tests/cases/fourslash/docCommentTemplateReturnsTag1.ts
+++ b/tests/cases/fourslash/docCommentTemplateReturnsTag1.ts
@@ -28,19 +28,19 @@
 
 verify.docCommentTemplateAt("0", 3, "/** */");
 
-verify.docCommentTemplateAt("1", 8,
+verify.docCommentTemplateAt("1", 7,
    `/**
  * 
  * @returns
  */`);
 
-verify.docCommentTemplateAt("2", 8,
+verify.docCommentTemplateAt("2", 7,
    `/**
  * 
  * @returns
  */`);
 
-verify.docCommentTemplateAt("3", 8,
+verify.docCommentTemplateAt("3", 7,
    `/**
  * 
  * @returns
@@ -49,7 +49,7 @@ verify.docCommentTemplateAt("3", 8,
 verify.docCommentTemplateAt("4", 3, "/** */");
 
 
-verify.docCommentTemplateAt("5", 12,
+verify.docCommentTemplateAt("5", 11,
    `/**
      * 
      * @returns

--- a/tests/cases/fourslash/docCommentTemplateReturnsTag2.ts
+++ b/tests/cases/fourslash/docCommentTemplateReturnsTag2.ts
@@ -5,7 +5,7 @@
 ////    return 1;
 ////}
 
-verify.docCommentTemplateAt("0", 8,
+verify.docCommentTemplateAt("0", 7,
    `/**
  * 
  * @param x
@@ -13,7 +13,7 @@ verify.docCommentTemplateAt("0", 8,
  * @returns
  */`, { generateReturnInDocTemplate: true });
 
-verify.docCommentTemplateAt("0", 8,
+verify.docCommentTemplateAt("0", 7,
    `/**
  * 
  * @param x

--- a/tests/cases/fourslash/docCommentTemplateVariableStatements01.ts
+++ b/tests/cases/fourslash/docCommentTemplateVariableStatements01.ts
@@ -33,7 +33,7 @@ for (const varName of ["a", "b", "c", "d"]) {
         "/** */");
 }
 
-verify.docCommentTemplateAt("e", /*newTextOffset*/ 8,
+verify.docCommentTemplateAt("e", /*newTextOffset*/ 7,
 `/**
  * 
  * @param x
@@ -42,7 +42,7 @@ verify.docCommentTemplateAt("e", /*newTextOffset*/ 8,
  * @returns
  */`);
 
-verify.docCommentTemplateAt("f", /*newTextOffset*/ 8,
+verify.docCommentTemplateAt("f", /*newTextOffset*/ 7,
 `/**
  * 
  * @param a

--- a/tests/cases/fourslash/docCommentTemplateVariableStatements03.ts
+++ b/tests/cases/fourslash/docCommentTemplateVariableStatements03.ts
@@ -29,14 +29,14 @@
 ////    }
 ////}))
 
-verify.docCommentTemplateAt("a", /*newTextOffset*/ 8,
+verify.docCommentTemplateAt("a", /*newTextOffset*/ 7,
 `/**
  * 
  * @param x
  * @returns
  */`);
 
-verify.docCommentTemplateAt("b", /*newTextOffset*/ 8,
+verify.docCommentTemplateAt("b", /*newTextOffset*/ 7,
 `/**
  * 
  * @param x
@@ -45,7 +45,7 @@ verify.docCommentTemplateAt("b", /*newTextOffset*/ 8,
  * @returns
  */`);
 
-verify.docCommentTemplateAt("c", /*newTextOffset*/ 8,
+verify.docCommentTemplateAt("c", /*newTextOffset*/ 7,
 `/**
  * 
  * @param x
@@ -55,7 +55,7 @@ verify.docCommentTemplateAt("c", /*newTextOffset*/ 8,
 verify.docCommentTemplateAt("d", /*newTextOffset*/ 3,
 "/** */");
 
-verify.docCommentTemplateAt("e", /*newTextOffset*/ 8,
+verify.docCommentTemplateAt("e", /*newTextOffset*/ 7,
 `/**
  * 
  * @param param0
@@ -65,7 +65,7 @@ verify.docCommentTemplateAt("e", /*newTextOffset*/ 8,
 verify.docCommentTemplateAt("f", /*newTextOffset*/ 3,
 "/** */");
 
-verify.docCommentTemplateAt("g", /*newTextOffset*/ 8,
+verify.docCommentTemplateAt("g", /*newTextOffset*/ 7,
 `/**
  * 
  * @param x

--- a/tests/cases/fourslash/docCommentTemplate_insideEmptyComment.ts
+++ b/tests/cases/fourslash/docCommentTemplate_insideEmptyComment.ts
@@ -6,7 +6,7 @@
 /////** Doc/*1*/ */
 ////function g(p) { return p; }
 
-verify.docCommentTemplateAt("", /*newTextOffset*/ 8,
+verify.docCommentTemplateAt("", /*newTextOffset*/ 7,
 `/**
  * 
  * @param p


### PR DESCRIPTION
Fixes #52348

~This will fail at the moment because it (rightfully!) fails tests.~ The fourslash verify call expects the newlines to match the newlines in the source file's multi-line template, which in our repo is CRLF at checkout, but the format settings are:

```ts
export const testFormatSettings = getDefaultFormatCodeSettings("\n");
```