### PR TITLE
Try and ignore newline change PR in git blames

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,5 @@ b6c053882696af8ddd94a600429f30584d303d7f
 9a0b85ce2a3f85f498ab2c05474b4c0b96b111c9
 # Generated module conversion step - unindent
 94724a8c2e68a4c7e267072ca79971f317c45e4a
+# Change default newLine, forceConsistentCasingInFileNames (#52298)
+ff92ab0ac92b66397bd3b92ff5a3aca3c1ad8f43


### PR DESCRIPTION
I've confirmed that this works locally; the newline change is ignored.

But, this will also ignore the `forceConsistentCasingInFileNames` changes too because the PR changed both.